### PR TITLE
build: INF-1227: also require evaluation success for auto merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
+      - status-success=hydra:dfinity-ci-build:evaluation
       - status-success=hydra:dfinity-ci-build:sdk:all-jobs
       - base=master
       - label=automerge-squash


### PR DESCRIPTION
It seems that when evaluation fails, github/mergify still waits for
`hydra:dfinity-ci-build:sdk:all-jobs`. This commit configures mergify
to also require that `hydra:dfinity-ci-build:evaluation` succeeds, so
that it doesn’t get stuck on this.