### PR TITLE
chore: use nix-hash --to-base16 not nix --to-base16

### DIFF
--- a/scripts/write-dfx-asset-sources.sh
+++ b/scripts/write-dfx-asset-sources.sh
@@ -23,7 +23,7 @@ read_sha256_from_nix_sources() {
 
     SHA256_BASE32=$(jq -r .'"'"$KEY"'".sha256' "$NIX_SOURCES_JSON")
 
-    nix to-base16 --type sha256 "$SHA256_BASE32"
+    nix-hash --to-base16 --type sha256 "$SHA256_BASE32"
 }
 
 read_url_from_nix_sources() {


### PR DESCRIPTION
This fixes new errors of the form:
```
    warning: 'to-base16' is a deprecated alias for 'hash to-base16'
    error: experimental Nix feature 'nix-command' is disabled; use '--extra-experimental-features nix-command' to override
```

Example failed build: https://github.com/dfinity/sdk/runs/4074667958?check_suite_focus=true