### PR TITLE
build: set the correct content-type for manifest.json

### DIFF
--- a/publish.nix
+++ b/publish.nix
@@ -79,7 +79,7 @@ in
       # See: https://dfinity.atlassian.net/browse/INF-1145
 
       pkg="${install-sh-release.x86_64-linux}"
-      s3cp "$pkg" "manifest.json" "sdk" "application/x-sh" "$do_not_cache"
+      s3cp "$pkg" "manifest.json" "sdk" "application/json" "$do_not_cache"
       s3cp "$pkg" "install.sh" "sdk" "application/x-sh" "$do_not_cache"
     ''
   );


### PR DESCRIPTION
This sets the Content-Type header for the `manifest.json` file in the
`dfinity-download` S3 bucket to the correct value of `application/json`.