### PR TITLE
feat: When dfx.json is not present, use an empty {} default.

### DIFF
--- a/e2e/tests-dfx/usage.bash
+++ b/e2e/tests-dfx/usage.bash
@@ -25,7 +25,7 @@ teardown() {
     cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
 
     assert_command_fail dfx build
-    assert_match "Cannot find configuration file in the current working directory"
+    assert_match "dfx.json not found, using default"
 
     dfx new t --no-frontend
     cd t

--- a/src/dfx/src/lib/provider.rs
+++ b/src/dfx/src/lib/provider.rs
@@ -35,7 +35,7 @@ pub fn get_network_descriptor<'a>(
 ) -> DfxResult<NetworkDescriptor> {
     set_network_context(network);
     let config = env.get_config().unwrap_or_else(|| {
-        eprintln!("dfx.json not fouund, using default.");
+        eprintln!("dfx.json not found, using default.");
         Arc::new(Config::from_str("{}").unwrap())
     });
     let config = config.as_ref().get_config();


### PR DESCRIPTION
Signed-off-by: John Plevyak <jplevyak@gmail.com>