### PR TITLE
chore: Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.55.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Prevents developers from having to run `rustup override set 1.55.0` for accurate lints and lang/library features.