### PR TITLE
Allow e2e tests to run in Darwin sandbox

### DIFF
--- a/e2e/default.nix
+++ b/e2e/default.nix
@@ -7,6 +7,7 @@ let
   sources = pkgs.sources;
 in
 pkgs.runCommandNoCC "e2e-tests" {
+    __darwinAllowLocalNetworking = true;
     buildInputs = with pkgs; [ bats coreutils curl dfinity-sdk.packages.rust-workspace-debug nodejs stdenv.cc ps python3 netcat which ];
 } ''
     # We want $HOME/.cache to be in a new temporary directory.


### PR DESCRIPTION
This is needed, otherwise the Darwin sandbox disables network entirely. Not a problem on CI because the sandbox is not enabled (yet).