### PR TITLE
chore: add github workflow-based e2e and fmt as required mergify status checks

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   test:
-    name: fmt:required
+    name: fmt
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -32,3 +32,13 @@ jobs:
         run: cargo fmt --all -- --check
         env:
           RUST_BACKTRACE: 1
+
+  aggregate:
+    name: fmt:required
+    if: ${{ always() }}
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: check step result directly
+        if: ${{ needs.test.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   test:
-    name: fmt
+    name: fmt:required
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,6 +5,7 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - status-success=hydra:dfinity-ci-build:evaluation
       - status-success=hydra:dfinity-ci-build:sdk:required
+      - status-success=lint:required
       - base=master
       - label=automerge-squash
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,6 +5,7 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - status-success=hydra:dfinity-ci-build:evaluation
       - status-success=hydra:dfinity-ci-build:sdk:required
+      - status-success=e2e:required
       - status-success=fmt:required
       - status-success=lint:required
       - base=master

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,6 +5,7 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - status-success=hydra:dfinity-ci-build:evaluation
       - status-success=hydra:dfinity-ci-build:sdk:required
+      - status-success=fmt:required
       - status-success=lint:required
       - base=master
       - label=automerge-squash


### PR DESCRIPTION
Also renamed status name to `fmt:required` to match the other required statuses.

The 'aggregate' step removes the matrix parameters from the status name.