### PR TITLE
Consistency fix (in help text)

### DIFF
--- a/dfx/src/lib/message.rs
+++ b/dfx/src/lib/message.rs
@@ -75,7 +75,7 @@ impl UserMessage {
             UserMessage::CanisterName => "Specifies the canister name. If you don't specify this argument, all canisters are processed.",
 
             // dfx stop
-            UserMessage::StopNode => "Stop the local network client.",
+            UserMessage::StopNode => "Stops the local network client.",
         }
     }
 }


### PR DESCRIPTION
Perhaps the full-stops (periods) should be removed at the ends of the explanations:
```
    ...
    config      Configures project options for your currently-selected project.
    help        Prints this message or the help of the given subcommand(s)       <<<< usual convention
    new         Creates a new project.
    ...
```

C.f. `rustc --help`