### PR TITLE
fix: changed maximum value of --memory-allocation to 12 GiB

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,6 +35,10 @@ New: dfx canister create --controller <controller> [canister name]
 
 Previously this would always look in `$HOME/.dfinity/identity/creds.pem`.
 
+=== fix: changed dfx canister (create|update-settings) --memory-allocation limit to 12 GiB
+
+Updated the maximum value for the --memory-allocation value to be 12 GiB (12,884,901,888 bytes)
+
 == Cycles Wallet
 
 - Module hash: 9183a38dd2eb1a4295f360990f87e67aa006f225910ab14880748e091248e086

--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -44,7 +44,10 @@ pub struct CanisterCreateOpts {
     compute_allocation: Option<String>,
 
     /// Specifies how much memory the canister is allowed to use in total.
-    /// This should be a value in the range [0..256 TB]
+    /// This should be a value in the range [0..12 GiB]
+    /// A setting of 0 means the canister will have access to memory on a “best-effort” basis:
+    /// It will only be charged for the memory it uses, but at any point in time may stop running
+    /// if it tries to allocate more memory when there isn’t space available on the subnet.
     #[clap(long, validator(memory_allocation_validator))]
     memory_allocation: Option<String>,
 

--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -37,7 +37,10 @@ pub struct UpdateSettingsOpts {
     compute_allocation: Option<String>,
 
     /// Specifies how much memory the canister is allowed to use in total.
-    /// This should be a value in the range [0..256 TB]
+    /// This should be a value in the range [0..12 GiB].
+    /// A setting of 0 means the canister will have access to memory on a “best-effort” basis:
+    /// It will only be charged for the memory it uses, but at any point in time may stop running
+    /// if it tries to allocate more memory when there isn’t space available on the subnet.
     #[clap(long, validator(memory_allocation_validator))]
     memory_allocation: Option<String>,
 

--- a/src/dfx/src/util/clap/validators.rs
+++ b/src/dfx/src/util/clap/validators.rs
@@ -54,13 +54,15 @@ pub fn compute_allocation_validator(compute_allocation: &str) -> Result<(), Stri
 }
 
 pub fn memory_allocation_validator(memory_allocation: &str) -> Result<(), String> {
-    let limit = Bytes::new(256, Unit::TByte).map_err(|_| "Parse Overflow.")?;
+    // This limit should track MAX_MEMORY_ALLOCATION
+    // at https://gitlab.com/dfinity-lab/core/ic/-/blob/master/rs/types/types/src/lib.rs#L492
+    let limit = Bytes::new(12, Unit::GiByte).map_err(|_| "Parse Overflow.")?;
     if let Ok(bytes) = memory_allocation.parse::<Bytes>() {
         if bytes.size() <= limit.size() {
             return Ok(());
         }
     }
-    Err("Must be a value between 0..256 TB inclusive.".to_string())
+    Err("Must be a value between 0..12 GiB inclusive.".to_string())
 }
 
 pub fn freezing_threshold_validator(freezing_threshold: &str) -> Result<(), String> {


### PR DESCRIPTION
Also changed the help descriptions for `dfx canister create` and `dfx canister update-settings` to describe the meaning of a setting of 0.