### PR TITLE
ci: base rev on src.rev and give it a proper fallback

### DIFF
--- a/ci/ci.nix
+++ b/ci/ci.nix
@@ -10,7 +10,7 @@ in
 pkgs.ci ../.
   {
     inherit supportedSystems scrubJobs isMaster;
-    rev = src.rev;
+    rev = if src != null then src.rev else pkgs.lib.commitIdFromGitRepo (pkgs.lib.gitDir ../.);
     packageSetArgs = {
       inherit RustSec-advisory-db;
     };

--- a/ci/release.nix
+++ b/ci/release.nix
@@ -8,5 +8,5 @@ in
 pkgs.ci ../release.nix
   {
     inherit supportedSystems scrubJobs src;
-    rev = pkgs.lib.commitIdFromGitRepo (pkgs.lib.gitDir ../.);
+    rev = if src != null then src.rev else pkgs.lib.commitIdFromGitRepo (pkgs.lib.gitDir ../.);
   }

--- a/release.nix
+++ b/release.nix
@@ -36,7 +36,7 @@ let
 
   pkgs = import ./nix { inherit system config overlays releaseVersion; };
 
-  packages = import ./. { inherit pkgs; };
+  packages = import ./. { inherit pkgs src; };
 
 in
 pkgs.lib.optionalAttrs doRelease {


### PR DESCRIPTION
Also pass `src` to `./default.nix` in `release.nix` such that the
former has access to it. This is to avoid surprises and I plan to use
this later on.