### PR TITLE
chore: bump replica

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -40,8 +40,7 @@
     "dfinity": {
         "branch": "master",
         "repo": "ssh://git@github.com/dfinity-lab/dfinity",
-        "rev": "fc46573d03d0024b85eae4f93ce8dc823308fcfd",
-        "tag": "release-2020-11-26.RC01",
+        "rev": "092af45344df4746afc33545201080c1b2c433a6",
         "type": "git"
     },
     "ic-ref": {


### PR DESCRIPTION
Move replica to `092af45344df4746afc33545201080c1b2c433a6` which [contains the Consensus change to use LMDB](https://github.com/dfinity-lab/dfinity/pull/6916). This breaks the local state for developers.
