### PR TITLE
chore: respect provider when determining whether on IC or not

### DIFF
--- a/src/dfx/src/commands/ping.rs
+++ b/src/dfx/src/commands/ping.rs
@@ -1,4 +1,4 @@
-use crate::config::dfinity::{NetworkType, DEFAULT_IC_GATEWAY};
+use crate::config::dfinity::NetworkType;
 use crate::lib::environment::{AgentEnvironment, Environment};
 use crate::lib::error::{DfxError, DfxResult};
 use crate::lib::network::network_descriptor::NetworkDescriptor;
@@ -39,11 +39,12 @@ pub fn exec(env: &dyn Environment, opts: PingOpts) -> DfxResult {
             warn!(logger, "{}", err);
             let network_name = get_network_context()?;
             let url = command_line_provider_to_url(&network_name)?;
+            let is_ic = NetworkDescriptor::is_ic(&network_name, &vec![url.to_string()]);
             let network_descriptor = NetworkDescriptor {
                 name: "-ping-".to_string(),
                 providers: vec![url],
                 r#type: NetworkType::Ephemeral,
-                is_ic: network_name == "ic" || network_name == DEFAULT_IC_GATEWAY,
+                is_ic,
             };
             Ok(network_descriptor)
         })?;

--- a/src/dfx/src/lib/builders/assets.rs
+++ b/src/dfx/src/lib/builders/assets.rs
@@ -1,5 +1,4 @@
 use crate::config::cache::Cache;
-use crate::config::dfinity::DEFAULT_IC_GATEWAY;
 use crate::config::dfx_version;
 use crate::lib::builders::{
     BuildConfig, BuildOutput, CanisterBuilder, IdlBuildOutput, WasmBuildOutput,
@@ -9,6 +8,7 @@ use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
 use crate::lib::error::{BuildError, DfxError, DfxResult};
 use crate::lib::models::canister::CanisterPool;
+use crate::lib::network::network_descriptor::NetworkDescriptor;
 use crate::util;
 
 use anyhow::{anyhow, bail, Context};
@@ -276,7 +276,7 @@ fn build_frontend(
             .env("DFX_VERSION", &format!("{}", dfx_version()))
             .env("DFX_NETWORK", &network_name);
 
-        if network_name == "ic" || network_name == DEFAULT_IC_GATEWAY {
+        if NetworkDescriptor::is_ic(network_name, &vec![]) {
             cmd.env("NODE_ENV", "production");
         }
 

--- a/src/dfx/src/lib/network/network_descriptor.rs
+++ b/src/dfx/src/lib/network/network_descriptor.rs
@@ -1,4 +1,5 @@
 use crate::config::dfinity::NetworkType;
+use crate::config::dfinity::DEFAULT_IC_GATEWAY;
 
 #[derive(Clone, Debug)]
 pub struct NetworkDescriptor {
@@ -6,4 +7,57 @@ pub struct NetworkDescriptor {
     pub providers: Vec<String>,
     pub r#type: NetworkType,
     pub is_ic: bool,
+}
+
+impl NetworkDescriptor {
+    // Determines whether the provided connection is the official IC or not.
+    #[allow(clippy::ptr_arg)]
+    pub fn is_ic(network_name: &str, providers: &Vec<String>) -> bool {
+        let name_match = network_name == "ic" || network_name == DEFAULT_IC_GATEWAY;
+        let provider_match =
+            { providers.len() == 1 && providers.get(0).unwrap() == "https://ic0.app" };
+        name_match || provider_match
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn ic_by_netname() {
+        assert!(NetworkDescriptor::is_ic("ic", &vec![]));
+    }
+
+    #[test]
+    fn ic_by_provider() {
+        assert!(NetworkDescriptor::is_ic(
+            "not_ic",
+            &vec!["https://ic0.app".to_string()]
+        ));
+    }
+
+    #[test]
+    fn ic_by_netname_fail() {
+        assert!(!NetworkDescriptor::is_ic("not_ic", &vec![]));
+    }
+
+    #[test]
+    fn ic_by_provider_fail_string() {
+        assert!(!NetworkDescriptor::is_ic(
+            "not_ic",
+            &vec!["not_ic_provider".to_string()]
+        ));
+    }
+
+    #[test]
+    fn ic_by_provider_fail_unique() {
+        assert!(!NetworkDescriptor::is_ic(
+            "not_ic",
+            &vec![
+                "https://ic0.app".to_string(),
+                "some_other_provider".to_string()
+            ]
+        ));
+    }
 }


### PR DESCRIPTION
Replaces pull #2007 with an internal pull since Hydra doesn't approve of external ones.

Jira: [SDK-279](https://dfinity.atlassian.net/browse/SDK-279)

Previously: dfx only allowed to access the main IC net with two reserved strings for `--network`.
New: main IC net can also be accessed by an alias that looks like this: `"staging": { "providers": [ "https://ic0.app" ], "type": "persistent" }`