### PR TITLE
chore: add Monterey as a recognised macos version in install.sh

### DIFF
--- a/public/install/200_downloader.sh
+++ b/public/install/200_downloader.sh
@@ -18,6 +18,7 @@ check_help_for() {
             10.14*) ;; # Mojave
             10.15*) ;; # Catalina
             11.*) ;;   # Big Sur
+            12.*) ;;   # Monterey
             *)
                 warn "Detected OS X platform older than 10.13 (High Sierra)"
                 _ok="n"


### PR DESCRIPTION
When installing on macos Montery (12.1) the installer told me that 12.1 is older than 10.13