### PR TITLE
feat: rename ide command to _language-service

### DIFF
--- a/dfx/src/commands/language_service.rs
+++ b/dfx/src/commands/language_service.rs
@@ -3,15 +3,16 @@ use crate::lib::env::{BinaryResolverEnv, ProjectConfigEnv};
 use crate::lib::error::{DfxError, DfxResult};
 use crate::lib::message::UserMessage;
 use atty;
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use std::process::Stdio;
 
 const CANISTER_ARG: &str = "canister";
 const FORCE_TTY: &str = "force-tty";
 
 pub fn construct() -> App<'static, 'static> {
-    SubCommand::with_name("ide")
-        .about(UserMessage::StartIDE.to_str())
+    SubCommand::with_name("_language-service")
+        .setting(AppSettings::Hidden) // Hide it from help menus as it shouldn't be used by users.
+        .about(UserMessage::StartLanguageService.to_str())
         .arg(Arg::with_name(CANISTER_ARG).help(UserMessage::CanisterName.to_str()))
         .arg(
             Arg::with_name(FORCE_TTY)
@@ -30,7 +31,7 @@ where
     let force_tty = args.is_present(FORCE_TTY);
     // Are we being run from a terminal? That's most likely not what we want
     if atty::is(atty::Stream::Stdout) && !force_tty {
-        Err(DfxError::IdeServerFromATerminal)
+        Err(DfxError::LanguageServerFromATerminal)
     } else {
         let config = &env
             .get_config()

--- a/dfx/src/commands/mod.rs
+++ b/dfx/src/commands/mod.rs
@@ -8,7 +8,7 @@ mod build;
 mod cache;
 mod canister;
 mod config;
-mod ide;
+mod language_service;
 mod new;
 mod start;
 mod stop;
@@ -47,9 +47,9 @@ where
         CliCommand::new(cache::construct::<T>(), cache::exec),
         CliCommand::new(canister::construct::<T>(), canister::exec),
         CliCommand::new(config::construct(), config::exec),
+        CliCommand::new(language_service::construct(), language_service::exec),
         CliCommand::new(new::construct(), new::exec),
         CliCommand::new(start::construct(), start::exec),
         CliCommand::new(stop::construct(), stop::exec),
-        CliCommand::new(ide::construct(), ide::exec),
     ]
 }

--- a/dfx/src/lib/error/mod.rs
+++ b/dfx/src/lib/error/mod.rs
@@ -51,7 +51,7 @@ pub enum DfxError {
     InvalidData(String),
 
     // The ide server shouldn't be started from a terminal
-    IdeServerFromATerminal,
+    LanguageServerFromATerminal,
 }
 
 /// The result of running a DFX command.

--- a/dfx/src/lib/message.rs
+++ b/dfx/src/lib/message.rs
@@ -33,7 +33,7 @@ pub enum UserMessage {
     StopNode,
     NodeAddress,
     StartBackground,
-    StartIDE,
+    StartLanguageService,
     ForceTTY,
 }
 
@@ -93,7 +93,7 @@ impl UserMessage {
             // dfx stop
             UserMessage::StopNode => "Stops the local network client.",
             // dfx ide
-            UserMessage::StartIDE => "Starts the Motoko IDE Language Server. This is meant to be run by editor plugins not the end-user.",
+            UserMessage::StartLanguageService => "Starts the Motoko IDE Language Server. This is meant to be run by editor plugins not the end-user.",
             UserMessage::ForceTTY => "Forces the language server to start even when run from a terminal"
         }
     }

--- a/dfx/src/main.rs
+++ b/dfx/src/main.rs
@@ -117,8 +117,8 @@ fn main() {
             DfxError::InvalidData(e) => {
                 eprintln!("Invalid data: {}", e);
             }
-            DfxError::IdeServerFromATerminal => {
-                eprintln!("The `ide` command is meant to be run by editors to start a language service. You probably don't want to run it from a terminal.\nIf you _really_ want to, you can pass the --force-tty flag.");
+            DfxError::LanguageServerFromATerminal => {
+                eprintln!("The `_language-service` command is meant to be run by editors to start a language service. You probably don't want to run it from a terminal.\nIf you _really_ want to, you can pass the --force-tty flag.");
             }
             err => {
                 eprintln!("An error occured:\n{:#?}", err);


### PR DESCRIPTION
BREAKING CHANGE:
The _language-service command is now hidden from help.