### PR TITLE
INF-536: fix shell build

### DIFF
--- a/nix/rust-shell.nix
+++ b/nix/rust-shell.nix
@@ -3,12 +3,16 @@ pkgs.mkCompositeShell {
   name = "dfinity-sdk-rust-env";
   inputsFrom = [
 
-    (pkgs.dfinity-sdk.packages.rust-workspace-debug.overrideAttrs (_oldAttrs: {
+    (pkgs.dfinity-sdk.packages.rust-workspace-debug.overrideAttrs (oldAttrs: {
       # _oldAttrs.configurePhase refers to the dfinity-application-and-others-deps
       # derivation which is the build of all 3rd-party Rust dependencies. Since in this
       # nix-shell we use cargo locally to build all dependencies we don't need to depend
       # on this derivation saving a lot of time downloading/building.
       configurePhase = "";
+
+      # for some odd reason this is needed in the shell:
+      # https://dfinity.atlassian.net/browse/INF-542
+      nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ pkgs.stdenv.cc ];
     })) ];
 
   shellHook = ''


### PR DESCRIPTION
For some reason the nix-shell build needs pkgs.stdenv.cc as a build inputs.
For more information, see [INF-542](https://dfinity.atlassian.net/browse/INF-542)