### PR TITLE
fix: Stop using full network URI as a file path

### DIFF
--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -5,7 +5,7 @@ use crate::lib::error::DfxResult;
 
 use crate::lib::models::canister::CanisterPool;
 use crate::lib::provider::get_network_context;
-use crate::util::check_candid_file;
+use crate::util::{self, check_candid_file};
 
 use anyhow::{bail, Context};
 use ic_types::principal::Principal as CanisterId;
@@ -226,7 +226,9 @@ impl BuildConfig {
     pub fn from_config(config: &Config) -> DfxResult<Self> {
         let config_intf = config.get_config();
         let network_name = get_network_context()?;
-        let build_root = config.get_temp_path().join(&network_name);
+        let build_root = config
+            .get_temp_path()
+            .join(util::network_to_pathcompat(&network_name));
         let build_root = build_root.join("canisters");
 
         Ok(BuildConfig {

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -5,6 +5,7 @@ use crate::lib::canister_info::custom::CustomCanisterInfo;
 use crate::lib::canister_info::motoko::MotokoCanisterInfo;
 use crate::lib::error::DfxResult;
 use crate::lib::provider::get_network_context;
+use crate::util;
 
 use anyhow::{anyhow, bail};
 use ic_types::principal::Principal as CanisterId;
@@ -57,7 +58,9 @@ impl CanisterInfo {
         let workspace_root = config.get_path().parent().unwrap();
         let build_defaults = config.get_config().get_defaults().get_build();
         let network_name = get_network_context()?;
-        let build_root = config.get_temp_path().join(network_name);
+        let build_root = config
+            .get_temp_path()
+            .join(util::network_to_pathcompat(&network_name));
         let build_root = build_root.join("canisters");
         std::fs::create_dir_all(&build_root)?;
 

--- a/src/dfx/src/lib/provider.rs
+++ b/src/dfx/src/lib/provider.rs
@@ -2,7 +2,7 @@ use crate::config::dfinity::{Config, ConfigNetwork, NetworkType, DEFAULT_IC_GATE
 use crate::lib::environment::{AgentEnvironment, Environment};
 use crate::lib::error::DfxResult;
 use crate::lib::network::network_descriptor::NetworkDescriptor;
-use crate::util::expiry_duration;
+use crate::util::{self, expiry_duration};
 
 use anyhow::{anyhow, Context};
 use lazy_static::lazy_static;
@@ -78,10 +78,7 @@ pub fn get_network_descriptor<'a>(
             if let Ok(url) = parse_provider_url(&network_name) {
                 // Replace any non-ascii-alphanumeric characters with `_`, to create an
                 // OS-friendly directory name for it.
-                let name = network_name
-                    .chars()
-                    .map(|x| if x.is_ascii_alphanumeric() { x } else { '_' })
-                    .collect();
+                let name = util::network_to_pathcompat(&network_name);
 
                 Ok(NetworkDescriptor {
                     name,

--- a/src/dfx/src/util/mod.rs
+++ b/src/dfx/src/util/mod.rs
@@ -36,6 +36,10 @@ pub fn expiry_duration() -> Duration {
     Duration::from_secs(60 * 5)
 }
 
+pub fn network_to_pathcompat(network_name: &str) -> String {
+    network_name.replace(|c: char| !c.is_ascii_alphanumeric(), "_")
+}
+
 /// Deserialize and print return values from canister method.
 pub fn print_idl_blob(
     blob: &[u8],


### PR DESCRIPTION
This should make DFX only use one directory for a network. Fixes SDK-159