### PR TITLE
chore: update thread_local to 1.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]


### PR DESCRIPTION
Fixes this cargo audit failure, in order to un-stick https://github.com/dfinity/sdk/pull/1966

```
Crate:         thread_local
Version:       1.1.3
Title:         Data race in `Iter` and `IterMut`
Date:          2022-01-23
ID:            RUSTSEC-2022-0006
URL:           https://rustsec.org/advisories/RUSTSEC-2022-0006
Solution:      Upgrade to >=1.1.4
Dependency tree:
thread_local 1.1.3
├── slog-term 2.8.0
│   └── dfx 0.9.0
└── slog-async 2.7.0
    └── dfx 0.9.0
```