### PR TITLE
chore: disable some unavoidable cargo audit errors

### DIFF
--- a/cargo-audit.nix
+++ b/cargo-audit.nix
@@ -22,5 +22,24 @@ pkgs.lib.cargo-security-audit {
   # Solution:  upgrade to >= 0.14.0
   # Dependency tree:
   # generic-array 0.12.3
-  ignores = [ "RUSTSEC-2020-0146" ];
+
+  # Ignore this as we cannot remove the dependency (slog-term depends on it)
+  # Crate:         chrono
+  # Version:       0.4.19
+  # Title:         Potential segfault in `localtime_r` invocations
+  # Date:          2020-11-10
+  # ID:            RUSTSEC-2020-0159
+  # URL:           https://rustsec.org/advisories/RUSTSEC-2020-0159
+  # Solution:      No safe upgrade is available!
+
+  # chrono depends on time-0.1.43
+  # Crate:         time
+  # Version:       0.1.43
+  # Title:         Potential segfault in the time crate
+  # Date:          2020-11-18
+  # ID:            RUSTSEC-2020-0071
+  # URL:           https://rustsec.org/advisories/RUSTSEC-2020-0071
+  # Solution:      Upgrade to >=0.2.23
+
+  ignores = [ "RUSTSEC-2020-0071" "RUSTSEC-2020-0146" "RUSTSEC-2020-0159" ];
 }


### PR DESCRIPTION
`chrono` depends on `localtime_r`, which has issues.

We have a couple direct dependencies on chrono in 'sign.rs` and `signed_message.rs', but slog-term also depends on chrono.