### PR TITLE
Use isMaster to retrigger build on master

### DIFF
--- a/ci/ci.nix
+++ b/ci/ci.nix
@@ -1,4 +1,4 @@
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 , scrubJobs ? true
 }:
-(import ../nix {}).ci ../jobset.nix { inherit supportedSystems scrubJobs; }
+(import ../nix {}).ci ../jobset.nix { inherit supportedSystems scrubJobs; isMaster = true; }

--- a/jobset.nix
+++ b/jobset.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem
 , crossSystem ? null
 , config ? {}
+, overlays ? []
 }: {
-  inherit (import ./nix { inherit system crossSystem config; }) dfinity-sdk;
+  inherit (import ./nix { inherit system crossSystem config overlays; }) dfinity-sdk;
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,7 +19,7 @@ let
     then localCommonSrc
     else builtins.fetchGit {
       url = "ssh://git@github.com/dfinity-lab/common";
-      rev = "3fd8991a369e21c69e4e713e627aaa325f420c73";
+      rev = "9034bf84910c4cc23a41c8363c5f725f63d5a81b";
     };
 in import commonSrc {
   inherit system crossSystem config;

--- a/nix/overlays/mk-release.nix
+++ b/nix/overlays/mk-release.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, gzip, jo, patchelf }:
+{ stdenv, lib, gzip, jo, patchelf, isMaster ? false }:
 rname: version: from: what:
 stdenv.mkDerivation {
   name = "${rname}-release";
@@ -6,6 +6,7 @@ stdenv.mkDerivation {
   phases = [ "buildPhase" ];
   buildInputs = [ gzip jo patchelf ];
   allowedRequisites = [];
+  inherit isMaster;
   buildPhase = ''
     # Building the artifacts
     mkdir -p $out


### PR DESCRIPTION
This sets `isMaster` to `true` on master builds and passes `isMaster` as an input to the `mkRelease` function, effectively forcing a build on master. This will trigger the `runCommand` pipeline and will push new `dfx` releases.