### PR TITLE
fix: stop overflowing when in release mode

### DIFF
--- a/dfx/src/config/mod.rs
+++ b/dfx/src/config/mod.rs
@@ -13,6 +13,7 @@ pub fn dfx_version() -> &'static str {
             Some(x) => x.as_str(),
             None => {
                 let version = env!("CARGO_PKG_VERSION");
+                DFX_VERSION = Some(version.to_owned());
 
                 #[cfg(debug_assertions)]
                 {


### PR DESCRIPTION
Also simplified the logic to find the configuration file.

This was preventing `dfx` from running from a `nix-build` output.