### PR TITLE
chore: build with rust 1.55.0 to match common

### DIFF
--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [ '1.52.1' ]
+        rust: [ '1.55.0' ]
         os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-10.15, macos-11, ubuntu-20.04 ]
-        rust: [ '1.52.1' ]
+        rust: [ '1.55.0' ]
         binary_path: [ 'target/release' ]
     steps:
       - uses: actions/checkout@v1
@@ -66,7 +66,7 @@ jobs:
         #     /home/runner/.cache/dfinity/versions/0.8.3-34-g36e39809/ic-starter:
         #     /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found
         os: [ macos-10.15, macos-11, ubuntu-20.04 ]
-        rust: [ '1.52.1' ]
+        rust: [ '1.55.0' ]
     steps:
       - uses: actions/checkout@v1
       - name: Download dfx binary

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [ '1.52.1' ]
+        rust: [ '1.55.0' ]
         os: [ ubuntu-latest ]
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [ '1.52.1', '1.55.0' ]
+        rust: [ '1.55.0' ]
         os: [ ubuntu-latest, macos-latest ]
 
     steps:

--- a/scripts/workflows/e2e-matrix.py
+++ b/scripts/workflows/e2e-matrix.py
@@ -18,7 +18,7 @@ matrix = {
     'test': test,
     'backend': [ 'ic-ref', 'replica' ],
     'os': [ 'macos-11', 'ubuntu-20.04' ],
-    'rust': [ '1.52.1' ]
+    'rust': [ '1.55.0' ]
 }
 
 print(json.dumps(matrix))


### PR DESCRIPTION
In our nix builds (which are what we still ship), we are now using rust 1.55.0 from https://github.com/dfinity-lab/common/blob/master/pkgs/overlays/rust/1_55.nix