### PR TITLE
[INF-897] Run E2E tests with no stdenv

### DIFF
--- a/e2e/default.nix
+++ b/e2e/default.nix
@@ -21,24 +21,23 @@ let
     which
     dfinity-sdk.packages.rust-workspace-standalone
   ];
-
-  self = builtins.derivation {
-    name = "e2e-tests";
-    inherit system;
-    PATH = pkgs.lib.makeSearchPath "bin" inputs;
-    BATSLIB = sources.bats-support;
-    builder =
-      pkgs.writeScript "builder.sh" ''
-        #!${pkgs.stdenv.shell}
-        set -eo pipefail
-
-        # We want $HOME/.cache to be in a new temporary directory.
-        export HOME=$(mktemp -d -t dfx-e2e-home-XXXX)
-
-        # Timeout of 10 minutes is enough for now. Reminder; CI might be running with
-        # less resources than a dev's computer, so e2e might take longer.
-        timeout --preserve-status 600 bats --recursive ${e2e}/* | tee $out
-      '';
-  } // { meta = {}; };
 in
-self
+
+builtins.derivation {
+  name = "e2e-tests";
+  inherit system;
+  PATH = pkgs.lib.makeSearchPath "bin" inputs;
+  BATSLIB = sources.bats-support;
+  builder =
+    pkgs.writeScript "builder.sh" ''
+      #!${pkgs.stdenv.shell}
+      set -eo pipefail
+
+      # We want $HOME/.cache to be in a new temporary directory.
+      export HOME=$(mktemp -d -t dfx-e2e-home-XXXX)
+
+      # Timeout of 10 minutes is enough for now. Reminder; CI might be running with
+      # less resources than a dev's computer, so e2e might take longer.
+      timeout --preserve-status 600 bats --recursive ${e2e}/* | tee $out
+    '';
+} // { meta = {}; }


### PR DESCRIPTION
As title.

I dropped `__darwinAllowLocalNetworking`. It only applies in sandbox (see https://github.com/NixOS/nix/blob/f8dbde0813c4e8beed6dfd09b093589e027a6675/src/libstore/build.cc#L3445) and E2E tests fail in the sandbox, both here and on master. If it ever actually did work, I'll bisect later today to figure out if we can fix it.