### PR TITLE
ci: add the dfinity-sdk.packages.cargo-security-audit job

### DIFF
--- a/ci/ci-pr.nix
+++ b/ci/ci-pr.nix
@@ -1,4 +1,4 @@
 # This file is used to govern CI jobs for GitHub PRs
 
 args@{supportedSystems ? [ "x86_64-linux" ], ...}:
-import ./ci.nix (args // { inherit supportedSystems; })
+import ./ci.nix (args // { inherit supportedSystems; isMaster = false; })

--- a/ci/ci.nix
+++ b/ci/ci.nix
@@ -1,9 +1,14 @@
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 , scrubJobs ? true
+, RustSec-advisory-db ? null
+, isMaster ? true
 }:
 let pkgs = import ../nix {};
 in
 pkgs.ci ../jobset.nix
-  { inherit supportedSystems scrubJobs; isMaster = true;
+  { inherit supportedSystems scrubJobs isMaster;
     rev = pkgs.lib.commitIdFromGitRepo (pkgs.lib.gitDir ../.);
+    packageSetArgs = {
+      inherit RustSec-advisory-db;
+    };
   }

--- a/jobset.nix
+++ b/jobset.nix
@@ -3,6 +3,9 @@
 , config ? {}
 , overlays ? []
 , src ? null
+, RustSec-advisory-db ? null
 }: {
-  inherit (import ./nix { inherit system crossSystem config overlays; }) dfinity-sdk;
+  inherit (import ./nix {
+    inherit system crossSystem config overlays RustSec-advisory-db;
+  }) dfinity-sdk;
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,6 +5,7 @@
 , config ? {}
 , overlays ? []
 , releaseVersion ? "latest"
+, RustSec-advisory-db ? null
 }:
 let
   # The `common` repo provides code (mostly Nix) that is used in the
@@ -21,9 +22,18 @@ let
     else builtins.fetchGit {
       name = "common-sources";
       url = "ssh://git@github.com/dfinity-lab/common";
-      rev = "8872018a48260010599e945526fe0dcf28022444";
+      rev = "a066833f9ce8fac453f736639d46021a714682b2";
     };
 in import commonSrc {
   inherit system crossSystem config;
-  overlays = import ./overlays ++ [ (_self: _super: { inherit releaseVersion; }) ] ++ overlays;
+  overlays = import ./overlays ++ [
+    (_self: _super: {
+      inherit
+        releaseVersion
+        # The dfinity-sdk.packages.cargo-security-audit job has this RustSec
+        # advisory-db as a dependency so we add it here to the package set so
+        # that job has access to it.
+        RustSec-advisory-db;
+    })
+  ] ++ overlays;
  }


### PR DESCRIPTION
The `dfinity-sdk.packages.cargo-security-audit` job only exists in the `sdk` jobset (i.e. the jobset which corresponds to the `master` branch).

The job will run `cargo audit` which scans `Cargo.lock` for security vulnerabilities in crates reported in the [RustSec advisory-db](https://github.com/RustSec/advisory-db). The DB is an input to the jobset. This means that whenever a new vulnerability is reported or when `Cargo.lock` changes `cargo audit` will run.

This depends on: 
* https://github.com/dfinity-lab/common/pull/84
* https://github.com/dfinity-lab/hydra-jobsets/pull/29

https://github.com/dfinity-lab/dfinity/pull/2161 is the corresponding PR in the `dfinity` repo.