### PR TITLE
build: fix batslib fetchGit arguments

### DIFF
--- a/nix/e2e-tests.nix
+++ b/nix/e2e-tests.nix
@@ -8,7 +8,7 @@
 }:
 let batslib = builtins.fetchGit {
     url = "ssh://git@github.com/ztombol/bats-support";
-    ref = "0.3.0";
+    # ref = "0.3.0";  # TODO
     rev = "24a72e14349690bcbf7c151b9d2d1cdd32d36eb1";
 }; in
 


### PR DESCRIPTION
Apparently it was working on CI for a PR, but isn't working on master...?