### PR TITLE
Substitute the release version in the install.sh script instead of hard coding it

### DIFF
--- a/nix/overlays/dfinity-sdk.nix
+++ b/nix/overlays/dfinity-sdk.nix
@@ -98,7 +98,8 @@ in {
         cp $manifest $version_manifest_file
         # we stamp the file with the revision
         substitute "$installSh" $out/install.sh \
-          --subst-var revision
+          --subst-var revision \
+          --subst-var version
 
         # Creating the manifest
         hydra_manifest_file=$out/_manifest.json

--- a/public/install.sh
+++ b/public/install.sh
@@ -11,7 +11,7 @@
 set -u
 
 # If DFX_RELEASE_ROOT is unset or empty, default it.
-LATEST="0.4.3"
+LATEST="@version@"
 SDK_WEBSITE="https://sdk.dfinity.org"
 DFX_RELEASE_ROOT="${DFX_RELEASE_ROOT:-$SDK_WEBSITE}/downloads/dfx/${LATEST}"
 


### PR DESCRIPTION
If the latest commit has an annotated tag like `0.1.2` the `version` will be set to that tag. On unannotated commits `version` will default to `latest`.

We probably want to use the same trick in `public/manifest.json` because I see it also contains hard coded versions. I didn't touch that file because I don't understand how it's used yet.