### PR TITLE
nix: upgrade common to get the latest nixpkgs-19.09

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,7 +19,7 @@ let
     then localCommonSrc
     else builtins.fetchGit {
       url = "ssh://git@github.com/dfinity-lab/common";
-      rev = "9034bf84910c4cc23a41c8363c5f725f63d5a81b";
+      rev = "29946dfa7c4c3a3131e111f9f7073a0b9c646c1d";
     };
 in import commonSrc {
   inherit system crossSystem config;


### PR DESCRIPTION
* Includes a libressl 3.0.1 -> 3.0.2 upgrade
* Includes cargo-audit which I would like to start using

See the following for all nixpkgs changes:

https://github.com/NixOS/nixpkgs/compare/c35f7161aae554cfe40fa3db57ee7df684b72951...release-19.09