### PR TITLE
chore: remove unneeded pull_request event types

### DIFF
--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -1,10 +1,6 @@
 name: Check cargo build
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
   push:
     branches:
       - master

--- a/.github/workflows/consistent-sources.yml
+++ b/.github/workflows/consistent-sources.yml
@@ -1,10 +1,6 @@
 name: Check that nix/sources.json and scripts/dfx-asset-sources.sh are consistent
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
   push:
     branches:
       - master

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,10 +1,6 @@
 name: Check shell scripts
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
     paths:
       - 'e2e/**'
       - '.github/**'


### PR DESCRIPTION
The default is usually right (opened, reopened, synchronize)