### PR TITLE
feat: clarify the default webpack config

### DIFF
--- a/src/dfx/assets/new_project_node_files/webpack.config.js
+++ b/src/dfx/assets/new_project_node_files/webpack.config.js
@@ -9,7 +9,8 @@ let canisters;
 function initCanisterIds() {
   if(dfx_network = process.env.DFX_NETWORK) {
     network = dfx_network;
-    console.log(`network ${network} was inferred from environment variable DFX_NETWORK`);
+    network_alphanum = network.replace(/[^a-zA-Z0-9]/g, "_"); // replace non-alphanumeric like dfx
+    console.log(`network ${network} (${network_alphanum}) was inferred from environment variable DFX_NETWORK`);
   } else {
     network = process.env.NODE_ENV === "production" ? "ic" : "local";
     console.log(`environment variable DFX_NETWORK not set, inferred network ${network} from node environment`);
@@ -26,11 +27,11 @@ function initCanisterIds() {
 
   canisters = network === "ic" ?
         getCanisterIds(path.resolve("canister_ids.json")) :
-        getCanisterIds(path.resolve(".dfx", network.replace(/[^a-zA-Z0-9]/g, "_") /* replace non-alphanumeric like dfx */, "canister_ids.json"));
+        getCanisterIds(path.resolve(".dfx", network_alphanum, "canister_ids.json"));
 
   for (const canister in canisters) {
     process.env[canister.toUpperCase() + "_CANISTER_ID"] =
-      canisters[canister][network];
+      canisters[canister][network_alphanum];
   }
 }
 initCanisterIds();


### PR DESCRIPTION
This simplifies the logic for finding canister IDs, as well as extends
the logic for arbitrary networks. This also adds some output, clarifying
the heuristics to the user.

The code is also a tad more robust because we never end up in a situation where e.g. both `localCanisters` and `prodCanisters` are undefined (previously the two seemingly exclusive catch-cases occurred together).

NOTE: **I HAVE NOT TESTED THIS!!** 

ok, I _did_ test this, but only for my use case (custom network name).