### PR TITLE
fix: add CBOR self-describe tag 55799 to replica messages

### DIFF
--- a/src/agent/rust/src/agent/mod.rs
+++ b/src/agent/rust/src/agent/mod.rs
@@ -19,6 +19,7 @@ use crate::agent::replica_api::{AsyncContent, Envelope, SyncContent};
 use crate::identity::Identity;
 use crate::{to_request_id, Blob, CanisterAttributes, CanisterId, Principal, RequestId};
 use reqwest::Method;
+use serde::Serialize;
 
 use public::*;
 
@@ -50,7 +51,11 @@ impl Agent {
         endpoint: &str,
         envelope: Envelope<T>,
     ) -> Result<Vec<u8>, AgentError> {
-        let serialized_bytes = serde_cbor::to_vec(&envelope)?;
+        let mut serialized_bytes = Vec::new();
+        let mut serializer = serde_cbor::Serializer::new(&mut serialized_bytes);
+        serializer.self_describe()?;
+        envelope.serialize(&mut serializer)?;
+
         let url = self.url.join(endpoint)?;
 
         let mut http_request = reqwest::Request::new(Method::POST, url);


### PR DESCRIPTION
It is required by the spec but the Replica wasnt checking it (because serde_cbor
does not require it). The ic-router was made in Haskell and is more strict so we
need this tag, otherwise every request will error.