### PR TITLE
Fix link to https://sdk.dfinity.org/developers-guide/quickstart.html

### DIFF
--- a/dfx/assets/new_project_files/README.md
+++ b/dfx/assets/new_project_files/README.md
@@ -6,7 +6,7 @@ To get started, you might want to explore the project directory structure and th
 
 To learn more before you start working with {project_name}, see the following documentation available online:
 
-- [Quick Start](https://sdk.dfinity.org/quickstart)
+- [Quick Start](https://sdk.dfinity.org/developers-guide/quickstart.html)
 - [Developer's Guide](https://sdk.dfinity.org/developers-guide)
 - [Language Reference](https://sdk.dfinity.org/language-reference)
 

--- a/dfx/assets/welcome.txt
+++ b/dfx/assets/welcome.txt
@@ -6,7 +6,7 @@
 
 To learn more before you start coding, see the documentation available online:
 
-- Quick Start:        https://sdk.dfinity.org/quickstart
+- Quick Start:        https://sdk.dfinity.org/developers-guide/quickstart.html
 - Developer's Guide:  https://sdk.dfinity.org/developers-guide
 - Language Reference: https://sdk.dfinity.org/language-reference
 


### PR DESCRIPTION
drive-by contribution. Maybe there was a reason for the old link, then
just close this PR.