### PR TITLE
test: add status code to output when failing a command

### DIFF
--- a/e2e/utils/assertions.bash
+++ b/e2e/utils/assertions.bash
@@ -21,7 +21,7 @@ assert_command() {
     )"
 
     [[ $status == 0 ]] || \
-        (  (echo "$*"; echo "$output" | batslib_decorate "Output") \
+        (  (echo "$*"; echo "status: $status"; echo "$output" | batslib_decorate "Output") \
          | batslib_decorate "Command failed" \
          | fail)
 }


### PR DESCRIPTION
This will help us investigate the flake, which is weird because there is a curl output so it should have succeeded.