### PR TITLE
revert: "build: INF-1236: use updated buildDfinityRustPackage (#607)"

### DIFF
--- a/dfx.nix
+++ b/dfx.nix
@@ -28,11 +28,7 @@ let
       ''cargo $cargo_options test $cargo_test_options --workspace --exclude ic-agent''
       ''RUST_TEST_THREADS=1 cargo $cargo_options test $cargo_test_options -p ic-agent''
     ];
-    override = oldAttrs: {
-      # ps is needed in the wabt build. otherwise it passes a bad command line to clang,
-      # causing a linker error
-      extraBuildInputs = lib.optional pkgs.stdenv.isDarwin pkgs.ps;
-    };
+    static = pkgs.stdenv.isLinux;
   };
 
   # add extra executables used when linting

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -28,7 +28,7 @@
     "common": {
         "ref": "master",
         "repo": "ssh://git@github.com/dfinity-lab/common",
-        "rev": "fd65c40a6816c9a3493c48f41fcac8502704b0d1",
+        "rev": "fa5190ac6a299744e1174a576fa540b7fd856bff",
         "type": "git"
     },
     "dfinity": {


### PR DESCRIPTION
This reverts commit c2b7e24bf44cba04ecc4bd7924150331810e628c from PR #607.

The PR breaks local compilation in Darwin.