### PR TITLE
chore: remove dependency on brotli-sys.  

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb8958da437716f3f31b0e76f8daf36554128517d7df37ceba7df00f09622ee"
+checksum = "2be6b66b62a794a8e6d366ac9415bb7d475ffd1e9f4671f38c1d8a8a5df950b3"
 dependencies = [
  "actix-codec",
  "actix-connect",
@@ -136,7 +136,7 @@ dependencies = [
  "actix-utils",
  "base64 0.13.0",
  "bitflags",
- "brotli2",
+ "brotli",
  "bytes 0.5.6",
  "cookie",
  "copyless",
@@ -389,6 +389,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "annotate-snippets"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,23 +608,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli-sys"
-version = "0.3.2"
+name = "brotli"
+version = "3.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
+checksum = "f838e47a451d5a8fa552371f80024dd6ace9b7acdf25c4c3d0f9bc6816fb1c39"
 dependencies = [
- "cc",
- "libc",
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
 ]
 
 [[package]]
-name = "brotli2"
-version = "0.3.2"
+name = "brotli-decompressor"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
 dependencies = [
- "brotli-sys",
- "libc",
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -999,6 +1015,7 @@ dependencies = [
  "actix",
  "actix-cors",
  "actix-files",
+ "actix-http",
  "actix-server",
  "actix-web",
  "anyhow",

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -19,6 +19,7 @@ tar = "0.4.26"
 actix = "0.10.0"
 actix-cors = "0.4.0"
 actix-files = "0.3.0"
+actix-http = { version = "2.2.2", default-features = false }
 actix-server = "1.0.4"
 actix-web = { version = "3.0.2", features = [ "default", "openssl", "rustls" ] }
 anyhow = "1.0.51"


### PR DESCRIPTION
We only use actix-http for serving candid files anyway.

Avoids this cargo audit failure:
Crate:         brotli-sys
Version:       0.3.2
Title:         Integer overflow in the bundled Brotli C library
Date:          2021-12-20
ID:            RUSTSEC-2021-0131
URL:           https://rustsec.org/advisories/RUSTSEC-2021-0131
Solution:      No safe upgrade is available!
Dependency tree:
brotli-sys 0.3.2
└── brotli2 0.3.2
    └── actix-http 2.2.1
        ├── dfx 0.9.0
        ├── awc 2.0.3
        │   └── actix-web 3.3.2
        │       ├── dfx 0.9.0
        │       ├── actix-files 0.3.0
        │       │   └── dfx 0.9.0
        │       └── actix-cors 0.4.1
        │           └── dfx 0.9.0
        ├── actix-web 3.3.2
        └── actix-files 0.3.0