### PR TITLE
INF-562: Upgrade to rust 1.39

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -20,8 +20,7 @@ let
     else builtins.fetchGit {
       name = "common-sources";
       url = "ssh://git@github.com/dfinity-lab/common";
-      ref = "nm-rust-1.39";
-      rev = "55ba47ad33cf1d01cc4b34633e5aac4a3c4111c9";
+      rev = "d5af3fda55af07de25f06fc46a2bf5f83424f02b";
     };
 in import commonSrc {
   inherit system crossSystem config;


### PR DESCRIPTION
This updates common to get rustc 1.39.

