### PR TITLE
Add dfx/demo.nix

### DIFF
--- a/dfx/demo.nix
+++ b/dfx/demo.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import ../. {} }:
+
+pkgs.mkCiShell {
+  name = "dfinity-sdk-dfx-demo";
+  buildInputs = [
+    pkgs.dfinity-sdk.dfx
+  ];
+}


### PR DESCRIPTION
Following up on #15.

Example usage:

```
$ cd dfx
$ nix-shell demo.nix
[nix-shell:~/projects/dfinity-lab/sdk/paulyoung/dfx-mock/dfx]$ dfx --help
```