### PR TITLE
Add a folder for public-facing documentation source files

### DIFF
--- a/public-docs/README.adoc
+++ b/public-docs/README.adoc
@@ -1,0 +1,3 @@
+= Welcome to DFINITY Developer Network
+
+This folder contains public-facing documentation for the DFINITY SDK.


### PR DESCRIPTION
This is just a placeholder folder for public-facing documentation. Not sure if this is the right location yet, but this lets me test creating a PR for my sample repo.