### PR TITLE
Allow dfinity-lab/infra to approve Nix PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 # The whole SDK team owns the whole repo for now.
 * @dfinity-lab/sdk
 
+# The infra team can still approve Nix PRs.
+**/*.nix @dfinity-lab/infra
+nix/** @dfinity-lab/infra


### PR DESCRIPTION
The infra team regularly submits Nix PRs that don't impact the Rust code. Whatever we do, we do it in your best interest, I promise! The `dfinity` repo trusts us.