### PR TITLE
ci: Fix SDK test script unbound variable error

### DIFF
--- a/scripts/run_sdk_test.sh
+++ b/scripts/run_sdk_test.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 echo "Running SDK tests against $SDK_TEST_BRANCH_NAME $SDK_TEST_COMMIT_SHA"
 
-if [ -z "$SDK_VER" ]; then
+if [ -z ${SDK_VER+x}]; then
   export SDK_VER=$(jq -r '.tags.latest' public/manifest.json)
 fi
 


### PR DESCRIPTION
ci: Fix SDK test script unbound variable error

The problem with the original script is that we set set -u at the top which treats unset variables as errors.
This causes an error when evaluating "$DFX_VER" inside the if statement, because DFX_VER is unset.

${var+x} is a parameter expansion which evaluates to nothing if var is unset, and substitutes the string x otherwise.
https://stackoverflow.com/questions/3601515/how-to-check-if-a-variable-is-set-in-bash