### PR TITLE
ci: update smallvec to fix cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3327,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"


### PR DESCRIPTION
This is an attempt to solve the cargo audit failure. Bumping smallvec from 1.5.1 to 1.6.1
```
      Loaded 175 security advisories (from /nix/store/jcfdb61pfr6d0jmviwylrc8yc276z878-source)
    Updating crates.io index
warning: couldn't update crates.io index: registry: failed to make directory '/homeless-shelter': Permission denied; class=Os (2)
    Scanning /nix/store/xwhpzxz3z2gb4fhhzwh56njr1kqq19cp-Cargo.lock for vulnerabilities (409 crate dependencies)
error: Vulnerable crates found!

ID:       RUSTSEC-2021-0003
Crate:    smallvec
Version:  1.5.1
Date:     2021-01-08
URL:      https://rustsec.org/advisories/RUSTSEC-2021-0003
Title:    Buffer overflow in SmallVec::insert_many
Solution:  upgrade to >= 0.6.14, < 1.0.0 OR >= 1.6.1
```