### PR TITLE
Add a shared environment for commands

### DIFF
--- a/dfx/src/commands/send.rs
+++ b/dfx/src/commands/send.rs
@@ -1,20 +1,15 @@
+use crate::lib::env::{Env};
 use crate::lib::api_client::*;
 use crate::lib::error::{DfxError, DfxResult};
 use clap::{App, Arg, ArgMatches, SubCommand};
 use futures::future::{err, ok, Future};
 use tokio::runtime::Runtime;
 
-const HOST_ARG: &str = "host";
 const NAME_ARG: &str = "name";
 
 pub fn construct() -> App<'static, 'static> {
     SubCommand::with_name("send")
         .about(r#"Send a "Hello World" request to the canister 42."#)
-        .arg(
-            Arg::with_name(HOST_ARG)
-                .help("The host (with port) to send the query to.")
-                .required(true),
-        )
         .arg(
             Arg::with_name(NAME_ARG)
                 .help("The person to say hello to.")
@@ -22,16 +17,11 @@ pub fn construct() -> App<'static, 'static> {
         )
 }
 
-pub fn exec(args: &ArgMatches<'_>) -> DfxResult {
+pub fn exec(env: &'static Env, args: &ArgMatches<'_>) -> DfxResult {
     let name = args.value_of(NAME_ARG).unwrap();
-    let url = args.value_of(HOST_ARG).unwrap();
-
-    let client = Client::new(ClientConfig {
-        url: url.to_string(),
-    });
 
     let query = query(
-        client,
+        &env.client,
         CanisterQueryCall {
             canister_id: 42,
             method_name: "dfn_msg greet".to_string(),

--- a/dfx/src/lib/env.rs
+++ b/dfx/src/lib/env.rs
@@ -1,0 +1,18 @@
+use crate::lib::api_client::{Client};
+
+#[derive(Default)]
+pub struct Env {
+    pub client: Client,
+}
+
+impl Env {
+    pub fn new(client: Client) -> Env {
+        Env {
+            client,
+        }
+    }
+
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+}

--- a/dfx/src/lib/mod.rs
+++ b/dfx/src/lib/mod.rs
@@ -1,2 +1,3 @@
 pub mod api_client;
+pub mod env;
 pub mod error;

--- a/dfx/src/main.rs
+++ b/dfx/src/main.rs
@@ -1,10 +1,13 @@
-use clap::{App, AppSettings};
+use clap::{App, AppSettings, Arg};
+use crate::lib::api_client::{Client, ClientConfig};
+use crate::lib::env::{Env};
 
 mod commands;
 pub mod lib;
 
 use lib::error::*;
 
+const HOST_FLAG: &str = "host";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn cli() -> App<'static, 'static> {
@@ -12,14 +15,19 @@ fn cli() -> App<'static, 'static> {
         .about("The DFINITY Executor.")
         .version(VERSION)
         .setting(AppSettings::ColoredHelp)
+        .arg(
+            Arg::with_name(HOST_FLAG)
+                .global(true)
+                .help("The host (with port) to send the query to.")
+                .long(HOST_FLAG)
+                .takes_value(true)
+        )
         .subcommands(
-            commands::builtin()
-                .into_iter()
-                .map(|x| x.get_subcommand().clone()),
+            commands::ctors(),
         )
 }
 
-fn exec(args: &clap::ArgMatches<'_>) -> DfxResult {
+fn exec(env: &'static Env, args: &clap::ArgMatches<'_>) -> DfxResult {
     let (name, subcommand_args) = match args.subcommand() {
         (name, Some(args)) => (name, args),
         _ => {
@@ -30,7 +38,7 @@ fn exec(args: &clap::ArgMatches<'_>) -> DfxResult {
         }
     };
 
-    match commands::builtin()
+    match commands::builtin(&env)
         .into_iter()
         .find(|x| name == x.get_name())
     {
@@ -49,8 +57,19 @@ fn exec(args: &clap::ArgMatches<'_>) -> DfxResult {
 
 fn main() {
     let matches = cli().get_matches();
+    let host = matches.value_of(HOST_FLAG);
 
-    match exec(&matches) {
+    let default_config = ClientConfig::default();
+    let default_host = default_config.host;
+
+    let env = Env {
+        client: Client::new(ClientConfig {
+            host: host.map_or_else(|| default_host, |x| x.to_string()),
+            .. default_config
+        })
+    };
+
+    match exec(Box::leak(Box::new(env)), &matches) {
         Ok(()) => ::std::process::exit(0),
         Err(err) => {
             println!("An error occured:\n{:#?}", err);


### PR DESCRIPTION
This intends to enable things like sharing values from simple flags as well as
more complex things like API clients.

I started thinking about how we might implement some of the commands we have planned and write unit tests for the related functions. I think something like this might be a necessary step towards that.

Right now this demonstrates how a single API client could be used across multiple commands. We could do add things to the environment that commands might want to make use of without exposing their implementation (like a shared tokio runtime) or have it just contain simple values parsed from global flags (like the host). I think the former is conceptually an extension of the latter, but more useful.

I struggled with ownership and lifetimes in some places so I'm not sure if there's a better way to do this.