### PR TITLE
fix: dfx cache list: skip cache directories being installed

### DIFF
--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -215,6 +215,10 @@ pub fn list_versions() -> DfxResult<Vec<Version>> {
     for entry in std::fs::read_dir(root)? {
         let entry = entry?;
         if let Some(version) = entry.file_name().to_str() {
+            if version.starts_with('_') {
+                // temp directory for version being installed
+                continue;
+            }
             result.push(Version::parse(version)?);
         }
     }


### PR DESCRIPTION
When dfx installs a cache directory, it first copies all of the files into a directory `_<version>_<random>`, and once all files have been copied, renames the directory to `<version>`.  This prevents dfx from later using partially copied cache directories.

This change makes `dfx cache list` ignore these temporary directories, rather than exiting with an error message like `unexpected character '_' while parsing major version number`.