### PR TITLE
feat: publish dfx to github release when a version tag is pushed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,130 @@
+name: Publish
+
+# We have to use gtar on macOS because apple's tar is literally broken.
+# Yes, I know how stupid that sounds. But it's true:
+# https://github.com/actions/virtual-environments/issues/2619
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
+      - 'test-[0-9]+.[0-9]+.[0-9]+'
+      - 'test-[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
+
+jobs:
+  build_dfx:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ '1.55.0' ]
+        target: [ x86_64-apple-darwin, x86_64-unknown-linux-musl ]
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            binary_path: target/x86_64-apple-darwin/release
+            name: macos
+            tar: gtar
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            binary_path: target/x86_64-unknown-linux-musl/release
+            name: linux
+            tar: tar
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup environment variables
+        run: |
+          echo "OPENSSL_STATIC=yes" >> $GITHUB_ENV
+          echo "RUSTFLAGS=--remap-path-prefix=${GITHUB_WORKSPACE}=/builds/dfinity" >> $GITHUB_ENV
+          echo "DFX_VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV
+
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.rust }}-1
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+        if: contains(matrix.os, 'macos')
+
+      - name: Linux hack (musl only)
+        run: |
+          echo "[toolchain]" >./rust-toolchain.toml
+          echo 'channel = "1.58.1"' >>./rust-toolchain.toml
+          echo 'components = ["rustfmt", "clippy"]' >>./rust-toolchain.toml
+        if: contains(matrix.target, 'linux-musl')
+
+      - name: Generate DFX_ASSETS (musl only)
+        run: |
+          ./scripts/prepare-dfx-assets.sh .dfx-assets
+          echo "DFX_ASSETS=$(pwd)/.dfx-assets" >> $GITHUB_ENV
+        if: contains(matrix.target, 'linux-musl')
+
+      - name: Linux build (musl)
+        uses: dfinity/rust-musl-action@master
+        with:
+          args: |
+            echo "[toolchain]" >./rust-toolchain.toml
+            echo 'channel = "1.55.0"' >>./rust-toolchain.toml
+            echo 'components = ["rustfmt", "clippy"]' >>./rust-toolchain.toml
+            rustup target add ${{ matrix.target }}
+
+            cargo clean --target ${{ matrix.target }} --release
+            cargo build --target ${{ matrix.target }} --locked --release
+        if: contains(matrix.target, 'linux-musl')
+
+      - name: Build (non-musl)
+        run: |
+          cargo clean --target ${{ matrix.target }} --release
+          cargo build --target ${{ matrix.target }} --locked --release
+        if: contains(matrix.target, 'linux-musl') == false
+
+      - name: Strip binaries
+        run: |
+          cd ${{ matrix.binary_path }}
+          sudo chown -R $(whoami) .
+          strip dfx
+        if: contains(matrix.os, 'ubuntu')
+
+      - name: Create tarball of binaries
+        run: ${{ matrix.tar }} -zcC ${{ matrix.binary_path }} -f binaries.tar.gz dfx
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: binary-tarball-${{ matrix.rust }}-${{ matrix.name }}
+          path: binaries.tar.gz
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build_dfx
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ '1.55.0' ]
+        name: [ 'macos', 'linux' ]
+    steps:
+      - name: Setup environment variables
+        run: echo "VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: binary-tarball-${{ matrix.rust }}-${{ matrix.name }}
+
+      - name: Upload tarball
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: binaries.tar.gz
+          asset_name: dfx-${{ env.VERSION }}-${{ matrix.name }}.tar.gz
+          tag: ${{ env.VERSION }}

--- a/src/dfx/assets/build.rs
+++ b/src/dfx/assets/build.rs
@@ -134,12 +134,11 @@ fn write_archive_accessor(fn_name: &str, f: &mut File) {
 }
 
 fn get_git_hash() -> Option<String> {
-    let describe = Command::new("git").arg("describe").arg("--dirty").output();
-
-    if let Ok(output) = describe {
-        Some(String::from_utf8_lossy(&output.stdout).to_string())
-    } else {
-        None
+    match Command::new("git").arg("describe").arg("--dirty").output() {
+        Ok(output) if output.status.success() => {
+            Some(String::from_utf8_lossy(&output.stdout).to_string())
+        }
+        _ => None,
     }
 }
 


### PR DESCRIPTION
As a first step, this publishes binary tarballs when a release tag is pushed.  The linux binary is statically linked.

A follow-up PR will either also publish these to s3, or make the install script download these releases from github.com/dfinity/sdk/release.

Also:
- `get_git_hash()`: don't report an empty string if git describe --dirty fails