### PR TITLE
nix/sources.json: upgrade common the get the latest nixpkgs 19.09

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -28,7 +28,7 @@
     "common": {
         "ref": "master",
         "repo": "ssh://git@github.com/dfinity-lab/common",
-        "rev": "ba3bf5db25b4b610db613887f6f475345583962b",
+        "rev": "e69a1c1d6e92db172272f9ae5c932988c79fd078",
         "type": "git"
     },
     "dfinity": {


### PR DESCRIPTION
See https://github.com/dfinity-lab/common/pull/130 for the changelog. Nothing major but it includes fixes for moving us to a "no cache.nixos.org" situation.

EDIT (@nmattia ): I've updated common again to ensure https://github.com/dfinity-lab/common/pull/131 is included