### PR TITLE
nix: Ensure install.sh is published from master branch

### DIFF
--- a/nix/overlays/dfinity-sdk.nix
+++ b/nix/overlays/dfinity-sdk.nix
@@ -46,6 +46,7 @@ in {
         shellcheckOpts = "-s sh -S warning";
       in self.lib.linuxOnly (super.runCommandNoCC "install-sh-release" {
         inherit version;
+        inherit (self) isMaster;
         installSh = ../../public/install.sh;
         buildInputs = [ self.jo self.shfmt self.shellcheck ];
       } ''


### PR DESCRIPTION
This follows the changes done to mk-release.nix script, in order to ensure that
we publish all the latest changes on the installer script to
https://sdk.dfinity.systems/downloads.