### PR TITLE
chore: update to agent-rs 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,8 +1725,8 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.11.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=22c7bb2ec77be4779f85313791a066ff75939bfb#22c7bb2ec77be4779f85313791a066ff75939bfb"
+version = "0.12.1"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427#8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427"
 dependencies = [
  "async-trait",
  "base32",
@@ -1755,8 +1755,8 @@ dependencies = [
 
 [[package]]
 name = "ic-asset"
-version = "0.11.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=22c7bb2ec77be4779f85313791a066ff75939bfb#22c7bb2ec77be4779f85313791a066ff75939bfb"
+version = "0.12.1"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427#8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427"
 dependencies = [
  "anyhow",
  "candid",
@@ -1778,8 +1778,8 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.11.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=22c7bb2ec77be4779f85313791a066ff75939bfb#22c7bb2ec77be4779f85313791a066ff75939bfb"
+version = "0.12.1"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427#8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1807,8 +1807,8 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.11.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=22c7bb2ec77be4779f85313791a066ff75939bfb#22c7bb2ec77be4779f85313791a066ff75939bfb"
+version = "0.12.1"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427#8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427"
 dependencies = [
  "async-trait",
  "candid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,21 +4,21 @@ members = [
 ]
 
 [patch.crates-io.ic-agent]
-version = "0.11.0"
+version = "0.12.1"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "22c7bb2ec77be4779f85313791a066ff75939bfb"
+rev = "8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427"
 
 [patch.crates-io.ic-asset]
-version = "0.11.0"
+version = "0.12.1"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "22c7bb2ec77be4779f85313791a066ff75939bfb"
+rev = "8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427"
 
 [patch.crates-io.ic-identity-hsm]
-version = "0.11.0"
+version = "0.12.1"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "22c7bb2ec77be4779f85313791a066ff75939bfb"
+rev = "8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427"
 
 [patch.crates-io.ic-utils]
-version = "0.11.0"
+version = "0.12.1"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "22c7bb2ec77be4779f85313791a066ff75939bfb"
+rev = "8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427"

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -79,25 +79,25 @@ walkdir = "2.2.9"
 wasmparser = "0.81.0"
 
 [dependencies.ic-agent]
-version = "0.11.0"
+version = "0.12.1"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "22c7bb2ec77be4779f85313791a066ff75939bfb"
+rev = "8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427"
 features = ["reqwest"]
 
 [dependencies.ic-asset]
-version = "0.11.0"
+version = "0.12.1"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "22c7bb2ec77be4779f85313791a066ff75939bfb"
+rev = "8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427"
 
 [dependencies.ic-identity-hsm]
-version = "0.11.0"
+version = "0.12.1"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "22c7bb2ec77be4779f85313791a066ff75939bfb"
+rev = "8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427"
 
 [dependencies.ic-utils]
-version = "0.11.0"
+version = "0.12.1"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "22c7bb2ec77be4779f85313791a066ff75939bfb"
+rev = "8ed6cb82c9aaca80e4c7c9dfe1889c2022a3f427"
 
 [dev-dependencies]
 env_logger = "0.9"


### PR DESCRIPTION
Nothing user-facing, but won't break when we next upgrade the certified assets canister.