### PR TITLE
chore: aggregate all lint checks into a single status

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,6 +38,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - name: check with needs
+        if: ${{ needs.test.result != 'success' }}
+        run: exit 1
       - name: A job failed
         if: ${{ failure() }}
         run: exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,7 @@ jobs:
 
   aggregate:
     name: lint:required
+    if: ${{ always() }}
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,8 +39,7 @@ jobs:
       - name: display
         env:
           needs_lint: ${{toJSON(needs.lint)}}
-          jobs_lint: ${{toJSON(jobs.lint)}}
-          cancelled: ${{toJSON(cancelled())}}
+          #cancelled: ${{toJSON(cancelled())}}
           failure: ${{toJSON(failure())}}
           success: ${{toJSON(success())}}
         run: export

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,18 +43,18 @@ jobs:
           #failure: ${{toJSON(failure())}}
           #success: ${{toJSON(success())}}
         run: export
-      - name: check step result directly
-        if: ${{ needs.lint.result != 'success' }}
-        run: exit 1
-      - name: A job failed
-        if: ${{ failure() }}
-        run: exit 1
-      - name: The workflow was cancelled
-        if: ${{ cancelled() }}
-        run: exit 1
-      - name: All jobs succeeded
-        if: ${{ success() }}
-        run: echo pass
+#      - name: check step result directly
+#        if: ${{ needs.lint.result != 'success' }}
+#        run: exit 1
+#      - name: A job failed
+#        if: ${{ failure() }}
+#        run: exit 1
+#      - name: The workflow was cancelled
+#        if: ${{ cancelled() }}
+#        run: exit 1
+#      - name: All jobs succeeded
+#        if: ${{ success() }}
+#        run: echo pass
       - name: Not success
         if: ${{ !success() }}
         run: exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,17 @@ jobs:
         run: cargo clippy --verbose --tests --benches -- -D clippy::all
         env:
           RUST_BACKTRACE: 1
+
+  aggregate:
+    name: lint_required
+    needs: test
+    steps:
+      - name: aggregate
+        run: |
+          echo "success is ${{ success() }}"
+          if [ "${{ success }}" = "true" ]; then
+              echo "pass"
+          else
+              echo "fail"
+              exit 1
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,16 +33,9 @@ jobs:
           RUST_BACKTRACE: 1
 
   aggregate:
-    name: lint_required
+    name: lint:required
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - name: A job failed
-        if: ${{ failure() }}
+      - if: ${{ !success() }}
         run: exit 1
-      - name: The workflow was cancelled
-        if: ${{ cancelled() }}
-        run: exit 1
-      - name: All jobs succeeded
-        if: ${{ success() }}
-        run: exit 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,25 +36,6 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-      - name: display
-        env:
-          needs_lint: ${{toJSON(needs.lint)}}
-          #cancelled: ${{toJSON(cancelled())}}
-          #failure: ${{toJSON(failure())}}
-          #success: ${{toJSON(success())}}
-        run: export
       - name: check step result directly
         if: ${{ needs.lint.result != 'success' }}
-        run: exit 1
-#      - name: A job failed
-#        if: ${{ failure() }}
-#        run: exit 1
-#      - name: The workflow was cancelled
-#        if: ${{ cancelled() }}
-#        run: exit 1
-#      - name: All jobs succeeded
-#        if: ${{ success() }}
-#        run: echo pass
-      - name: Not success
-        if: ${{ !success() }}
         run: exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,5 +38,15 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ !success() }}
+      - name: A job failed
+        if: ${{ failure() }}
+        run: exit 1
+      - name: The workflow was cancelled
+        if: ${{ cancelled() }}
+        run: exit 1
+      - name: All jobs succeeded
+        if: ${{ success() }}
+        run: echo pass
+      - name: Not success
+        if: ${{ !success() }}
         run: exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,8 @@
-name: Lint
-
 on: [pull_request]
 
 jobs:
-  test:
-    name: lint
+  lint:
+    name: Lint
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -35,11 +33,19 @@ jobs:
   aggregate:
     name: lint:required
     if: ${{ always() }}
-    needs: test
+    needs: lint
     runs-on: ubuntu-latest
     steps:
-      - name: check with needs
-        if: ${{ needs.test.result != 'success' }}
+      - name: display
+        env:
+          needs_lint: ${{toJSON(needs.lint)}}
+          jobs_lint: ${{toJSON(jobs.lint)}}
+          cancelled: ${{toJSON(cancelled())}}
+          failure: ${{toJSON(failure())}}
+          success: ${{toJSON(success())}}
+        run: export
+      - name: check step result directly
+        if: ${{ needs.lint.result != 'success' }}
         run: exit 1
       - name: A job failed
         if: ${{ failure() }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,8 +40,8 @@ jobs:
         env:
           needs_lint: ${{toJSON(needs.lint)}}
           #cancelled: ${{toJSON(cancelled())}}
-          failure: ${{toJSON(failure())}}
-          success: ${{toJSON(success())}}
+          #failure: ${{toJSON(failure())}}
+          #success: ${{toJSON(success())}}
         run: export
       - name: check step result directly
         if: ${{ needs.lint.result != 'success' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,13 +35,14 @@ jobs:
   aggregate:
     name: lint_required
     needs: test
+    runs-on: ubuntu-latest
     steps:
-      - name: aggregate
-        run: |
-          echo "success is ${{ success() }}"
-          if [ "${{ success }}" = "true" ]; then
-              echo "pass"
-          else
-              echo "fail"
-              exit 1
-          fi
+      - name: A job failed
+        if: ${{ failure() }}
+        run: exit 1
+      - name: The workflow was cancelled
+        if: ${{ cancelled() }}
+        run: exit 1
+      - name: All jobs succeeded
+        if: ${{ success() }}
+        run: exit 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,9 +43,9 @@ jobs:
           #failure: ${{toJSON(failure())}}
           #success: ${{toJSON(success())}}
         run: export
-#      - name: check step result directly
-#        if: ${{ needs.lint.result != 'success' }}
-#        run: exit 1
+      - name: check step result directly
+        if: ${{ needs.lint.result != 'success' }}
+        run: exit 1
 #      - name: A job failed
 #        if: ${{ failure() }}
 #        run: exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,10 @@
+name: Lint
+
 on: [pull_request]
 
 jobs:
-  lint:
-    name: Lint
+  test:
+    name: lint
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -33,9 +35,9 @@ jobs:
   aggregate:
     name: lint:required
     if: ${{ always() }}
-    needs: lint
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: check step result directly
-        if: ${{ needs.lint.result != 'success' }}
+        if: ${{ needs.test.result != 'success' }}
         run: exit 1

--- a/src/dfx/src/commands/new.rs
+++ b/src/dfx/src/commands/new.rs
@@ -424,7 +424,7 @@ pub fn exec(env: &dyn Environment, opts: NewOpts) -> DfxResult {
 
         #[cfg(not(target_os = "macos"))]
         {
-            init_git(log, &project_name)?;
+            init_git(log, project_name)?;
         }
     }
 

--- a/src/dfx/src/commands/new.rs
+++ b/src/dfx/src/commands/new.rs
@@ -424,7 +424,7 @@ pub fn exec(env: &dyn Environment, opts: NewOpts) -> DfxResult {
 
         #[cfg(not(target_os = "macos"))]
         {
-            init_git(log, project_name)?;
+            init_git(log, &project_name)?;
         }
     }
 


### PR DESCRIPTION
This is for branch protection rules, so that we can require a single status check rather than several.