### PR TITLE
ci/ci-pr.nix: accept `src` such that we can get access `src.rev`

### DIFF
--- a/ci/ci-pr.nix
+++ b/ci/ci-pr.nix
@@ -1,4 +1,4 @@
 # This file is used to govern CI jobs for GitHub PRs
 
-args@{ supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ], ... }:
-import ./ci.nix (args // { inherit supportedSystems; isMaster = false; })
+args@{ supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ], src ? null, ... }:
+import ./ci.nix (args // { inherit supportedSystems src; isMaster = false; })


### PR DESCRIPTION
Otherwise this will lead to the following Nix evaluation error:

```
hydra-eval-jobs returned exit code 1:
error: opening file
'/nix/store/3nxk3mfy2lv7hd9i4pbg1314f22rizgz-source/.git': No such
file or directory
```