### PR TITLE
fix: fixed-width IDL types off-by-one error fix

### DIFF
--- a/js-user-library/src/idl.test.ts
+++ b/js-user-library/src/idl.test.ts
@@ -75,19 +75,30 @@ test('IDL encoding (nat)', () => {
 
 test('IDL encoding (fixed-width number)', () => {
   // Fixed-width number
+  test_(IDL.Int8, 0, '4449444c00017700', 'Int8');
+  test_(IDL.Int8, -1, '4449444c000177ff', 'Int8');
   test_(IDL.Int8, 42, '4449444c0001772a', 'Int8');
+  test_(IDL.Int8, 127, '4449444c0001777f', 'Int8');
+  test_(IDL.Int8, -128, '4449444c00017780', 'Int8');
   test_(IDL.Int32, 42, '4449444c0001752a000000', 'Int32');
   test_(IDL.Int32, -42, '4449444c000175d6ffffff', 'Negative Int32');
   test_(IDL.Int32, 1234567890, '4449444c000175d2029649', 'Positive Int32');
   test_(IDL.Int32, -1234567890, '4449444c0001752efd69b6', 'Negative Int32');
+  test_(IDL.Int32, -0x7fffffff, '4449444c00017501000080', 'Negative Int32');
+  test_(IDL.Int32, 0x7fffffff, '4449444c000175ffffff7f', 'Positive Int32');
   test_(IDL.Int64, new BigNumber(42), '4449444c0001742a00000000000000', 'Int64');
   test_(IDL.Int64, new BigNumber(-42), '4449444c000174d6ffffffffffffff', 'Int64');
   test_(IDL.Int64, new BigNumber(1234567890), '4449444c000174d202964900000000', 'Positive Int64');
   test_(IDL.Nat8, 42, '4449444c00017b2a', 'Nat8');
+  test_(IDL.Nat8, 0, '4449444c00017b00', 'Nat8');
+  test_(IDL.Nat8, 255, '4449444c00017bff', 'Nat8');
+  test_(IDL.Nat32, 0, '4449444c00017900000000', 'Nat32');
   test_(IDL.Nat32, 42, '4449444c0001792a000000', 'Nat32');
+  test_(IDL.Nat32, 0xffffffff, '4449444c000179ffffffff', 'Nat32');
   test_(IDL.Nat64, new BigNumber(1234567890), '4449444c000178d202964900000000', 'Positive Nat64');
   expect(() => IDL.encode([IDL.Nat32], [-42])).toThrow(/Invalid Nat32 argument/);
   expect(() => IDL.encode([IDL.Int8], [256])).toThrow(/Invalid Int8 argument/);
+  expect(() => IDL.encode([IDL.Int32], [0xffffffff])).toThrow(/Invalid Int32 argument/);
 });
 
 test('IDL encoding (tuple)', () => {

--- a/js-user-library/src/idl.ts
+++ b/js-user-library/src/idl.ts
@@ -349,12 +349,12 @@ export class FixedNatClass extends PrimitiveType<BigNumber | number> {
   }
 
   public covariant(x: any): x is BigNumber {
-    const max = new BigNumber(2).pow(this._bits - 1);
+    const max = new BigNumber(2).pow(this._bits);
     if (x instanceof BigNumber && x.isInteger() && !x.isNegative()) {
-      return x.lte(max);
+      return x.lt(max);
     } else if (Number.isInteger(x) && x >= 0) {
       const v = new BigNumber(x);
-      return v.lte(max);
+      return v.lt(max);
     } else {
       return false;
     }


### PR DESCRIPTION
Nat8 was accepting integers up to 127 instead of 255. Also true for
all Nat16/32/64 and Int8/16/32/64.