### PR TITLE
Bump motoko

### DIFF
--- a/nix/overlays/motoko.nix
+++ b/nix/overlays/motoko.nix
@@ -4,19 +4,9 @@ let src = builtins.fetchGit {
   name = "motoko-sources";
   url = "ssh://git@github.com/dfinity-lab/motoko";
   ref = "master";
-  rev = "8676951c41fbf9b9c87c1c4de606d4dfd321a829";
+  rev = "6901c536deff066671aa96c6e765d96a7415bb40";
 }; in
 
-let motoko = import src { }; in
-
 {
-  motoko = motoko // {
-    stdlib = motoko.stdlib.overrideAttrs (oldAttrs: {
-      installPhase = ''
-        mkdir -p $out
-        cp ${src}/stdlib/*.mo $out
-        rm $out/*Test.mo
-      '';
-    });
-  };
+  motoko = import src { };
 }


### PR DESCRIPTION
and drop the patching of motoko derivations in the SDK’s overlay, by
pulling in
https://github.com/dfinity-lab/motoko/pull/887#event-2813168664.

```
~/dfinity/motoko $ git log 8676951c41fbf9b9c87c1c4de606d4dfd321a829..6901c536deff066671aa96c6e765d96a7415bb40 --oneline --first-parent
6901c536 (HEAD -> master, origin/master, origin/HEAD) default.nix: Remove packaging code (#887)
b5a74f08 Fix for #874 (#877)
ce3a3107 Merge pull request #841 from dfinity-lab/joachim/ic-stub
cbe634ed Claudio/oneway awaits (#773)
14793c25 IDL-Motoko: Pass actor and func references as data (#883)
abf22153 Update IDL func type (#881)
```