### PR TITLE
fix: fix niv-updater-action

### DIFF
--- a/.github/workflows/motoko-updater.yml
+++ b/.github/workflows/motoko-updater.yml
@@ -16,10 +16,12 @@ on:
 jobs:
   niv-updater:
     name: 'Check for Motoko updates'
+    timeout-minutes: 2 # if this takes more than 2 minutes then something's wrong
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        uses: knl/niv-updater-action@v7
+        # Use our fork until https://github.com/knl/niv-updater-action/pull/46 is merged
+        uses: dfinity-lab/niv-updater-action@46d903454cded66eb06b1d17aeb2ddae403fc553
         with:
           whitelist: 'motoko'
           title_prefix: 'build: '

--- a/.github/workflows/niv-updater.yml
+++ b/.github/workflows/niv-updater.yml
@@ -15,10 +15,12 @@ on:
 jobs:
   niv-updater:
     name: 'Check for updates'
+    timeout-minutes: 2 # if this takes more than 2 minutes then something's wrong
     runs-on: ubuntu-latest
     steps:
       - name: niv-updater-action
-        uses: knl/niv-updater-action@v7
+        # Use our fork until https://github.com/knl/niv-updater-action/pull/46 is merged
+        uses: dfinity-lab/niv-updater-action@46d903454cded66eb06b1d17aeb2ddae403fc553
         with:
           whitelist: 'common,advisory-db,napalm'
           title_prefix: 'build: '


### PR DESCRIPTION
The action didn't pull niv from the cache and wasted many GitHub Actions
minutes building niv. We use our fork where the issue is fixed until
https://github.com/knl/niv-updater-action/pull/46 is merged.

This also sets a timeout of 2mn.

@nomeata wanna have a look this time?