### PR TITLE
public: rename "unreleased" back to "latest" & always include a rev

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,7 +4,7 @@
 , crossSystem ? null
 , config ? {}
 , overlays ? []
-, releaseVersion ? "unreleased"
+, releaseVersion ? "latest"
 , RustSec-advisory-db ? null
 }:
 let

--- a/public/default.nix
+++ b/public/default.nix
@@ -88,21 +88,10 @@ rec {
         # `revision` will be printed by `install.sh` as follows:
         #
         #   log "Executing DFINITY SDK install script, commit: @revision@"
-        #
-        # On release `version` will be based on the git tag and will be a
-        # version number like `0.5.0`. In that case the revision that gets
-        # embedded in `install.sh` is: `140bc06 (0.5.0)`.
-        #
-        # Note that this is the revision corresponding to the `0.5.0` tag.
-        #
-        # When not doing a release, like when building locally, on PRs or for
-        # `master`, `version` will be set to `unreleased` and `revision` will be set
-        # to a default of `omitted when not a release`. We do this so that
-        # we don't build the `install-sh-release` derivation for every commit.
         revision =
-          if src != null && version != "unreleased"
-          then "${builtins.substring 0 7 src.rev} (${version})"
-          else "omitted when not a release";
+          if src != null
+          then src.revision
+          else pkgs.lib.commitIdFromGitRepo (pkgs.lib.gitDir ../.);
 
         manifest = ./manifest.json;
         buildInputs = [ pkgs.jo install-sh-lint install-sh ];

--- a/release.nix
+++ b/release.nix
@@ -32,7 +32,7 @@ let
   # versionMatch is `null` if `src.gitTag` is not of the right format like "1.23.456"
   # and it's a list of matches like [ "1.23.456" ] when it is.
   versionMatches = builtins.match "([0-9]+\.[0-9]+\.[0-9]+)" src.gitTag;
-  releaseVersion = if versionMatches == null then "unreleased" else builtins.head versionMatches;
+  releaseVersion = if versionMatches == null then "latest" else builtins.head versionMatches;
 
   pkgs = import ./nix { inherit system config overlays releaseVersion; };
 


### PR DESCRIPTION
To quote: https://dfinity.slack.com/archives/CL7Q2RXUM/p1582295540092400

It seems that we serve the latest installer script from the `sdk`
`master` branch. Shouldn't we serve the latest *released* installer?

This is how I understand things are working now:

* https://sdk-ext.dfinity.systems/install.sh redirects to: https://sdk-ext.dfinity.systems/downloads/public/latest/installer
* https://sdk-ext.dfinity.systems/downloads/public/ proxies to the blobules S3 bucket at the path `sdk/public`
* So https://sdk-ext.dfinity.systems/downloads/public/latest/installer fetches https://blobules.dfinity.systems/sdk/public/latest/installer

The problematic bit is that `latest` got renamed to `unreleased` so
we're now serving a slightly out of date installer.

This commit renamed `unreleased` back to `latest`. However, we should
discuss why were not serving the latest *released* installer.

This commit also now always includes the `revision` in the install
script regardless of whether we're doing a release or not.
