### PR TITLE
Update version of common being used

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,7 +19,7 @@ let
     then localCommonSrc
     else builtins.fetchGit {
       url = "ssh://git@github.com/dfinity-lab/common";
-      rev = "29946dfa7c4c3a3131e111f9f7073a0b9c646c1d";
+      rev = "dfbc3ec34dcfdb8b49259a33834083fe645cff3c";
     };
 in import commonSrc {
   inherit system crossSystem config;


### PR DESCRIPTION
This is needed to ensure that Darwin builds are actually Darwin builds.