### PR TITLE
build: INF-1477: Update niv for better ref support

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -21,8 +21,8 @@ let
   sources = import sourcesnix { sourcesFile = ./sources.json; inherit pkgs; };
 
   sourcesnix = builtins.fetchurl {
-    url = https://raw.githubusercontent.com/nmattia/niv/506b896788d9705899592a303de95d8819504c55/nix/sources.nix;
-    sha256 = "007bgq4zy1mjnnkbmaaxvvn4kgpla9wkm0d3lfrz3y1pa3wp9ha1";
+    url = https://raw.githubusercontent.com/nmattia/niv/d13bf5ff11850f49f4282d59b25661c45a851936/nix/sources.nix;
+    sha256 = "0a2rhxli7ss4wixppfwks0hy3zpazwm9l3y2v9krrnyiska3qfrw";
   };
 
   pkgs = import (commonSrc + "/pkgs") {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -26,25 +26,25 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "common": {
-        "ref": "refs/heads/master",
+        "branch": "master",
         "repo": "ssh://git@github.com/dfinity-lab/common",
         "rev": "b0fb6fd07826e20ec0d484c7de8d94846ff4b45d",
         "type": "git"
     },
     "dfinity": {
-        "ref": "refs/tags/release-2020-08-17.RC00",
+        "branch": "release-2020-08-17.RC00",
         "repo": "ssh://git@github.com/dfinity-lab/dfinity",
         "rev": "4402d73e4470e8eccbe6b69b6218a9c098f4beb1",
         "type": "git"
     },
     "ic-ref": {
-        "ref": "refs/tags/release-0.9",
         "repo": "ssh://git@github.com/dfinity-lab/ic-ref",
         "rev": "14a8170db56db7ea3c902415ed23d7706f6e7c00",
+        "tag": "release-0.9",
         "type": "git"
     },
     "motoko": {
-        "ref": "refs/heads/release",
+        "branch": "release",
         "repo": "ssh://git@github.com/dfinity-lab/motoko",
         "rev": "7e436c2e095b63a8131b1cc7d19a59114b01db97",
         "type": "git"


### PR DESCRIPTION
This updates the sources.nix which has proper handling of `branch` and
`tag` attributes of sources.

NOTE: In order to update the git sources you'll need the latest version of niv (https://github.com/nmattia/niv/commit/d13bf5ff11850f49f4282d59b25661c45a851936)