### PR TITLE
chore: INF-1483: Update niv-updater-action

### DIFF
--- a/.github/workflows/niv-updater.yml
+++ b/.github/workflows/niv-updater.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        uses: knl/niv-updater-action@v6
+        uses: knl/niv-updater-action@v7
         with:
           whitelist: 'common,advisory-db,napalm'
           title_prefix: 'build: '


### PR DESCRIPTION
The upstream updater was using an incorrect attribute: https://github.com/knl/niv-updater-action/pull/32

The new version is new released and tagged as v7.