### PR TITLE
fix: Nix eval error due to fetchGit only supporting revisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,7 @@ dependencies = [
 [[package]]
 name = "ic-agent"
 version = "0.6.0"
-source = "git+ssh://git@github.com/dfinity-lab/agent-rust.git?tag=v0.6.3#5b2fab20e1902f8709d1b09fcb6f5ee9feb0084e"
+source = "git+ssh://git@github.com/dfinity-lab/agent-rust.git?branch=0.6#5b2fab20e1902f8709d1b09fcb6f5ee9feb0084e"
 dependencies = [
  "async-trait",
  "base32",

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -32,7 +32,6 @@ erased-serde = "0.3.10"
 flate2 = "1.0.11"
 futures = "0.1.28"
 hex = "0.3.2"
-ic-agent = { git = "ssh://git@github.com/dfinity-lab/agent-rust.git", tag = "v0.6.3" }
 ic-identity-manager = { path = "../ic_identity_manager" }
 indicatif = "0.13.0"
 lazy-init = "0.3.0"
@@ -63,6 +62,12 @@ tokio = "0.2.10"
 url = "2.1.0"
 walkdir = "2.2.9"
 wasmparser = "0.45.0"
+
+[dependencies.ic-agent]
+version = "0.6"
+git = "ssh://git@github.com/dfinity-lab/agent-rust.git"
+branch = "0.6"
+rev = "5b2fab20e1902f8709d1b09fcb6f5ee9feb0084e"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/src/ic_identity_manager/Cargo.toml
+++ b/src/ic_identity_manager/Cargo.toml
@@ -11,8 +11,12 @@ openssl = "0.10.28"
 pem = "0.7.0"
 ring = "0.16.11"
 serde = { version = "1.0", features = ["derive"] }
-ic-agent = { git = "ssh://git@github.com/dfinity-lab/agent-rust.git", tag = "v0.6.3" }
 
+[dependencies.ic-agent]
+version = "0.6"
+git = "ssh://git@github.com/dfinity-lab/agent-rust.git"
+branch = "0.6"
+rev = "5b2fab20e1902f8709d1b09fcb6f5ee9feb0084e"
 
 [dev-dependencies]
 serde_cbor = "0.10"


### PR DESCRIPTION
The following used to work:

```
nix-repl> builtins.fetchGit { url = "ssh://git@github.com/dfinity-lab/agent-rust"; ref = "v0.6.3"; }
{ outPath = "/nix/store/rrlmgrf9z0nm9jzbimbsl6rpj96ij9yn-source"; rev = "5b2fab20e1902f8709d1b09fcb6f5ee9feb0084e"; revCount = 42; shortRev = "5b2fab2"; }
```

However, due to a Nix upgrade on Hydra this doesn't seem to work anymore:

```
nix-repl> builtins.fetchGit { url = "ssh://git@github.com/dfinity-lab/agent-rust.git"; ref = "v0.6.3"; }
fetching Git repository 'ssh://git@github.com/dfinity-lab/agent-rust.git'fatal: couldn't find remote ref refs/heads/v0.6.3
error: --- Error ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- nix
program 'git' failed with exit code 128
```

I'm not sure this is intended behaviour but it could be that Nix wants to have a revision in order to guarantee that the source doesn't change:

```
nix-repl> builtins.fetchGit { url = "ssh://git@github.com/dfinity-lab/agent-rust"; rev = "5b2fab20e1902f8709d1b09fcb6f5ee9feb0084e"; ref = "0.6"; }
{ lastModified = 1596813025; lastModifiedDate = "20200807151025"; narHash = "sha256-LJY3PJeTFaR3nn0/SAxbAOhogkcQS3JkHUiyOY14lWA="; outPath = "/nix/store/rrlmgrf9z0nm9jzbimbsl6rpj96ij9yn-source"; rev = "5b2fab20e1902f8709d1b09fcb6f5ee9feb0084e"; revCount = 42; shortRev = "5b2fab2"; submodules = false; }
```

Note that if the revision is not reachable from `master` it's also required to specify a branch. Unfortunately this does currently raise a warning in cargo:

```
$ cargo build
warning: /Users/bas/d/sdk/hansl/move-ic-agent-to-own-repo/src/ic_identity_manager/Cargo.toml: dependency (ic-agent) specification is ambiguous. Only one of `branch`, `tag` or `rev` is allowed. This will be considered an error in future versions
warning: /Users/bas/d/sdk/hansl/move-ic-agent-to-own-repo/src/dfx/Cargo.toml: dependency (ic-agent) specification is ambiguous. Only one of `branch`, `tag` or `rev` is allowed. This will be considered an error in future versions
```