### PR TITLE
refactor: remove blobules publishing code

### DIFF
--- a/nix/mk-release.nix
+++ b/nix/mk-release.nix
@@ -22,25 +22,5 @@ stdenv.mkDerivation {
     chmod 0755 $collection/${what}
 
     tar -cvzf "$out/$the_release" -C $collection/ .
-
-    # Creating the manifest
-    manifest_file=$out/manifest.json
-
-    sha256hash=($(sha256sum "$out/$the_release")) # using this to autosplit on space
-    sha1hash=($(sha1sum "$out/$the_release")) # using this to autosplit on space
-
-    jo -pa \
-      $(jo package="${rname}" \
-          version="$version" \
-          system="${stdenv.system}" \
-          name="${stdenv.system}/$the_release" \
-          file="$out/$the_release" \
-          sha256hash="$sha256hash" \
-          sha1hash="$sha1hash") >$manifest_file
-
-    # Marking the manifest for publishing
-    mkdir -p $out/nix-support
-    echo "upload manifest $manifest_file" >> \
-      $out/nix-support/hydra-build-products
   '';
 }

--- a/public/default.nix
+++ b/public/default.nix
@@ -107,37 +107,6 @@ rec {
         # we stamp the file with the revision
         substitute "${install-sh}/install.sh" $out/install.sh \
           --subst-var revision
-
-        # Creating the manifest
-        # We name it "_manifest.json" as opposed to "manifest.json" because we
-        # also export a "manifest.json" (which has nothing to do with the
-        # release)
-        hydra_manifest_file=$out/_manifest.json
-
-        sha256hashinstall=($(sha256sum "$out/install.sh")) # using this to autosplit on space
-        sha1hashinstall=($(sha1sum "$out/install.sh")) # using this to autosplit on space
-
-        sha256manifest=($(sha256sum "$version_manifest_file")) # using this to autosplit on space
-        sha1manifest=($(sha1sum "$version_manifest_file")) # using this to autosplit on space
-
-        jo -pa \
-          $(jo package="public" \
-              version="$version" \
-              name="installer" \
-              file="$out/install.sh" \
-              sha256hash="$sha256hashinstall" \
-              sha1hash="$sha1hashinstall") \
-          $(jo package="public" \
-              version="$version" \
-              name="manifest.json" \
-              file="$version_manifest_file" \
-              sha256hash="$sha256manifest" \
-              sha1hash="$sha1manifest") >$hydra_manifest_file
-
-        # Marking the manifest for publishing
-        mkdir -p $out/nix-support
-        echo "upload manifest $hydra_manifest_file" >> \
-          $out/nix-support/hydra-build-products
       ''
     );
 }


### PR DESCRIPTION
Since we now publish the SDK to the https://download.dfinity.systems
CDN we don't need to publish to blobules anymore. So this commit
removes the code related to blobules publishing.