### PR TITLE
fix: e2e tests now use a standard setup and teardown, identity manager respects $DFX_CONFIG_ROOT

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,10 @@ rather than optionally following the canister name.
 Old: dfx canister create [canister name] [controller]
 New: dfx canister create --controller <controller> [canister name]
 
+=== fix: dfx now respects $DFX_CONFIG_ROOT when looking for legacy credentials
+
+Previously this would always look in `$HOME/.dfinity/identity/creds.pem`.
+
 == Cycles Wallet
 
 - Module hash: 9183a38dd2eb1a4295f360990f87e67aa006f225910ab14880748e091248e086

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -3,18 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a different temporary directory for every test.
-    x=$(mktemp -d -t dfx-e2e-XXXXXXXX)
-    export TEMPORARY_HOME="$x"
-    export HOME="$TEMPORARY_HOME"
-    cd "$TEMPORARY_HOME" || exit
+    standard_setup
 
     dfx_new
 }
 
 teardown() {
     dfx_stop
-    rm -rf "$TEMPORARY_HOME"
+
+    standard_teardown
 }
 
 @test "http_request percent-decodes urls" {

--- a/e2e/tests-dfx/base.bash
+++ b/e2e/tests-dfx/base.bash
@@ -3,14 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
 
     dfx_new
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "provides base library location by default" {

--- a/e2e/tests-dfx/basic-project.bash
+++ b/e2e/tests-dfx/basic-project.bash
@@ -3,15 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
 
     dfx_new hello
 }
 
 teardown() {
-  dfx_stop
+    dfx_stop
+
+    standard_teardown
 }
 
 @test "build + install + call + request-status -- greet_mo" {

--- a/e2e/tests-dfx/bootstrap.bash
+++ b/e2e/tests-dfx/bootstrap.bash
@@ -3,18 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a different temporary directory for every test.
-    x=$(mktemp -d -t dfx-e2e-XXXXXXXX)
-    export TEMPORARY_HOME="$x"
-    export HOME="$TEMPORARY_HOME"
-    cd "$TEMPORARY_HOME" || exit
+    standard_setup
 
     dfx_new hello
 }
 
 teardown() {
     dfx_stop_replica_and_bootstrap
-    rm -rf "$TEMPORARY_HOME"
+
+    standard_teardown
 }
 
 @test "bootstrap fetches candid file" {

--- a/e2e/tests-dfx/build.bash
+++ b/e2e/tests-dfx/build.bash
@@ -3,15 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
 
     dfx_new
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "build uses default build args" {

--- a/e2e/tests-dfx/build_granular.bash
+++ b/e2e/tests-dfx/build_granular.bash
@@ -3,14 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
 
     dfx_new
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "direct dependencies are built" {

--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -3,12 +3,15 @@
 load ../utils/_
 
 setup() {
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
+
     dfx_new hello
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "call subcommand accepts canister identifier as canister name" {

--- a/e2e/tests-dfx/candid_ui.bash
+++ b/e2e/tests-dfx/candid_ui.bash
@@ -3,14 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
+
     dfx_new hello
 }
 
 teardown() {
-  dfx_stop
+    dfx_stop
+
+    standard_teardown
 }
 
 @test "Candid UI" {

--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -3,9 +3,7 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
 
     dfx_new certificate
 
@@ -52,6 +50,8 @@ teardown() {
     kill -9 $MITMDUMP_PID
 
     dfx_stop
+
+    standard_teardown
 }
 
 @test "mitm attack - update: attack fails because certificate verification fails" {

--- a/e2e/tests-dfx/certified_info.bash
+++ b/e2e/tests-dfx/certified_info.bash
@@ -3,12 +3,15 @@
 load ../utils/_
 
 setup() {
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
+
     dfx_new hello
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "get certified-info" {

--- a/e2e/tests-dfx/config.bash
+++ b/e2e/tests-dfx/config.bash
@@ -3,10 +3,13 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
 
     dfx_new
+}
+
+teardown() {
+    standard_teardown
 }
 
 @test "dfx config -- read/write" {

--- a/e2e/tests-dfx/create.bash
+++ b/e2e/tests-dfx/create.bash
@@ -3,18 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    x=$(mktemp -d -t dfx-e2e-XXXXXXXX)
-    cd "$x" || exit
-    export DFX_CONFIG_ROOT="$x"
-    export RUST_BACKTRACE=1
+    standard_setup
 
     dfx_new
 }
 
 teardown() {
     dfx_stop
-    rm -rf "$DFX_CONFIG_ROOT"
+
+    standard_teardown
 }
 
 

--- a/e2e/tests-dfx/dfx_install.bash
+++ b/e2e/tests-dfx/dfx_install.bash
@@ -15,7 +15,7 @@ teardown() {
 @test "dfx cache show does not install the dfx version into the cache" {
     [ "$USE_IC_REF" ] && skip "skipped for ic-ref"
 
-    test -z "$(ls -A "$HOME")"
+    test -z "$(ls -A "$DFX_CONFIG_ROOT")"
 
     assert_command dfx cache show
 
@@ -23,8 +23,8 @@ teardown() {
     test ! -e "$(dfx cache show)"
 
     # it does create the empty versions directory though
-    test -d "$HOME/.cache/dfinity/versions"
-    test -z "$(ls -A "$HOME/.cache/dfinity/versions"``)"
+    test -d "$DFX_CONFIG_ROOT/.cache/dfinity/versions"
+    test -z "$(ls -A "$DFX_CONFIG_ROOT/.cache/dfinity/versions"``)"
 }
 
 @test "non-forced install populates an empty cache" {

--- a/e2e/tests-dfx/dfx_install.bash
+++ b/e2e/tests-dfx/dfx_install.bash
@@ -3,18 +3,13 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
-
-    # Each test gets a fresh cache directory
-    mkdir -p "$(pwd)"/cache-roots
-    x=$(mktemp -d "$(pwd)"/cache-roots/cache-XXXXXXXX)
-    export HOME="$x"
+    standard_setup
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "dfx cache show does not install the dfx version into the cache" {

--- a/e2e/tests-dfx/frontend.bash
+++ b/e2e/tests-dfx/frontend.bash
@@ -3,14 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
 
     dfx_new_frontend
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "dfx start serves a frontend with static assets" {

--- a/e2e/tests-dfx/id.bash
+++ b/e2e/tests-dfx/id.bash
@@ -3,12 +3,15 @@
 load ../utils/_
 
 setup() {
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
+
     dfx_new
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "id subcommand prints valid canister identifier" {

--- a/e2e/tests-dfx/identity.bash
+++ b/e2e/tests-dfx/identity.bash
@@ -3,21 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-
-    # Each test gets its own home directory in order to have its own identities.
-    x=$(pwd)/home-for-test
-    mkdir "$x"
-    export HOME="$x"
+    standard_setup
 
     dfx_new
 }
 
 teardown() {
     dfx_stop
-    x=$(pwd)/home-for-test
-    rm -rf "$x"
+
+    standard_teardown
 }
 
 

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -4,8 +4,6 @@ load ../utils/_
 
 setup() {
     standard_setup
-    export TEMPORARY_HOME="$DFX_CONFIG_ROOT"
-    export HOME="$TEMPORARY_HOME"
 }
 
 teardown() {
@@ -65,7 +63,7 @@ teardown() {
     assert_command dfx identity new alice
     assert_match 'Creating identity: "alice".' "$stderr"
     assert_match 'Created identity: "alice".' "$stderr"
-    assert_command head "$HOME/.config/dfx/identity/alice/identity.pem"
+    assert_command head "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
     assert_match "BEGIN PRIVATE KEY"
 
     # does not change the default identity
@@ -85,9 +83,9 @@ teardown() {
 
 @test "identity new: create an HSM-backed identity" {
     assert_command dfx identity new --hsm-pkcs11-lib-path /something/else/somewhere.so --hsm-key-id abcd4321 bob
-    assert_command jq -r .hsm.pkcs11_lib_path "$HOME/.config/dfx/identity/bob/identity.json"
+    assert_command jq -r .hsm.pkcs11_lib_path "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.json"
     assert_eq "/something/else/somewhere.so"
-    assert_command jq -r .hsm.key_id "$HOME/.config/dfx/identity/bob/identity.json"
+    assert_command jq -r .hsm.key_id "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.json"
     assert_eq "abcd4321"
 }
 
@@ -106,10 +104,10 @@ teardown() {
 ##
 
 @test "identity remove: can remove an identity that exists" {
-    assert_command_fail head "$HOME/.config/dfx/identity/alice/identity.pem"
+    assert_command_fail head "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
     assert_command dfx identity new alice
 
-    assert_command head "$HOME/.config/dfx/identity/alice/identity.pem"
+    assert_command head "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
     assert_match "BEGIN PRIVATE KEY"
     assert_command dfx identity list
     assert_match 'alice anonymous default'
@@ -117,7 +115,7 @@ teardown() {
     assert_command dfx identity remove alice
     assert_match 'Removing identity "alice".' "$stderr"
     assert_match 'Removed identity "alice".' "$stderr"
-    assert_command_fail cat "$HOME/.config/dfx/identity/alice/identity.pem"
+    assert_command_fail cat "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
 
     assert_command dfx identity list
     assert_match 'default'
@@ -132,7 +130,7 @@ teardown() {
     assert_command dfx identity use alice
     assert_command_fail dfx identity remove alice
 
-    assert_command head "$HOME/.config/dfx/identity/alice/identity.pem"
+    assert_command head "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
     assert_match "BEGIN PRIVATE KEY"
     assert_command dfx identity list
     assert_match 'alice anonymous default'
@@ -151,14 +149,14 @@ teardown() {
 
 @test "identity remove: can remove an HSM-backed identity" {
     assert_command dfx identity new --hsm-pkcs11-lib-path /something/else/somewhere.so --hsm-key-id abcd4321 bob
-    assert_command jq -r .hsm.pkcs11_lib_path "$HOME/.config/dfx/identity/bob/identity.json"
+    assert_command jq -r .hsm.pkcs11_lib_path "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.json"
     assert_eq "/something/else/somewhere.so"
-    assert_command jq -r .hsm.key_id "$HOME/.config/dfx/identity/bob/identity.json"
+    assert_command jq -r .hsm.key_id "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.json"
     assert_eq "abcd4321"
-    assert_command ls "$HOME/.config/dfx/identity/bob"
+    assert_command ls "$DFX_CONFIG_ROOT/.config/dfx/identity/bob"
 
     assert_command dfx identity remove bob
-    assert_command_fail ls "$HOME/.config/dfx/identity/bob"
+    assert_command_fail ls "$DFX_CONFIG_ROOT/.config/dfx/identity/bob"
 }
 
 ##
@@ -169,9 +167,9 @@ teardown() {
     assert_command dfx identity new alice
     assert_command dfx identity list
     assert_match 'alice anonymous default'
-    assert_command head "$HOME/.config/dfx/identity/alice/identity.pem"
+    assert_command head "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
     assert_match "BEGIN PRIVATE KEY"
-    x=$(cat "$HOME/.config/dfx/identity/alice/identity.pem")
+    x=$(cat "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem")
     local key="$x"
 
     assert_command dfx identity rename alice bob
@@ -180,10 +178,10 @@ teardown() {
 
     assert_command dfx identity list
     assert_match 'anonymous bob default'
-    assert_command cat "$HOME/.config/dfx/identity/bob/identity.pem"
-    assert_eq "$key" "$(cat "$HOME/.config/dfx/identity/bob/identity.pem")"
+    assert_command cat "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.pem"
+    assert_eq "$key" "$(cat "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.pem")"
     assert_match "BEGIN PRIVATE KEY"
-    assert_command_fail cat "$HOME/.config/dfx/identity/alice/identity.pem"
+    assert_command_fail cat "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
 }
 
 @test "identity rename: can rename the default identity, which also changes the default" {
@@ -192,7 +190,7 @@ teardown() {
     assert_command dfx identity rename default bob
     assert_command dfx identity list
     assert_match 'bob'
-    assert_command head "$HOME/.config/dfx/identity/bob/identity.pem"
+    assert_command head "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.pem"
     assert_match "BEGIN PRIVATE KEY"
 
     assert_command dfx identity whoami
@@ -212,9 +210,9 @@ teardown() {
     assert_command dfx identity whoami
     assert_eq 'charlie'
 
-    assert_command head "$HOME/.config/dfx/identity/charlie/identity.pem"
+    assert_command head "$DFX_CONFIG_ROOT/.config/dfx/identity/charlie/identity.pem"
     assert_match "BEGIN PRIVATE KEY"
-    assert_command_fail cat "$HOME/.config/dfx/identity/alice/identity.pem"
+    assert_command_fail cat "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
 }
 
 @test "identity rename: cannot create an anonymous identity via rename" {
@@ -227,11 +225,11 @@ teardown() {
     skip "Need to instantiate identity when renaming so skipping until we have an hsm mock"
     assert_command dfx identity new --hsm-pkcs11-lib-path /something/else/somewhere.so --hsm-key-id abcd4321 bob
     assert_command dfx identity rename bob alice
-    assert_command_fail ls "$HOME/.config/dfx/identity/bob"
+    assert_command_fail ls "$DFX_CONFIG_ROOT/.config/dfx/identity/bob"
 
-    assert_command jq -r .hsm.pkcs11_lib_path "$HOME/.config/dfx/identity/alice/identity.json"
+    assert_command jq -r .hsm.pkcs11_lib_path "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.json"
     assert_eq "/something/else/somewhere.so"
-    assert_command jq -r .hsm.key_id "$HOME/.config/dfx/identity/alice/identity.json"
+    assert_command jq -r .hsm.key_id "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.json"
     assert_eq "abcd4321"
 }
 
@@ -320,21 +318,21 @@ teardown() {
 ##
 ## Identity key migration
 ##
-@test "identity manager copies existing key from ~/.dfinity/identity/creds.pem" {
+@test "identity manager copies existing key from $DFX_CONFIG_ROOT/.dfinity/identity/creds.pem" {
     assert_command dfx identity whoami
-    assert_command mkdir -p "$TEMPORARY_HOME/.dfinity/identity"
-    assert_command mv "$TEMPORARY_HOME/.config/dfx/identity/default/identity.pem" "$TEMPORARY_HOME/.dfinity/identity/creds.pem"
-    ORIGINAL_KEY=$(cat "$TEMPORARY_HOME/.dfinity/identity/creds.pem")
-    assert_command rmdir "$TEMPORARY_HOME/.config/dfx/identity/default"
-    assert_command rmdir "$TEMPORARY_HOME/.config/dfx/identity"
-    assert_command rm "$TEMPORARY_HOME/.config/dfx/identity.json"
-    assert_command rmdir "$TEMPORARY_HOME/.config/dfx"
-    assert_command rmdir "$TEMPORARY_HOME/.config"
+    assert_command mkdir -p "$DFX_CONFIG_ROOT/.dfinity/identity"
+    assert_command mv "$DFX_CONFIG_ROOT/.config/dfx/identity/default/identity.pem" "$DFX_CONFIG_ROOT/.dfinity/identity/creds.pem"
+    ORIGINAL_KEY=$(cat "$DFX_CONFIG_ROOT/.dfinity/identity/creds.pem")
+    assert_command rmdir "$DFX_CONFIG_ROOT/.config/dfx/identity/default"
+    assert_command rmdir "$DFX_CONFIG_ROOT/.config/dfx/identity"
+    assert_command rm "$DFX_CONFIG_ROOT/.config/dfx/identity.json"
+    assert_command rmdir "$DFX_CONFIG_ROOT/.config/dfx"
+    assert_command rmdir "$DFX_CONFIG_ROOT/.config"
 
     assert_command dfx identity whoami
 
     assert_match "migrating key from"
-    assert_eq "$(cat "$TEMPORARY_HOME"/.config/dfx/identity/default/identity.pem)" "$ORIGINAL_KEY"
+    assert_eq "$(cat "$DFX_CONFIG_ROOT"/.config/dfx/identity/default/identity.pem)" "$ORIGINAL_KEY"
 }
 
 @test "identity: import" {
@@ -342,22 +340,22 @@ teardown() {
     assert_command dfx identity import alice identity.pem
     assert_match 'Creating identity: "alice".' "$stderr"
     assert_match 'Created identity: "alice".' "$stderr"
-    assert_command diff identity.pem "$TEMPORARY_HOME/.config/dfx/identity/alice/identity.pem"
+    assert_command diff identity.pem "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
     assert_eq ""
 }
 
 @test "identity: import default" {
     assert_command dfx identity new alice
-    assert_command dfx identity import bob "$TEMPORARY_HOME/.config/dfx/identity/alice/identity.pem"
+    assert_command dfx identity import bob "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
     assert_match 'Creating identity: "bob".' "$stderr"
     assert_match 'Created identity: "bob".' "$stderr"
-    assert_command diff "$TEMPORARY_HOME/.config/dfx/identity/alice/identity.pem" "$TEMPORARY_HOME/.config/dfx/identity/bob/identity.pem"
+    assert_command diff "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem" "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.pem"
     assert_eq ""
 }
 
 @test "identity: cannot import invalid PEM file" {
     assert_command dfx identity new alice
-    assert_command cp "$TEMPORARY_HOME/.config/dfx/identity/alice/identity.pem" ./alice.pem
+    assert_command cp "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem" ./alice.pem
     # Following 3 lines manipulate the pem file so that it will be invalid
     head -n 1 alice.pem > bob.pem
     echo -n 1 >> bob.pem

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -3,14 +3,13 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    x=$(mktemp -d -t dfx-identity-home-XXXXXXXX)
-    export TEMPORARY_HOME="$x"
+    standard_setup
+    export TEMPORARY_HOME="$DFX_CONFIG_ROOT"
     export HOME="$TEMPORARY_HOME"
 }
 
 teardown() {
-    rm -rf "$TEMPORARY_HOME"
+    standard_teardown
 }
 
 ##

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -3,15 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
 
     dfx_new
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "install fails if no argument is provided" {

--- a/e2e/tests-dfx/leak.bash
+++ b/e2e/tests-dfx/leak.bash
@@ -3,15 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
 
     dfx_new
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "repeated install wasm" {

--- a/e2e/tests-dfx/network.bash
+++ b/e2e/tests-dfx/network.bash
@@ -3,13 +3,7 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-
-    # Each test gets its own home directory in order to have its own identities.
-    x=$(pwd)/home-for-test
-    mkdir "$x"
-    export HOME="$x"
+    standard_setup
 
     dfx identity new test_id
     dfx identity use test_id
@@ -18,6 +12,8 @@ setup() {
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "create with wallet stores canister ids for default-persistent networks in canister_ids.json" {

--- a/e2e/tests-dfx/new.bash
+++ b/e2e/tests-dfx/new.bash
@@ -3,9 +3,11 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
+}
+
+teardown() {
+    standard_teardown
 }
 
 @test "dfx new - good names" {

--- a/e2e/tests-dfx/packtool.bash
+++ b/e2e/tests-dfx/packtool.bash
@@ -3,14 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
 
     dfx_new
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "build fails if packtool is not configured" {

--- a/e2e/tests-dfx/ping.bash
+++ b/e2e/tests-dfx/ping.bash
@@ -3,14 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
 
     dfx_new
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "dfx ping fails if replica not running" {

--- a/e2e/tests-dfx/print.bash
+++ b/e2e/tests-dfx/print.bash
@@ -3,14 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
+
     dfx_new
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "print_mo" {

--- a/e2e/tests-dfx/provider.bash
+++ b/e2e/tests-dfx/provider.bash
@@ -3,16 +3,16 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
 
     dfx_new
 }
 
 teardown() {
-  [ -f replica.pid ] && kill -9 "$(cat replica.pid)"
-  dfx_stop
+    [ -f replica.pid ] && kill -9 "$(cat replica.pid)"
+    dfx_stop
+
+    standard_teardown
 }
 
 # This test is around 15 seconds to run. I don't think it should be faster without raising the

--- a/e2e/tests-dfx/request_status.bash
+++ b/e2e/tests-dfx/request_status.bash
@@ -3,15 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
 
     dfx_new hello
 }
 
 teardown() {
-  dfx_stop
+    dfx_stop
+
+    standard_teardown
 }
 
 @test "request-status output raw" {

--- a/e2e/tests-dfx/secp256k1.bash
+++ b/e2e/tests-dfx/secp256k1.bash
@@ -3,16 +3,13 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a different temporary directory for every test.
-    x=$(mktemp -d -t dfx-identity-home-XXXXXXXX)
-    export TEMPORARY_HOME="$x"
-    export HOME="$TEMPORARY_HOME"
-    cd "$HOME" || exit
+    standard_setup
 }
 
 teardown() {
     dfx_stop
-    rm -rf "$TEMPORARY_HOME"
+
+    standard_teardown
 }
 
 @test "can call a canister using a secp256k1 identity" {

--- a/e2e/tests-dfx/sign_send.bash
+++ b/e2e/tests-dfx/sign_send.bash
@@ -3,15 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
 
     dfx_new hello
 }
 
 teardown() {
-  dfx_stop
+    dfx_stop
+
+    standard_teardown
 }
 
 @test "sign + send" {

--- a/e2e/tests-dfx/signals.bash
+++ b/e2e/tests-dfx/signals.bash
@@ -3,14 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
 
     dfx_new hello
 }
 
 teardown() {
-  dfx_stop
+    dfx_stop
+
+    standard_teardown
 }
 
 @test "dfx replica kills the replica upon SIGINT" {

--- a/e2e/tests-dfx/start.bash
+++ b/e2e/tests-dfx/start.bash
@@ -3,14 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
 
     dfx_new hello
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "dfx restarts the replica" {

--- a/e2e/tests-dfx/update_settings.bash
+++ b/e2e/tests-dfx/update_settings.bash
@@ -3,20 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-
-    # Each test gets its own home directory in order to have its own identities.
-    x=$(pwd)/home-for-test
-    mkdir "$x"
-    export HOME="$x"
+    standard_setup
 
     dfx_new hello
 }
 
 teardown() {
     dfx_stop
-    rm -rf "$(pwd)/home-for-test"
+
+    standard_teardown
 }
 
 @test "set controller with wallet" {

--- a/e2e/tests-dfx/upgrade.bash
+++ b/e2e/tests-dfx/upgrade.bash
@@ -5,8 +5,7 @@ load ../utils/_
 RANDOM_EMPHEMERAL_PORT=$(shuf -i 49152-65535 -n 1)
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
 }
 
 @test "upgrade succeeds" {

--- a/e2e/tests-dfx/usage.bash
+++ b/e2e/tests-dfx/usage.bash
@@ -10,8 +10,7 @@ teardown() {
     standard_teardown
 }
 
-@test "dfx help succeeds"
-} {
+@test "dfx help succeeds" {
   dfx --help
 }
 

--- a/e2e/tests-dfx/usage.bash
+++ b/e2e/tests-dfx/usage.bash
@@ -1,10 +1,17 @@
 load ../utils/_
 
-teardown() {
-    dfx_stop
+setup() {
+    standard_setup
 }
 
-@test "dfx help succeeds" {
+teardown() {
+    dfx_stop
+
+    standard_teardown
+}
+
+@test "dfx help succeeds"
+} {
   dfx --help
 }
 
@@ -21,8 +28,6 @@ teardown() {
 }
 
 @test "returns the right error if not in a project" {
-    # Make sure we're in an empty directory.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
 
     assert_command_fail dfx build
     assert_match "dfx.json not found, using default"

--- a/e2e/tests-dfx/usage_env.bash
+++ b/e2e/tests-dfx/usage_env.bash
@@ -4,17 +4,9 @@ load ../utils/_
 
 setup() {
     standard_setup
-
-    # these tests compare behavior when DFX_CONFIG_ROOT is and is not set,
-    # so we need a separate unique home directory.
-    x=$(mktemp -d -t dfx-usage-env-home-XXXXXXXX)
-    export TEMPORARY_HOME="$x"
-    export HOME="$TEMPORARY_HOME"
 }
 
 teardown() {
-    rm -rf "$TEMPORARY_HOME"
-
     standard_teardown
 }
 

--- a/e2e/tests-dfx/usage_env.bash
+++ b/e2e/tests-dfx/usage_env.bash
@@ -3,18 +3,14 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    x=$(mktemp -d -t dfx-usage-env-home-XXXXXXXX)
-    export TEMPORARY_HOME=$x
+    standard_setup
+
+    export TEMPORARY_HOME="$DFX_CONFIG_ROOT"
     export HOME=$TEMPORARY_HOME
-    x=$(mktemp -d -t dfx-usage-env-config-root-XXXXXXXX)
-    export CONFIG_ROOT=$x
-    export DFX_CONFIG_ROOT=$CONFIG_ROOT
 }
 
 teardown() {
-    rm -rf "$CONFIG_ROOT"
-    rm -rf "$TEMPORARY_HOME"
+    standard_teardown
 }
 
 @test "dfx config root env var stores identity & cache" {

--- a/e2e/tests-dfx/wallet.bash
+++ b/e2e/tests-dfx/wallet.bash
@@ -4,11 +4,6 @@ load ../utils/_
 
 setup() {
     standard_setup
-
-    # Each test gets its own home directory in order to have its own identities.
-    x=$(pwd)/home-for-test
-    mkdir "$x"
-    export HOME="$x"
 }
 
 teardown() {

--- a/e2e/tests-dfx/wallet.bash
+++ b/e2e/tests-dfx/wallet.bash
@@ -3,8 +3,7 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
 
     # Each test gets its own home directory in order to have its own identities.
     x=$(pwd)/home-for-test
@@ -14,8 +13,8 @@ setup() {
 
 teardown() {
     dfx_stop
-    x=$(pwd)/home-for-test
-    rm -rf "$x"
+
+    standard_teardown
 }
 
 @test "DFX_WALLET_WASM environment variable overrides wallet module wasm at installation" {
@@ -81,7 +80,7 @@ teardown() {
     assert_not_match "Setting wallet for identity"
     assert_command dfx identity --network actuallylocal set-wallet --force "${ID}"
     assert_match "Setting wallet for identity 'default' on network 'actuallylocal' to id '$ID'"
-    assert_command jq -r .identities.default.actuallylocal <"$HOME"/.config/dfx/identity/default/wallets.json
+    assert_command jq -r .identities.default.actuallylocal <"$DFX_CONFIG_ROOT"/.config/dfx/identity/default/wallets.json
     assert_eq "$ID"
 }
 
@@ -100,13 +99,13 @@ teardown() {
     dfx canister --network actuallylocal update-settings hello --controller "$(dfx identity get-principal)"
     dfx canister --network actuallylocal update-settings hello_assets --controller "$(dfx identity get-principal)"
 
-    rm "$HOME"/.config/dfx/identity/default/wallets.json
+    rm "$DFX_CONFIG_ROOT"/.config/dfx/identity/default/wallets.json
 
     assert_command_fail dfx identity set-wallet "${ID}"
     assert_not_match "Setting wallet for identity"
     assert_command dfx identity --network ic set-wallet "${ID}"
     assert_match "Setting wallet for identity 'default' on network 'ic' to id '$ID'"
-    assert_command jq -r .identities.default.ic <"$HOME"/.config/dfx/identity/default/wallets.json
+    assert_command jq -r .identities.default.ic <"$DFX_CONFIG_ROOT"/.config/dfx/identity/default/wallets.json
     assert_eq "$ID"
 }
 
@@ -127,7 +126,7 @@ teardown() {
 
     # We're testing on a local network so the create command actually creates a wallet
     # Delete this file to force associate wallet created by deploy-wallet to identity
-    rm "$HOME"/.config/dfx/identity/default/wallets.json
+    rm "$DFX_CONFIG_ROOT"/.config/dfx/identity/default/wallets.json
 
     assert_command dfx identity --network actuallylocal deploy-wallet "${ID}"
     GET_WALLET_RES=$(dfx identity --network actuallylocal get-wallet)

--- a/e2e/tests-replica/deploy.bash
+++ b/e2e/tests-replica/deploy.bash
@@ -3,13 +3,13 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
 }
 
 teardown() {
-  dfx_stop
+    dfx_stop
+
+    standard_teardown
 }
 
 @test "deploy from a fresh project" {

--- a/e2e/tests-replica/deploy.bash
+++ b/e2e/tests-replica/deploy.bash
@@ -41,9 +41,6 @@ teardown() {
 
 @test "deploy a canister with non-circular shared dependencies" {
     install_asset transitive_deps_canisters
-    pwd
-    ls -l
-    ls -lR
     dfx_start
     assert_command dfx deploy canister_f
     assert_match 'Deploying: canister_a canister_f canister_g canister_h'

--- a/e2e/tests-replica/deploy.bash
+++ b/e2e/tests-replica/deploy.bash
@@ -41,6 +41,9 @@ teardown() {
 
 @test "deploy a canister with non-circular shared dependencies" {
     install_asset transitive_deps_canisters
+    pwd
+    ls -l
+    ls -lR
     dfx_start
     assert_command dfx deploy canister_f
     assert_match 'Deploying: canister_a canister_f canister_g canister_h'

--- a/e2e/tests-replica/lifecycle.bash
+++ b/e2e/tests-replica/lifecycle.bash
@@ -3,12 +3,15 @@
 load ../utils/_
 
 setup() {
-    cd "$(mktemp -d -t dfx-e2e-XXXXXXXX)" || exit
+    standard_setup
+
     dfx_new hello
 }
 
 teardown() {
     dfx_stop
+
+    standard_teardown
 }
 
 @test "test canister lifecycle" {

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -56,13 +56,13 @@ dfx_patchelf() {
     (uname -a | grep Linux) || return 0
     echo dfx = $(which dfx)
     local CACHE_DIR="$(dfx cache show)"
-    echo "patchelf: CACHE_DIR=$CACHE_DIR"
-    ls -l "$CACHE_DIR"
+
+    dfx cache install
+
     # Both ldd and iconv are providedin glibc.bin package
     local LD_LINUX_SO=$(ldd $(which iconv)|grep ld-linux-x86|cut -d' ' -f3)
     for binary in ic-starter icx-proxy replica; do
         local BINARY="${CACHE_DIR}/${binary}"
-        echo "patchelf: BINARY=$BINARY"
         test -f "$BINARY" || continue
         local IS_STATIC=$(ldd "${BINARY}" | grep 'not a dynamic executable')
         local USE_LIB64=$(ldd "${BINARY}" | grep '/lib64/ld-linux-x86-64.so.2')

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -56,10 +56,13 @@ dfx_patchelf() {
     (uname -a | grep Linux) || return 0
     echo dfx = $(which dfx)
     local CACHE_DIR="$(dfx cache show)"
+    echo "patchelf: CACHE_DIR=$CACHE_DIR"
+    ls -l "$CACHE_DIR"
     # Both ldd and iconv are providedin glibc.bin package
     local LD_LINUX_SO=$(ldd $(which iconv)|grep ld-linux-x86|cut -d' ' -f3)
     for binary in ic-starter icx-proxy replica; do
         local BINARY="${CACHE_DIR}/${binary}"
+        echo "patchelf: BINARY=$BINARY"
         test -f "$BINARY" || continue
         local IS_STATIC=$(ldd "${BINARY}" | grep 'not a dynamic executable')
         local USE_LIB64=$(ldd "${BINARY}" | grep '/lib64/ld-linux-x86-64.so.2')

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -11,6 +11,18 @@ install_asset() {
     [ -f ./patch.bash ] && source ./patch.bash
 }
 
+standard_setup() {
+    # We want to work from a temporary directory, different for every test.
+    x=$(mktemp -d -t dfx-e2e-XXXXXXXX)
+    cd "$x" || exit
+    export DFX_CONFIG_ROOT="$x"
+    export RUST_BACKTRACE=1
+}
+
+standard_teardown() {
+  rm -rf "$DFX_CONFIG_ROOT"
+}
+
 dfx_new_frontend() {
     local project_name=${1:-e2e_project}
     dfx new ${project_name} --frontend

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -14,13 +14,21 @@ install_asset() {
 standard_setup() {
     # We want to work from a temporary directory, different for every test.
     x=$(mktemp -d -t dfx-e2e-XXXXXXXX)
-    cd "$x" || exit
-    export DFX_CONFIG_ROOT="$x"
+    export DFX_E2E_TEMP_DIR="$x"
+
+    mkdir "$x/working-dir"
+    mkdir "$x/config-root"
+    mkdir "$x/home-dir"
+
+    cd "$x/working-dir" || exit
+
+    export HOME="$x/home-dir"
+    export DFX_CONFIG_ROOT="$x/config-root"
     export RUST_BACKTRACE=1
 }
 
 standard_teardown() {
-  rm -rf "$DFX_CONFIG_ROOT"
+    rm -rf "$DFX_E2E_TEMP_DIR"
 }
 
 dfx_new_frontend() {

--- a/src/dfx/src/lib/error/identity.rs
+++ b/src/dfx/src/lib/error/identity.rs
@@ -28,6 +28,9 @@ pub enum IdentityError {
     #[error("Cannot create an anonymous identity.")]
     CannotCreateAnonymousIdentity(),
 
+    #[error("Cannot find home directory.")]
+    CannotFindHomeDirectory(),
+
     #[error("Cannot read identity file at '{0}': {1}")]
     CannotReadIdentityFile(PathBuf, Box<DfxError>),
 }

--- a/src/dfx/src/lib/error/identity.rs
+++ b/src/dfx/src/lib/error/identity.rs
@@ -28,9 +28,6 @@ pub enum IdentityError {
     #[error("Cannot create an anonymous identity.")]
     CannotCreateAnonymousIdentity(),
 
-    #[error("Cannot find home directory.")]
-    CannotFindHomeDirectory(),
-
     #[error("Cannot read identity file at '{0}': {1}")]
     CannotReadIdentityFile(PathBuf, Box<DfxError>),
 }

--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -322,10 +322,11 @@ fn initialize(
 }
 
 fn get_legacy_creds_pem_path() -> DfxResult<PathBuf> {
-    let home = std::env::var("HOME")
-        .map_err(|_| DfxError::new(IdentityError::CannotFindHomeDirectory()))?;
+    let config_root = std::env::var("DFX_CONFIG_ROOT").ok();
+    let home = std::env::var("HOME").context("Cannot find home directory.")?;
+    let root = config_root.unwrap_or(home);
 
-    Ok(PathBuf::from(home)
+    Ok(PathBuf::from(root)
         .join(".dfinity")
         .join("identity")
         .join("creds.pem"))

--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -323,7 +323,8 @@ fn initialize(
 
 fn get_legacy_creds_pem_path() -> DfxResult<PathBuf> {
     let config_root = std::env::var("DFX_CONFIG_ROOT").ok();
-    let home = std::env::var("HOME").context("Cannot find home directory.")?;
+    let home = std::env::var("HOME")
+        .map_err(|_| DfxError::new(IdentityError::CannotFindHomeDirectory()))?;
     let root = config_root.unwrap_or(home);
 
     Ok(PathBuf::from(root)


### PR DESCRIPTION
All e2e tests now use a standard setup and teardown sequence.  This keeps e2e tests from using or changing the user's $HOME directory, and keeps e2e tests from interfering with each other, for example when patching elf files in the cache.

`standard_setup` creates a temporary directory, and three directories within it:
- $HOME: a home directory
- $DFX_CONFIG_ROOT: another directory
- a working directory (and changes into it)

`standard_teardown` deletes the temporary directory.

Updated all tests to use `$DFX_CONFIG_ROOT`, since it's set, rather than `$HOME`.  One test remains that unsets `$DFX_CONFIG_ROOT` and verifies that dfx looks in `$HOME`.

Also updated `patchelf` to install the dfx cache, because some tests don't run first `dfx new` or another command that installs the dfx cache.  This previously sort of worked (at least, didn't report an error) because most tests were using a shared `$HOME` directory.

Updated the identity manager to look for the legacy credentials file in `$DFX_CONFIG_ROOT/.dfinity/identity/creds.pem` if `$DFX_CONFIG_ROOT` is set, otherwise in `$HOME/.dfinity/identity/creds.pem`.

