### PR TITLE
install.sh: Accept <enter> as No

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -323,8 +323,8 @@ can be found here [https://sdk.dfinity.org/sdk-license-agreement]. It comes with
             [Yy][Ee][Ss] | [Yy])
                 return 0
                 ;;
-            # Exit on no or n
-            [Nn][Oo] | [Nn])
+            # Exit on no or n, or <enter>
+            [Nn][Oo] | [Nn] | '')
                 return 1
                 ;;
             *)


### PR DESCRIPTION
Our prompt says '[y/N]' which is standard UX that enter will choose the
default answer. Make sure we adhere to that convention and treat empty
input as No.