### PR TITLE
fix: remove extraneous log output wrt stopping icx-proxy

### DIFF
--- a/src/dfx/src/actors/icx_proxy.rs
+++ b/src/dfx/src/actors/icx_proxy.rs
@@ -101,15 +101,17 @@ impl IcxProxy {
     }
 
     fn stop_icx_proxy(&mut self) {
-        info!(self.logger, "Stopping icx-proxy...");
-        if let Some(sender) = self.stop_sender.take() {
-            let _ = sender.send(());
-        }
+        if self.stop_sender.is_some() || self.thread_join.is_some() {
+            info!(self.logger, "Stopping icx-proxy...");
+            if let Some(sender) = self.stop_sender.take() {
+                let _ = sender.send(());
+            }
 
-        if let Some(join) = self.thread_join.take() {
-            let _ = join.join();
+            if let Some(join) = self.thread_join.take() {
+                let _ = join.join();
+            }
+            info!(self.logger, "Stopped.");
         }
-        info!(self.logger, "Stopped.");
     }
 }
 


### PR DESCRIPTION
When dfx starts, it logs "Stopping icx-proxy..." "Stopped" when it didn't actually do that.