### PR TITLE
feat: remove --wait and add --async

### DIFF
--- a/dfx/src/commands/canister/call.rs
+++ b/dfx/src/commands/canister/call.rs
@@ -25,10 +25,9 @@ pub fn construct() -> App<'static, 'static> {
                 .required(true),
         )
         .arg(
-            Arg::with_name("wait")
-                .help(UserMessage::WaitForResult.to_str())
-                .long("wait")
-                .short("w")
+            Arg::with_name("async")
+                .help(UserMessage::AsyncResult.to_str())
+                .long("async")
                 .takes_value(false),
         )
         .arg(
@@ -91,7 +90,10 @@ where
     let mut runtime = Runtime::new().expect("Unable to create a runtime");
     let request_id = runtime.block_on(call_future)?;
 
-    if args.is_present("wait") {
+    if args.is_present("async") {
+        println!("0x{}", String::from(request_id));
+        Ok(())
+    } else {
         let request_status = request_status(env.get_client(), request_id);
         let mut runtime = Runtime::new().expect("Unable to create a runtime");
         match runtime.block_on(request_status) {
@@ -115,8 +117,5 @@ where
             Ok(ReadResponse::Unknown) => Err(DfxError::Unknown("Unknown response".to_owned())),
             Err(x) => Err(x),
         }
-    } else {
-        println!("0x{}", String::from(request_id));
-        Ok(())
     }
 }

--- a/dfx/src/commands/canister/install.rs
+++ b/dfx/src/commands/canister/install.rs
@@ -20,10 +20,9 @@ pub fn construct() -> App<'static, 'static> {
                 .validator(validators::is_canister_id),
         )
         .arg(
-            Arg::with_name("wait")
-                .help(UserMessage::WaitForResult.to_str())
-                .long("wait")
-                .short("w")
+            Arg::with_name("async")
+                .help(UserMessage::AsyncResult.to_str())
+                .long("async")
                 .takes_value(false),
         )
         .arg(
@@ -60,7 +59,10 @@ where
     let mut runtime = Runtime::new().expect("Unable to create a runtime");
     let request_id = runtime.block_on(install)?;
 
-    if args.is_present("wait") {
+    if args.is_present("async") {
+        println!("0x{}", String::from(request_id));
+        Ok(())
+    } else {
         let request_status = request_status(env.get_client(), request_id);
         let mut runtime = Runtime::new().expect("Unable to create a runtime");
         match runtime.block_on(request_status) {
@@ -85,8 +87,5 @@ where
             Ok(ReadResponse::Unknown) => Err(DfxError::Unknown("Unknown response".to_owned())),
             Err(x) => Err(x),
         }
-    } else {
-        println!("0x{}", String::from(request_id));
-        Ok(())
     }
 }

--- a/dfx/src/lib/message.rs
+++ b/dfx/src/lib/message.rs
@@ -5,7 +5,7 @@ pub enum UserMessage {
     DeploymentId,
     SetDeploymentId,
     MethodName,
-    WaitForResult,
+    AsyncResult,
     ArgumentType,
     ArgumentValue,
     InstallCanister,
@@ -34,9 +34,9 @@ impl UserMessage {
             // dfx canister call
             UserMessage::CallCanister => "Calls a method on a deployed canister.",
             UserMessage::SetDeploymentId => "Specifies the numeric identifier to assign this deployment.",
-            UserMessage::DeploymentId => "Specifies the deployment identifier to call.",            
+            UserMessage::DeploymentId => "Specifies the deployment identifier to call.",
             UserMessage::MethodName => "Specifies the method name to call on the canister.",
-            UserMessage::WaitForResult => "Waits for the result of the call to be returned by polling the client.",
+            UserMessage::AsyncResult => "Do not wait for the result of the call to be returned by polling the client. Instead return a response ID.",
             UserMessage::ArgumentType => "Specifies the data type for the argument when making the call using an argument.",
             UserMessage::ArgumentValue => "Specifies the argument to pass to the method.",
 

--- a/e2e/basic-project.bash
+++ b/e2e/basic-project.bash
@@ -20,18 +20,17 @@ teardown() {
     install_asset greet_mo
     dfx_start
     dfx build
-    INSTALL_REQUEST_ID=$(dfx canister install 1 canisters/greet.wasm)
+    INSTALL_REQUEST_ID=$(dfx canister install 1 canisters/greet.wasm --async)
     dfx canister request-status $INSTALL_REQUEST_ID
 
     assert_command dfx canister query 1 greet '("Banzai")'
     assert_eq '("Hello, Banzai!")'
 
-    # Using call --wait.
-    assert_command dfx canister call --wait 1 greet '("Bongalo")'
+    assert_command dfx canister call 1 greet '("Bongalo")'
     assert_eq '("Hello, Bongalo!")'
 
-    # Using call and request-status.
-    assert_command dfx canister call 1 greet '("Blueberry")'
+    # Using call --async and request-status.
+    assert_command dfx canister call --async 1 greet '("Blueberry")'
     # At this point $output is the request ID.
     assert_command dfx canister request-status $output
     assert_eq '("Hello, Blueberry!")'
@@ -49,7 +48,7 @@ teardown() {
     # 64 times. This is important because query returns a byte, and 64 is
     # "A" in UTF8. We then just compare and work around the alphabet.
     for _x in {0..64}; do
-        dfx canister call --wait 42 write
+        dfx canister call 42 write
     done
 
     run dfx canister query 42 read
@@ -57,21 +56,21 @@ teardown() {
     run dfx canister query 42 read
     [[ "$output" == "A" ]]
 
-    dfx canister call --wait 42 write
+    dfx canister call 42 write
     run dfx canister query 42 read
     [[ "$output" == "B" ]]
 
-    dfx canister call --wait 42 write
+    dfx canister call 42 write
     run dfx canister query 42 read
     [[ "$output" == "C" ]]
 
-    run dfx canister call 42 write
+    run dfx canister call 42 write --async
     [[ $status == 0 ]]
     dfx canister request-status $output
     [[ $status == 0 ]]
 
     # Write has no return value. But we can _call_ read too.
-    run dfx canister call 42 read
+    run dfx canister call 42 read --async
     [[ $status == 0 ]]
     run dfx canister request-status $output
     [[ $status == 0 ]]
@@ -82,34 +81,34 @@ teardown() {
     install_asset counter_mo
     dfx_start
     dfx build
-    dfx canister install 1 canisters/counter.wasm --wait
+    dfx canister install 1 canisters/counter.wasm
 
-    assert_command dfx canister call 1 read --wait
+    assert_command dfx canister call 1 read
     assert_eq "(0)"
 
-    assert_command dfx canister call 1 inc --wait
+    assert_command dfx canister call 1 inc
     assert_eq "()"
 
     assert_command dfx canister query 1 read
     assert_eq "(1)"
 
-    dfx canister call --wait 1 inc
+    dfx canister call 1 inc
     assert_command dfx canister query 1 read
     assert_eq "(2)"
 
-    dfx canister call --wait 1 inc
+    dfx canister call 1 inc
     assert_command dfx canister query 1 read
     assert_eq "(3)"
 
-    assert_command dfx canister call 1 inc
+    assert_command dfx canister call 1 inc --async
     assert_command dfx canister request-status $output
 
     # Call write.
-    assert_command dfx canister call 1 write --type=number 1337 --wait
+    assert_command dfx canister call 1 write --type=number 1337
     assert_eq "()"
 
     # Write has no return value. But we can _call_ read too.
-    assert_command dfx canister call 1 read
+    assert_command dfx canister call 1 read --async
     assert_command dfx canister request-status $output
     assert_eq "(1337)"
 }
@@ -118,8 +117,8 @@ teardown() {
     install_asset counter_idl_mo
     dfx_start
     dfx build
-    dfx canister install 1 canisters/counter_idl.wasm --wait
+    dfx canister install 1 canisters/counter_idl.wasm
 
-    assert_command dfx canister call 1 inc '(42,false,"testzZ",vec{1;2;3},opt record{head=42; tail=opt record{head=43; tail=none}})' --wait
+    assert_command dfx canister call 1 inc '(42,false,"testzZ",vec{1;2;3},opt record{head=42; tail=opt record{head=43; tail=none}})'
     assert_eq "(43, true, \"uftu{[\", vec { 2; 3; 4; }, opt record { 1158359328 = 43; 1291237008 = opt record { 1158359328 = 44; 1291237008 = none; }; })"
 }

--- a/e2e/print.bash
+++ b/e2e/print.bash
@@ -19,8 +19,8 @@ teardown() {
     install_asset print_mo
     dfx_start 2>stderr.txt
     dfx build
-    dfx canister install 1 canisters/print.wasm --wait
-    dfx canister call 1 hello --wait
+    dfx canister install 1 canisters/print.wasm
+    dfx canister call 1 hello
     run cat stderr.txt
     assert_match "debug.print: Hello, World! from DFINITY"
 }


### PR DESCRIPTION
The default is now to wait. Using --async on call or install would
do the old default behaviour.