### PR TITLE
fix: use a custom jsonpFunction to allow other webpack bundles

### DIFF
--- a/src/bootstrap/webpack.config.js
+++ b/src/bootstrap/webpack.config.js
@@ -24,6 +24,9 @@ module.exports = {
   },
   target: 'web',
   output: {
+    // This is necessary to allow internal apps to bundle their own code with
+    // webpack which may conflict with us.
+    jsonpFunction: '__dfinityJsonp',
     path: path.resolve(__dirname, './dist'),
     filename: '[name].js',
   },


### PR DESCRIPTION
Otherwise webpack will use the same webpackJsonp function which will conflict
with our own modules.