### PR TITLE
fix: Nix evaluation by upgrading dfinity

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -32,9 +32,9 @@
         "type": "git"
     },
     "dfinity": {
-        "ref": "release-2020-08-04.RC00",
+        "ref": "master",
         "repo": "ssh://git@github.com/dfinity-lab/dfinity",
-        "rev": "72eafca6f1b27f323ed9d16e8284152a2335bc98",
+        "rev": "c4bf03c11e89dbe773822d6e128203588808d652",
         "type": "git"
     },
     "ic-ref": {


### PR DESCRIPTION
Due to a Hydra and Nix upgrade the `builtins.fetchGit` Nix function does not accept the `name` argument anymore.

`dfinity` revisions older than [c4bf03c](https://github.com/dfinity-lab/dfinity/commit/c4bf03c11e89dbe773822d6e128203588808d652) use `builtins.fetchGit` with a `name` argument so we need to upgrade
our dependency on it to at least that revision.