### PR TITLE
docs: Adding a pointer to what should be added as a comment

### DIFF
--- a/src/dfx/assets/new_project_node_files/webpack.config.js
+++ b/src/dfx/assets/new_project_node_files/webpack.config.js
@@ -45,8 +45,9 @@ function generateWebpackConfigForCanister(name, info) {
 
 // Depending in the language or framework you are using for
 // front-end development, add module loaders to the default 
-// webpack configuration. For example, if following the
-// "Adding a stylesheet" tutorial, uncomment the following lines:
+// webpack configuration. For example, if you are using React
+// modules and CSS as described in the "Adding a stylesheet"
+// tutorial, uncomment the following lines:
 // module: {
 //  rules: [
 //    { test: /\.(js|ts)x?$/, loader: "ts-loader" },


### PR DESCRIPTION
Per Diego's feedback from the hackthaon, adding a comment to the webpack cobfig file about where the module loaders should be added
Also, added a little more text to the last comment (although it wasn't clear if "here" meant the section above or the export section below, so I took a guess)