### PR TITLE
RFC: Specification for the version management

### DIFF
--- a/docs/specification/version-management.adoc
+++ b/docs/specification/version-management.adoc
@@ -14,7 +14,7 @@ This document details the design and decisions made to solve the problem of havi
 == User-facing Version
 The version of `dfx` is the only version the user should be aware of. Any upstream version will be hidden behind the `dfx` version.
 
-For example, assuming `v1.1.5` and `v1.2.3` of DFX are supported stable versions, with unstable being `v1.3.0-beta.1`. Assuming a version of the DFINITY client could be released with bug fixes that affect both the previous stable, current stable and unstable releases. Without changes to the DFX client, we should release a `v1.1.6`, `v1.2.4` and `v1.3.0-beta.2` versions of the DFX containing the DFINITY client with the fix included.
+For example, assuming `v1.1.5` and `v1.2.3` of `dfx` are supported stable versions, with unstable being `v1.3.0-beta.1`, and assuming a version of the DFINITY client could be released with bug fixes that affect both the previous stable, current stable, and unstable releases, without changes to `dfx` itself we should release a `v1.1.6`, `v1.2.4` and `v1.3.0-beta.2` versions of `dfx` containing the DFINITY client with the fix included.
 
 This means the user would never actually see the version of DFINITY client that they are running.
 


### PR DESCRIPTION
Requesting comments on this proposal. This is coming from a week of brainstorming and whiteboarding with Paul, Diego and myself.

Essentially this would allow us to manage versions independently from project to project, create a project with always the latest version, allow users to start new projects without an internet connection, let user upgrade at their own pace (even if it means their test net is versions behind the main net), and let us run integration tests on any version necessary (even custom SHAs). This cover all use cases I could think of, so if you think of something else let me know so I can integrate it.

This does not require a significant amount of code from our part. As a matter of fact the mocked CLI implement _some_ of this proposal already (bundling and checking versions).

The complex part will be the migration scripts, but I would like to defer that work to after the 1.0 release.