### PR TITLE
chore: update replica to 0.5.7

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -32,9 +32,9 @@
         "type": "git"
     },
     "dfinity": {
-        "ref": "v0.5.6",
+        "ref": "v0.5.7",
         "repo": "ssh://git@github.com/dfinity-lab/dfinity",
-        "rev": "c2445f9aa8cf16dd29aabf2c47c2a5f3c870ee76",
+        "rev": "eb653572373754564ac815cd0785c5f7b9674d6d",
         "type": "git"
     },
     "ic-ref": {


### PR DESCRIPTION
This fixes an issue with principal being changed during a consensus round,
which was cherry picked on top of 0.5.6.