### PR TITLE
fix: High Sierra, Mojave no longer supported

### DIFF
--- a/public/install/200_downloader.sh
+++ b/public/install/200_downloader.sh
@@ -14,13 +14,11 @@ check_help_for() {
     # fail to find these options to force fallback
     if check_cmd sw_vers; then
         case "$(sw_vers -productVersion)" in
-            10.13*) ;; # High Sierra
-            10.14*) ;; # Mojave
             10.15*) ;; # Catalina
             11.*) ;;   # Big Sur
             12.*) ;;   # Monterey
             *)
-                warn "Detected OS X platform older than 10.13 (High Sierra)"
+                warn "Detected OS X platform older than 10.15 (Catalina)"
                 _ok="n"
                 ;;
         esac


### PR DESCRIPTION
This is so that we display an error about the minimum supported OSX version being Catalina, rather than an error message about an expired cert.