### PR TITLE
refactor: Address minor comments on identity_interface

### DIFF
--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -2,7 +2,7 @@ use crate::config::cache::{Cache, DiskBasedCache};
 use crate::config::dfinity::Config;
 use crate::config::dfx_version;
 use crate::lib::error::DfxResult;
-use crate::lib::identity_interface::Identity;
+use crate::lib::identity::Identity;
 use crate::lib::progress_bar::ProgressBar;
 
 use ic_http_agent::{Agent, AgentConfig};

--- a/src/dfx/src/lib/identity.rs
+++ b/src/dfx/src/lib/identity.rs
@@ -13,8 +13,7 @@ impl Identity {
     /// configuration.
     pub fn new(identity_config_path: PathBuf) -> Self {
         Self(
-            // We panic as discussed, as that should not be the
-            // case. I personally prefer this to be an error.
+            // We expect an identity profile to be provided.
             ic_identity_manager::Identity::new(identity_config_path)
                 .expect("Expected a valid identity configuration"),
         )

--- a/src/dfx/src/lib/mod.rs
+++ b/src/dfx/src/lib/mod.rs
@@ -1,7 +1,7 @@
 pub mod canister_info;
 pub mod environment;
 pub mod error;
-pub mod identity_interface;
+pub mod identity;
 pub mod logger;
 pub mod message;
 pub mod progress_bar;


### PR DESCRIPTION
Renames identity_interface to identity; Fixes comment about profile panic.