### PR TITLE
nix/sources.json: upgrade common to upgrade rust: 1.41.0 -> 1.41.1

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -26,9 +26,10 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "common": {
-        "ref": "master",
+        "branch": "basvandijk/rust-1.41.1",
+        "ref": "basvandijk/rust-1.41.1",
         "repo": "ssh://git@github.com/dfinity-lab/common",
-        "rev": "b7a8085fd17a5a970be267245634099339186f7a",
+        "rev": "fee34af0457e582e0cd2dbea7d69bb8623def448",
         "type": "git"
     },
     "dfinity": {


### PR DESCRIPTION
See: https://blog.rust-lang.org/2020/02/27/Rust-1.41.1.html