### PR TITLE
Base rust shell on debug derivation

### DIFF
--- a/nix/rust-shell.nix
+++ b/nix/rust-shell.nix
@@ -3,7 +3,7 @@ pkgs.mkCompositeShell {
   name = "dfinity-sdk-rust-env";
   inputsFrom = [
 
-    (pkgs.dfinity-sdk.packages.rust-workspace.overrideAttrs (_oldAttrs: {
+    (pkgs.dfinity-sdk.packages.rust-workspace-debug.overrideAttrs (_oldAttrs: {
       # _oldAttrs.configurePhase refers to the dfinity-application-and-others-deps
       # derivation which is the build of all 3rd-party Rust dependencies. Since in this
       # nix-shell we use cargo locally to build all dependencies we don't need to depend


### PR DESCRIPTION
This is primarily so that the `clippy` and `fmt` commands are available. More generally this is because development is intended to be done in the nix shell, and the debug derivation seems to make more sense for that.