### PR TITLE
Add information for nodemanager failures

### DIFF
--- a/dfx/src/commands/start.rs
+++ b/dfx/src/commands/start.rs
@@ -78,7 +78,7 @@ where
                 .get_defaults()
                 .get_start()
                 .get_binding_socket_addr("localhost:8000")
-                .unwrap())
+                .expect("could not get socket_addr"))
         })?;
     let frontend_url = format!(
         "http://{}:{}",
@@ -119,7 +119,9 @@ where
 
                 // If the nodemanager itself fails, we are probably deeper into troubles than
                 // we can solve at this point and the user is better rerunning the server.
-                let mut child = cmd.spawn().unwrap();
+                let mut child = cmd.spawn().unwrap_or_else(|e| {
+                    panic!("Couldn't spawn node manager with command {:?}: {}", cmd, e)
+                });
                 if child.wait().is_err() {
                     break;
                 }

--- a/e2e/basic-project.bash
+++ b/e2e/basic-project.bash
@@ -13,7 +13,7 @@ setup() {
 teardown() {
     # Kill the node manager, the dfx and the client. Ignore errors (ie. if processes aren't
     # running).
-    killall dfx nodemanager client || true
+    killall dfx nodemanager client |& sed 's/^/killall: /' || true
 }
 
 @test "build + install + call + request-status -- greet_as" {

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -24,5 +24,9 @@ dfx_start() {
     # wait for it to close. Because `dfx start` leave a child process running, we need
     # to close this pipe, otherwise Bats will wait indefinitely.
     dfx start --background "$@" 3>&-
+
+    timeout 5 sh -c \
+        'until nc -z localhost 8080; do echo waiting for client; sleep 1; done' \
+        || (echo "could not connect to client on port 8080" && exit 1)
 }
 

--- a/nix/e2e-tests.nix
+++ b/nix/e2e-tests.nix
@@ -2,6 +2,7 @@
 ,   coreutils
 ,   curl
 ,   dfinity-sdk
+,   netcat
 ,   runCommandNoCC
 ,   stdenv
 ,   killall
@@ -13,7 +14,7 @@ let batslib = builtins.fetchGit {
 }; in
 
 runCommandNoCC "e2e-tests" {
-    buildInputs = [ bats batslib coreutils curl dfinity-sdk.packages.rust-workspace-debug stdenv.cc killall ];
+    buildInputs = [ bats batslib coreutils curl dfinity-sdk.packages.rust-workspace-debug stdenv.cc killall netcat ];
 } ''
     # We want $HOME/.cache to be in a new temporary directory.
     export HOME=$(mktemp -d -t dfx-e2e-home-XXXX)


### PR DESCRIPTION
I added some helpful information when debugging https://github.com/dfinity-lab/sdk/pull/75: 

* add log when socket_addr cannot be read
* print nodemanager command on failure
* tag killall output
* wait for client to be up before running tests