### PR TITLE
Use a retry loop to get the request status

### DIFF
--- a/dfx/src/commands/canister/install.rs
+++ b/dfx/src/commands/canister/install.rs
@@ -97,10 +97,10 @@ pub fn wait_on_request_status(client: &Client, request_id: RequestId) -> DfxResu
             reject_code,
             reject_message,
         } => Err(DfxError::ClientError(reject_code, reject_message)),
-        ReadResponse::Unknown => Err(DfxError::TimeoutWaitingForResponse(format!(
-            "Timed out waiting for {:?} for more than {:?}",
-            request_id, REQUEST_TIMEOUT
-        ))),
+        ReadResponse::Unknown => Err(DfxError::TimeoutWaitingForResponse(
+            request_id,
+            REQUEST_TIMEOUT,
+        )),
     }
 }
 

--- a/dfx/src/lib/error/mod.rs
+++ b/dfx/src/lib/error/mod.rs
@@ -1,3 +1,6 @@
+use ic_http_agent::RequestId;
+use std::time::Duration;
+
 mod build;
 mod cache;
 
@@ -73,7 +76,7 @@ pub enum DfxError {
     LanguageServerFromATerminal,
 
     /// Timeout while waiting for a request to the IC client.
-    TimeoutWaitingForResponse(String),
+    TimeoutWaitingForResponse(RequestId, Duration),
 }
 
 /// The result of running a DFX command.


### PR DESCRIPTION
The recursion used to poll for the request status causes problems because we keep using FDs that are not closed because we cannot drop them until we've returned from the recursive call. I'm switching to a retry loop where we wait until the response is not `Unknown` or until it's been a minute.