### PR TITLE
build: Update niv-updater-action to v5

### DIFF
--- a/.github/workflows/niv-updater.yml
+++ b/.github/workflows/niv-updater.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        uses: knl/niv-updater-action@v4
+        uses: knl/niv-updater-action@v5
         with:
           whitelist: 'common,advisory-db,napalm'
           labels: |


### PR DESCRIPTION
This brings back nice changelogs, as update commits now have a proper
subject.