### PR TITLE
chore: Update ic-ref to fix /nix/store dependency

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -40,7 +40,7 @@
     "ic-ref": {
         "branch": "master",
         "repo": "ssh://git@github.com/dfinity/ic-hs",
-        "rev": "c49a2f443d177b6486a1797ca646d8546ac7288c",
+        "rev": "380d66d631d9147a46a69b133142cab9c542ad03",
         "type": "git"
     },
     "ic-starter-x86_64-darwin": {


### PR DESCRIPTION
This PR uses a newer commit for the ic-hs repo so that the Darin `ic-ref` binary that we distribute with `dfx` won't depend on /nix/store, and will therefore have a chance to run when nix isn't installed.

Before:
```
$ otool -L ic-ref
ic-ref:
	/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-Libsystem-osx-10.12.6/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
	@executable_path/libz.1.2.11.dylib (compatibility version 1.0.0, current version 1.2.11)
	@executable_path/libiconv.dylib (compatibility version 7.0.0, current version 7.0.0)
	@executable_path/libgmp.10.dylib (compatibility version 15.0.0, current version 15.0.0)
	@executable_path/libffi.7.dylib (compatibility version 9.0.0, current version 9.0.0)
```

After:
```
$ otool -L ic-ref
ic-ref:
	@executable_path/libz.1.2.11.dylib (compatibility version 1.0.0, current version 1.2.11)
	@executable_path/libiconv.dylib (compatibility version 7.0.0, current version 7.0.0)
	@executable_path/libgmp.10.dylib (compatibility version 15.0.0, current version 15.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.60.2)
	@executable_path/libffi.8.dylib (compatibility version 10.0.0, current version 10.0.0)
```

The commit that fixed the specific issue is https://github.com/dfinity/ic-hs/commit/fb558eb58aed501a6b46768baf0a50ece6bedeaa