### PR TITLE
nix/sources.json: upgrade dfinity to v0.5.1 and motoko to master

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -32,15 +32,15 @@
         "type": "git"
     },
     "dfinity": {
-        "ref": "v0.5.0-alpha.0",
+        "ref": "v0.5.1",
         "repo": "ssh://git@github.com/dfinity-lab/dfinity",
-        "rev": "85aa86a2b2a5fbba63caff11e38c3d157636658c",
+        "rev": "b521d3e05332d64094f0d13ad9becb406c59b96c",
         "type": "git"
     },
     "motoko": {
         "ref": "master",
         "repo": "ssh://git@github.com/dfinity-lab/motoko",
-        "rev": "c178e042321ae45fe9c0bb3842f04abb423e043d",
+        "rev": "788395608cdf75ecdff3c904bef52f2478467d5f",
         "type": "git"
     },
     "napalm": {


### PR DESCRIPTION
These versions of `motoko` and `dfinity` can be fully built without using the
upstream Nix cache (cache.nixos.org) which means that also `sdk` can
be built without the upstream cache. This is desirable because it
allows us to disable this upstream cache which has the following
advantages:

* No dependence on the availability of cache.nixos.org. If that cache
  goes down, our cache will have everything needed to build DFINITY.

* Harder to attack: we now don't have to trust cache.nixos.org for not
  introducing vulnerabilties or letting attackers upload trojan horses
  to the cache. Since we now only need our own cache we are in full
  control of our dependencies.