### PR TITLE
feat: Drop rustsec overlay

### DIFF
--- a/cargo-audit.nix
+++ b/cargo-audit.nix
@@ -6,10 +6,11 @@
 # audit` will run.
 { pkgs ? import ./nix { inherit system; }
 , system ? builtins.currentSystem
+, RustSec-advisory-db ? pkgs.sources.advisory-db
 }:
 pkgs.lib.cargo-security-audit {
   name = "dfinity-sdk";
   cargoLock = ./Cargo.lock;
-  db = pkgs.RustSec-advisory-db;
+  db = RustSec-advisory-db;
   ignores = [];
 }

--- a/ci/ci.nix
+++ b/ci/ci.nix
@@ -1,12 +1,12 @@
 { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 , system ? builtins.currentSystem
 , src ? builtins.fetchGit ../.
-, RustSec-advisory-db ? null
+, RustSec-advisory-db ? pkgs.sources.advisory-db
 
   # The version of the release. Will be set to the right value in ./release.nix.
 , releaseVersion ? "latest"
 
-, pkgs ? import ../nix { inherit system RustSec-advisory-db; }
+, pkgs ? import ../nix { inherit system; }
 }:
 pkgs.lib.mk-jobset {
   inherit supportedSystems;

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { system ? builtins.currentSystem
 , src ? builtins.fetchGit ./.
 , releaseVersion ? "latest"
-, RustSec-advisory-db ? null
+, RustSec-advisory-db ? pkgs.sources.advisory-db
 , pkgs ? import ./nix { inherit system RustSec-advisory-db; }
 , jobset ? import ./ci/ci.nix { inherit system releaseVersion RustSec-advisory-db pkgs src; }
 }:
@@ -18,7 +18,7 @@ rec {
   # Bootstrap frontend.
   bootstrap-js = import ./src/bootstrap { inherit pkgs agent-js; };
 
-  cargo-audit = import ./cargo-audit.nix { inherit pkgs; };
+  cargo-audit = import ./cargo-audit.nix { inherit pkgs RustSec-advisory-db; };
 
   assets = import ./assets.nix { inherit pkgs bootstrap-js distributed-canisters; };
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,7 +1,6 @@
 # Returns the nixpkgs set overridden and extended with DFINITY specific
 # packages.
 { system ? builtins.currentSystem
-, RustSec-advisory-db ? null
 }:
 let
   # The `common` repo provides code (mostly Nix) that is used in the
@@ -37,15 +36,6 @@ let
             nixFmt = self.lib.nixFmt {};
           in
             {
-
-              # The RustSec-advisory-db used by cargo-audit.nix.
-              # Hydra injects the latest RustSec-advisory-db, otherwise we piggy
-              # back on the one defined in sources.json.
-              RustSec-advisory-db =
-                if ! isNull RustSec-advisory-db
-                then RustSec-advisory-db
-                else self.sources.advisory-db;
-
               motoko = import self.sources.motoko { inherit (self) system; };
               dfinity = (import self.sources.dfinity { inherit (self) system; }).dfinity.rs;
               napalm = self.callPackage self.sources.napalm {
@@ -68,7 +58,6 @@ let
                   if supportedSystem == system
                   then self
                   else import ./. {
-                    inherit RustSec-advisory-db;
                     system = supportedSystem;
                   }
               );


### PR DESCRIPTION
This drops the RustSec-advisory-db overlay ~and prevents `default.nix`
from pulling `ci/ci.nix`. The latter was done as an optimization; after
running a few measurements the evaluation of ci/ci.nix went from 24.76s
(before this commit) to 24.62s (this commit).~