### PR TITLE
feat: add a version command that prints the versions

### DIFF
--- a/dfx/src/commands/mod.rs
+++ b/dfx/src/commands/mod.rs
@@ -11,6 +11,7 @@ mod ide;
 mod new;
 mod start;
 mod stop;
+mod version;
 
 pub type CliExecFn<T> = fn(&T, &ArgMatches<'_>) -> DfxResult;
 pub struct CliCommand<T> {
@@ -49,5 +50,6 @@ where
         CliCommand::new(start::construct(), start::exec),
         CliCommand::new(stop::construct(), stop::exec),
         CliCommand::new(ide::construct(), ide::exec),
+        CliCommand::new(version::construct(), version::exec),
     ]
 }

--- a/dfx/src/commands/version.rs
+++ b/dfx/src/commands/version.rs
@@ -1,0 +1,42 @@
+use crate::config::cache;
+use crate::lib::env::VersionEnv;
+use crate::lib::error::DfxResult;
+use crate::lib::message::UserMessage;
+use clap::{App, ArgMatches, SubCommand};
+use std::io::Write;
+
+pub fn construct() -> App<'static, 'static> {
+    SubCommand::with_name("version").about(UserMessage::Version.to_str())
+}
+
+pub fn exec<T>(env: &T, _args: &ArgMatches<'_>) -> DfxResult
+where
+    T: VersionEnv,
+{
+    let mut current_printed = false;
+    let current_version = env.get_version();
+    let mut all_versions = cache::list_versions()?;
+    all_versions.sort();
+    for version in all_versions {
+        if current_version.eq(&version) {
+            current_printed = true;
+            // Same version, prefix with `*`.
+            std::io::stderr().flush()?;
+            print!("{}", version);
+            std::io::stdout().flush()?;
+            eprintln!(" *");
+        } else {
+            eprintln!("{}", version);
+        }
+    }
+
+    if !current_printed {
+        // The current version wasn't printed, so it's not in the cache.
+        std::io::stderr().flush()?;
+        print!("{}", version);
+        std::io::stdout().flush()?;
+        eprintln!(" [missing]");
+    }
+
+    Ok(())
+}

--- a/dfx/src/config/cache.rs
+++ b/dfx/src/config/cache.rs
@@ -90,3 +90,17 @@ pub fn binary_command_from_version(version: &str, name: &str) -> DfxResult<std::
 
     Ok(cmd)
 }
+
+pub fn list_versions() -> DfxResult<Vec<String>> {
+    let root = get_bin_cache_root()?;
+    let mut result: Vec<String> = Vec::new();
+
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        if let Some(version) = entry.file_name().to_str() {
+            result.push(version.to_owned());
+        }
+    }
+
+    Ok(result)
+}

--- a/dfx/src/lib/message.rs
+++ b/dfx/src/lib/message.rs
@@ -26,6 +26,7 @@ pub enum UserMessage {
     NodeAddress,
     StartBackground,
     StartIDE,
+    Version,
 }
 
 impl UserMessage {
@@ -78,7 +79,10 @@ impl UserMessage {
             // dfx stop
             UserMessage::StopNode => "Stops the local network client.",
             // dfx ide
-            UserMessage::StartIDE => "Starts Motoko IDE Language Server"
+            UserMessage::StartIDE => "Starts Motoko IDE Language Server",
+
+            // dfx version
+            UserMessage::Version => "Shows and manage the version of DFX installed.",
         }
     }
 }


### PR DESCRIPTION
Including cached versions. Everything is printed to STDERR except
the current version, which can be scripted.