### PR TITLE
Add "-debug" suffix to rust debug derivation name

### DIFF
--- a/nix/overlays/dfinity-sdk.nix
+++ b/nix/overlays/dfinity-sdk.nix
@@ -2,11 +2,13 @@ self: super: {
   dfinity-sdk = rec {
     packages = rec {
         rust-workspace = super.callPackage ../rust-workspace.nix {};
-        rust-workspace-debug = rust-workspace.override (_: {
+        rust-workspace-debug = (rust-workspace.override (_: {
           release = false;
           doClippy = true;
           doFmt = true;
           doDoc = true;
+        })).overrideAttrs (oldAttrs: {
+          name = "${oldAttrs.name}-debug";
         });
         rust-workspace-doc = rust-workspace-debug.doc;
     };


### PR DESCRIPTION
This allows us to know which one is the debug build :)