### PR TITLE
chore: update cdk version in new rust project

### DIFF
--- a/src/dfx/assets/new_project_rust_files/src/__project_name__/Cargo.toml
+++ b/src/dfx/assets/new_project_rust_files/src/__project_name__/Cargo.toml
@@ -10,5 +10,6 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-ic-cdk = "0.3"
-ic-cdk-macros = "0.3"
+candid = "0.7.4"
+ic-cdk = "0.4"
+ic-cdk-macros = "0.4"


### PR DESCRIPTION
`candid` is included in the `dependencies`