### PR TITLE
Seamlessly raise permissions during binary mv

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -60,6 +60,8 @@ main() {
     need_cmd tar
     need_cmd gzip
     need_cmd touch
+    # For instance in Debian sudo can be missing.
+    need_cmd sudo
 
     if ! confirm_license; then
         echo "Please accept the license to continue."


### PR DESCRIPTION
Users (internal :) )  have raised confusion statements over the
seemingly failing install succeeding. We drop errors on mv, as we are
going to run sudo mv in that case.