### PR TITLE
fix: fix a helpstring for canister call and fix language services name

### DIFF
--- a/src/dfx/src/commands/bootstrap.rs
+++ b/src/dfx/src/commands/bootstrap.rs
@@ -19,7 +19,6 @@ use url::Url;
 
 /// Starts the bootstrap server.
 #[derive(Clap, Clone)]
-#[clap(name("bootstrap"))]
 pub struct BootstrapOpts {
     /// Specifies the IP address that the bootstrap server listens on. Defaults to 127.0.0.1.
     #[clap(long)]

--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -9,7 +9,6 @@ use clap::Clap;
 
 /// Builds all or specific canisters from the code in your project. By default, all canisters are built.
 #[derive(Clap)]
-#[clap(name("build"))]
 pub struct CanisterBuildOpts {
     /// Specifies the name of the canister to build.
     /// You must specify either a canister name or the --all option.

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -11,9 +11,8 @@ use clap::Clap;
 use ic_types::principal::Principal as CanisterId;
 use std::option::Option;
 
-/// Deletes a canister on the Internet Computer network.
+/// Calls a method on a deployed canister.
 #[derive(Clap)]
-#[clap(name("call"))]
 pub struct CanisterCallOpts {
     /// Specifies the name of the canister to build.
     /// You must specify either a canister name or the --all option.

--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -10,7 +10,6 @@ use clap::Clap;
 /// Creates an empty canister on the Internet Computer and
 /// associates the Internet Computer assigned Canister ID to the canister name.
 #[derive(Clap)]
-#[clap(name("create"))]
 pub struct CanisterCreateOpts {
     /// Specifies the canister name. Either this or the --all flag are required.
     canister_name: Option<String>,

--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -15,7 +15,6 @@ use std::time::Duration;
 
 /// Deletes a canister on the Internet Computer network.
 #[derive(Clap)]
-#[clap(name("delete"))]
 pub struct CanisterDeleteOpts {
     /// Specifies the name of the canister to delete.
     /// You must specify either a canister name or the --all flag.

--- a/src/dfx/src/commands/canister/id.rs
+++ b/src/dfx/src/commands/canister/id.rs
@@ -7,7 +7,6 @@ use ic_types::principal::Principal as CanisterId;
 
 /// Prints the identifier of a canister.
 #[derive(Clap)]
-#[clap(name("id"))]
 pub struct CanisterIdOpts {
     /// Specifies the name of the canister to stop.
     /// You must specify either a canister name or the --all option.

--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -17,7 +17,6 @@ use std::str::FromStr;
 
 /// Deploys compiled code as a canister on the Internet Computer.
 #[derive(Clap, Clone)]
-#[clap(name("install"))]
 pub struct CanisterInstallOpts {
     /// Specifies the canister name to deploy. You must specify either canister name or the --all option.
     canister_name: Option<String>,

--- a/src/dfx/src/commands/canister/request_status.rs
+++ b/src/dfx/src/commands/canister/request_status.rs
@@ -14,7 +14,6 @@ use std::str::FromStr;
 
 /// Requests the status of a specified call from a canister.
 #[derive(Clap)]
-#[clap(name("request-status"))]
 pub struct RequestStatusOpts {
     /// Specifies the request identifier.
     /// The request identifier is an hexadecimal string starting with 0x.

--- a/src/dfx/src/commands/canister/set_controller.rs
+++ b/src/dfx/src/commands/canister/set_controller.rs
@@ -15,7 +15,6 @@ use ic_utils::interfaces::ManagementCanister;
 /// Sets the provided identity's name or its principal as the
 /// new controller of a canister on the Internet Computer network.
 #[derive(Clap)]
-#[clap(name("set-controller"))]
 pub struct SetControllerOpts {
     /// Specifies the canister name or the canister identifier for the canister to be controlled.
     canister: String,

--- a/src/dfx/src/commands/canister/start.rs
+++ b/src/dfx/src/commands/canister/start.rs
@@ -15,7 +15,6 @@ use std::time::Duration;
 
 /// Starts a canister on the Internet Computer network.
 #[derive(Clap)]
-#[clap(name("start"))]
 pub struct CanisterStartOpts {
     /// Specifies the name of the canister to start. You must specify either a canister name or the --all flag.
     canister_name: Option<String>,

--- a/src/dfx/src/commands/canister/status.rs
+++ b/src/dfx/src/commands/canister/status.rs
@@ -15,7 +15,6 @@ use std::time::Duration;
 
 /// Returns the current status of the canister on the Internet Computer network: Running, Stopping, or Stopped.
 #[derive(Clap)]
-#[clap(name("status"))]
 pub struct CanisterStatusOpts {
     /// Specifies the name of the canister to return information for.
     /// You must specify either a canister name or the --all flag.

--- a/src/dfx/src/commands/canister/stop.rs
+++ b/src/dfx/src/commands/canister/stop.rs
@@ -15,7 +15,6 @@ use std::time::Duration;
 
 /// Stops a canister that is currently running on the Internet Computer network.
 #[derive(Clap)]
-#[clap(name("stop"))]
 pub struct CanisterStopOpts {
     /// Specifies the name of the canister to stop.
     /// You must specify either a canister name or the --all option.

--- a/src/dfx/src/commands/config.rs
+++ b/src/dfx/src/commands/config.rs
@@ -8,7 +8,6 @@ use serde_json::value::Value;
 
 /// Configures project options for your currently-selected project.
 #[derive(Clap)]
-#[clap(name("config"))]
 pub struct ConfigOpts {
     /// Specifies the name of the configuration option to set or read.
     /// Use the period delineated path to specify the option to set or read.

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -10,7 +10,6 @@ use tokio::runtime::Runtime;
 
 /// Deploys all or a specific canister from the code in your project. By default, all canisters are deployed.
 #[derive(Clap)]
-#[clap(name("deploy"))]
 pub struct DeployOpts {
     /// Specifies the name of the canister you want to deploy.
     /// If you don’t specify a canister name, all canisters defined in the dfx.json file are deployed.

--- a/src/dfx/src/commands/identity/list.rs
+++ b/src/dfx/src/commands/identity/list.rs
@@ -7,7 +7,6 @@ use std::io::Write;
 
 /// Lists existing identities.
 #[derive(Clap)]
-#[clap(name("list"))]
 pub struct ListOpts {}
 
 pub fn exec(env: &dyn Environment, _opts: ListOpts) -> DfxResult {

--- a/src/dfx/src/commands/identity/new.rs
+++ b/src/dfx/src/commands/identity/new.rs
@@ -11,7 +11,6 @@ use IdentityCreationParameters::{Hardware, Pem};
 
 /// Creates a new identity.
 #[derive(Clap)]
-#[clap(name("new"))]
 pub struct NewIdentityOpts {
     /// The identity to create.
     identity: String,

--- a/src/dfx/src/commands/identity/principal.rs
+++ b/src/dfx/src/commands/identity/principal.rs
@@ -7,7 +7,6 @@ use clap::Clap;
 
 /// Shows the textual representation of the Principal associated with the current identity.
 #[derive(Clap)]
-#[clap(name("get-principal"))]
 pub struct GetPrincipalOpts {}
 
 pub fn exec(env: &dyn Environment, _opts: GetPrincipalOpts) -> DfxResult {

--- a/src/dfx/src/commands/identity/remove.rs
+++ b/src/dfx/src/commands/identity/remove.rs
@@ -7,7 +7,6 @@ use slog::info;
 
 /// Removes an existing identity.
 #[derive(Clap)]
-#[clap(name("remove"))]
 pub struct RemoveOpts {
     /// The identity to remove.
     identity: String,

--- a/src/dfx/src/commands/identity/rename.rs
+++ b/src/dfx/src/commands/identity/rename.rs
@@ -7,7 +7,6 @@ use slog::info;
 
 /// Renames an existing identity.
 #[derive(Clap)]
-#[clap(name("rename"))]
 pub struct RenameOpts {
     /// The current name of the identity.
     from: String,

--- a/src/dfx/src/commands/identity/use.rs
+++ b/src/dfx/src/commands/identity/use.rs
@@ -7,7 +7,6 @@ use slog::info;
 
 /// Specifies the identity to use.
 #[derive(Clap)]
-#[clap(name("use"))]
 pub struct UseOpts {
     /// The identity to use.
     identity: String,

--- a/src/dfx/src/commands/identity/whoami.rs
+++ b/src/dfx/src/commands/identity/whoami.rs
@@ -6,7 +6,6 @@ use clap::Clap;
 
 /// Shows the name of the current identity.
 #[derive(Clap)]
-#[clap(name("whoami"))]
 pub struct WhoAmIOpts {}
 
 pub fn exec(env: &dyn Environment, _opts: WhoAmIOpts) -> DfxResult {

--- a/src/dfx/src/commands/language_service.rs
+++ b/src/dfx/src/commands/language_service.rs
@@ -13,7 +13,6 @@ const CANISTER_ARG: &str = "canister";
 /// Starts the Motoko IDE Language Server. This is meant to be run by editor plugins not the
 /// end-user.
 #[derive(Clap)]
-#[clap(name("_language-service"))]
 #[clap(setting = AppSettings::Hidden)]
 pub struct LanguageServiceOpts {
     /// Specifies the canister name. If you don't specify this argument, all canisters are

--- a/src/dfx/src/commands/mod.rs
+++ b/src/dfx/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub enum Command {
     Config(config::ConfigOpts),
     Deploy(deploy::DeployOpts),
     Identity(identity::IdentityOpt),
+    #[clap(name("_language-service"))]
     LanguageServices(language_service::LanguageServiceOpts),
     New(new::NewOpts),
     Ping(ping::PingOpts),

--- a/src/dfx/src/commands/new.rs
+++ b/src/dfx/src/commands/new.rs
@@ -35,7 +35,6 @@ lazy_static! {
 
 /// Creates a new project.
 #[derive(Clap)]
-#[clap(name("new"))]
 pub struct NewOpts {
     /// Specifies the name of the project to create.
     #[clap(validator(project_name_validator))]

--- a/src/dfx/src/commands/ping.rs
+++ b/src/dfx/src/commands/ping.rs
@@ -14,7 +14,6 @@ use tokio::runtime::Runtime;
 
 /// Pings an Internet Computer network and returns its status.
 #[derive(Clap)]
-#[clap(name("ping"))]
 pub struct PingOpts {
     /// The provider to use.
     network: Option<String>,

--- a/src/dfx/src/commands/replica.rs
+++ b/src/dfx/src/commands/replica.rs
@@ -13,7 +13,6 @@ use std::default::Default;
 
 /// Starts a local Internet Computer replica.
 #[derive(Clap)]
-#[clap(name("replica"))]
 pub struct ReplicaOpts {
     /// Specifies the maximum number of cycles a single message can consume.
     #[clap(long, hidden = true)]

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -26,7 +26,6 @@ use tokio::runtime::Runtime;
 
 /// Starts the local replica and a web server for the current project.
 #[derive(Clap)]
-#[clap(name("start"))]
 pub struct StartOpts {
     /// Specifies the host name and port number to bind the frontend to.
     #[clap(long)]

--- a/src/dfx/src/commands/stop.rs
+++ b/src/dfx/src/commands/stop.rs
@@ -6,7 +6,6 @@ use sysinfo::{Pid, Process, ProcessExt, Signal, System, SystemExt};
 
 /// Stops the local network replica.
 #[derive(Clap)]
-#[clap(name("stop"))]
 pub struct StopOpts {}
 
 fn list_all_descendants(pid: Pid) -> Vec<Pid> {

--- a/src/dfx/src/commands/upgrade.rs
+++ b/src/dfx/src/commands/upgrade.rs
@@ -12,7 +12,6 @@ use tar::Archive;
 
 /// Upgrade DFX.
 #[derive(Clap)]
-#[clap(name("upgrade"))]
 pub struct UpgradeOpts {
     /// Current Version.
     #[clap(long)]


### PR DESCRIPTION
specifying the clap name like so `#[clap(name("bootstrap"))]` for the structopt is redundant as clap will derive it from the mod.rs
this also caused an error for the `_language-service` command and so the name is explicitly renamed here

Fixes https://github.com/dfinity/sdk/issues/1261

also fixed the help string for `dfx canister call`