### PR TITLE
build: Set the build environment for cargo build (OPS-91)

### DIFF
--- a/dfx.nix
+++ b/dfx.nix
@@ -28,7 +28,11 @@ let
       ''cargo $cargo_options test $cargo_test_options --workspace --exclude ic-agent''
       ''RUST_TEST_THREADS=1 cargo $cargo_options test $cargo_test_options -p ic-agent''
     ];
-    static = pkgs.stdenv.isLinux;
+    override = oldAttrs: {
+      # both needed for bindgen, used by rocksdb-sys, zstd-sys, lmdb-sys, etc
+      LIBCLANG_PATH = "${pkgs.llvmPackages.libclang}/lib";
+      CLANG_PATH = "${pkgs.llvmPackages.clang}/bin/clang";
+    };
   };
 
   # add extra executables used when linting
@@ -94,13 +98,24 @@ let
         };
     };
 
+  # Note that on Linux we need the static environment.
+  cc = if pkgs.stdenv.isLinux
+  then pkgs.pkgsStatic.stdenv.cc
+  else pkgs.stdenv.cc;
+
   # fixup the shell for more convenient developer use
   fixShell = ws:
     ws // {
       shell =
         pkgs.mkCompositeShell {
           name = "dfinity-sdk-rust-env";
-          nativeBuildInputs = [ pkgs.rls ];
+          nativeBuildInputs = [
+            pkgs.rls
+            # wabt-sys needs file in path, as well as cc (for cmake).
+            pkgs.file
+            cc
+            pkgs.coreutils
+          ] ++ lib.optional pkgs.stdenv.isDarwin pkgs.stdenv.cc.bintools;
           inputsFrom = [ ws.shell ];
           shellHook = ''
             # Set CARGO_HOME to minimize interaction with any environment outside nix

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -28,7 +28,7 @@
     "common": {
         "ref": "master",
         "repo": "ssh://git@github.com/dfinity-lab/common",
-        "rev": "fa5190ac6a299744e1174a576fa540b7fd856bff",
+        "rev": "027bda4a40176ef3eb676610d8673affe6cde81c",
         "type": "git"
     },
     "dfinity": {


### PR DESCRIPTION
Prior to this change, `cargo build` would fail on master, trying to build
`wabt-sys`:

    error: failed to run custom build command for `wabt-sys v0.7.0`

    Caused by:
      process didn't exit successfully: `/Users/knl/work/github.com/dfinity-lab/sdk/target/debug/build/wabt-sys-ef25f33c54a27675/build-script-build` (exit code: 101)
    --- stdout
    running: "/nix/store/v2q4mzbi55wlicfp85j468rlxdibslpf-cmake-3.16.3/bin/cmake" "/Users/knl/work/github.com/dfinity-lab/sdk/.cargo-home/registry/src/github.com-1ecc6299db9ec823/wabt-sys-0.7.0/wabt" "-DBUILD_TESTS=OFF" "-DBUILD_TOOLS=OFF" "-DCMAKE_INSTALL_PREFIX=/Users/knl/work/github.com/dfinity-lab/sdk/target/debug/build/wabt-sys-ff367b98d9a92cb3/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_BUILD_TYPE=Debug"
    -- The C compiler identification is AppleClang 10.0.1.10010046
    -- The CXX compiler identification is AppleClang 10.0.1.10010046
    -- Check for working C compiler: /usr/bin/cc
    -- Check for working C compiler: /usr/bin/cc -- broken
    -- Configuring incomplete, errors occurred!
    See also "/Users/knl/work/github.com/dfinity-lab/sdk/target/debug/build/wabt-sys-ff367b98d9a92cb3/out/build/CMakeFiles/CMakeOutput.log".
    See also "/Users/knl/work/github.com/dfinity-lab/sdk/target/debug/build/wabt-sys-ff367b98d9a92cb3/out/build/CMakeFiles/CMakeError.log".

    --- stderr
    CMake Error at /nix/store/v2q4mzbi55wlicfp85j468rlxdibslpf-cmake-3.16.3/share/cmake-3.16/Modules/CMakeTestCCompiler.cmake:60 (message):
      The C compiler

        "/usr/bin/cc"

      is not able to compile a simple test program.

      It fails with the following output:

        Change Dir: /Users/knl/work/github.com/dfinity-lab/sdk/target/debug/build/wabt-sys-ff367b98d9a92cb3/out/build/CMakeFiles/CMakeTmp

        Run Build Command(s):/nix/store/i05xxyfzvjaymf39gr5fvyjvxi882yay-gnumake-4.2.1/bin/make cmTC_d24c7/fast && /nix/store/i05xxyfzvjaymf39gr5fvyjvxi882yay-gnumake-4.2.1/bin/make -f CMakeFiles/cmTC_d24c7.dir/build.make CMakeFiles/cmTC_d24c7.dir/build
        make[1]: Entering directory '/Users/knl/work/github.com/dfinity-lab/sdk/target/debug/build/wabt-sys-ff367b98d9a92cb3/out/build/CMakeFiles/CMakeTmp'
        Building C object CMakeFiles/cmTC_d24c7.dir/testCCompiler.c.o
        /usr/bin/cc   -ffunction-sections -fdata-sections -fPIC -m64  -isysroot /nix/store/cr2q0jfdwbys1yz9cpxvq45a9f8yfw7s-xcodebuild-0.1.2-pre/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -mmacosx-version-min=10.12   -o CMakeFiles/cmTC_d24c7.dir/testCCompiler.c.o   -c /Users/knl/work/github.com/dfinity-lab/sdk/target/debug/build/wabt-sys-ff367b98d9a92cb3/out/build/CMakeFiles/CMakeTmp/testCCompiler.c
        Linking C executable cmTC_d24c7
        /nix/store/v2q4mzbi55wlicfp85j468rlxdibslpf-cmake-3.16.3/bin/cmake -E cmake_link_script CMakeFiles/cmTC_d24c7.dir/link.txt --verbose=1
        /usr/bin/cc  -ffunction-sections -fdata-sections -fPIC -m64  -isysroot /nix/store/cr2q0jfdwbys1yz9cpxvq45a9f8yfw7s-xcodebuild-0.1.2-pre/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -mmacosx-version-min=10.12 -Wl,-search_paths_first -Wl,-headerpad_max_install_names   CMakeFiles/cmTC_d24c7.dir/testCCompiler.c.o  -o cmTC_d24c7
        ld: library not found for -lSystem
        clang: error: linker command failed with exit code 1 (use -v to see invocation)
        make[1]: *** [CMakeFiles/cmTC_d24c7.dir/build.make:87: cmTC_d24c7] Error 1
        make[1]: Leaving directory '/Users/knl/work/github.com/dfinity-lab/sdk/target/debug/build/wabt-sys-ff367b98d9a92cb3/out/build/CMakeFiles/CMakeTmp'
        make: *** [Makefile:121: cmTC_d24c7/fast] Error 2

The telling part is `/usr/bin/cc` as the compiler (it should always be something
under the nix store).

This change adds all the necessary setting for the CMake invoked by wabt-sys's
`build.rs` file.

It also updates the common to be on par with the dfinity repo.