### PR TITLE
fix: add bignumber.js to package.json

### DIFF
--- a/src/dfx/assets/new_project_node_files/package.json
+++ b/src/dfx/assets/new_project_node_files/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@dfinity/agent": "{js_agent_version}",
+    "bignumber.js": "^9.0.0",
     "terser-webpack-plugin": "2.2.2",
     "webpack": "4.41.3",
     "webpack-cli": "3.3.10"


### PR DESCRIPTION
Candid decodes `Int/Nat` to `bignumber.js`. So we need to include this in `package.json`.