### PR TITLE
Allow users to force reinstall a canister without prompting

### DIFF
--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -28,6 +28,10 @@ pub struct CanisterInstallOpts {
     #[clap(long)]
     async_call: bool,
 
+    /// Specifies whether to automatically proceed with reinstalling a canister without prompting the user for manual confirmation. Only matters if mode is reinstall.
+    #[clap(long, short('y')]
+    yes: bool,
+
     /// Specifies the type of deployment. You can set the canister deployment modes to install, reinstall, or upgrade.
     #[clap(long, short('m'), default_value("install"),
         possible_values(&["install", "reinstall", "upgrade"]))]
@@ -81,6 +85,7 @@ pub async fn exec(
             &canister_info,
             &install_args,
             mode,
+            yes,
             timeout,
             call_sender,
             installed_module_hash,

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -25,6 +25,7 @@ pub async fn install_canister(
     canister_info: &CanisterInfo,
     args: &[u8],
     mode: InstallMode,
+    force_reinstall: bool,
     timeout: Duration,
     call_sender: &CallSender,
     installed_module_hash: Option<Vec<u8>>,
@@ -34,7 +35,7 @@ pub async fn install_canister(
         named_canister::install_ui_canister(env, network, None).await?;
     }
 
-    if mode == InstallMode::Reinstall {
+    if mode == InstallMode::Reinstall && !force_reinstall {
         eprintln!("Warning!");
         eprintln!(
             "You are about to reinstall the {} canister.",


### PR DESCRIPTION
Useful for scripting