### PR TITLE
refactor: move mk-jobset to an overlay

### DIFF
--- a/ci/ci.nix
+++ b/ci/ci.nix
@@ -1,9 +1,6 @@
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 , system ? builtins.currentSystem
-, src ? {
-    rev = pkgs.lib.commitIdFromGitRepo (pkgs.lib.gitDir ../.);
-    revCount = 0; # TODO: would be nice to get the `revCount` using Nix as well.
-  }
+, src ? builtins.fetchGit ../.
 , RustSec-advisory-db ? null
 
   # The version of the release. Will be set to the right value in ./release.nix.
@@ -12,12 +9,10 @@
   # TODO: Remove isMaster once switched to new CD system (https://dfinity.atlassian.net/browse/INF-1149)
 , isMaster ? true
 
-, pkgsPath ? ../nix
-, pkgs ? import pkgsPath pkgsArgs
-, pkgsArgs ? { inherit RustSec-advisory-db releaseVersion isMaster; }
+, pkgs ? import ../nix { inherit system releaseVersion isMaster RustSec-advisory-db; }
 }:
-import ./mk-jobset.nix {
-  inherit supportedSystems system pkgsPath pkgs pkgsArgs;
+pkgs.lib.mk-jobset {
+  inherit supportedSystems;
   inherit (src) rev;
   jobsetSpecificationPath = ../.;
   jobsArgs = { inherit RustSec-advisory-db releaseVersion isMaster src; };

--- a/nix/mk-jobset.nix
+++ b/nix/mk-jobset.nix
@@ -1,3 +1,4 @@
+pkgs:
 # This function returns a Hydra jobset like for example:
 #
 #   {
@@ -39,22 +40,8 @@
   # This should only be overridden in debugging scenarios.
 , system ? pkgs.system
 
-  # The nixpkgs set used to implement this function.
-, pkgs
-
   # The git revision used in the `all-jobs` job.
 , rev
-
-  # Path to the Nix expression defining the nixpkgs set.
-  #
-  # It's recommended to standardize this to `../nix`.
-  #
-  # Note that nixpkgs will be called with the following arguments:
-  #
-  #   pkgsArgs // { inherit system; }
-  #
-  # for every supported `system`.
-, pkgsPath
 
   # Path to the jobset specification.
   #
@@ -65,7 +52,7 @@
   #
   #   jobsArgs // {
   #     inherit system;
-  #     pkgs = pkgsForSystem."${system}";
+  #     pkgs = pkgs.pkgsForSystem."${system}";
   #
   #     # We pass the final jobset such that jobs (like `publish.*` in the `sdk`
   #     # repo) can select pre-evaluated jobs (like `dfx-release.x86_64-linux`)
@@ -76,27 +63,11 @@
   # for every supported `system`.
 , jobsetSpecificationPath
 
-  # Extra arguments to the `pkgsPath` function.
-, pkgsArgs ? {}
-
   # Extra arguments to the `jobsetSpecificationPath` function.
 , jobsArgs ? {}
 }:
 let
-  # This functions creates a nixpkgs set for the given system.
-  pkgsFor = system: import pkgsPath (pkgsArgs // { inherit system; });
-
   lib = pkgs.lib;
-
-  # An attribute set mapping every supported system to a nixpkgs evaluated for
-  # that system. Special care is taken not to reevaluate nixpkgs for the current
-  # system because we already did that in pkgs.
-  pkgsForSystem = lib.genAttrs supportedSystems (
-    supportedSystem:
-      if supportedSystem == system
-      then pkgs
-      else pkgsFor supportedSystem
-  );
 
   # An attribute set mapping every supported system to an attribute set of jobs
   # (as defined by `jobsetSpecificationPath`) evaluated for that system.
@@ -104,7 +75,7 @@ let
     system: import jobsetSpecificationPath (
       jobsArgs // {
         inherit system;
-        pkgs = pkgsForSystem."${system}";
+        pkgs = pkgs.pkgsForSystem."${system}";
 
         # We pass the final jobset such that jobs (like `publish.*` in the `sdk`
         # repo) can select pre-evaluated jobs (like `dfx-release.x86_64-linux`)


### PR DESCRIPTION
This gets rid of the `pkgs` arguments.