### PR TITLE
fix: sh: 35: [[: not found in install.sh

### DIFF
--- a/public/install/020_flags.sh
+++ b/public/install/020_flags.sh
@@ -38,7 +38,7 @@ read_flags() {
     # Set values from command line.
     # shellcheck disable=SC2199
     # https://github.com/koalaman/shellcheck/wiki/SC2199
-    while [ -n "$@" ]; do
+    while [ -n "$*" ]; do
         local ARG=$1
         shift
 


### PR DESCRIPTION
As reported by many users and also the first entry in the Tungsten Hackathon bug list:
https://docs.google.com/spreadsheets/d/19BVoL8wpLiIfuT1b1-yPeaKBeSeWoi14DGSHJm7_6Z4/edit#gid=0