### PR TITLE
refactor: rename BinaryCacheEnv to BinaryResolverEnv

### DIFF
--- a/dfx/src/commands/build.rs
+++ b/dfx/src/commands/build.rs
@@ -1,5 +1,5 @@
 use crate::config::dfinity::ConfigCanistersCanister;
-use crate::lib::env::{BinaryCacheEnv, ProjectConfigEnv};
+use crate::lib::env::{BinaryResolverEnv, ProjectConfigEnv};
 use crate::lib::error::DfxResult;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use std::path::Path;
@@ -12,7 +12,7 @@ pub fn construct() -> App<'static, 'static> {
 
 fn build_file<T>(env: &T, input_path: &Path, output_path: &Path) -> DfxResult
 where
-    T: BinaryCacheEnv,
+    T: BinaryResolverEnv,
 {
     let output_wasm_path = output_path.with_extension("wasm");
     let output_idl_path = output_path.with_extension("did");
@@ -41,7 +41,7 @@ where
 
 pub fn exec<T>(env: &T, _args: &ArgMatches<'_>) -> DfxResult
 where
-    T: BinaryCacheEnv + ProjectConfigEnv,
+    T: BinaryResolverEnv + ProjectConfigEnv,
 {
     // Read the config.
     let config = env.get_config().unwrap();
@@ -94,7 +94,7 @@ mod tests {
             out_file: &'a fs::File,
         }
 
-        impl<'a> BinaryCacheEnv for TestEnv<'a> {
+        impl<'a> BinaryResolverEnv for TestEnv<'a> {
             fn get_binary_command_path(&self, _binary_name: &str) -> io::Result<PathBuf> {
                 // This should not be used.
                 panic!("get_binary_command_path should not be called.")

--- a/dfx/src/commands/mod.rs
+++ b/dfx/src/commands/mod.rs
@@ -1,4 +1,4 @@
-use crate::lib::env::{BinaryCacheEnv, ClientEnv, ProjectConfigEnv, VersionEnv};
+use crate::lib::env::{BinaryResolverEnv, ClientEnv, ProjectConfigEnv, VersionEnv};
 use crate::lib::error::DfxResult;
 use clap::ArgMatches;
 
@@ -33,7 +33,7 @@ impl<T> CliCommand<T> {
 /// Returns all builtin commands understood by DFx.
 pub fn builtin<T>() -> Vec<CliCommand<T>>
 where
-    T: BinaryCacheEnv + ClientEnv + ProjectConfigEnv + VersionEnv,
+    T: BinaryResolverEnv + ClientEnv + ProjectConfigEnv + VersionEnv,
 {
     vec![
         CliCommand::new(build::construct(), build::exec),

--- a/dfx/src/commands/start.rs
+++ b/dfx/src/commands/start.rs
@@ -1,4 +1,4 @@
-use crate::lib::env::BinaryCacheEnv;
+use crate::lib::env::BinaryResolverEnv;
 use crate::lib::error::DfxResult;
 use clap::{App, Arg, ArgMatches, SubCommand};
 
@@ -16,7 +16,7 @@ pub fn construct() -> App<'static, 'static> {
 /// Find the binary path for the client, then start the node manager.
 pub fn exec<T>(env: &T, _args: &ArgMatches<'_>) -> DfxResult
 where
-    T: BinaryCacheEnv,
+    T: BinaryResolverEnv,
 {
     println!("Starting up the DFINITY node manager...");
 

--- a/dfx/src/main.rs
+++ b/dfx/src/main.rs
@@ -6,8 +6,7 @@ mod lib;
 mod util;
 
 use crate::commands::CliCommand;
-use crate::config::DFX_VERSION;
-use crate::lib::env::{InProjectEnvironment, VersionEnv};
+use crate::lib::env::{BinaryCacheEnv, InProjectEnvironment, VersionEnv};
 use crate::lib::error::*;
 
 fn cli<T>(env: &T) -> App<'_, '_>
@@ -56,12 +55,11 @@ fn main() {
 
     let matches = cli(&env).get_matches();
 
-    // TODO: move this somewhere more appropriate
-    if !config::cache::is_version_installed(DFX_VERSION).unwrap_or(false) {
-        config::cache::install_version(DFX_VERSION).unwrap();
-        println!("Version v{} installed successfully.", DFX_VERSION);
+    if !env.is_installed().unwrap() {
+        env.install().unwrap();
+        println!("Version v{} installed successfully.", env.get_version());
     } else {
-        println!("Version v{} already installed.", DFX_VERSION);
+        println!("Version v{} already installed.", env.get_version());
     }
 
     if let Err(err) = exec(&env, &matches, &(cli(&env))) {


### PR DESCRIPTION
And add a new install part as BinaryCacheEnv. So the Resolver is only
needed when resolving binaries, while the Cache one is used to manage
it.