### PR TITLE
chore: promote 0.7.0 to latest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
     "tags": {
-        "latest": "0.6.26"
+        "latest": "0.7.0"
     },
     "versions": [
         "0.5.0",


### PR DESCRIPTION
Updating the manifest to promote 0.7.0 to latest.