### PR TITLE
INF-870: Fix clippy and fmt issues on Darwin

### DIFF
--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -124,7 +124,7 @@ fn motoko_compile(cache: &dyn Cache, params: &MotokoParams<'_>, assets: &AssetMa
         let mut rng = thread_rng();
         let input_path = input_path.with_extension(format!("mo-{}", rng.gen::<u64>()));
         std::fs::write(&input_path, content.as_bytes())?;
-        input_path.clone()
+        input_path
     } else {
         params.input.to_path_buf()
     };

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -166,7 +166,7 @@ pub fn exec(env: &dyn Environment, args: &ArgMatches<'_>) -> DfxResult {
     let mut runtime = Runtime::new().expect("Unable to create a runtime");
     if is_query {
         let future = query(
-            client.clone(),
+            client,
             canister_id,
             method_name.to_owned(),
             arg_value.map(Blob::from),
@@ -185,7 +185,7 @@ pub fn exec(env: &dyn Environment, args: &ArgMatches<'_>) -> DfxResult {
             println!("0x{}", String::from(request_id));
             Ok(())
         } else {
-            wait_on_request_status(&client.clone(), request_id)
+            wait_on_request_status(&client, request_id)
         }
     }
 }

--- a/src/dfx/src/commands/canister/query.rs
+++ b/src/dfx/src/commands/canister/query.rs
@@ -76,7 +76,9 @@ pub fn exec(env: &dyn Environment, args: &ArgMatches<'_>) -> DfxResult {
         None
     };
 
-    eprintln!(r#"The 'canister query' command has been deprecated. Please use the 'canister call' command."#);
+    eprintln!(
+        r#"The 'canister query' command has been deprecated. Please use the 'canister call' command."#
+    );
 
     let client = env
         .get_client()

--- a/src/dfx/src/lib/api_client.rs
+++ b/src/dfx/src/lib/api_client.rs
@@ -320,7 +320,7 @@ mod tests {
                 ),
                 (
                     Value::Text("method_name".to_string()),
-                    Value::Text(method_name.clone()),
+                    Value::Text(method_name),
                 ),
                 (Value::Text("arg".to_string()), Value::Bytes(vec![])),
             ]
@@ -360,9 +360,7 @@ mod tests {
             serde_cbor::from_slice(&serde_cbor::to_vec(&response).unwrap()).unwrap();
 
         let expected = ReadResponse::Replied {
-            reply: Some(QueryResponseReply {
-                arg: Blob(arg.clone()),
-            }),
+            reply: Some(QueryResponseReply { arg: Blob(arg) }),
         };
 
         assert_eq!(actual, expected);
@@ -434,7 +432,7 @@ mod tests {
 
         let expected: ReadResponse<QueryResponseReply> = ReadResponse::Rejected {
             reject_code: 1, // ReadRejectCode::SysFatal,
-            reject_message: reject_message.clone(),
+            reject_message,
         };
 
         assert_eq!(actual, expected);

--- a/src/dfx_derive/src/lib.rs
+++ b/src/dfx_derive/src/lib.rs
@@ -92,7 +92,7 @@ impl Variant {
                     .iter()
                     .map(|ident| {
                         let ident = ident.to_string();
-                        let var = format!("__field{}", ident.to_string());
+                        let var = format!("__field{}", ident);
                         syn::parse_str(&var).unwrap()
                     })
                     .collect();

--- a/src/serde_idl/src/de.rs
+++ b/src/serde_idl/src/de.rs
@@ -51,7 +51,7 @@ impl<'de> IDLDeserialize<'de> {
             .types
             .pop_front()
             .ok_or_else(|| Error::msg("No more values to deserialize"))?;
-        self.de.current_type.push_back(ty.clone());
+        self.de.current_type.push_back(ty);
 
         let v = T::deserialize(&mut self.de).map_err(|e| self.de.dump_error_state(e))?;
         if self.de.current_type.is_empty() && self.de.field_name.is_none() {


### PR DESCRIPTION
Some issues slipped through the CI checks and only surfaced on Darwin. This fixes the issues to unblock developers, INF-871 is tracking the work to figure out _why_ the clippy/rustfmt suggestions are different on Linux/Darwin.