### PR TITLE
INF-869: Use standalone artifact in e2e tests

### DIFF
--- a/e2e/default.nix
+++ b/e2e/default.nix
@@ -8,7 +8,7 @@ let
 in
 pkgs.runCommandNoCC "e2e-tests" {
   __darwinAllowLocalNetworking = true;
-  buildInputs = with pkgs; [ bats coreutils curl dfinity-sdk.packages.rust-workspace-debug nodejs stdenv.cc ps python3 netcat which ];
+  buildInputs = with pkgs; [ bats coreutils curl dfinity-sdk.packages.rust-workspace-standalone nodejs stdenv.cc ps python3 netcat which ];
 } ''
   # We want $HOME/.cache to be in a new temporary directory.
   export HOME=$(mktemp -d -t dfx-e2e-home-XXXX)


### PR DESCRIPTION
This ensures that the tests are run with the executable that gets shipped.