### PR TITLE
Integrate ic-starter

### DIFF
--- a/dfx.nix
+++ b/dfx.nix
@@ -68,6 +68,7 @@ let
                 DFX_ASSETS = pkgs.runCommandNoCC "dfx-assets" {} ''
                   mkdir -p $out
                   cp ${pkgs.dfinity.ic-replica}/bin/replica $out
+                  cp ${pkgs.dfinity.ic-starter}/bin/ic-starter $out
                   cp ${pkgs.motoko.moc-bin}/bin/moc $out
                   cp ${pkgs.motoko.mo-ide}/bin/mo-ide $out
                   cp ${pkgs.motoko.didc}/bin/didc $out

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -32,9 +32,9 @@
         "type": "git"
     },
     "dfinity": {
-        "ref": "v0.5.7",
+        "ref": "master",
         "repo": "ssh://git@github.com/dfinity-lab/dfinity",
-        "rev": "eb653572373754564ac815cd0785c5f7b9674d6d",
+        "rev": "b479d14729c86279a647fc984b34863d5c40002e",
         "type": "git"
     },
     "ic-ref": {

--- a/src/dfx/src/commands/replica.rs
+++ b/src/dfx/src/commands/replica.rs
@@ -112,11 +112,13 @@ fn get_round_gas_limit(config: &ConfigDefaultsReplica, args: &ArgMatches<'_>) ->
 /// replica at the moment) and the proxy.
 pub fn exec(env: &dyn Environment, args: &ArgMatches<'_>) -> DfxResult {
     let replica_pathbuf = env.get_cache().get_binary_command_path("replica")?;
+    let ic_starter_pathbuf = env.get_cache().get_binary_command_path("ic-starter")?;
 
     let system = actix::System::new("dfx-replica");
     let config = get_config(env, args)?;
 
     actors::replica::Replica::new(actors::replica::Config {
+        ic_starter_path: ic_starter_pathbuf,
         replica_config: config,
         replica_path: replica_pathbuf,
         logger: Some(env.get_logger().clone()),

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -72,6 +72,8 @@ pub fn exec(env: &dyn Environment, args: &ArgMatches<'_>) -> DfxResult {
     let (frontend_url, address_and_port) = frontend_address(args, &config)?;
 
     let client_pathbuf = env.get_cache().get_binary_command_path("replica")?;
+    let ic_starter_pathbuf = env.get_cache().get_binary_command_path("ic-starter")?;
+
     let temp_dir = env.get_temp_dir();
     let state_root = env.get_state_dir();
 
@@ -88,6 +90,8 @@ pub fn exec(env: &dyn Environment, args: &ArgMatches<'_>) -> DfxResult {
 
     let client_configuration_dir = temp_dir.join("client-configuration");
     fs::create_dir_all(&client_configuration_dir)?;
+    let state_dir = temp_dir.join("state/replicated_state");
+    fs::create_dir_all(&state_dir)?;
     let client_port_path = client_configuration_dir.join("client-1.port");
 
     // Touch the client port file. This ensures it is empty prior to
@@ -121,8 +125,7 @@ pub fn exec(env: &dyn Environment, args: &ArgMatches<'_>) -> DfxResult {
     let rcv_wait_fwatcher = rcv_wait.clone();
     b.set_message("Generating IC local replica configuration.");
     let replica_config = ReplicaConfig::new(state_root)
-        .with_random_port(&client_port_path)
-        .to_toml()?;
+        .with_random_port(&client_port_path);
 
     // TODO(eftychis): we need a proper manager type when we start
     // spawning multiple client processes and registry.
@@ -133,6 +136,7 @@ pub fn exec(env: &dyn Environment, args: &ArgMatches<'_>) -> DfxResult {
         move || {
             start_client(
                 &client_pathbuf,
+                &ic_starter_pathbuf,
                 &pid_file_path,
                 is_killed_client,
                 request_stop,
@@ -311,17 +315,22 @@ fn check_previous_process_running(dfx_pid_path: &PathBuf) -> DfxResult<()> {
 /// We panic here to transmit an error to the parent thread.
 fn start_client(
     client_pathbuf: &PathBuf,
+    ic_starter_pathbuf: &PathBuf,
     pid_file_path: &PathBuf,
     is_killed_client: Receiver<()>,
     request_stop: Sender<()>,
-    config: String,
+    config: ReplicaConfig,
     b: ProgressBar,
 ) -> DfxResult<()> {
     b.set_message("Generating IC local replica configuration.");
-    let client = client_pathbuf.as_path().as_os_str();
 
-    let mut cmd = std::process::Command::new(client);
-    cmd.args(&["--config", config.as_str()]);
+    let ic_starter = ic_starter_pathbuf.as_path().as_os_str();
+    let mut cmd = std::process::Command::new(ic_starter);
+    // if None is returned, then an empty String will be provided to replica-path
+    // TODO: figure out the right solution
+    cmd.args(&["--replica-path", client_pathbuf.to_str().unwrap_or_default(),
+               "--http-port-file", config.http_handler.write_port_to.unwrap_or_default().to_str().unwrap_or_default(),
+               "--state-dir", config.state_manager.state_root.to_str().unwrap_or_default()]);
     cmd.stdout(std::process::Stdio::inherit());
     cmd.stderr(std::process::Stdio::inherit());
 
@@ -332,7 +341,7 @@ fn start_client(
             .try_send(())
             .expect("Replica thread couldn't signal parent to stop");
         // We still want to send an error message.
-        panic!("Couldn't spawn node manager with command {:?}: {}", cmd, e);
+        panic!("Couldn't spawn ic-starter with command {:?}: {}", cmd, e);
     });
 
     // Update the pid file.

--- a/src/dfx/src/lib/error/mod.rs
+++ b/src/dfx/src/lib/error/mod.rs
@@ -73,9 +73,6 @@ pub enum DfxError {
     /// Generic IDL error.
     CouldNotSerializeIdlFile(candid::Error),
 
-    /// Client TOML Serialization error.
-    CouldNotSerializeClientConfiguration(toml::ser::Error),
-
     /// An error during parsing of a version string.
     VersionCouldNotBeParsed(semver::SemVerError),
 

--- a/src/dfx/src/lib/replica_config.rs
+++ b/src/dfx/src/lib/replica_config.rs
@@ -87,13 +87,10 @@ impl ReplicaConfig {
         self
     }
 
-    pub fn with_random_port(&mut self, write_port_to: &Path) -> &mut Self {
+    pub fn with_random_port(&mut self, write_port_to: &Path) -> Self {
         self.http_handler.port = None;
         self.http_handler.write_port_to = Some(write_port_to.to_path_buf());
-        self
-    }
-
-    pub fn to_toml(&self) -> DfxResult<String> {
-        toml::to_string(&self).map_err(DfxError::CouldNotSerializeClientConfiguration)
+        let config = &*self;
+        config.clone()
     }
 }


### PR DESCRIPTION
Couple of issues found during integration of replica (also seen on latest commit from replica master `f5b30d959d07143faa6daf3f618d6bc0fa62ba1e`)

- [ ] canister can't be installed
`dfx canister install hello_world`
`Installing code for canister hello_world, with canister_id ic:0B81804858D54035B6`
`Replica error (code 3): IC0301: Canister ic:0B81804858D54035B6 not found.`

- [ ] ThresholdSigDataNotFound error after starting, stopping, then starting replica (dfx start, ^C, dfx start)
`Jun 01 00:29:07.958 ERRO Couldn't create a signature: ThresholdSigDataNotFound { dkg_id: DkgId { instance_id: 1, subnet_id: 0 } }, Application: Consensus, Subcomponent: RandomBeaconMaker`
