### PR TITLE
build: upgrade beef to 0.5.0 to fix beef::Cow lacks a Sync bound on i…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,9 +518,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "beef"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474a626a67200bd107d44179bb3d4fc61891172d11696609264589be6a0e6a43"
+checksum = "6736e2428df2ca2848d846c43e88745121a6654696e349ce0054a420815a7409"
 
 [[package]]
 name = "bit-set"


### PR DESCRIPTION
upgrade beef to 0.5.0 to fix beef::Cow lacks a Sync bound on its Send trait allowing for data races
```
      Loaded 213 security advisories (from /nix/store/1g31flfwbfb4kydjaycdjjkmzy050j8r-source)
    Updating crates.io index
warning: couldn't update crates.io index: registry: failed to make directory '/homeless-shelter': Permission denied; class=Os (2)
    Scanning /nix/store/pfpbys2n4j5bdim46s4hhaalrgmvzc0k-Cargo.lock for vulnerabilities (405 crate dependencies)
error: Vulnerable crates found!

ID:       RUSTSEC-2020-0122
Crate:    beef
Version:  0.4.4
Date:     2020-10-28
URL:      https://rustsec.org/advisories/RUSTSEC-2020-0122
Title:    beef::Cow lacks a Sync bound on its Send trait allowing for data races
Solution:  upgrade to >= 0.5.0
Dependency tree:
beef 0.4.4
└── logos-derive 0.11.5
    └── logos 0.11.4
        └── candid 0.6.13
            ├── ic-utils 0.1.0
            │   └── dfx 0.6.21
            └── dfx 0.6.21
```