### PR TITLE
nix: upgrade common

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,15 +9,14 @@ let
   # The `common` repo provides code (mostly Nix) that is used in the
   # `infra`, `dfinity` and `sdk` repositories.
   #
-  # To conveniently test changes to a local `common` repo you point
-  # the `COMMON` environment variable to it. The path should be
-  # relative to the root of the `sdk` repo. For example:
+  # To conveniently test changes to a local `common` repo you set the `COMMON`
+  # environment variable to an absolute path of it. For example:
   #
-  #   COMMON="../common" nix-build -A rust-workspace
+  #   COMMON="$(realpath ../common)" nix-build -A rust-workspace
   commonSrc =
     let localCommonSrc = builtins.getEnv "COMMON"; in
     if localCommonSrc != ""
-    then ../. + "/${localCommonSrc}"
+    then localCommonSrc
     else builtins.fetchGit {
       url = "ssh://git@github.com/dfinity-lab/common";
       rev = "633ff01d07bac061001d5a2713363ef3de5df2df";


### PR DESCRIPTION
* This will set RUST_BACKTRACE to get a backtrace when a Rust
  test-suite panics.

* This upgrades naersk to have support for multiple executables per crate.

* The naersk upgrade also adds support for custom rust build scripts. These are used by the `dfx` crate for example.

* This also includes a commit to require the COMMON env-var to be an absolute path. This makes it possible to work with nested imports of `common`. For example `sdk` importing `dfinity` which imports `common`.