### PR TITLE
refactor: remove some branded types that are excessive

### DIFF
--- a/js-user-library/src/actor.test.ts
+++ b/js-user-library/src/actor.test.ts
@@ -1,8 +1,7 @@
 import { Buffer } from 'buffer/';
 import * as blob from './blob';
-import * as canisterId from './canisterId';
+import { CanisterId } from './canisterId';
 import * as cbor from './cbor';
-import { Hex } from './hex';
 import { Nonce } from './nonce';
 import { requestIdOf } from './requestId';
 import { RequestType } from './requestType';
@@ -20,7 +19,7 @@ test('makeActor', async () => {
   };
 
   const expectedReplyArg = blob.fromHex(
-    _IDL.encode([_IDL.Text], ['Hello, World!']).toString('hex') as Hex,
+    _IDL.encode([_IDL.Text], ['Hello, World!']).toString('hex'),
   );
 
   const mockFetch: jest.Mock = jest
@@ -65,9 +64,9 @@ test('makeActor', async () => {
   const methodName = 'greet';
   const argValue = 'Name';
 
-  const arg = blob.fromHex(_IDL.encode([_IDL.Text], [argValue]).toString('hex') as Hex);
+  const arg = blob.fromHex(_IDL.encode([_IDL.Text], [argValue]).toString('hex'));
 
-  const canisterIdent = '0000000000000001' as Hex;
+  const canisterIdent = '0000000000000001';
   const senderPubKey = Buffer.alloc(32, 0) as SenderPubKey;
   const senderSecretKey = Buffer.alloc(32, 0) as SenderSecretKey;
   const senderSig = Buffer.from([0]) as SenderSig;
@@ -82,7 +81,7 @@ test('makeActor', async () => {
   const expectedCallRequest = {
     request_type: 'call' as RequestType,
     nonce: nonces[0],
-    canister_id: canisterId.fromHex(canisterIdent),
+    canister_id: CanisterId.fromHex(canisterIdent),
     method_name: methodName,
     arg,
     sender_pubkey: senderPubKey,

--- a/js-user-library/src/actor.ts
+++ b/js-user-library/src/actor.ts
@@ -1,6 +1,5 @@
 import { Buffer } from 'buffer/';
 import * as blob from './blob';
-import { Hex } from './hex';
 import { HttpAgent } from './httpAgent';
 import * as _IDL from './IDL';
 import * as requestId from './requestId';
@@ -45,7 +44,7 @@ export const makeActor = (
       // convert to a ferross/buffer `Buffer` so that our `instanceof` checks
       // succeed. TODO: reconcile these `Buffer` types.
       const safeBuffer = _IDL.encode(func.argTypes, args);
-      const hex = safeBuffer.toString('hex') as Hex;
+      const hex = safeBuffer.toString('hex');
       const arg = blob.fromHex(hex);
       const isQuery = func.annotations.includes('query');
 

--- a/js-user-library/src/blob.ts
+++ b/js-user-library/src/blob.ts
@@ -1,17 +1,16 @@
 import { Buffer } from 'buffer/';
-import { Hex } from './hex';
 
 // TODO
 // Switch back to Uint8Array once hansl/simple-cbor provides deserialization
 
 // Named `BinaryBlob` as opposed to `Blob` so not to conflict with
 // https://developer.mozilla.org/en-US/docs/Web/API/Blob
-export type BinaryBlob = Buffer & { __blob__: void };
+export type BinaryBlob = Buffer;
 
-export const fromHex = (hex: Hex): BinaryBlob => {
+export const fromHex = (hex: string): BinaryBlob => {
   return Buffer.from(hex, 'hex') as BinaryBlob;
 };
 
-export const toHex = (blob: BinaryBlob): Hex => {
-  return blob.toString('hex') as Hex;
+export const toHex = (blob: BinaryBlob) => {
+  return blob.toString('hex');
 };

--- a/js-user-library/src/canisterId.ts
+++ b/js-user-library/src/canisterId.ts
@@ -1,13 +1,14 @@
 import BigNumber from 'bignumber.js';
-import { Hex } from './hex';
 
 // Canister IDs are represented as u64 in the HTTP handler of the client.
-export type CanisterId = BigNumber & { __canisterID__: void };
+export class CanisterId {
+  public static fromHex(hex: string) {
+    return new this(new BigNumber(hex, 16));
+  }
 
-export const fromHex = (hex: Hex): CanisterId => {
-  return new BigNumber(`0x${hex}`) as CanisterId;
-};
+  constructor(private _id: BigNumber) {}
 
-export const toHex = (id: CanisterId): Hex => {
-  return id.toString(16) as Hex;
-};
+  public toHex(): string {
+    return this._id.toString(16);
+  }
+}

--- a/js-user-library/src/cbor.test.ts
+++ b/js-user-library/src/cbor.test.ts
@@ -3,14 +3,11 @@ import { Buffer } from 'buffer/';
 import { BinaryBlob } from './blob';
 import * as blob from './blob';
 import { CanisterId } from './canisterId';
-import * as canisterId from './canisterId';
 import { CborValue, decode, encode } from './cbor';
-import { Hex } from './hex';
-import { Int } from './int';
 
 test('round trip', () => {
   interface Data extends Record<string, CborValue> {
-    a: Int;
+    a: number;
     b: string;
     c: BinaryBlob;
     d: { four: string };
@@ -23,11 +20,11 @@ test('round trip', () => {
   // BigNumber types actually containing big numbers, since small numbers are
   // represented as numbers and big numbers are represented as strings.
   const input: Data = {
-    a: 1 as Int,
+    a: 1,
     b: 'two',
     c: Buffer.from([3]) as BinaryBlob,
     d: { four: 'four' },
-    e: canisterId.fromHex('ffffffffffffffff' as Hex),
+    e: CanisterId.fromHex('ffffffffffffffff'),
     f: Buffer.from([]) as BinaryBlob,
     g: new BigNumber('0xffffffffffffffff'),
   };

--- a/js-user-library/src/cbor.ts
+++ b/js-user-library/src/cbor.ts
@@ -11,7 +11,6 @@ import * as cbor from 'simple-cbor';
 import { CborEncoder, SelfDescribeCborSerializer } from 'simple-cbor';
 import { BinaryBlob } from './blob';
 import { CanisterId } from './canisterId';
-import { Int } from './int';
 
 // We are using hansl/simple-cbor for CBOR serialization, to avoid issues with
 // encoding the uint64 values that the HTTP handler of the client expects for
@@ -20,9 +19,9 @@ import { Int } from './int';
 // `Uint8Array` (respectively) so that we can use the dignifiedquire/borc CBOR
 // decoder.
 
-class BigNumberEncoder implements CborEncoder<BigNumber> {
+class CanisterIdEncoder implements CborEncoder<CanisterId> {
   public get name() {
-    return 'BigNumber';
+    return 'CanisterId';
   }
 
   public get priority() {
@@ -30,11 +29,11 @@ class BigNumberEncoder implements CborEncoder<BigNumber> {
   }
 
   public match(value: any): boolean {
-    return value instanceof BigNumber;
+    return value instanceof CanisterId;
   }
 
-  public encode(v: BigNumber): cbor.CborValue {
-    return cbor.value.u64(v.toString(16), 16);
+  public encode(v: CanisterId): cbor.CborValue {
+    return cbor.value.u64(v.toHex(), 16);
   }
 }
 
@@ -57,7 +56,7 @@ class BufferEncoder implements CborEncoder<Buffer> {
 }
 
 const serializer = SelfDescribeCborSerializer.withDefaultEncoders();
-serializer.addEncoder(new BigNumberEncoder());
+serializer.addEncoder(new CanisterIdEncoder());
 serializer.addEncoder(new BufferEncoder());
 
 interface CborRecord extends Record<string, CborValue> {}
@@ -71,7 +70,8 @@ export type CborValue =
 
   // Integer numbers: Major type 0 or 1 (“Unsigned/signed integer”) if small
   // enough to fit that type, else the Bignum format is used.
-  | Int
+  | number
+
   // TODO: switch back to BigInt once hansl/simple-cbor provides deserialization
   | BigNumber
 

--- a/js-user-library/src/hex.ts
+++ b/js-user-library/src/hex.ts
@@ -1,1 +1,0 @@
-export type Hex = string & { __hex__: void };

--- a/js-user-library/src/httpAgent.test.ts
+++ b/js-user-library/src/httpAgent.test.ts
@@ -1,9 +1,8 @@
 import { Buffer } from 'buffer/';
 import { createKeyPairFromSeed, sign, verify } from './auth';
 import { BinaryBlob } from './blob';
-import * as canisterId from './canisterId';
+import { CanisterId } from './canisterId';
 import * as cbor from './cbor';
-import { Hex } from './hex';
 import { makeHttpAgent } from './index';
 import { Nonce } from './nonce';
 import { CommonFields, Request } from './request';
@@ -20,7 +19,7 @@ test('call', async () => {
     );
   });
 
-  const canisterIdent = '0000000000000001' as Hex;
+  const canisterIdent = '0000000000000001';
   const nonce = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7]) as Nonce;
   // prettier-ignore
   const seed = Buffer.from([
@@ -50,7 +49,7 @@ test('call', async () => {
   const mockPartialRequest: CommonFields = {
     request_type: 'call' as RequestType,
     nonce,
-    canister_id: canisterId.fromHex(canisterIdent),
+    canister_id: CanisterId.fromHex(canisterIdent),
     method_name: methodName,
     // We need a request id for the signature and at the same time we
     // are checking that signature does not impact the request id.
@@ -102,7 +101,7 @@ test('requestStatus', async () => {
     );
   });
 
-  const canisterIdent = '0000000000000001' as Hex;
+  const canisterIdent = '0000000000000001';
   const nonce = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7]) as Nonce;
 
   // prettier-ignore
@@ -126,7 +125,7 @@ test('requestStatus', async () => {
   const requestId = await requestIdOf({
     request_type: 'call' as RequestType,
     nonce,
-    canister_id: canisterId.fromHex(canisterIdent),
+    canister_id: CanisterId.fromHex(canisterIdent),
     method_name: 'greet',
     arg: Buffer.from([]),
   });

--- a/js-user-library/src/int.ts
+++ b/js-user-library/src/int.ts
@@ -1,7 +1,0 @@
-import { Hex } from './hex';
-
-export type Int = number & { __int__: void };
-
-export const fromHex = (hex: Hex) => parseInt(hex, 16);
-
-export const toHex = (int: Int): Hex => int.toString(16) as Hex;

--- a/js-user-library/src/requestId.ts
+++ b/js-user-library/src/requestId.ts
@@ -4,17 +4,14 @@ import { Buffer } from 'buffer/';
 import { BinaryBlob } from './blob';
 import * as blob from './blob';
 import { CborValue } from './cbor';
-import { Hex } from './hex';
-import { Int } from './int';
-import * as int from './int';
 import * as Request from './request';
 
 export type RequestId = BinaryBlob & { __requestId__: void };
 
-export const toHex = (requestId: RequestId): Hex => blob.toHex(requestId);
+export const toHex = (requestId: RequestId): string => blob.toHex(requestId);
 
 // The spec describes encoding for these types.
-type HashableValue = string | Buffer | Int | BigNumber | borc.Tagged;
+type HashableValue = number | string | Buffer | BigNumber | borc.Tagged;
 
 export const hash = async (data: BinaryBlob): Promise<BinaryBlob> => {
   const hashed: ArrayBuffer = await crypto.subtle.digest(
@@ -26,8 +23,8 @@ export const hash = async (data: BinaryBlob): Promise<BinaryBlob> => {
   return Buffer.from(hashed) as BinaryBlob;
 };
 
-const padHex = (hex: Hex): Hex => {
-  return `${'0000000000000000'.slice(hex.length)}${hex}` as Hex;
+const padHex = (hex: string): string => {
+  return `${'0000000000000000'.slice(hex.length)}${hex}`;
 };
 
 const hashValue = (value: HashableValue): Promise<Buffer> => {
@@ -37,11 +34,11 @@ const hashValue = (value: HashableValue): Promise<Buffer> => {
     return hashString(value as string);
   } else if (isBigNumber(value)) {
     // HTTP handler expects canister_id to be an u64 & hashed in this way.
-    const hex = value.toString(16) as Hex;
+    const hex = value.toString(16);
     const padded = padHex(hex);
     return hash(blob.fromHex(padded));
   } else if (isInt(value)) {
-    const hex = int.toHex(value);
+    const hex = value.toString(16);
     const padded = padHex(hex);
     return hash(blob.fromHex(padded));
   } else if (isBlob(value)) {
@@ -65,7 +62,7 @@ const isBlob = (value: HashableValue): value is BinaryBlob => {
   return value instanceof Buffer;
 };
 
-const isInt = (value: HashableValue): value is Int => {
+const isInt = (value: HashableValue): value is number => {
   return typeof value === 'number';
 };
 


### PR DESCRIPTION
This actually cuts down on code.

This PR purpose is to simplify the amount of code / files we need. The JS can be a bit complex to follow right now.