### PR TITLE
fix: add support for unknown read response to request-status

### DIFF
--- a/dfx/src/commands/canister/request_status.rs
+++ b/dfx/src/commands/canister/request_status.rs
@@ -1,4 +1,4 @@
-use crate::lib::api_client::request_status;
+use crate::commands::canister::install::wait_on_request_status;
 use crate::lib::env::ClientEnv;
 use crate::lib::error::{DfxError, DfxResult};
 use crate::lib::message::UserMessage;
@@ -6,7 +6,6 @@ use crate::util::clap::validators;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use ic_http_agent::RequestId;
 use std::str::FromStr;
-use tokio::runtime::Runtime;
 
 pub fn construct() -> App<'static, 'static> {
     SubCommand::with_name("request-status")
@@ -26,8 +25,5 @@ where
 {
     let request_id = RequestId::from_str(&args.value_of("request_id").unwrap()[2..])
         .map_err(|e| DfxError::InvalidArgument(format!("Invalid request ID: {:?}", e)))?; // FIXME Default formatter for RequestIdFromStringError
-    let request_status = request_status(env.get_client(), request_id);
-    let mut runtime = Runtime::new().expect("Unable to create a runtime");
-    let response = runtime.block_on(request_status)?;
-    crate::commands::canister::call::read_response(response, Some(request_id))
+    wait_on_request_status(&env.get_client(), request_id)
 }


### PR DESCRIPTION
It was missing from the last PR.