### PR TITLE
feat: specify encoding for index.html

### DIFF
--- a/src/userlib/js/bootstrap/index.html
+++ b/src/userlib/js/bootstrap/index.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+    <meta charset="UTF-8">
     <title>DFINITY Canister</title>
 </head>
 <body>


### PR DESCRIPTION
Removes error from Firefox's console log.

Previously one would encounter
```
The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol.
```

I use HTML-5 syntax, documented here: https://www.w3schools.com/tags/att_meta_charset.asp