### PR TITLE
SDK-485 fix: install.sh should use TLS 1.3 if available

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -3,5 +3,6 @@
 . install/010_manifest.sh
 . install/100_log.sh
 . install/110_assert.sh
+. install/200_downloader.sh
 . install/300_license.sh
 . install/999_footer.sh

--- a/public/install/100_log.sh
+++ b/public/install/100_log.sh
@@ -12,6 +12,14 @@ say() {
     printf 'dfinity-sdk: %s\n' "$1"
 }
 
+warn() {
+    if $_ansi_escapes_are_valid; then
+        printf "\33[1mwarn:\33[0m %s\n" "$1" 1>&2
+    else
+        printf '%s\n' "$1" 1>&2
+    fi
+}
+
 err() {
     say "$1" >&2
     exit 1

--- a/public/install/200_downloader.sh
+++ b/public/install/200_downloader.sh
@@ -1,0 +1,65 @@
+check_help_for() {
+    local _cmd
+    local _arg
+    local _ok
+    _cmd="$1"
+    _ok="y"
+    shift
+
+    # If we're running on OS-X, older than 10.13, then we always
+    # fail to find these options to force fallback
+    if check_cmd sw_vers; then
+        if [ "$(sw_vers -productVersion | cut -d. -f2)" -lt 13 ]; then
+            # Older than 10.13
+            echo "Warning: Detected OS X platform older than 10.13"
+            _ok="n"
+        fi
+    fi
+
+    for _arg in "$@"; do
+        if ! "$_cmd" --help | grep -q -- "$_arg"; then
+            _ok="n"
+        fi
+    done
+
+    test "$_ok" = "y"
+}
+
+# This wraps curl or wget. Try curl first, if not installed,
+# use wget instead.
+# Arguments:
+#   $1 - URL to download.
+#   $2 - Path to output the download. Use - to output to stdout.
+downloader() {
+    local _dld
+    if check_cmd curl; then
+        _dld=curl
+    elif check_cmd wget; then
+        _dld=wget
+    else
+        _dld='curl or wget' # to be used in error message of need_cmd
+    fi
+
+    if [ "$1" = --check ]; then
+        need_cmd "$_dld"
+    elif [ "$_dld" = curl ]; then
+        if check_help_for curl --proto --tlsv1.3; then
+            curl --proto '=https' --tls-max=1.3 --silent --show-error --fail --location "$1" --output "$2"
+        elif check_help_for curl --proto --tlsv1.2; then
+            warn "Not forcing TLS v1.3, using TLS v1.2, this is potentially less secure"
+            curl --proto '=https' --tls-max=1.3 --silent --show-error --fail --location "$1" --output "$2"
+        else
+            warn "Not forcing TLS v1.3 or v1.2, this is potentially less secure"
+            curl --silent --show-error --fail --location "$1" --output "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if check_help_for wget --https-only --secure-protocol; then
+            wget --https-only --secure-protocol=TLSv1_3 "$1" -O "$2"
+        else
+            warn "Not forcing TLS v1.3, this is potentially less secure"
+            wget "$1" -O "$2"
+        fi
+    else
+        err "Unknown downloader" # should not reach here
+    fi
+}

--- a/public/install/999_footer.sh
+++ b/public/install/999_footer.sh
@@ -188,42 +188,6 @@ get_architecture() {
     RETVAL="$_arch"
 }
 
-# This wraps curl or wget. Try curl first, if not installed,
-# use wget instead.
-# Arguments:
-#   $1 - URL to download.
-#   $2 - Path to output the download. Use - to output to stdout.
-downloader() {
-    local _dld
-    if check_cmd curl; then
-        _dld=curl
-    elif check_cmd wget; then
-        _dld=wget
-    else
-        _dld='curl or wget' # to be used in error message of need_cmd
-    fi
-
-    if [ "$1" = --check ]; then
-        need_cmd "$_dld"
-    elif [ "$_dld" = curl ]; then
-        if ! check_help_for curl --proto --tlsv1.2; then
-            echo "Warning: Not forcing TLS v1.2, this is potentially less secure"
-            curl --silent --show-error --fail --location "$1" --output "$2"
-        else
-            curl --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2"
-        fi
-    elif [ "$_dld" = wget ]; then
-        if ! check_help_for wget --https-only --secure-protocol; then
-            echo "Warning: Not forcing TLS v1.2, this is potentially less secure"
-            wget "$1" -O "$2"
-        else
-            wget --https-only --secure-protocol=TLSv1_2 "$1" -O "$2"
-        fi
-    else
-        err "Unknown downloader" # should not reach here
-    fi
-}
-
 install_uninstall_script() {
     set +u
     local uninstall_file_path
@@ -270,33 +234,6 @@ EOF
     touch "${uninstall_file_path}"
     printf "%s" "$uninstall_script" >"${uninstall_file_path}"
     ensure chmod u+x "${uninstall_file_path}"
-}
-
-check_help_for() {
-    local _cmd
-    local _arg
-    local _ok
-    _cmd="$1"
-    _ok="y"
-    shift
-
-    # If we're running on OS-X, older than 10.13, then we always
-    # fail to find these options to force fallback
-    if check_cmd sw_vers; then
-        if [ "$(sw_vers -productVersion | cut -d. -f2)" -lt 13 ]; then
-            # Older than 10.13
-            echo "Warning: Detected OS X platform older than 10.13"
-            _ok="n"
-        fi
-    fi
-
-    for _arg in "$@"; do
-        if ! "$_cmd" --help | grep -q -- "$_arg"; then
-            _ok="n"
-        fi
-    done
-
-    test "$_ok" = "y"
 }
 
 main "$@" || exit $?


### PR DESCRIPTION
It was using 1.2 before which is not as secure.

I reversed the order of evaluation of help flags; instead of checking
if TLS is _not_ available, I check which version is available first,
and default to the insecure behaviour. This is less surprising when
reading the code.

Fixes SDK-485.