### PR TITLE
fix: only run moc once for dfx build

### DIFF
--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -10,7 +10,6 @@ use crate::lib::error::{BuildError, DfxError, DfxResult};
 use crate::lib::models::canister::CanisterPool;
 use crate::lib::package_arguments::{self, PackageArguments};
 
-use anyhow::Context;
 use ic_types::principal::Principal as CanisterId;
 use slog::{info, o, trace, warn, Logger};
 use std::collections::{BTreeMap, BTreeSet};
@@ -133,27 +132,13 @@ impl CanisterBuilder for MotokoBuilder {
             None => package_arguments,
         };
 
-        // Generate IDL
-        let output_idl_path = motoko_info.get_output_idl_path();
-        let params = MotokoParams {
-            build_target: BuildTarget::Idl,
-            suppress_warning: false,
-            input: input_path,
-            package_arguments: &moc_arguments,
-            output: output_idl_path,
-            idl_path: idl_dir_path,
-            idl_map: &id_map,
-        };
-        motoko_compile(&self.logger, cache.as_ref(), &params)?;
-
         // Generate wasm
         let params = MotokoParams {
             build_target: match profile {
                 Profile::Release => BuildTarget::Release,
                 _ => BuildTarget::Debug,
             },
-            // Suppress the warnings the second time we call moc
-            suppress_warning: true,
+            suppress_warning: false,
             input: input_path,
             package_arguments: &moc_arguments,
             output: output_wasm_path,
@@ -170,62 +155,6 @@ impl CanisterBuilder for MotokoBuilder {
             idl: IdlBuildOutput::File(motoko_info.get_output_idl_path().to_path_buf()),
         })
     }
-
-    fn generate_idl(
-        &self,
-        pool: &CanisterPool,
-        info: &CanisterInfo,
-        config: &BuildConfig,
-    ) -> DfxResult<PathBuf> {
-        let motoko_info = info.as_info::<MotokoCanisterInfo>()?;
-        let input_path = motoko_info.get_main_path();
-
-        let id_map = pool
-            .get_canister_list()
-            .iter()
-            .map(|c| (c.get_name().to_string(), c.canister_id().to_text()))
-            .collect();
-
-        let generate_output_dir = &info
-            .get_declarations_config()
-            .output
-            .as_ref()
-            .context("output here must not be None")?;
-
-        std::fs::create_dir_all(generate_output_dir)?;
-        let cache = &self.cache;
-        let idl_dir_path = &config.idl_root;
-        std::fs::create_dir_all(&idl_dir_path)?;
-
-        let package_arguments =
-            package_arguments::load(cache.as_ref(), motoko_info.get_packtool())?;
-
-        let moc_arguments = match motoko_info.get_args() {
-            Some(args) => [
-                package_arguments,
-                args.split_whitespace().map(str::to_string).collect(),
-            ]
-            .concat(),
-            None => package_arguments,
-        };
-
-        // Generate IDL
-        let output_idl_path = generate_output_dir
-            .join(info.get_name())
-            .with_extension("did");
-        let params = MotokoParams {
-            build_target: BuildTarget::Idl,
-            suppress_warning: false,
-            input: input_path,
-            package_arguments: &moc_arguments,
-            output: &output_idl_path,
-            idl_path: idl_dir_path,
-            idl_map: &id_map,
-        };
-        motoko_compile(&self.logger, cache.as_ref(), &params)?;
-
-        Ok(output_idl_path)
-    }
 }
 
 type CanisterIdMap = BTreeMap<String, String>;
@@ -233,7 +162,6 @@ type CanisterIdMap = BTreeMap<String, String>;
 enum BuildTarget {
     Release,
     Debug,
-    Idl,
 }
 
 struct MotokoParams<'a> {
@@ -250,11 +178,10 @@ struct MotokoParams<'a> {
 impl MotokoParams<'_> {
     fn to_args(&self, cmd: &mut std::process::Command) {
         cmd.arg(self.input);
-        cmd.arg("-o").arg(self.output);
+        cmd.arg("-o").arg(self.output).arg("--idl");
         match self.build_target {
             BuildTarget::Release => cmd.args(&["-c", "--release"]),
             BuildTarget::Debug => cmd.args(&["-c", "--debug"]),
-            BuildTarget::Idl => cmd.arg("--idl"),
         };
         if !self.idl_map.is_empty() {
             cmd.arg("--actor-idl").arg(self.idl_path);


### PR DESCRIPTION
moc 0.6.14 generates did file while compiling to Wasm, so we no longer need to run moc twice in the build process.