### PR TITLE
chore: Upgrade replica to v0.5.5

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -32,9 +32,9 @@
         "type": "git"
     },
     "dfinity": {
-        "ref": "v0.5.4",
+        "ref": "v0.5.5",
         "repo": "ssh://git@github.com/dfinity-lab/dfinity",
-        "rev": "a77551d2c630c2f30d18860bfb556ce46a0e8b08",
+        "rev": "da6e3dfb867f23c62e86adbee1d548fbb5a0ad64",
         "type": "git"
     },
     "motoko": {


### PR DESCRIPTION
@chenyan-dfinity reported CPU usage of replica would increase dramatically if running for longer than a couple hours for v0.5.4. This is likely related to a performance degradation problem that was already fixed in a later version. So we just cut a v0.5.5 release, and this PR is to see if everything works out for sdk.