### PR TITLE
ci: gitlab sdk test, do not store nix output

### DIFF
--- a/scripts/run_sdk_test.sh
+++ b/scripts/run_sdk_test.sh
@@ -14,4 +14,4 @@ fi
 
 git switch --detach $SDK_VER
 contents=$(jq --indent 4 ".dfinity.ref = \"$SDK_TEST_BRANCH_NAME\" | .dfinity.rev = \"$SDK_TEST_COMMIT_SHA\"" nix/sources.json) && echo "$contents" > nix/sources.json
-nix-build --max-jobs 10 -A e2e-tests . -o $CI_JOB_STAGE/$CI_JOB_NAME --show-trace
+nix-build --max-jobs 10 -A e2e-tests . --show-trace


### PR DESCRIPTION
ci: gitlab sdk test, do not store nix output

The -o option for nix-build saves /nix/store/ build outputs as symlinks in the specified directory.
This makes no sense under GitLab because symlinks cannot be used as artifacts.