### PR TITLE
Cargo.lock: serde_cbor: 0.10.1 -> 0.10.2 (fix RUSTSEC-2019-0025)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-idl 0.1.0",
  "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_cbor 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_cbor 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sysinfo 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1266,7 +1266,7 @@ dependencies = [
  "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_cbor 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_cbor 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "serde_cbor"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3350,7 +3350,7 @@ dependencies = [
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "45af0182ff64abaeea290235eb67da3825a576c5d53e642c4d5b652e12e6effc"
-"checksum serde_cbor 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "318690c4f04ae6553665f3846c0614c9995bb1ea51a2f1c5c4b4ed338c248b49"
+"checksum serde_cbor 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f7081ed758ec726a6ed8ee7e92f5d3f6e6f8c3901b1f972e3a4a2f2599fad14f"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"

--- a/dfx/Cargo.toml
+++ b/dfx/Cargo.toml
@@ -35,7 +35,7 @@ semver = "0.9.0"
 serde = "1.0"
 serde-idl = { "path" = "../lib/serde_idl" }
 serde_bytes = "0.11.2"
-serde_cbor = "0.10.1"
+serde_cbor = "0.10"
 serde_json = "1.0.40"
 serde_repr = "0.1.5"
 sysinfo = "0.9.6"

--- a/lib/ic_http_agent/Cargo.toml
+++ b/lib/ic_http_agent/Cargo.toml
@@ -14,7 +14,7 @@ openssl = "0.10.24"
 reqwest = "0.9.20"
 serde = "1.0.101"
 serde_bytes = "0.11.2"
-serde_cbor = "0.10.1"
+serde_cbor = "0.10"
 
 [dev-dependencies]
 rand = "0.7.2"


### PR DESCRIPTION
This fixes security vulnerability:

```
ID:       RUSTSEC-2019-0025
Crate:    serde_cbor
Version:  0.10.1
Date:     2019-10-03
URL:      https://rustsec.org/advisories/RUSTSEC-2019-0025
Title:    Flaw in CBOR deserializer allows stack overflow
Solution:  upgrade to >= 0.10.2
Dependency tree:
serde_cbor 0.10.1
├── ic-http-agent 0.1.0
│   └── dfx 0.4.10
└── dfx 0.4.10
```