### PR TITLE
fix: fix issue with package.json in the project template.

### DIFF
--- a/src/dfx/assets/new_project_node_files/package.json
+++ b/src/dfx/assets/new_project_node_files/package.json
@@ -23,7 +23,7 @@
     "stream-browserify": "3.0.0",
     "terser-webpack-plugin": "5.1.1",
     "util": "0.12.3",
-    "webpack-cli": "4.5.0",
+    "webpack-cli": "4.9.0",
     "webpack-dev-server": "^3.11.2",
     "webpack": "5.24.4"
   },


### PR DESCRIPTION
In order to make the app run again, one has to bump "webpack-cli" to 4.9.0. 
Referencing this issue: https://github.com/webpack/webpack-cli/issues/2990#issuecomment-939925116