### PR TITLE
fix: output help to stderr

### DIFF
--- a/dfx/src/commands/canister/mod.rs
+++ b/dfx/src/commands/canister/mod.rs
@@ -49,8 +49,8 @@ where
         }
     } else {
         construct::<T>().write_help(&mut std::io::stderr())?;
-        println!();
-        println!();
+        eprintln!();
+        eprintln!();
         Ok(())
     }
 }

--- a/dfx/src/main.rs
+++ b/dfx/src/main.rs
@@ -36,8 +36,8 @@ where
         (name, Some(args)) => (name, args),
         _ => {
             cli.write_help(&mut std::io::stderr())?;
-            println!();
-            println!();
+            eprintln!();
+            eprintln!();
             return Ok(());
         }
     };
@@ -49,8 +49,8 @@ where
         Some(cmd) => cmd.execute(env, subcommand_args),
         _ => {
             cli.write_help(&mut std::io::stderr())?;
-            println!();
-            println!();
+            eprintln!();
+            eprintln!();
             Err(DfxError::UnknownCommand(name.to_owned()))
         }
     }


### PR DESCRIPTION
We should only output actual command output (scriptable) to STDOUT.