### PR TITLE
INF-631: make CI restrict-eval compliant

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nmattia",
         "repo": "napalm",
-        "rev": "78cb7d391f14a33a8f7b5cfaa5ff26d97470549c",
-        "sha256": "15rq6lkaic9lzsgjz379pn0h21vnpr96rb3pc7vm23lx5z646dzm",
+        "rev": "d9dc1b0419b6a740e30a4a49d7c47da9c95ecf85",
+        "sha256": "1p7py28sjpgz879fkz64qzir3ddcmmly67vsfs9z9633y1cd5ycf",
         "type": "tarball",
-        "url": "https://github.com/nmattia/napalm/archive/78cb7d391f14a33a8f7b5cfaa5ff26d97470549c.tar.gz",
+        "url": "https://github.com/nmattia/napalm/archive/d9dc1b0419b6a740e30a4a49d7c47da9c95ecf85.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
    
The following command evaluates successfully:
    
> NIX_PATH=foo=.:napalm=/Users/nicolas/napalm nix-build ./ci/ci.nix --option restrict-eval true --option allowed-uris 'ssh://git@github.com/dfinity-lab https://github.com/NixOS https://github.com/nmattia http://jftp.inai.de/hxtools'

* Update `common` which transitively updates `naersk` to be restrict-eval friendly
* Update `dfinity`, which is now restrict-eval friendly
* Update `napalm` for https://github.com/nmattia/napalm/pull/5