### PR TITLE
chore: Update mergify configuration to account for deprecations

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,18 @@
+queue_rules:
+  - name: default
+    conditions:
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - status-success=hydra:dfinity-ci-build:evaluation
+      - status-success=hydra:dfinity-ci-build:sdk:required
+      - status-success=audit:required
+      - status-success=e2e:required
+      - status-success=fmt:required
+      - status-success=lint:required
+      - status-success=prepare-dfx-assets:required
+      - base=master
+      - label=automerge-squash
+
 pull_request_rules:
   - name: Automatic merge (squash)
     conditions:
@@ -5,16 +20,21 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - status-success=hydra:dfinity-ci-build:evaluation
       - status-success=hydra:dfinity-ci-build:sdk:required
+      - status-success=audit:required
       - status-success=e2e:required
       - status-success=fmt:required
       - status-success=lint:required
+      - status-success=prepare-dfx-assets:required
       - base=master
       - label=automerge-squash
     actions:
       merge:
-        method: squash
-        strict: smart
-        commit_message: title+body
+        method: merge
+        name: default
+        commit_message_template: |
+          {{ title }} (#{{ number }})
+
+          {{ body }}
       delete_head_branch: {}
   - name: Clean up automerge tags
     conditions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -28,7 +28,7 @@ pull_request_rules:
       - base=master
       - label=automerge-squash
     actions:
-      merge:
+      queue:
         method: merge
         name: default
         commit_message_template: |


### PR DESCRIPTION
For:

The configuration uses the deprecated strict mode of the merge action.
A brownout is planned for the whole December 6th, 2021 day.
This option will be removed on January 10th, 2022.
For more information: https://blog.mergify.com/strict-mode-deprecation/

The configuration uses the deprecated commit_message mode of the merge action.
A brownout is planned for the whole March 21th, 2022 day.
This option will be removed on April 25th, 2022.
For more information: https://docs.mergify.com/actions/merge/


Also added two new required checks (audit and prepare-dfx-assets)