### PR TITLE
fix: Nix evaluation of ci/release.nix

### DIFF
--- a/ci/release.nix
+++ b/ci/release.nix
@@ -11,5 +11,5 @@ let
   ci = import ./ci.nix { inherit src releaseVersion; };
 in
 if !doRelease then {} else {
-  publish.dfx.x86_64-linux = ci.publish.dfx.x86_64-linux;
+  publish.dfx = ci.publish.dfx;
 }


### PR DESCRIPTION
https://github.com/dfinity-lab/sdk/pull/949 removed the `x86_64-linux` attribute of the `publish.dfx.x86_64-linux` job which broke evaluation of `ci/release.nix`.