### PR TITLE
INF-591: Make cargo-audit a standalone target

### DIFF
--- a/cargo-audit.nix
+++ b/cargo-audit.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import ./nix { inherit system; }
+, system ? builtins.currentSystem
+}:
+pkgs.lib.cargo-security-audit {
+  name = "dfinity-sdk";
+  cargoLock = ./Cargo.lock;
+  db = pkgs.RustSec-advisory-db;
+  ignores = [];
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -24,13 +24,22 @@ let
 in import commonSrc {
   inherit system crossSystem config;
   overlays = import ./overlays ++ [
-    (_self: _super: {
-      inherit
-        releaseVersion
-        # The dfinity-sdk.packages.cargo-security-audit job has this RustSec
-        # advisory-db as a dependency so we add it here to the package set so
-        # that job has access to it.
-        RustSec-advisory-db;
-    })
+    (
+      _self: super:
+        {
+          inherit
+            releaseVersion
+            ;
+          # The dfinity-sdk.packages.cargo-security-audit job has this RustSec
+          # advisory-db as a dependency so we add it here to the package set so
+          # that job has access to it.
+          # Hydra injects the latest RustSec-advisory-db, otherwise we piggy
+          # back on the one defined in sources.json.
+          RustSec-advisory-db =
+            if ! isNull RustSec-advisory-db
+            then RustSec-advisory-db
+            else super.sources.advisory-db;
+        }
+    )
   ] ++ overlays;
- }
+}

--- a/nix/overlays/dfinity-sdk.nix
+++ b/nix/overlays/dfinity-sdk.nix
@@ -23,22 +23,14 @@ in {
           };
 
         e2e-tests = super.callPackage ../../e2e {};
-    } //
-    # We only run `cargo audit` on the `master` branch so to not let PRs
-    # fail because of an updated RustSec advisory-db. Also we only add the
-    # job if the RustSec advisory-db is defined. Note that by default
-    # RustSec-advisory-db is undefined (null). However, on Hydra the
-    # `sdk` master jobset has RustSec-advisory-db defined as an
-    # input. This means that whenever a new security vulnerability is
-    # published or when Cargo.lock has been changed `cargo audit` will
-    # run.
-    self.lib.optionalAttrs (self.isMaster && self.RustSec-advisory-db != null) {
-      cargo-security-audit = self.lib.cargo-security-audit {
-        name = "dfinity-sdk";
-        cargoLock = ../../Cargo.lock;
-        db = self.RustSec-advisory-db;
-        ignores = [];
-      };
+
+        # The cargo audit job for known vulnerabilities. This generally run
+        # against the advisory database pinned in sources.json; on Hydra
+        # (master) however the latest advisory database is fetched from
+        # RustSec/advisory-db. This means that whenever a new security
+        # vulnerability is published or when Cargo.lock has been changed `cargo
+        # audit` will run.
+        cargo-security-audit = import ../../cargo-audit.nix { pkgs = self; };
     };
 
     dfx-release = mkRelease "dfx" self.releaseVersion packages.rust-workspace-standalone "dfx";

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "advisory-db": {
+        "branch": "master",
+        "description": "Security advisory database for Rust crates published through crates.io",
+        "homepage": "https://rustsec.org",
+        "owner": "RustSec",
+        "repo": "advisory-db",
+        "rev": "891a872b7303281141cc554dc78279d91ce1efd7",
+        "sha256": "0r2figyrax8db3d5l50yxkybpgdlf0xm16l4ks5c1ymx8p3gjk0x",
+        "type": "tarball",
+        "url": "https://github.com/RustSec/advisory-db/archive/891a872b7303281141cc554dc78279d91ce1efd7.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "bats-support": {
         "branch": "v0.3.0",
         "description": "Supporting library for Bats test helpers",


### PR DESCRIPTION
This puts the `cargo-audit` job in a dedicated nix file, which can be
built with:

```
$ nix-build ./cargo-audit.nix
```

This also adds a pinned advisory DB which means the job can be built
outside of Hydra. Hydra master is still able to inject the latest
advisory DB.