### PR TITLE
chore: by default create canisters with a 10T cycle balance

### DIFF
--- a/src/dfx/src/lib/operations/canister/create_canister.rs
+++ b/src/dfx/src/lib/operations/canister/create_canister.rs
@@ -13,10 +13,11 @@ use slog::info;
 use std::format;
 use std::time::Duration;
 
+// The cycle fee for create request is 1T cycles.
+const CANISTER_CREATE_FEE: u64 = 1_000_000_000_000_u64;
 // We do not know the minimum cycle balance a canister should have.
 // For now create the canister with 10T cycle balance.
-// This value accounts for the 1T canister create fee as well.
-const CREATE_FEE_PLUS_DEPOSIT: u64 = 11_000_000_000_000_u64;
+const CANISTER_INITIAL_CYCLE_BALANCE: u64 = 10_000_000_000_000_u64;
 
 pub async fn create_canister(
     env: &dyn Environment,
@@ -89,9 +90,10 @@ pub async fn create_canister(
                         create_result.canister_id
                     } else {
                         // amount has been validated by cycle_amount_validator
-                        let cycles = with_cycles.map_or(CREATE_FEE_PLUS_DEPOSIT, |amount| {
-                            amount.parse::<u64>().unwrap()
-                        });
+                        let cycles = with_cycles.map_or(
+                            CANISTER_CREATE_FEE + CANISTER_INITIAL_CYCLE_BALANCE,
+                            |amount| amount.parse::<u64>().unwrap(),
+                        );
                         wallet
                             .wallet_create_canister(cycles, None)
                             .call_and_wait(waiter_with_timeout(timeout))


### PR DESCRIPTION
Until we get a good definition for the minimum cycle balance a canister should have, just create it with a 10T balance. 
See: https://dfinity.slack.com/archives/CGA566TPV/p1617360552174500?thread_ts=1617359379.164400&cid=CGA566TPV