### PR TITLE
bump dfinity

### DIFF
--- a/nix/overlays/dfinity.nix
+++ b/nix/overlays/dfinity.nix
@@ -4,7 +4,7 @@ let src = builtins.fetchGit {
   name = "dfinity-sources";
   url = "ssh://git@github.com/dfinity-lab/dfinity";
   ref = "master";
-  rev = "7c6fc6bc06fa0dc4abf0f1b3d6438d39e1e72649";
+  rev = "5c7efff0524adbf97d85b27adb180e6137a3428f";
 }; in
 
 {


### PR DESCRIPTION
wanted to include https://github.com/dfinity-lab/common/pull/69.
Big kudo to @nomeata for the fix! This saves everybody several hours each day for entering `nix-shell`!

