### PR TITLE
nix: specify a sha256 for fetching sources.nix

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,8 +25,10 @@ let
 
   sources = import sourcesnix { sourcesFile = ./sources.json; inherit pkgs; };
 
-  sourcesnix = builtins.fetchurl
-    https://raw.githubusercontent.com/nmattia/niv/506b896788d9705899592a303de95d8819504c55/nix/sources.nix;
+  sourcesnix = builtins.fetchurl {
+    url = https://raw.githubusercontent.com/nmattia/niv/506b896788d9705899592a303de95d8819504c55/nix/sources.nix;
+    sha256 = "007bgq4zy1mjnnkbmaaxvvn4kgpla9wkm0d3lfrz3y1pa3wp9ha1";
+  };
 
   pkgs = import commonSrc {
     inherit system crossSystem config;


### PR DESCRIPTION
Without the hash Nix will check the URL each time you evaluate. This
makes it impossible to work offline unless you know about
`--option tarball-ttl 1000000`.

See: https://dfinity.slack.com/archives/CL7Q2RXUM/p1582367096114000