### PR TITLE
ci: Isolate CD SDK tests to run on cd runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,8 @@ before_script:
 #
 sdk_test:
   stage: test
+  tags:
+    - cd
   rules:
     # Only trigger this job from upstream pipelines or manual execution
     - if: '$CI_PIPELINE_SOURCE == "pipeline"'


### PR DESCRIPTION
ci: Isolate CD SDK tests to run on cd runner

This change makes SDK tests run on gitlab runners that have the label "cd".
This provides machine level isolation from other jobs such as Docker and Rust builds.