### PR TITLE
INF-1015: Fix unused_unit for rustc 1.41

### DIFF
--- a/src/dfx/assets/build.rs
+++ b/src/dfx/assets/build.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-fn add_assets(fn_name: &str, f: &mut File, path: &str) -> () {
+fn add_assets(fn_name: &str, f: &mut File, path: &str) {
     let out_dir = env::var("OUT_DIR").unwrap();
     let tgz_path = Path::new(&out_dir).join(format!("{}.tgz", fn_name));
     let tar_gz = File::create(&tgz_path).unwrap();


### PR DESCRIPTION
Otherwise clippy complains:

```
[2020-02-25 13:43:28] error: unneeded unit return type
[2020-02-25 13:43:28]  --> src/dfx/assets/build.rs:8:56
[2020-02-25 13:43:28]   |
[2020-02-25 13:43:28] 8 | fn add_assets(fn_name: &str, f: &mut File, path: &str) -> () {
[2020-02-25 13:43:28]   |                                                        ^^^^^ help: remove the `-> ()`
[2020-02-25 13:43:28]   |
[2020-02-25 13:43:28]   = note: `-D clippy::unused-unit` implied by `-D clippy::all`
[2020-02-25 13:43:28]   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_unit
```