### PR TITLE
build: prevent the nix-shell from breaking once common is upgraded

### DIFF
--- a/dfx.nix
+++ b/dfx.nix
@@ -100,7 +100,7 @@ let
       shell =
         pkgs.mkCompositeShell {
           name = "dfinity-sdk-rust-env";
-          buildInputs = [ pkgs.rls ];
+          nativeBuildInputs = [ pkgs.rls ];
           inputsFrom = [ ws.shell ];
           shellHook = ''
             # Set CARGO_HOME to minimize interaction with any environment outside nix


### PR DESCRIPTION
## Commit Message
build: prevent the nix-shell from breaking once common is upgraded

To prevent the same error from [OPS-72](https://dfinity.atlassian.net/browse/OPS-72) to happen in the SDK's `nix-shell` we apply the same fix as in https://github.com/dfinity-lab/dfinity/pull/3467 which makes sure that `rls` remains in the `PATH` after which we upgrade `common` to include https://github.com/dfinity-lab/common/pull/177.