### PR TITLE
build: upgrade common to upgrade nixpkgs and rust from 1.41.1 to 1.43

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -28,7 +28,7 @@
     "common": {
         "ref": "master",
         "repo": "ssh://git@github.com/dfinity-lab/common",
-        "rev": "05c44eddb864464c06c27295460eabcf923bc2e9",
+        "rev": "abdf4a17760e481fcc95ae62b20a38672fb9c4b5",
         "type": "git"
     },
     "dfinity": {

--- a/src/agent/rust/src/types/canister_id.rs
+++ b/src/agent/rust/src/types/canister_id.rs
@@ -1,6 +1,5 @@
 use crate::types::blob::Blob;
 use crc8::Crc8;
-use hex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, str};
 

--- a/src/dfx/src/commands/language_service.rs
+++ b/src/dfx/src/commands/language_service.rs
@@ -3,7 +3,6 @@ use crate::lib::environment::Environment;
 use crate::lib::error::{DfxError, DfxResult};
 use crate::lib::message::UserMessage;
 use crate::lib::package_arguments::{self, PackageArguments};
-use atty;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use std::process::Stdio;
 

--- a/src/dfx/src/lib/logger.rs
+++ b/src/dfx/src/lib/logger.rs
@@ -1,7 +1,5 @@
 use crate::config::dfx_version_str;
 use slog::{Drain, Level, Logger};
-use slog_async;
-use slog_term;
 use std::fs::File;
 use std::path::PathBuf;
 

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -5,7 +5,6 @@ use crate::lib::error::*;
 use crate::lib::logger::{create_root_logger, LoggingMode};
 use clap::{App, AppSettings, Arg, ArgMatches};
 use ic_agent::AgentError;
-use slog;
 use std::path::PathBuf;
 
 mod actors;


### PR DESCRIPTION
`dfinity` has also been [updated](https://github.com/dfinity-lab/dfinity/pull/3760) with this.

nixpkgs changelog: 
* https://github.com/dfinity-lab/common/pull/194
* https://github.com/dfinity-lab/common/pull/200

rust-1.43 changelog:
* https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1430-2020-04-23