### PR TITLE
chore: use dfx generate instead of copy types

### DIFF
--- a/src/dfx/assets/new_project_node_files/package.json
+++ b/src/dfx/assets/new_project_node_files/package.json
@@ -5,10 +5,9 @@
   "keywords": ["Internet Computer", "Motoko", "JavaScript", "Canister"],
   "scripts": {
     "build": "webpack",
-    "prebuild": "npm run copy:types",
+    "prebuild": "dfx generate",
     "start": "webpack serve --mode development --env development",
-    "prestart": "npm run copy:types",
-    "copy:types": "rsync -avr .dfx/$(echo ${DFX_NETWORK:-'**'})/canisters/** --exclude='assets/' --exclude='idl/' --exclude='*.wasm' --delete src/declarations"
+    "prestart": "dfx generate"
   },
   "devDependencies": {
     "@dfinity/agent": "{js_agent_version}",


### PR DESCRIPTION
Now that dfx generate is released, we should use it to output the types. 

Behavior is the same as our previous command