### PR TITLE
chore: remove require-valid-signatures flag as it's enforced in replica

### DIFF
--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -242,7 +242,6 @@ fn replica_start_thread(
             &port.unwrap_or_default().to_string(),
             "--state-dir",
             config.state_manager.state_root.to_str().unwrap_or_default(),
-            "--require-valid-signatures",
             "--create-funds-whitelist",
             "*",
         ]);

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -406,7 +406,6 @@ fn start_client(
             .unwrap_or_default(),
         "--state-dir",
         config.state_manager.state_root.to_str().unwrap_or_default(),
-        "--require-valid-signatures",
         "--create-funds-whitelist",
         "*",
     ]);


### PR DESCRIPTION
According to https://github.com/dfinity-lab/dfinity/pull/5900 valid signatures are already enabled in replica. That pull request also removes the flag from ic-starter, therefore this change needs to be merged beforehand.