### PR TITLE
chore: update hyper to 0.13.10 to address RUSTSEC-2021-0020

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",


### PR DESCRIPTION
`reqwest 0.10.10` pulls in `hyper 0.13.9`
The latest `reqwest 0.11.0` still has dependency on a vulnerable `hyper 0.14.0`
Running
`cargo update -p hyper:0.13.9` as per https://www.notion.so/HOWTO-Deal-with-a-vulnerable-Rust-dependency-0b256ff5549448158a39867689b776dc

```
ID:       RUSTSEC-2021-0020
Crate:    hyper
Version:  0.13.9
Date:     2021-02-05
URL:      https://rustsec.org/advisories/RUSTSEC-2021-0020
Title:    Multiple Transfer-Encoding headers misinterprets request payload
Solution:  upgrade to >= 0.14.3 OR ^0.13.10
Dependency tree:
hyper 0.13.9
├── reqwest 0.10.10
│   ├── ic-agent 0.1.0
│   │   ├── ic-utils 0.1.0
│   │   │   └── dfx 0.6.22
│   │   ├── ic-identity-hsm 0.1.0
│   │   │   └── dfx 0.6.22
│   │   └── dfx 0.6.22
│   ├── dhall 0.9.0
│   │   └── serde_dhall 0.9.0
│   │       └── candid 0.6.14
│   │           ├── ic-utils 0.1.0
│   │           └── dfx 0.6.22
│   └── dfx 0.6.22
├── hyper-tls 0.4.3
│   └── reqwest 0.10.10
└── hyper-rustls 0.21.0
    └── reqwest 0.10.10
```