### PR TITLE
chore: Update replica to latest proven release

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -40,8 +40,9 @@
     "dfinity": {
         "branch": "master",
         "repo": "ssh://git@github.com/dfinity-lab/dfinity",
-        "rev": "8849766d3d65ce56c34129d6714344b18f4d3fdb",
-        "type": "git"
+        "rev": "94eab7550438f93256269e6814760a257a66b33e",
+        "type": "git",
+        "ref": "master"
     },
     "ic-ref": {
         "branch": "release-0.10",


### PR DESCRIPTION
# Motivation
I am updating the version of the replica on the Tungsten and Sodium networks, and a testnet, to the latest commit that has tested positive.