### PR TITLE
Revert "INF-1015: Update to rust 1.41 (#413)"

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -28,7 +28,7 @@
     "common": {
         "ref": "master",
         "repo": "ssh://git@github.com/dfinity-lab/common",
-        "rev": "5917427ed5233ef768f1d9991c28db6210510514",
+        "rev": "53663c4957c0db10ce9bf8401ed768ad0cb8faa9",
         "type": "git"
     },
     "dfinity": {


### PR DESCRIPTION
This reverts commit e8ab85c29aa69b82fefd2ca21017cf54d7a6ed47.

The version 1.41 of rustc is not fully working in the
`dfinity-lab/dfinity` repo.