### PR TITLE
fix: add fs:empty for webpack.config.js

### DIFF
--- a/src/dfx/assets/new_project_node_files/webpack.config.js
+++ b/src/dfx/assets/new_project_node_files/webpack.config.js
@@ -39,6 +39,9 @@ function generateWebpackConfigForCanister(name, info) {
     entry: {
       index: path.join(__dirname, info.frontend.entrypoint),
     },
+    node: {
+      fs: "empty"
+    },
     devtool: "source-map",
     optimization: {
       minimize: true,


### PR DESCRIPTION
Before we find a proper fix for https://github.com/dfinity/agent-js/issues/119, add this to unblock new project.