### PR TITLE
refactor: move all env factories to a single env struct

### DIFF
--- a/dfx/src/commands/build.rs
+++ b/dfx/src/commands/build.rs
@@ -1,7 +1,8 @@
-use crate::config::cache::binary_command_from_config;
-use crate::config::dfinity::{Config, ConfigCanistersCanister};
+use crate::config::dfinity::ConfigCanistersCanister;
+use crate::lib::env::{BinaryCacheEnv, ProjectConfigEnv};
 use crate::lib::error::DfxResult;
 use clap::{App, Arg, ArgMatches, SubCommand};
+use std::path::Path;
 
 pub fn construct() -> App<'static, 'static> {
     SubCommand::with_name("build")
@@ -9,10 +10,42 @@ pub fn construct() -> App<'static, 'static> {
         .arg(Arg::with_name("canister").help("The canister name to build."))
 }
 
-pub fn exec(_args: &ArgMatches<'_>) -> DfxResult {
+fn build_file<T>(env: &T, input_path: &Path, output_path: &Path) -> DfxResult
+where
+    T: BinaryCacheEnv,
+{
+    let output_wasm_path = output_path.with_extension("wasm");
+    let output_idl_path = output_path.with_extension("did");
+    let output_js_path = output_path.with_extension("js");
+
+    env.get_binary_command("asc")?
+        .arg(input_path)
+        .arg("-o")
+        .arg(&output_wasm_path)
+        .output()?;
+    env.get_binary_command("asc")?
+        .arg("--idl")
+        .arg(input_path)
+        .arg("-o")
+        .arg(&output_idl_path)
+        .output()?;
+    env.get_binary_command("didc")?
+        .arg("--js")
+        .arg(&output_idl_path)
+        .arg("-o")
+        .arg(output_js_path)
+        .output()?;
+
+    Ok(())
+}
+
+pub fn exec<T>(env: &T, _args: &ArgMatches<'_>) -> DfxResult
+where
+    T: BinaryCacheEnv + ProjectConfigEnv,
+{
     // Read the config.
-    let config = Config::from_current_dir()?;
-    // get_path() returns the name of the config.
+    let config = env.get_config().unwrap();
+    // get_path() returns the full path of the config file. We need to get the dirname.
     let project_root = config.get_path().parent().unwrap();
 
     let build_root = project_root.join(
@@ -29,37 +62,80 @@ pub fn exec(_args: &ArgMatches<'_>) -> DfxResult {
 
             println!("Building {}...", k);
             if let Some(x) = v.main {
-                let input_as_path = project_root.join(x.as_str()).into_os_string();
+                let input_as_path = project_root.join(x.as_str());
+                let output_path = build_root.join(x.as_str()).with_extension("wasm");
+                std::fs::create_dir_all(output_path.parent().unwrap())?;
 
-                let mut output_wasm_path = build_root.join(x.as_str());
-                let mut output_idl_path = output_wasm_path.clone();
-                let mut output_js_path = output_wasm_path.clone();
-                output_wasm_path.set_extension("wasm");
-                output_idl_path.set_extension("did");
-                output_js_path.set_extension("js");
-
-                std::fs::create_dir_all(output_wasm_path.parent().unwrap())?;
-
-                binary_command_from_config(&config, "asc")?
-                    .arg(&input_as_path)
-                    .arg("-o")
-                    .arg(&output_wasm_path)
-                    .output()?;
-                binary_command_from_config(&config, "asc")?
-                    .arg("--idl")
-                    .arg(&input_as_path)
-                    .arg("-o")
-                    .arg(&output_idl_path)
-                    .output()?;
-                binary_command_from_config(&config, "didc")?
-                    .arg("--js")
-                    .arg(&output_idl_path)
-                    .arg("-o")
-                    .arg(&output_js_path)
-                    .output()?;
+                build_file(env, &input_as_path, &output_path)?;
             }
         }
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::env::temp_dir;
+    use std::fs;
+    use std::io;
+    use std::io::{Read, Write};
+    use std::path::PathBuf;
+    use std::process;
+
+    #[test]
+    /// Runs "echo" instead of the compiler to make sure the binaries are called in order
+    /// with the good arguments.
+    fn build_file_wasm() -> () {
+        // Create a binary cache environment that just returns "echo", so we can test the STDOUT.
+        struct TestEnv<'a> {
+            out_file: &'a fs::File,
+        }
+
+        impl<'a> BinaryCacheEnv for TestEnv<'a> {
+            fn get_binary_command_path(&self, _binary_name: &str) -> io::Result<PathBuf> {
+                // This should not be used.
+                panic!("get_binary_command_path should not be called.")
+            }
+            fn get_binary_command(&self, binary_name: &str) -> io::Result<process::Command> {
+                let stdout = self.out_file.try_clone()?;
+                let stderr = self.out_file.try_clone()?;
+
+                let mut cmd = process::Command::new("echo");
+
+                cmd.arg(binary_name)
+                    .stdout(process::Stdio::from(stdout))
+                    .stderr(process::Stdio::from(stderr));
+
+                Ok(cmd)
+            }
+        }
+
+        let temp_path = temp_dir().join("stdout").with_extension("txt");
+        let mut out_file = fs::File::create(temp_path.clone()).expect("Could not create file.");
+        let env = TestEnv {
+            out_file: &out_file,
+        };
+
+        build_file(&env, Path::new("/in/file.as"), Path::new("/out/file.wasm"))
+            .expect("Function failed.");
+
+        out_file.flush().expect("Could not flush.");
+
+        let mut s = String::new();
+        fs::File::open(temp_path)
+            .expect("Could not open temp file.")
+            .read_to_string(&mut s)
+            .expect("Could not read temp file.");
+
+        assert_eq!(
+            s.trim(),
+            r#"asc /in/file.as -o /out/file.wasm
+                asc --idl /in/file.as -o /out/file.did
+                didc --js /out/file.did -o /out/file.js"#
+                .replace("                ", "")
+        );
+    }
 }

--- a/dfx/src/commands/send.rs
+++ b/dfx/src/commands/send.rs
@@ -1,4 +1,5 @@
 use crate::lib::api_client::*;
+use crate::lib::env::ClientEnv;
 use crate::lib::error::{DfxError, DfxResult};
 use clap::{App, Arg, ArgMatches, SubCommand};
 use futures::future::{err, ok, Future};
@@ -22,13 +23,12 @@ pub fn construct() -> App<'static, 'static> {
         )
 }
 
-pub fn exec(args: &ArgMatches<'_>) -> DfxResult {
+pub fn exec<T>(env: &T, args: &ArgMatches<'_>) -> DfxResult
+where
+    T: ClientEnv,
+{
     let name = args.value_of(NAME_ARG).unwrap();
-    let url = args.value_of(HOST_ARG).unwrap();
-
-    let client = Client::new(ClientConfig {
-        url: url.to_string(),
-    });
+    let client = env.get_client();
 
     let query = query(
         client,

--- a/dfx/src/commands/start.rs
+++ b/dfx/src/commands/start.rs
@@ -1,6 +1,4 @@
-use crate::config;
-use crate::config::cache::{binary_command_from_version, get_binary_path_from_version};
-use crate::config::dfinity::Config;
+use crate::lib::env::BinaryCacheEnv;
 use crate::lib::error::DfxResult;
 use clap::{App, Arg, ArgMatches, SubCommand};
 
@@ -15,19 +13,17 @@ pub fn construct() -> App<'static, 'static> {
         )
 }
 
-pub fn exec(_args: &ArgMatches<'_>) -> DfxResult {
-    // Read the config.
-    let version: String = Config::from_current_dir().ok().map_or_else(
-        || config::DFX_VERSION.to_string(),
-        |config| config.get_config().get_dfx(),
-    );
-
+/// Find the binary path for the client, then start the node manager.
+pub fn exec<T>(env: &T, _args: &ArgMatches<'_>) -> DfxResult
+where
+    T: BinaryCacheEnv,
+{
     println!("Starting up the DFINITY node manager...");
 
-    let client_pathbuf = get_binary_path_from_version(&version, "client")?;
+    let client_pathbuf = env.get_binary_command_path("client")?;
     let client = client_pathbuf.as_path();
 
-    let mut cmd = binary_command_from_version(&version, "nodemanager")?;
+    let mut cmd = env.get_binary_command("nodemanager")?;
     cmd.args(&[client]);
 
     let _child = cmd.spawn()?;

--- a/dfx/src/config/cache.rs
+++ b/dfx/src/config/cache.rs
@@ -1,7 +1,6 @@
 use std::io::{Error, ErrorKind, Result};
 use std::path::PathBuf;
 
-use crate::config::dfinity::Config;
 use crate::util;
 
 pub fn get_bin_cache_root() -> Result<PathBuf> {
@@ -81,9 +80,4 @@ pub fn binary_command_from_version(version: &str, name: &str) -> Result<std::pro
     let path = get_binary_path_from_version(version, name)?;
     let cmd = std::process::Command::new(path);
     Ok(cmd)
-}
-
-pub fn binary_command_from_config(config: &Config, name: &str) -> Result<std::process::Command> {
-    let version = config.get_config().get_dfx();
-    binary_command_from_version(&version, name)
 }

--- a/dfx/src/config/dfinity.rs
+++ b/dfx/src/config/dfinity.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use crate::config::DFX_VERSION;
 use crate::lib::error::DfxResult;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -103,10 +102,8 @@ impl ConfigInterface {
     pub fn get_version(&self) -> u32 {
         self.version.unwrap_or(1)
     }
-    pub fn get_dfx(&self) -> String {
-        self.dfx
-            .to_owned()
-            .unwrap_or_else(|| DFX_VERSION.to_owned())
+    pub fn get_dfx(&self) -> Option<String> {
+        self.dfx.to_owned()
     }
 }
 

--- a/dfx/src/lib/api_client.rs
+++ b/dfx/src/lib/api_client.rs
@@ -14,6 +14,7 @@ pub struct Blob(#[serde(with = "serde_bytes")] pub Vec<u8>);
 
 type CanisterId = u64;
 
+#[derive(Clone)]
 pub struct Client {
     client: ReqwestClient,
     url: String,

--- a/dfx/src/lib/env.rs
+++ b/dfx/src/lib/env.rs
@@ -1,0 +1,96 @@
+use crate::config::dfinity::Config;
+use crate::config::{cache, DFX_VERSION};
+use crate::lib::api_client::{Client, ClientConfig};
+use crate::lib::error::DfxResult;
+use std::cell::RefCell;
+use std::path::PathBuf;
+
+/// An environment that can resolve binaries from the user-level cache.
+pub trait BinaryCacheEnv {
+    fn get_binary_command_path(&self, binary_name: &str) -> std::io::Result<PathBuf>;
+    fn get_binary_command(&self, binary_name: &str) -> std::io::Result<std::process::Command>;
+}
+
+/// An environment that can get the project configuration.
+pub trait ProjectConfigEnv {
+    fn is_in_project(&self) -> bool;
+    fn get_config(&self) -> Option<&Config>;
+}
+
+/// An environment that can create clients from environment.
+pub trait ClientEnv {
+    fn get_client(&self) -> Client;
+}
+
+/// An environment that can get the version of the DFX we should be using.
+pub trait VersionEnv {
+    fn get_version(&self) -> &String;
+}
+
+/// An environment that is inside a project.
+pub struct InProjectEnvironment {
+    version: String,
+    config: Config,
+    client: RefCell<Option<Client>>,
+}
+
+impl BinaryCacheEnv for InProjectEnvironment {
+    fn get_binary_command_path(&self, binary_name: &str) -> std::io::Result<PathBuf> {
+        cache::get_binary_path_from_version(self.version.as_str(), binary_name)
+    }
+    fn get_binary_command(&self, binary_name: &str) -> std::io::Result<std::process::Command> {
+        cache::binary_command_from_version(self.version.as_str(), binary_name)
+    }
+}
+
+impl ProjectConfigEnv for InProjectEnvironment {
+    fn is_in_project(&self) -> bool {
+        true
+    }
+    fn get_config(&self) -> Option<&Config> {
+        Some(&self.config)
+    }
+}
+
+impl ClientEnv for InProjectEnvironment {
+    fn get_client(&self) -> Client {
+        {
+            let mut cache = self.client.borrow_mut();
+            if cache.is_some() {
+                return cache.as_ref().unwrap().clone();
+            }
+
+            let start = self.config.get_config().get_defaults().get_start();
+            let address = start.get_address("localhost");
+            let port = start.get_port(8080);
+
+            *cache = Some(Client::new(ClientConfig {
+                url: format!("http://{}:{}", address, port),
+            }));
+        }
+
+        // Have to recursively call ourselves to avoid cache getting out of scope.
+        self.get_client()
+    }
+}
+
+impl VersionEnv for InProjectEnvironment {
+    fn get_version(&self) -> &String {
+        &self.version
+    }
+}
+
+impl InProjectEnvironment {
+    pub fn from_current_dir() -> DfxResult<InProjectEnvironment> {
+        let config = Config::from_current_dir()?;
+
+        Ok(InProjectEnvironment {
+            version: config
+                .get_config()
+                .get_dfx()
+                .unwrap_or_else(|| DFX_VERSION.to_owned()),
+            config,
+            client: RefCell::new(None),
+        })
+    }
+}

--- a/dfx/src/lib/error.rs
+++ b/dfx/src/lib/error.rs
@@ -11,6 +11,7 @@ pub enum DfxError {
     SerdeJson(serde_json::error::Error),
     Url(reqwest::UrlError),
 
+    /// An unknown command was used. The argument is the command itself.
     UnknownCommand(String),
 
     ClientError(RejectCode, String),
@@ -18,7 +19,7 @@ pub enum DfxError {
 }
 
 /// The result of running a DFX command.
-pub type DfxResult = Result<(), DfxError>;
+pub type DfxResult<T = ()> = Result<T, DfxError>;
 
 impl From<clap::Error> for DfxError {
     fn from(err: clap::Error) -> DfxError {

--- a/dfx/src/lib/mod.rs
+++ b/dfx/src/lib/mod.rs
@@ -1,2 +1,3 @@
 pub mod api_client;
+pub mod env;
 pub mod error;


### PR DESCRIPTION
Each dimension which commands might require is a different trait, and commands
should require a type that matches the trait it needs. So we can now create
tests for commands executors, and inject a special environment to mock
whats needed.

This is a very crude version of IoC. It works very well for us as everything
is top down (main is responsible for creating the env object that is passed
around).

TODO:

- [x] Tests
- [ ] More tests.