### PR TITLE
INF-673: Don't set repoRoot globally

### DIFF
--- a/ci/ci.nix
+++ b/ci/ci.nix
@@ -1,4 +1,9 @@
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 , scrubJobs ? true
 }:
-(import ../nix {}).ci ../jobset.nix { inherit supportedSystems scrubJobs; isMaster = true; }
+let pkgs = import ../nix {};
+in
+pkgs.ci ../jobset.nix
+  { inherit supportedSystems scrubJobs; isMaster = true;
+    rev = pkgs.lib.commitIdFromGitRepo (pkgs.lib.gitDir ../.);
+  }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -21,7 +21,7 @@ let
     else builtins.fetchGit {
       name = "common-sources";
       url = "ssh://git@github.com/dfinity-lab/common";
-      rev = "b35ba23941c5f3b555eba33c144f2cf9e5036cfb";
+      rev = "8872018a48260010599e945526fe0dcf28022444";
     };
 in import commonSrc {
   inherit system crossSystem config;

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,5 +1,4 @@
 [
-  (_self: _super: { repoRoot = ../..; })
   (_self: super: { isMaster = super.isMaster or false; })
   (import ./sources.nix)
   (import ./motoko.nix)

--- a/nix/overlays/dfinity-sdk.nix
+++ b/nix/overlays/dfinity-sdk.nix
@@ -6,6 +6,8 @@ let
   rust-package = removeAttrs rust-package'
     [ "override" "overrideDerivation" ];
   rust-workspace = rust-package.build;
+  repoRoot = ../../.;
+  gitDir = super.lib.gitDir repoRoot;
 in {
   dfinity-sdk = rec {
     packages =
@@ -108,18 +110,18 @@ in {
         # the released version of the script
         revision = super.lib.fileContents (
           let
-            commondir = super.lib.gitDir + "/commondir";
+            commondir = gitDir + "/commondir";
             isWorktree = builtins.pathExists commondir;
-            mainGitDir = super.lib.gitDir + "/${super.lib.fileContents commondir}";
+            mainGitDir = gitDir + "/${super.lib.fileContents commondir}";
             worktree = super.lib.optionalString isWorktree (
               super.lib.dropString (builtins.stringLength (toString mainGitDir))
-                (toString super.lib.gitDir));
+                (toString gitDir));
           in super.runCommandNoCC "install_sh_timestamp" {
             git_dir = builtins.path {
               name = "sdk-git-dir";
               path = if isWorktree
                      then mainGitDir
-                     else super.lib.gitDir;
+                     else gitDir;
             };
             nativeBuildInputs = [ self.git ];
             preferLocalBuild = true;

--- a/nix/rust-shell.nix
+++ b/nix/rust-shell.nix
@@ -6,7 +6,7 @@ pkgs.mkCompositeShell {
   inputsFrom = [ shell ];
   shellHook = ''
     # Set CARGO_HOME to minimize interaction with any environment outside nix
-    export CARGO_HOME=${pkgs.lib.dfinityRoot}/.cargo-home
+    export CARGO_HOME=${if pkgs.lib.isHydra then "." else toString ../.}/.cargo-home
 
     # Set environment variable for debug version.
     export DFX_TIMESTAMP_DEBUG_MODE_ONLY=$(date +%s)

--- a/nix/rust-workspace.nix
+++ b/nix/rust-workspace.nix
@@ -12,6 +12,7 @@
 }:
 let
   workspace = buildDfinityRustPackage {
+    repoRoot = ../.;
     name = "dfinity-sdk-rust";
     srcDir = ../.;
     regexes = [


### PR DESCRIPTION
This removes the overlay setting `repoRoot` and removes uses of `pkgs.repoRoot`.

This was dangerous, as repositories importing `common` would override it.