### PR TITLE
SDK-730 use snake_case request_status

### DIFF
--- a/e2e/basic-project.bash
+++ b/e2e/basic-project.bash
@@ -14,12 +14,12 @@ teardown() {
   dfx_stop
 }
 
-@test "build + install + call + request-status -- greet_mo" {
+@test "build + install + call + request_status -- greet_mo" {
     install_asset greet_mo
     dfx_start
     dfx build
     INSTALL_REQUEST_ID=$(dfx canister install hello --async)
-    dfx canister request-status $INSTALL_REQUEST_ID
+    dfx canister request_status $INSTALL_REQUEST_ID
 
     assert_command dfx canister call hello greet '("Banzai")'
     assert_eq '("Hello, Banzai!")'
@@ -33,14 +33,14 @@ teardown() {
     assert_command dfx canister call --query hello greet '("Bongalo")'
     assert_eq '("Hello, Bongalo!")'
 
-    # Using call --async and request-status.
+    # Using call --async and request_status.
     assert_command dfx canister call --async hello greet '("Blueberry")'
     # At this point $output is the request ID.
-    assert_command dfx canister request-status $stdout
+    assert_command dfx canister request_status $stdout
     assert_eq '("Hello, Blueberry!")'
 }
 
-@test "build + install + call + request-status -- counter_wat" {
+@test "build + install + call + request_status -- counter_wat" {
     skip "WAT not supporting IDL"
     install_asset counter_wat
 
@@ -70,18 +70,18 @@ teardown() {
 
     run dfx canister call 42 write --async
     [[ $status == 0 ]]
-    dfx canister request-status $stdout
+    dfx canister request_status $stdout
     [[ $status == 0 ]]
 
     # Write has no return value. But we can _call_ read too.
     run dfx canister call 42 read --async
     [[ $status == 0 ]]
-    run dfx canister request-status $stdout
+    run dfx canister request_status $stdout
     [[ $status == 0 ]]
     [[ "$stdout" == "D" ]]
 }
 
-@test "build + install + call + request-status -- counter_mo" {
+@test "build + install + call + request_status -- counter_mo" {
     install_asset counter_mo
     dfx_start
     dfx build
@@ -109,7 +109,7 @@ teardown() {
     assert_eq "(3)"
 
     assert_command dfx canister call hello inc --async
-    assert_command dfx canister request-status $stdout
+    assert_command dfx canister request_status $stdout
 
     # Call write.
     assert_command dfx canister call hello write '(1337)'
@@ -117,7 +117,7 @@ teardown() {
 
     # Write has no return value. But we can _call_ read too.
     assert_command dfx canister call hello read --async
-    assert_command dfx canister request-status $stdout
+    assert_command dfx canister request_status $stdout
     assert_eq "(1337)"
 }
 

--- a/src/dfx/src/commands/canister/request_status.rs
+++ b/src/dfx/src/commands/canister/request_status.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use tokio::runtime::Runtime;
 
 pub fn construct() -> App<'static, 'static> {
-    SubCommand::with_name("request-status")
+    SubCommand::with_name("request_status")
         .about(UserMessage::RequestCallStatus.to_str())
         .arg(
             Arg::with_name("request_id")

--- a/src/userlib/js/src/actor.test.ts
+++ b/src/userlib/js/src/actor.test.ts
@@ -129,7 +129,7 @@ test('makeActor', async () => {
         'Content-Type': 'application/cbor',
       },
       body: cbor.encode({
-        request_type: 'request-status',
+        request_type: 'request_status',
         request_id: expectedCallRequestId,
         nonce: nonces[1],
         sender_pubkey: senderPubKey,
@@ -145,7 +145,7 @@ test('makeActor', async () => {
       'Content-Type': 'application/cbor',
     },
     body: cbor.encode({
-      request_type: 'request-status',
+      request_type: 'request_status',
       request_id: expectedCallRequestId,
       nonce: nonces[2],
       sender_pubkey: senderPubKey,
@@ -160,7 +160,7 @@ test('makeActor', async () => {
       'Content-Type': 'application/cbor',
     },
     body: cbor.encode({
-      request_type: 'request-status',
+      request_type: 'request_status',
       request_id: expectedCallRequestId,
       nonce: nonces[3],
       sender_pubkey: senderPubKey,

--- a/src/userlib/js/src/http_agent_types.ts
+++ b/src/userlib/js/src/http_agent_types.ts
@@ -87,7 +87,7 @@ export const enum QueryResponseStatus {
 // The types of values allowed in the `request_type` field for read requests.
 export const enum ReadRequestType {
   Query = 'query',
-  RequestStatus = 'request-status',
+  RequestStatus = 'request_status',
 }
 
 // The fields in a "query" read request.
@@ -98,13 +98,13 @@ export interface QueryRequest extends Record<string, any> {
   arg: BinaryBlob;
 }
 
-// The fields in a "request-status" read request.
+// The fields in a "request_status" read request.
 export interface RequestStatusRequest extends Record<string, any> {
   request_type: ReadRequestType.RequestStatus;
   request_id: RequestId;
 }
 
-// An ADT that represents responses to a "request-status" read request.
+// An ADT that represents responses to a "request_status" read request.
 export type RequestStatusResponse =
   | RequestStatusResponsePending
   | RequestStatusResponseReplied


### PR DESCRIPTION
https://github.com/dfinity-lab/dfinity/pull/1459
Public spec changed to snake_case, and the replica update the HTTP Handler accordingly.
Therefore, if dfx updates to any version of replica after this change https://github.com/dfinity-lab/dfinity/pull/2446 things break.
