### PR TITLE
Update dfinity and common

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,7 +19,7 @@ let
     then localCommonSrc
     else builtins.fetchGit {
       url = "ssh://git@github.com/dfinity-lab/common";
-      rev = "1e0bcae55fb9290aa197576ee1aaa88767e375a2";
+      rev = "3fd8991a369e21c69e4e713e627aaa325f420c73";
     };
 in import commonSrc {
   inherit system crossSystem config;

--- a/nix/overlays/actorscript.nix
+++ b/nix/overlays/actorscript.nix
@@ -2,8 +2,8 @@ self: super:
 
 let src = builtins.fetchGit {
   url = "ssh://git@github.com/dfinity-lab/actorscript";
-  ref = "master";
-  rev = "62a3e50336ac3d99960a9b75e83fc8f972066909";
+  ref = "nm-recover";
+  rev = "df7308d4b38b0f8044cb4afda7e0e11fbce7806a";
 }; in
 
 let actorscript = import src { nixpkgs = self; }; in

--- a/nix/overlays/dfinity-sdk.nix
+++ b/nix/overlays/dfinity-sdk.nix
@@ -19,7 +19,10 @@ in {
         });
         rust-workspace-doc = rust-workspace-debug.doc;
 
-        rust-workspace-standalone = (super.lib.standaloneRust rust-workspace "dfx");
+        rust-workspace-standalone = super.lib.standaloneRust
+          { drv = rust-workspace;
+            exename = "dfx";
+          };
 
         e2e-tests = super.callPackage ../e2e-tests.nix {};
 

--- a/nix/overlays/dfinity.nix
+++ b/nix/overlays/dfinity.nix
@@ -2,8 +2,7 @@ self: super:
 
 let src = builtins.fetchGit {
   url = "ssh://git@github.com/dfinity-lab/dfinity";
-  # ref = "v0.2.0"; # TODO
-  rev = "f8c94d70ef76e6301aa226b52386cc5dfcc9f24a";
+  rev = "ece3f0cde776bf26bb498fe0bec61cbdd0c3ebc7";
 }; in
 
 {

--- a/nix/rust-workspace.nix
+++ b/nix/rust-workspace.nix
@@ -29,11 +29,10 @@ let
   };
 in
 drv.overrideAttrs (oldAttrs: {
-  # The nodemanager does not have a standalone build, but the client does and we need it.
   DFX_ASSETS = runCommandNoCC "dfx-assets" {} ''
     mkdir -p $out
-    cp ${if release then dfinity.rust-workspace else dfinity.rust-workspace-debug}/bin/nodemanager $out
-    cp ${if release then dfinity.ic-client else dfinity.rust-workspace-debug}/bin/client $out
+    cp ${dfinity.nodemanager}/bin/nodemanager $out
+    cp ${dfinity.ic-client}/bin/client $out
     cp ${actorscript.asc-bin}/bin/asc $out
     cp ${actorscript.as-ide}/bin/as-ide $out
     cp ${actorscript.didc}/bin/didc $out


### PR DESCRIPTION
This updates the following repositories:

* `dfinity` to latest master
* `common` to latest master
* `motoko` to 62a3e50336ac3d99960a9b75e83fc8f972066909 which is more recent than what was there before. It's branched off master and includes a few fixes from @crusso .

The `dfinity`/`common` upgrade includes fixes for standalone nodemanager and client executables.

Note also that the sdk now uses release builds only from dfinity.