### PR TITLE
ci/ci-pr.nix: disable darwin jobs for PRs

### DIFF
--- a/ci/ci-pr.nix
+++ b/ci/ci-pr.nix
@@ -1,3 +1,4 @@
 # This file is used to govern CI jobs for GitHub PRs
 
-args@{...}: import ./ci.nix args
+args@{supportedSystems ? [ "x86_64-linux" ], ...}:
+import ./ci.nix (args // { inherit supportedSystems; })


### PR DESCRIPTION
Our Darwin builders (actually "builder" since we currently only have zrh-darwin-1 because the PA darwin builders are down as usual) are overloaded (mostly the network). PR jobs take too long to finish because of it.

Once all builders have moved to the Zurich DC we can consider enabling darwin jobs for PRs again:
https://dfinity.atlassian.net/browse/INF-488