### PR TITLE
refactor: generate idiomatic Motoko for __dfx_asset_path

### DIFF
--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -54,7 +54,7 @@ fn get_asset_fn(assets: &AssetMap) -> String {
               switch path {par}
                 {}
                 case _ {par}assert false; ""{end}
-              {end};
+              {end}
             {end};
         "#,
         cases,


### PR DESCRIPTION
Also fail the query when being asked for a non-existing path.

To illustrate, we now generate
``` swift
            public query func __dfx_asset_path(path: Text): async Text {
              switch path {
                case "index.js" "<the asset contents>";
                case _ {assert false; ""}
              };
            };
```