### PR TITLE
Tune install.sh

### DIFF
--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,5 +1,6 @@
 [
   (_self: _super: { repoRoot = ../..; })
+  (_self: super: { isMaster = super.isMaster or false; })
   (import ./sources.nix)
   (import ./motoko.nix)
   (import ./dfinity.nix)

--- a/public/install.sh
+++ b/public/install.sh
@@ -14,6 +14,9 @@ set -u
 SDK_WEBSITE="https://sdk.dfinity.org"
 DFX_RELEASE_ROOT="${DFX_RELEASE_ROOT:-$SDK_WEBSITE/downloads/dfx/latest}"
 
+# The SHA and the time of the last commit that touched this file.
+SCRIPT_COMMIT_DESC="@revision@"
+
 sdk_install_dir() {
     if [ "${DFX_INSTALL_ROOT:-}" ]; then
         # By default we install to a home directory.
@@ -36,6 +39,18 @@ sdk_install_dir() {
 }
 
 main() {
+    _ansi_escapes_are_valid=false
+    if [ -t 2 ]; then
+        if [ "${TERM+set}" = 'set' ]; then
+            case "$TERM" in
+                xterm* | rxvt* | urxvt* | linux* | vt*)
+                    _ansi_escapes_are_valid=true
+                    ;;
+            esac
+        fi
+    fi
+    log "Executing DFINITY SDK install script, commit: $SCRIPT_COMMIT_DESC"
+
     downloader --check
     need_cmd uname
     need_cmd mktemp
@@ -63,17 +78,6 @@ main() {
     _dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t dfinity-sdk)"
     local _dfx_archive="${_dir}/dfx.tar.gz"
     local _dfx_file="${_dir}/dfx"
-
-    _ansi_escapes_are_valid=false
-    if [ -t 2 ]; then
-        if [ "${TERM+set}" = 'set' ]; then
-            case "$TERM" in
-                xterm* | rxvt* | urxvt* | linux* | vt*)
-                    _ansi_escapes_are_valid=true
-                    ;;
-            esac
-        fi
-    fi
 
     log "Creating uninstall script in ~/.cache/dfinity"
     mkdir -p "${HOME}/.cache/dfinity/"


### PR DESCRIPTION
This change:

- adds a check for gzip
- adds a check for touch
- make the published script contain commit description and outputs it at the beginning. This way, we can track who has run what.

The script will output something like:
```
knl@yggdrasil % sh -ci "$(cat /nix/store/q9awr8zgq56pddvpjs1z6f2v4gxh7m43-install-sh-release/install.sh)"
info: Executing DFINITY SDK install script, commit: ff28ad3-2019-11-01T15:10:54+01:00

```