### PR TITLE
SDK-791 Better error message for failing custom build

### DIFF
--- a/src/dfx/src/lib/builders/custom.rs
+++ b/src/dfx/src/lib/builders/custom.rs
@@ -177,7 +177,12 @@ fn run_command(
         }
     }
 
-    let output = cmd.output().expect("Could not run custom tool.");
+    let output = cmd.output().unwrap_or_else(|_| {
+        panic!(
+            "Could not run custom tool. The failing command was:\n\t{:?}",
+            cmd
+        )
+    });
     if output.status.success() {
         Ok(())
     } else {


### PR DESCRIPTION
Fixes SDK-791: prints the failing custom build command when it fails.