### PR TITLE
chore: Bump ic-ref to track legacy3 branch

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -38,10 +38,10 @@
         "type": "git"
     },
     "ic-ref": {
-        "branch": "legacy2",
-        "ref": "legacy2",
+        "branch": "legacy3",
+        "ref": "legacy3",
         "repo": "ssh://git@github.com/dfinity-lab/ic-ref",
-        "rev": "6d8a3f28bdc6969754b354e56fb9caf280d6f887",
+        "rev": "6331356b20183bb9eda5589959ee18bf66becc06",
         "type": "git"
     },
     "motoko": {


### PR DESCRIPTION
in #471 we added running the e2e tests aginst the `legacy2` branch of
`ic-ref`, which was tailured to SDK’s behaviour at that time. That PR
was green.

But it was merged without updating the branch, and in the meantime SKD’s
`master` updated `replica` to 0.5.4, and also changed `dfx` accordingly.
At that version, `dfx` could no longer talk to `ic-ref`, and the test
made `master` red.

So I creaed a new branch `legacy3`, off `release-0.2` in `ic-ref`,
making the necessary adjustments to be compatible with `dfx` again.
These were:

 * Do not require CBOR tag
 * Make `sender` field optional
 * Do not check signatures
 * Do not require canister registration before installation