### PR TITLE
build: add jobs for dfx tarballs

### DIFF
--- a/ci/ci.nix
+++ b/ci/ci.nix
@@ -24,7 +24,7 @@ let
   publish = import ./publish.nix {
     inherit pkgs releaseVersion;
     inherit (jobset) install;
-    dfx = jobset.dfx.standalone;
+    dfx-standalone = jobset.dfx.standalone;
   };
 in
 jobset // { inherit publish; }


### PR DESCRIPTION
https://github.com/dfinity-lab/dfinity/pull/6105 needs to reference the `dfx` tarballs which require top-level attributes that point to these tarballs.