### PR TITLE
ci: start fiddling with overwriting nix's HOME=/homeless-shelter before npm installs of agent-js-monorepo

### DIFF
--- a/nix/agent-js/agent-js-monorepo.nix
+++ b/nix/agent-js/agent-js-monorepo.nix
@@ -6,16 +6,33 @@
 , agentJsMonorepoTools ? import ./monorepo-tools.nix { inherit pkgs system; }
 }:
 let
+  npmEnvironmentBuildInput = (pkgs.stdenv.mkDerivation {
+    name = "agent-js-monorepo-env";
+    src = agent-js-monorepo-src;
+    # Without this unsetting HOME, npm might try to write to default HOME=/homeless-shelter
+    HOME = "";
+    installPhase = ''
+      mkdir -p $out
+    '';
+  });
   monorepo = pkgs.napalm.buildPackage agent-js-monorepo-src {
     name = "agent-js-monorepo";
     propagatedBuildInputs = [
       (agentJsMonorepoTools agent-js-monorepo-src)
+      npmEnvironmentBuildInput
+    ];
+    buildInputs = [
+      npmEnvironmentBuildInput
     ];
     outputs = [
       "out"
       "lib"
       "agent"
       "bootstrap"
+    ];
+    # HOME = "";
+    npmCommands = [
+      "npm install"
     ];
     installPhase = ''
       # $out: Everything!


### PR DESCRIPTION
Note: the target branch is rm-agent-js, not master

I believe all that's left for the rm-agent-js PR is to get the e2e/node nix working. Locally, I was seeing errors when it was trying to `napalalm.buildPackage`, which calls `npm install`, which may kick off a postinstall task, which could do anything but in the agent-js-monorepo does `npm run build` which does `npx typescript -b`.

If **that** (I think `npx`) run in nix in a fresh checkout, and HOME=/homeless-shelter, than npx will try to `mkdir -p "$HOME/.npm-cache` or something, which fails because that nix fs is read-only, e.g. https://hydra.dfinity.systems/build/1337956/nixlog/1
* I have no idea why HOME was never an issue when building the pkgs in `./nix/agent-js/*.nix` until it was building `./e2e/node/default.nix`. @hansl any idea?

This was me trying to overwrite that HOME dir (or `NPM_CONFIG_CACHE`). It would be ideal to either unset it from nix's default, set it in this derivation to a writable directory that is a sibling of the npm packages we're installing.

Need to pause on this for a sec to start https://github.com/dfinity-lab/sdk/issues/989