### PR TITLE
Update common

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -14,7 +14,7 @@
     "common": {
         "ref": "master",
         "repo": "ssh://git@github.com/dfinity-lab/common",
-        "rev": "7fc0d40dc6e52a221b370be5a04292e59b32f17d",
+        "rev": "63dc86c9f05de00a40d402435970488d40f02c95",
         "type": "git"
     },
     "dfinity": {


### PR DESCRIPTION
SDK was falling behind. Updates in common:

```
commit c9a1e5aa18d19ab31e7a49fafb1e26ceeb948d97
Merge: 920dbf7 4ffd2a6
Author: Jude Taylor <me@jude.xyz>
Date:   Fri Jan 10 09:22:28 2020 -0800

    Merge pull request #83 from dfinity-lab/INF-532
    
    [INF-532] Use packager on Darwin

commit 4ffd2a611228a49a2efd0cf60d267796545b186a
Author: Jude Taylor <me@jude.xyz>
Date:   Fri Jan 10 07:59:19 2020 -0800

    address some PR comments

commit 49c9a4c205fdb172db4e203a13c277e2ef33ff46
Author: Jude Taylor <me@jude.xyz>
Date:   Tue Dec 17 15:37:02 2019 -0800

    use packager on darwin as well

commit 920dbf7732e4d978e7c95778b76d7172677c2a69
Merge: 2cb3f5e 150a27c
Author: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
Date:   Fri Jan 10 17:10:41 2020 +0000

    Merge pull request #94 from dfinity-lab/nm-cargo-audit-process
    
    INF-787: Volunteer Bas and John for cargo-audit responsibility

commit 150a27cd6120366c85e7e4d29ff0aa94c69301eb
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Fri Jan 10 13:36:20 2020 +0100

    INF-787: Volunteer Bas and John for cargo-audit responsibility

commit 2cb3f5e6c518c8818f7532929fd373f92fdb1d7b
Merge: 7362cbd c5f431c
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Fri Jan 10 12:31:15 2020 +0100

    Merge pull request #93 from dfinity-lab/nm-update-naersk
    
    INF-786: Update naersk to fix multiple git dep issue

commit c5f431c6d4e7ed3e246fd476726c473a14c73833
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Fri Jan 10 11:38:09 2020 +0100

    INF-786: Update naersk to fix multiple git dep issue

commit 7362cbdf8f998f3cd6d73a95914cf93d33fa3f35
Merge: 7f17995 ad1a874
Author: Jude Taylor <me@jude.xyz>
Date:   Thu Jan 9 10:06:15 2020 -0800

    Merge pull request #85 from dfinity-lab/INF-491
    
    [INF-491] Improve license reporting

commit ad1a874d50219d4726b53f3b17449cbd859b4a06
Author: Jude Taylor <me@jude.xyz>
Date:   Thu Jan 9 09:58:42 2020 -0800

    delete unused file

commit 8110c12ab2240aa54303161e9b29aeab04b4cc81
Author: Jude Taylor <me@jude.xyz>
Date:   Thu Jan 9 09:13:52 2020 -0800

    move and clean up source tree

commit 8c112abc98418fdc0b03fe32e271796658add13d
Author: Jude Taylor <me@jude.xyz>
Date:   Mon Jan 6 11:00:57 2020 -0800

    split into buildtime and runtime checks

commit 29770efb17de64ae41a4421e89444781502e69cd
Author: Jude Taylor <me@jude.xyz>
Date:   Thu Dec 19 09:04:58 2019 -0800

    oops, shouldn't error if the error list is empty

commit 8d9f517008708180c2988e2e23fdfd45ac7aff00
Author: Jude Taylor <me@jude.xyz>
Date:   Thu Dec 19 09:02:46 2019 -0800

    nix-fmt

commit 42803fba1131f2e938d263c861c4cb2c2fbce0bc
Author: Jude Taylor <me@jude.xyz>
Date:   Thu Dec 19 08:49:11 2019 -0800

    license report using jq

commit 7f17995f969873f3f755578fff5b2295727ab99a
Merge: 417bead 260b3b0
Author: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
Date:   Thu Jan 9 14:56:54 2020 +0000

    Merge pull request #92 from dfinity-lab/nm-robust-db
    
    Make cargo-security-audit more robust

commit 260b3b0bae19c2f1b5a8de7418a75f2980d69e51
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Thu Jan 9 15:53:11 2020 +0100

    Make cargo-security-audit more robust
    
    Before this, setting `db` to the empty string would copy the entirety of the file system to a temporary directory.

commit 417bead6462084724947014b30018cfcba8fe636
Merge: b17fa42 e2c8d00
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Thu Jan 9 13:58:33 2020 +0100

    Merge pull request #91 from dfinity-lab/nm-hydra-run-once
    
    Limit linuxOnly for cargo-audit only on Hydra

commit e2c8d00f4cf9f6446821be852823d62bc4a50f69
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Thu Jan 9 13:56:16 2020 +0100

    Limit linuxOnly for cargo-audit only on Hydra
    
    The `cargo-audit` job was limited to run on Linux. Turns out this is not the intention. The actual goal is to "run cargo-audit only once on Hydra". So we introduce `hydraRunOnce` which does exactly that.

commit b17fa426ad63e4c645891374a503a91ed4b2ea62
Merge: 8c956db ea264fe
Author: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
Date:   Thu Jan 9 11:36:30 2020 +0000

    Merge pull request #90 from dfinity-lab/nm-cargo-audit-no-git
    
    INF-779: Initialize dummy git repo for cargo audit DB

commit ea264fe3d04fc925431e5c1d114fabbf6e1d25ba
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Thu Jan 9 11:33:56 2020 +0100

    INF-779: Initialze dummy git repo for cargo audit DB
    
    This moves the `cargo-security-audit` definition to its own file, and
    initializes a dummy git repository if the database is not a git
    repository.

commit 8c956db9795364415c8372ddbc711148c0e0dbd5
Merge: 485a04e 3dee50d
Author: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
Date:   Wed Jan 8 14:20:38 2020 +0000

    Merge pull request #89 from dfinity-lab/nm-fmt-only-nix
    
    INF-435: Use upstream niv sources.nix

commit 3dee50d0701ab6f3c97a5803b34c369518c1e5fa
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Wed Jan 8 13:31:44 2020 +0100

    Use runCommandNoCC in fmt checks

commit 27e5c6ac8339d3fc1ac9266c156c9a71763ef122
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Wed Jan 8 12:31:24 2020 +0100

    Allow nixpkgs-fmt to format sources.nix
    
    We have an overlay names `sources.nix` that we'd like to be formatted. Moreover niv's latest `sources.nix` is formatted, so we don't need to skip it.

commit ff22a65ba418258c34bd6de46e353a4b80fcb4ea
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Wed Jan 8 12:27:05 2020 +0100

    Throw error if nixpkgs is used in sources

commit c866d05dc69a7692efb3a34e3784ff7330667f96
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Wed Jan 8 11:21:19 2020 +0100

    Clarify nixpkgs-fmt job
    
    This makes it clearer what the `src` input is, and only takes git files into account.

commit d42a7a1277634e3c4fbfd1ff3a4930f5547199f1
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Tue Jan 7 15:58:56 2020 +0100

    Use upstream sources.nix

commit 935232d6a04acb320d0f0281d2106d9a586997f3
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Tue Jan 7 15:57:12 2020 +0100

    Only use builtin fetchers
    
    ... and drop niv from sources.json

commit 996476079d8df481259b82b05a443e4fd705ac57
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Tue Jan 7 15:53:10 2020 +0100

    Only look at nix files when nixpkgs-fmt ing

commit 485a04e83a8e2cfe2d0cc7dc55d3541058e5be63
Merge: fd3895d 0a6b860
Author: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
Date:   Mon Jan 6 12:58:49 2020 +0000

    Merge pull request #88 from dfinity-lab/nm-git-deps
    
    INF-760: Update naersk for git dependency support

commit 0a6b860141db5810a67f9514f8f093572f7894a1
Author: Nicolas Mattia <nicolas@dfinity.org>
Date:   Mon Jan 6 12:28:14 2020 +0100

    INF-760: Update naersk for git dependency support

commit fd3895dbb7c02ab1766d6809b91397fe6ae1e379
Merge: 7fc0d40 77a06a0
Author: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
Date:   Mon Jan 6 12:28:11 2020 +0000

    Merge pull request #87 from dfinity-lab/basvandijk/cargo-audit-no-color
    
    nix/overlays/lib: don't output colors in cargo-security-audit

commit 77a06a091db861bedeeed6d5ce2df92e854de12b
Author: Bas van Dijk <v.dijk.bas@gmail.com>
Date:   Mon Jan 6 10:25:19 2020 +0100

    nix/overlays/lib: don't output colors in cargo-security-audit
   
```

[INF-532]: https://dfinity.atlassian.net/browse/INF-532
[INF-491]: https://dfinity.atlassian.net/browse/INF-491