### PR TITLE
fix: dfx identity import now handles pem files generated by quill

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,11 @@ Caused by:
   Odd number of digits
 ----
 
+=== fix: dfx import will now import pem files created by `quill generate`
+
+`quill generate` currently outputs .pem files without an `EC PARAMETERS` section.
+`dfx identity import` will now correctly identify these as EC keys, rather than Ed25519.
+
 == ic-ref
 
 Upgraded from a432156f24faa16d387c9d36815f7ddc5d50e09f to ab8e3f5a04f0f061b8157c2889f8f5de05f952bb

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -364,3 +364,19 @@ teardown() {
     assert_match 'Creating identity: "bob".' "$stderr"
     assert_match 'Invalid Ed25519 private key in PEM file at' "$stderr"
 }
+
+@test "identity: can import an EC key without an EC PARAMETERS section (as quill generate makes)" {
+    cat >private-key-no-ec-parameters.pem <<XXX
+-----BEGIN EC PRIVATE KEY-----
+MHQCAQEEIE+3ipe2ruuJOmeBAhImUP/jic7Qwk2fXC8BaAmu6VK4oAcGBSuBBAAK
+oUQDQgAEBQKn0CLyiA/fQf6L8S07/MDJ9kIJTzZvm2jFo2/yvSToGee+XzP/GCE4
+08ZcZFM1EwUsknDBoSd0EF1PzFRmJg==
+-----END EC PRIVATE KEY-----
+XXX
+    assert_command dfx identity import private-key-no-ec-parameters private-key-no-ec-parameters.pem
+    assert_command dfx --identity private-key-no-ec-parameters identity get-principal
+    assert_eq "j4p4p-o5ogq-4gzev-t3kay-hpm5o-xuwpz-yvrpp-47cc4-qyunt-k76yw-qae"
+    echo "{}" >dfx.json # avoid "dfx.json not found, using default."
+    assert_command dfx --identity private-key-no-ec-parameters ledger account-id
+    assert_eq "3c00cf85d77b9dbf74a2acec1d9a9e73a3fc65f5048c64800b15f3b2c4c8eb11"
+}

--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -416,7 +416,9 @@ pub(super) fn validate_pem_file(pem_file: &Path) -> DfxResult {
         "Cannot read PEM file at '{}'.",
         PathBuf::from(pem_file).display()
     ))?;
-    if contents.starts_with(b"-----BEGIN EC PARAMETERS-----") {
+    if contents.starts_with(b"-----BEGIN EC PARAMETERS-----")
+        || contents.starts_with(b"-----BEGIN EC PRIVATE KEY-----")
+    {
         let private_key = EcKey::private_key_from_pem(&contents).context(format!(
             "Cannot decode PEM file at '{}'.",
             PathBuf::from(pem_file).display()


### PR DESCRIPTION
`quill generate --pem-file <pem file>` generates .pem files that don't include an `EC PARAMETERS` section, in contrast to .pem files created by keysmith.  `dfx identity import` misidentifies these as Ed25519.

Since `dfx identity import` still checks that these keys are secp256k1, this change identifies .pem files that begin with either an `EC PARAMETERS` or `EC PRIVATE KEY` section as EC private keys, and therefore imports them.

Fixes https://dfinity.atlassian.net/browse/SDK-296

