### PR TITLE
fix: add CANISTER_ID_<canister_name> environment variable for frontend

### DIFF
--- a/src/dfx/src/lib/builders/assets.rs
+++ b/src/dfx/src/lib/builders/assets.rs
@@ -238,6 +238,10 @@ fn build_frontend(
                     format!("CANISTER_CANDID_PATH_{}", canister.get_name()),
                     candid_path,
                 );
+                cmd.env(
+                    format!("CANISTER_ID_{}", canister.get_name()),
+                    canister.canister_id().to_text(),
+                );
             }
         }
 


### PR DESCRIPTION
We were only adding the CANISTER_CANDID_PATH_<canister_name>, not its
Canister ID.

Fixes #1472.