### PR TITLE
Revert "Import motoko without passing nixpkgs (#178)"

### DIFF
--- a/nix/overlays/motoko.nix
+++ b/nix/overlays/motoko.nix
@@ -8,5 +8,5 @@ let src = builtins.fetchGit {
 }; in
 
 {
-  motoko = import src { };
+  motoko = import src { nixpkgs = self; };
 }


### PR DESCRIPTION
This reverts commit b63417352adc99aa09d2435b8c0ef61ab8a269e2.

The nixpkgs contain the build system which is necessary, otherwise we might build linux on mac or mac on linux.