### PR TITLE
fix: display the AgentError when set wallet fails

### DIFF
--- a/e2e/tests-dfx/network.bash
+++ b/e2e/tests-dfx/network.bash
@@ -23,6 +23,7 @@ teardown() {
 @test "create with wallet stores canister ids for default-persistent networks in canister_ids.json" {
     dfx_start
     setup_actuallylocal_network
+    dfx_set_wallet
     assert_command dfx_set_wallet
 
     assert_command dfx canister --network actuallylocal create --all

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -104,12 +104,10 @@ dfx_stop() {
     assert_no_dfx_start_or_replica_processes
 }
 
-# Create a canister to make sure we have a wallet on the local network, then
-# get that wallet canister ID and add it to the tungsten identity.
 dfx_set_wallet() {
-  dfx canister create --all
   export WALLET_CANISTER_ID=$(dfx identity get-wallet)
-  dfx identity  --network actuallylocal set-wallet ${WALLET_CANISTER_ID} --force
+  assert_command dfx identity  --network actuallylocal set-wallet ${WALLET_CANISTER_ID} --force
+  assert_match 'Wallet set successfully.'
 }
 
 setup_actuallylocal_network() {

--- a/src/dfx/src/commands/identity/set_wallet.rs
+++ b/src/dfx/src/commands/identity/set_wallet.rs
@@ -50,14 +50,6 @@ pub fn exec(env: &dyn Environment, opts: SetWalletOpts, network: Option<String>)
     };
     let force = opts.force;
 
-    info!(
-        log,
-        "Setting wallet for identity '{}' on network '{}' to id '{}'",
-        identity_name,
-        network.name,
-        canister_id
-    );
-
     // Try to check the canister_id for a `wallet_balance()` if the network is not the IC and available.
     // Otherwise we just trust the user.
     if !network.is_ic || force {
@@ -74,7 +66,7 @@ pub fn exec(env: &dyn Environment, opts: SetWalletOpts, network: Option<String>)
                     "Checking availability of the canister on the network..."
                 );
 
-                let canister = Identity::get_wallet_canister(env, &network, &identity_name).await?;
+                let canister = Identity::build_wallet_canister(canister_id.clone(), env)?;
                 let balance = canister.wallet_balance().call().await;
 
                 match balance {
@@ -89,6 +81,13 @@ pub fn exec(env: &dyn Environment, opts: SetWalletOpts, network: Option<String>)
                         Err(anyhow!("Unable to access the wallet: {}", err))
                     },
                     _ => {
+                        info!(
+                            log,
+                            "Setting wallet for identity '{}' on network '{}' to id '{}'",
+                            identity_name,
+                            network.name,
+                            canister_id
+                        );
                         Identity::set_wallet_id(env, &network, &identity_name, canister_id)?;
                         info!(log, "Wallet set successfully.");
                         Ok(())

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -468,16 +468,6 @@ impl Identity {
     }
 
     #[allow(clippy::needless_lifetimes)]
-    pub async fn get_wallet_canister<'env>(
-        env: &'env dyn Environment,
-        network: &NetworkDescriptor,
-        name: &str,
-    ) -> DfxResult<Canister<'env, Wallet>> {
-        let wallet_canister_id = Identity::wallet_canister_id(env, network, name)?;
-        Identity::build_wallet_canister(wallet_canister_id, env)
-    }
-
-    #[allow(clippy::needless_lifetimes)]
     pub async fn get_or_create_wallet_canister<'env>(
         env: &'env dyn Environment,
         network: &NetworkDescriptor,


### PR DESCRIPTION
display the AgentError when setting wallet fails and only set wallet if balance query succeeds