### PR TITLE
[chore] Stop worrying about `mo-rts.mo`

### DIFF
--- a/assets.nix
+++ b/assets.nix
@@ -12,8 +12,7 @@ pkgs.runCommandNoCCLocal "assets" {} ''
   cp ${pkgs.motoko.didc}/bin/didc $out
   cp ${pkgs.motoko.mo-doc}/bin/mo-doc $out
   cp ${pkgs.motoko.mo-ide}/bin/mo-ide $out
-  cp ${pkgs.motoko.moc-bin}/bin/moc $out
-  cp ${pkgs.motoko.rts}/rts/mo-rts.wasm $out
+  cp ${pkgs.motoko.moc}/bin/moc $out
 
   # Install agent
   mkdir $out/js-user-library

--- a/distributed-canisters.nix
+++ b/distributed-canisters.nix
@@ -7,7 +7,7 @@ let
 in
 pkgs.runCommandNoCCLocal "distributed-canisters" {
   inherit (pkgs.motoko) didc rts;
-  moc = pkgs.motoko.moc-bin;
+  moc = pkgs.motoko.moc;
   base = pkgs.motoko.base-src;
 } ''
   mkdir -p $out
@@ -23,7 +23,7 @@ pkgs.runCommandNoCCLocal "distributed-canisters" {
        -o $build_dir/$canister_name.did \
        --idl \
        --package base $base
-    MOC_RTS=$rts/rts/mo-rts.wasm $moc/bin/moc \
+    $moc/bin/moc \
        $canister_mo \
        -o $build_dir/$canister_name.wasm \
        -c --release \

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -203,9 +203,7 @@ impl MotokoParams<'_> {
 /// Compile a motoko file.
 fn motoko_compile(logger: &Logger, cache: &dyn Cache, params: &MotokoParams<'_>) -> DfxResult {
     let mut cmd = cache.get_binary_command("moc")?;
-    let mo_rts_path = cache.get_binary_command_path("mo-rts.wasm")?;
     params.to_args(&mut cmd);
-    let cmd = cmd.env("MOC_RTS", mo_rts_path.as_path());
     run_command(logger, cmd, params.surpress_warning)?;
     Ok(())
 }


### PR DESCRIPTION
to be cherry-picked in the PR that bumps `motoko` to a version that includes
https://github.com/dfinity-lab/motoko/pull/1772.