### PR TITLE
fix: a collection of small changes for the R&D demo

### DIFF
--- a/dfx/assets/new_project_node_files/package.json
+++ b/dfx/assets/new_project_node_files/package.json
@@ -7,8 +7,8 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "webpack": "5.0.0-beta.9",
-    "webpack-cli": "4.0.0-beta.1",
+    "webpack": "4.41.3",
+    "webpack-cli": "3.3.10",
     "terser-webpack-plugin": "2.2.2"
   }
 }

--- a/dfx/src/commands/new.rs
+++ b/dfx/src/commands/new.rs
@@ -334,6 +334,10 @@ where
         warn_upgrade(latest_version, current_version);
     }
 
+    if !env.is_installed()? {
+        env.install()?;
+    }
+
     eprintln!(r#"Creating new project "{}"..."#, project_name.display());
     if dry_run {
         eprintln!(r#"Running in dry mode. Nothing will be committed to disk."#);
@@ -419,8 +423,8 @@ fn warn_upgrade(latest_version: Option<Version>, current_version: Version) {
         red.apply_to(current_version.clone())
     );
     if let Some(v) = latest_version {
-        eprint!("{}", yellow.apply_to("→"));
-        eprintln!(" latest version: {}", green.apply_to(v));
+        eprint!("{}", yellow.apply_to(" → "));
+        eprintln!("latest version: {}", green.apply_to(v));
     }
     eprintln!("\nYou are strongly encouraged to upgrade by running 'dfx upgrade'!");
 }

--- a/dfx/src/commands/start.rs
+++ b/dfx/src/commands/start.rs
@@ -136,7 +136,7 @@ where
 
     b.set_message("Pinging the Internet Computer client...");
     ping_and_wait(&frontend_url)?;
-    b.set_message("Internet Computer client started...");
+    b.finish_with_message("Internet Computer client started...");
 
     // We have two side processes involving multiple threads running at
     // this point. We first wait for a signal that one of the processes
@@ -157,7 +157,10 @@ where
     // over the client and nodemanager as it provides little
     // handling. This is mostly done for completeness. In the future
     // we should also force kill, if it ends up being necessary.
+    let b = ProgressBar::new_spinner();
+    b.set_draw_target(ProgressDrawTarget::stderr());
     b.set_message("Terminating...");
+    b.enable_steady_tick(80);
     broadcast_stop.send(()).expect("Failed to signal children");
     // We can now start terminating our proxy server, we block to
     // ensure termination is done properly. At this point the client

--- a/dfx/src/commands/upgrade.rs
+++ b/dfx/src/commands/upgrade.rs
@@ -79,7 +79,7 @@ struct Manifest {
 
 pub fn is_upgrade_necessary(latest_version: Option<Version>, current: Version) -> bool {
     match latest_version {
-        Some(latest) => latest > current,
+        Some(latest) => latest > current && current.pre.is_empty(),
         None => true,
     }
 }

--- a/dfx/src/main.rs
+++ b/dfx/src/main.rs
@@ -70,6 +70,7 @@ fn main() {
                     Ok(status) => std::process::exit(status.code().unwrap_or(0)),
                     Err(e) => {
                         eprintln!("Error when trying to forward to project dfx:\n{:?}", e);
+                        eprintln!("Installed executable: {}", dfx_version());
                         std::process::exit(1)
                     }
                 };


### PR DESCRIPTION
- Spacing in the update message
- webpack 4
- stopping the spinner when done starting on dfx start
- not showing an upgrade message if there is a prerelease

This last point is interesting. We will need to remember to
specialize that check when doing beta releases as we want
those to move to the final one.