### PR TITLE
fix: remove branch specification in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,7 +1815,7 @@ dependencies = [
 [[package]]
 name = "ic-agent"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/agent-rs.git?branch=next#ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b#ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
 dependencies = [
  "async-trait",
  "base32",
@@ -1845,7 +1845,7 @@ dependencies = [
 [[package]]
 name = "ic-identity-hsm"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/agent-rs.git?branch=next#ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b#ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1860,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/agent-rs.git?branch=next#89c8dfd369131765279f4e3c3439b5ff9eb911f0"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b#ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
 dependencies = [
  "base32",
  "crc32fast",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/agent-rs.git?branch=next#ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b#ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
 dependencies = [
  "async-trait",
  "candid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,23 +6,19 @@ members = [
 [patch.crates-io.ic-agent]
 version = "0.1.0"
 git = "https://github.com/dfinity/agent-rs.git"
-branch = "next"
 rev = "ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
 
 [patch.crates-io.ic-identity-hsm]
 version = "0.1.0"
 git = "https://github.com/dfinity/agent-rs.git"
-branch = "next"
 rev = "ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
 
 [patch.crates-io.ic-types]
 version = "0.1.2"
 git = "https://github.com/dfinity/agent-rs.git"
-branch = "next"
 rev = "ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
 
 [patch.crates-io.ic-utils]
 version = "0.1.0"
 git = "https://github.com/dfinity/agent-rs.git"
-branch = "next"
 rev = "ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -71,25 +71,21 @@ wasmparser = "0.45.0"
 [dependencies.ic-agent]
 version = "0.1.0"
 git = "https://github.com/dfinity/agent-rs.git"
-branch = "next"
 rev = "ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
 
 [dependencies.ic-identity-hsm]
 version = "0.1.0"
 git = "https://github.com/dfinity/agent-rs.git"
-branch = "next"
 rev = "ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
 
 [dependencies.ic-types]
 version = "0.1.2"
 git = "https://github.com/dfinity/agent-rs.git"
-branch = "next"
 rev = "ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
 
 [dependencies.ic-utils]
 version = "0.1.0"
 git = "https://github.com/dfinity/agent-rs.git"
-branch = "next"
 rev = "ca3905e2c614ac84e4bfa2802143fc4f78ff4f2b"
 
 [dev-dependencies]


### PR DESCRIPTION
In Cargo.toml, dependencies specified via git repo can have one of `branch`, `tag` or `rev`. For our cases, only the `rev` specifications should be kept.