### PR TITLE
chore: Bump ic-ref a bit more

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,7 +41,6 @@
         "branch": "release-0.17",
         "repo": "ssh://git@github.com/dfinity-lab/ic-ref",
         "rev": "0da8f01f0a4d6fce0a4f2c14ff767789311dbfa2",
-        "tag": "0.17.0",
         "type": "git"
     },
     "motoko": {


### PR DESCRIPTION
this includes https://github.com/dfinity-lab/ic-ref/pull/333 which is
necessary so that `ic-ref` gives something close to real time to
canisters, and necessary to run programs like the Internet Identity.

(Not a tagged release because the spec didn’t change, only the code, hope that’s ok.)