### PR TITLE
Userlib: CanisterIds are little endian

### DIFF
--- a/src/userlib/js/src/actor.test.ts
+++ b/src/userlib/js/src/actor.test.ts
@@ -63,7 +63,7 @@ test('makeActor', async () => {
 
   const arg = blobFromHex(IDL.encode([IDL.Text], [argValue]).toString('hex'));
 
-  const canisterId: CanisterId = CanisterId.fromText('0000000000000001');
+  const canisterId: CanisterId = CanisterId.fromText('ic:000000000000000107');
   const senderPubKey = Buffer.alloc(32, 0) as SenderPubKey;
   const senderSecretKey = Buffer.alloc(32, 0) as SenderSecretKey;
   const senderSig = Buffer.from([0]) as SenderSig;

--- a/src/userlib/js/src/canisterId.ts
+++ b/src/userlib/js/src/canisterId.ts
@@ -4,10 +4,10 @@ export class CanisterId {
     if (hex.startsWith('ic:')) {
       // Remove the checksum from the hexadecimal.
       // TODO: validate the checksum.
-      return CanisterId.fromText(hex.slice(3, -2));
+      return new this(hex.slice(3, -2));
+    } else {
+      throw new Error('CanisterId not a ic: url: ' + hex);
     }
-
-    return new this(hex.padStart(16, '0'));
   }
 
   protected constructor(private _idHex: string) {}

--- a/src/userlib/js/src/cbor.test.ts
+++ b/src/userlib/js/src/cbor.test.ts
@@ -23,7 +23,7 @@ test('round trip', () => {
     b: 'two',
     c: Buffer.from([3]) as BinaryBlob,
     d: { four: 'four' },
-    e: CanisterId.fromText('ffffffffffffffff'),
+    e: CanisterId.fromText('ic:FFFFFFFFFFFFFFFFD7'),
     f: Buffer.from([]) as BinaryBlob,
     g: new BigNumber('0xffffffffffffffff'),
   };
@@ -37,6 +37,6 @@ test('round trip', () => {
   const { c: outputC, e: outputE, f: outputF, ...outputRest } = output;
 
   expect(blobToHex(outputC)).toBe(blobToHex(inputC));
-  expect(((outputE as any) as BigNumber).toString(16)).toBe(inputE.toHex());
+  expect(((outputE as any) as BigNumber).toString(16).toUpperCase()).toBe(inputE.toHex());
   expect(outputRest).toEqual(inputRest);
 });

--- a/src/userlib/js/src/cbor.ts
+++ b/src/userlib/js/src/cbor.ts
@@ -30,7 +30,18 @@ class CanisterIdEncoder implements CborEncoder<CanisterId> {
   }
 
   public encode(v: CanisterId): cbor.CborValue {
-    return cbor.value.u64(v.toHex(), 16);
+    return cbor.value.u64(this.changeEndianness(v.toHex()), 16);
+  }
+
+  // Drop once we use https://github.com/dfinity-lab/dfinity/pull/2286
+  private changeEndianness(str: string): string {
+    const result = [];
+    let len = str.length - 2;
+    while (len >= 0) {
+      result.push(str.substr(len, 2));
+      len -= 2;
+    }
+    return result.join('');
   }
 }
 

--- a/src/userlib/js/src/http_agent.test.ts
+++ b/src/userlib/js/src/http_agent.test.ts
@@ -24,7 +24,7 @@ test('call', async () => {
     );
   });
 
-  const canisterId: CanisterId = CanisterId.fromText('0000000000000001');
+  const canisterId: CanisterId = CanisterId.fromText('ic:000000000000000107');
   const nonce = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7]) as Nonce;
   // prettier-ignore
   const seed = Buffer.from([
@@ -102,7 +102,7 @@ test('requestStatus', async () => {
     );
   });
 
-  const canisterIdent = '0000000000000001';
+  const canisterIdent = 'ic:000000000000000107';
   const nonce = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7]) as Nonce;
 
   // prettier-ignore

--- a/src/userlib/js/types/borc.d.ts
+++ b/src/userlib/js/types/borc.d.ts
@@ -1,11 +1,8 @@
-declare module "borc" {
-  import { Buffer } from "buffer/";
+declare module 'borc' {
+  import { Buffer } from 'buffer/';
 
   class Decoder {
-    constructor(opts: {
-      size: Number,
-      tags: Record<number, (val: any) => any>,
-    });
+    constructor(opts: { size: Number; tags: Record<number, (val: any) => any> });
 
     decodeFirst(input: ArrayBuffer): any;
   }

--- a/src/userlib/js/types/buffer-pipe.d.ts
+++ b/src/userlib/js/types/buffer-pipe.d.ts
@@ -1,5 +1,5 @@
 declare module 'buffer-pipe' {
-  import { Buffer } from "buffer/";
+  import { Buffer } from 'buffer/';
 
   class BufferPipe {
     readonly buffer: Buffer;
@@ -27,19 +27,19 @@ declare module 'buffer-pipe' {
      * Whether or not there is more data to read from the buffer
      * returns {Boolean}
      */
-    get end (): boolean;
+    get end(): boolean;
 
     /**
      * returns the number of bytes read from the stream
      * @return {Integer}
      */
-    get bytesRead (): number;
+    get bytesRead(): number;
 
     /**
      * returns the number of bytes wrote to the stream
      * @return {Integer}
      */
-    get bytesWrote (): number;
+    get bytesWrote(): number;
   }
 
   export = BufferPipe;


### PR DESCRIPTION
this is the equivalent of what #303 did to `dfx`: When CBOR-encoding a
canisterid for submission in a request, we need to make sure it is
little endian.

We do the change in
```
class CanisterIdEncoder implements CborEncoder<CanisterId> { …
```
where it belongs: As close to the HTTP interface we can.

This means that once we migrate to
https://github.com/dfinity-lab/dfinity/pull/2286
we will adjust this code to switch to CBOR blob, and the work-around can
be dropped here. Note in the code about that.

Also cleans up `fromText` to be more robust: It will _only_ accept `ic:`
textual representation, and _always_ strip the checksum.

With this, I can
 * build and install Linkedup
 * copy the `ic:` url printed by `dfx` upon installation
 * use that in the url (e.g. `http://127.0.0.1:8000/?canisterId=ic:72028DEDFB546FA89A`)
 * see it load the assets