### PR TITLE
chore: use slack from common in ci/publish.nix

### DIFF
--- a/ci/publish.nix
+++ b/ci/publish.nix
@@ -34,23 +34,6 @@ let
       --no-progress
   '';
 
-  slack = pkgs.lib.writeCheckedShellScriptBin "slack" [] ''
-    set -eu
-    PATH="${pkgs.lib.makeBinPath [ pkgs.jq pkgs.curl ]}"
-    slack_channel_webhook="$1"
-    msg="$(</dev/stdin)"
-    echo {} | jq --arg msg "$msg" '.blocks=[
-      {
-        "type" : "section",
-        "text" : {
-          "type" : "mrkdwn",
-          "text" : $msg
-        }
-      }
-    ]' | curl -X POST --data @- "$slack_channel_webhook" \
-           --header "Content-Type: application/json" --silent --show-error
-  '';
-
   mkDfxTarball = dfx:
     pkgs.runCommandNoCC "dfx-${releaseVersion}.tar.gz" {
       inherit dfx;
@@ -66,7 +49,7 @@ in
 {
   dfx = pkgs.lib.writeCheckedShellScriptBin "activate" [] ''
     set -eu
-    PATH="${pkgs.lib.makeBinPath [ s3cp slack ]}"
+    PATH="${pkgs.lib.makeBinPath [ s3cp pkgs.slack ]}"
 
     v="${releaseVersion}"
     cache_long="max-age=31536000" # 1 year

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -28,7 +28,7 @@
     "common": {
         "branch": "master",
         "repo": "ssh://git@github.com/dfinity-lab/common",
-        "rev": "a52f71fd3a7ee015554b1d0bd5bfd1ab014ebd0c",
+        "rev": "01f876edfbafbaa2b4740489a3a179ebddda062e",
         "type": "git"
     },
     "dfinity": {


### PR DESCRIPTION
Our custom `slack` executable has been moved to the `common` repo so let's get it from there.