### PR TITLE
Add temp. nix derivation for reproducing SDK-543

### DIFF
--- a/temp-build.nix
+++ b/temp-build.nix
@@ -1,0 +1,26 @@
+let pkgs = (import ./. {}).pkgs; in
+let sdk = pkgs.dfinity-sdk.packages; in
+
+pkgs.runCommand
+  "temp"
+  {
+    buildInputs = [
+      pkgs.binutils
+      pkgs.mktemp
+      #sdk.rust-workspace # for dfx
+      sdk.rust-workspace-standalone # for dfx
+    ];
+  }
+  ''
+    export HOME=$(mktemp -d)
+
+    dfx new temp
+    cd temp
+    dfx start --background
+    dfx build hello
+    #dfx canister install 42 build/canisters/hello/main.wasm # SDK-546
+    dfx canister install 42 canisters/src/hello/main.wasm
+    
+    mkdir -p $out
+    cp -R ./. $out
+  ''


### PR DESCRIPTION
@nmattia this will allow you to reproduce the issue we discussed on macOS. I'm on macOS Mojave Version 10.14.6 (18G95).

```sh
$ nix-build --option extra-binary-caches https://nix.dfinity.systems temp-build.nix
these derivations will be built:
  /nix/store/i0s2h35nnfi0naslcya40rlysidzc2fv-temp.drv
building '/nix/store/i0s2h35nnfi0naslcya40rlysidzc2fv-temp.drv'...
Creating new project "temp"...
CREATE       temp/src/hello/public/hello.js (153B)...
CREATE       temp/src/hello/public/index.html (228B)...
CREATE       temp/src/hello/main.as (106B)...
CREATE       temp/dfx.json (322B)...
CREATE       temp/.gitignore (125B)...
CREATE       temp/README.md (989B)...
===============================================================================
        Welcome to the internet computer developer community!
                        You're using dfx 0.3.0

       ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄                ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
     ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄          ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
   ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄      ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
  ▄▄▄▄▄▄▄▄▄▄▀▀▀▀▀▄▄▄▄▄▄▄▄▄▄▄▄  ▄▄▄▄▄▄▄▄▄▄▄▄▀▀▀▀▀▀▄▄▄▄▄▄▄▄▄▄
 ▄▄▄▄▄▄▄▄▀         ▀▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▀         ▀▄▄▄▄▄▄▄▄▄
▄▄▄▄▄▄▄▄▀            ▀▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▀             ▄▄▄▄▄▄▄▄
▄▄▄▄▄▄▄▄               ▀▄▄▄▄▄▄▄▄▄▄▄▄▀                ▄▄▄▄▄▄▄
▄▄▄▄▄▄▄▄                ▄▄▄▄▄▄▄▄▄▄▄▄                 ▄▄▄▄▄▄▄
▄▄▄▄▄▄▄▄               ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄              ▄▄▄▄▄▄▄▄
 ▄▄▄▄▄▄▄▄           ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄          ▄▄▄▄▄▄▄▄▀
 ▀▄▄▄▄▄▄▄▄▄▄     ▄▄▄▄▄▄▄▄▄▄▄▄▀ ▀▄▄▄▄▄▄▄▄▄▄▄▄    ▄▄▄▄▄▄▄▄▄▄▄
  ▀▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▀     ▀▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▀
    ▀▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▀         ▀▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
      ▀▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▀▀             ▀▀▄▄▄▄▄▄▄▄▄▄▄▄▄▄▀
         ▀▀▀▀▀▀▀▀▀▀▀                    ▀▀▀▀▀▀▀▀▀▀▀



To learn more before you start coding, see the documentation available online:

- Quick Start:        https://sdk.dfinity.org/quickstart
- Developer's Guide:  https://sdk.dfinity.org/developers-guide
- Language Reference: https://sdk.dfinity.org/language-reference

If you want to work on programs right away, try the following commands to get started:

    cd temp
    dfx help
    dfx new --help
    dfx config --help

===============================================================================

version: 0.1.0
 Oct 22 20:46:25.194 INFO Starting /private/var/folders/yq/0b8xbm9j4yg8x3hjz_b3xvbh0000gn/T/nix-build-temp.drv-0/tmp.iYSpi37SmV/.cache/dfinity/versions/0.3.0/nodemanager /private/var/folders/yq/0b8xbm9j4yg8x3hjz_b3xvbh0000gn/T/nix-build-temp.drv-0/tmp.iYSpi37SmV/.cache/dfinity/versions/0.3.0/client
binding to: V4(127.0.0.1:8000)
client: "http://localhost:8080/api"
thread 'main' panicked at 'Installation of hello world canister failed: Error { code: Internal, description: "Can not emit a shared library to /private/var/folders/yq/0b8xbm9j4yg8x3hjz_b3xvbh0000gn/T/nix-build-temp.drv-0/ic.HcUaHj0bjyEQ/mod.so: ld of /private/var/folders/yq/0b8xbm9j4yg8x3hjz_b3xvbh0000gn/T/nix-build-temp.drv-0/lucetc2NzMPn/tmp.o failed: /nix/store/y4brv9mhqc4h4wqn8rc5p7lcn03s5nc9-binutils-wrapper-2.31.1/bin/ld: line 207: /nix/store/h127piinijypvq43x4vpfrnqvyfb1kpv-binutils-2.31.1/bin/ld: No such file or directory\n" }', src/libcore/result.rs:1084:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 Oct 22 20:46:25.309 INFO Stopped
 Oct 22 20:46:25.309 INFO Starting /private/var/folders/yq/0b8xbm9j4yg8x3hjz_b3xvbh0000gn/T/nix-build-temp.drv-0/tmp.iYSpi37SmV/.cache/dfinity/versions/0.3.0/nodemanager /private/var/folders/yq/0b8xbm9j4yg8x3hjz_b3xvbh0000gn/T/nix-build-temp.drv-0/tmp.iYSpi37SmV/.cache/dfinity/versions/0.3.0/client
thread 'main' panicked at 'Installation of hello world canister failed: Error { code: Internal, description: "Can not emit a shared library to /private/var/folders/yq/0b8xbm9j4yg8x3hjz_b3xvbh0000gn/T/nix-build-temp.drv-0/ic.e0KOw70Q8mc7/mod.so: ld of /private/var/folders/yq/0b8xbm9j4yg8x3hjz_b3xvbh0000gn/T/nix-build-temp.drv-0/lucetcAY7IXU/tmp.o failed: /nix/store/y4brv9mhqc4h4wqn8rc5p7lcn03s5nc9-binutils-wrapper-2.31.1/bin/ld: line 207: /nix/store/h127piinijypvq43x4vpfrnqvyfb1kpv-binutils-2.31.1/bin/ld: No such file or directory\n" }', src/libcore/result.rs:1084:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 Oct 22 20:46:25.337 INFO Stopped
 Oct 22 20:46:25.337 INFO Starting /private/var/folders/yq/0b8xbm9j4yg8x3hjz_b3xvbh0000gn/T/nix-build-temp.drv-0/tmp.iYSpi37SmV/.cache/dfinity/versions/0.3.0/nodemanager /private/var/folders/yq/0b8xbm9j4yg8x3hjz_b3xvbh0000gn/T/nix-build-temp.drv-0/tmp.iYSpi37SmV/.cache/dfinity/versions/0.3.0/client
thread 'main' panicked at 'Installation of hello world canister failed: Error { code: Internal, description: "Can not emit a shared library to /private/var/folders/yq/0b8xbm9j4yg8x3hjz_b3xvbh0000gn/T/nix-build-temp.drv-0/ic.EAd3KCGhwU1t/mod.so: ld of /private/var/folders/yq/0b8xbm9j4yg8x3hjz_b3xvbh0000gn/T/nix-build-temp.drv-0/lucetc0PhILS/tmp.o failed: /nix/store/y4brv9mhqc4h4wqn8rc5p7lcn03s5nc9-binutils-wrapper-2.31.1/bin/ld: line 207: /nix/store/h127piinijypvq43x4vpfrnqvyfb1kpv-binutils-2.31.1/bin/ld: No such file or directory\n" }', src/libcore/result.rs:1084:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 Oct 22 20:46:25.365 INFO Stopped
...
```