### PR TITLE
INF-680: Fix SDK release

### DIFF
--- a/ci/release.nix
+++ b/ci/release.nix
@@ -2,4 +2,10 @@
 , scrubJobs ? true
 , src ? null
 }:
-(import ../nix {}).ci ../release-jobset.nix { inherit supportedSystems scrubJobs src; }
+let
+  pkgs = import ../nix {};
+in
+pkgs.ci ../release-jobset.nix
+  { inherit supportedSystems scrubJobs src;
+    rev = pkgs.lib.commitIdFromGitRepo (pkgs.lib.gitDir ../.);
+  }


### PR DESCRIPTION
I broke this when fixing something else. We should really have a single jobset for this repo, otherwise releases are bound to break continuously.