### PR TITLE
build: add pkgs.libiconv

### DIFF
--- a/dfx.nix
+++ b/dfx.nix
@@ -77,6 +77,7 @@ let
             cc
             pkgs.gettext
             pkgs.coreutils
+            pkgs.libiconv
           ] ++ lib.optional pkgs.stdenv.isDarwin pkgs.stdenv.cc.bintools;
           inputsFrom = [ ws.shell ];
           shellHook = ''


### PR DESCRIPTION
add pkgs.libiconv to fix this error which can be seen when using this nix-shell to build other projects (i.e. wallet)
```
error note: ld: library not found for -liconv clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
```