### PR TITLE
[IDX-1961] Depend on motoko public releases instead of git checkout

### DIFF
--- a/assets.nix
+++ b/assets.nix
@@ -14,10 +14,10 @@ let
 
     gunzip <${replica-bin} >$out/replica
     gunzip <${starter-bin} >$out/ic-starter
-    cp -R ${pkgs.motoko.base-src} $out/base
-    cp ${pkgs.motoko.mo-doc}/bin/mo-doc $out
-    cp ${pkgs.motoko.mo-ide}/bin/mo-ide $out
-    cp ${pkgs.motoko.moc}/bin/moc $out
+    cp -R ${pkgs.sources.motoko-base} $out/base
+    cp ${pkgs.motoko}/bin/mo-doc $out
+    cp ${pkgs.motoko}/bin/mo-ide $out
+    cp ${pkgs.motoko}/bin/moc $out
     cp ${pkgs.ic-ref}/bin/* $out
     cp ${icx-proxy-standalone}/bin/icx-proxy $out
   '';

--- a/distributed-canisters.nix
+++ b/distributed-canisters.nix
@@ -6,9 +6,8 @@ let
 
 in
 pkgs.runCommandNoCCLocal "distributed-canisters" {
-  inherit (pkgs.motoko) rts;
-  moc = pkgs.motoko.moc;
-  base = pkgs.motoko.base-src;
+  moc = pkgs.motoko;
+  base = pkgs.sources.motoko-base;
 } ''
   mkdir -p $out
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -36,7 +36,6 @@ let
             nixFmt = self.lib.nixFmt {};
           in
             {
-              motoko = import self.sources.motoko { inherit (self) system; };
               agent-rs = self.naersk.buildPackage {
                 name = "agent-rs";
                 root = self.sources.agent-rs;
@@ -53,6 +52,12 @@ let
               };
               ic-ref =
                 (import self.sources.ic-ref { inherit (self) system; }).ic-ref-dist;
+              motoko = pkgs.runCommandNoCCLocal "motoko" {
+                src = self.sources."motoko-${self.system}";
+              } ''
+                mkdir -p $out/bin
+                tar -C $out/bin -xf $src
+              '';
 
               nix-fmt = nixFmt.fmt;
               nix-fmt-check = nixFmt.check;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -59,12 +59,33 @@
         "url": "https://download.dfinity.systems/ic/d35b7722f50645375a60ee905552513c76a0f426/nix-release/ic-starter.gz",
         "url_template": "https://download.dfinity.systems/ic/<rev>/nix-release/ic-starter.gz"
     },
-    "motoko": {
-        "branch": "release",
-        "repo": "https://github.com/dfinity/motoko",
-        "rev": "56326541bb4c7ba5f22609c97440dfd7feb91116",
-        "tag": "0.6.5",
-        "type": "git"
+    "motoko-base": {
+        "branch": "next-moc",
+        "description": "The Motoko base library",
+        "homepage": null,
+        "owner": "dfinity",
+        "repo": "motoko-base",
+        "rev": "45bd1abc8e81376d5e1c1dd6322e170e47555c57",
+        "sha256": "18i51cglq8131lyn6w2rjbhx32fbl7y62gga4cs10fdw2fmiw0d8",
+        "type": "tarball",
+        "url": "https://github.com/dfinity/motoko-base/archive/45bd1abc8e81376d5e1c1dd6322e170e47555c57.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "motoko-x86_64-darwin": {
+        "builtin": false,
+        "sha256": "0k7xy6p9sj6liz3n84h51q9radsc85xh4saqybilmwfpfqq3v30y",
+        "type": "file",
+        "url": "https://github.com/dfinity/motoko/releases/download/0.6.11/motoko-macos-0.6.11.tar.gz",
+        "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-macos-<version>.tar.gz",
+        "version": "0.6.11"
+    },
+    "motoko-x86_64-linux": {
+        "builtin": false,
+        "sha256": "003qkpaj7cycf2cagi6mna240v58kyvhs5067ia9r63gfx5hgj7k",
+        "type": "file",
+        "url": "https://github.com/dfinity/motoko/releases/download/0.6.11/motoko-linux64-0.6.11.tar.gz",
+        "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-linux64-<version>.tar.gz",
+        "version": "0.6.11"
     },
     "napalm": {
         "branch": "master",


### PR DESCRIPTION
This is slightly blocked on https://github.com/dfinity/motoko/pull/2845 ending up in the next motoko release. Until then, I've added the motoko-base dependency separately