### PR TITLE
fix: remove .most file from declaration

### DIFF
--- a/src/dfx/assets/new_project_node_files/package.json
+++ b/src/dfx/assets/new_project_node_files/package.json
@@ -8,7 +8,7 @@
     "prebuild": "npm run copy:types",
     "start": "webpack serve --mode development --env development",
     "prestart": "npm run copy:types",
-    "copy:types": "rsync -avr .dfx/$(echo ${DFX_NETWORK:-'**'})/canisters/** --exclude='assets/' --exclude='idl/' --exclude='*.wasm' --delete src/declarations"
+    "copy:types": "rsync -avr .dfx/$(echo ${DFX_NETWORK:-'**'})/canisters/** --exclude='assets/' --exclude='idl/' --exclude='*.wasm' --exclude='*.most' --delete src/declarations"
   },
   "devDependencies": {
     "@dfinity/agent": "{js_agent_version}",


### PR DESCRIPTION
`.most` file are generated by motoko compiler for internal use, it should not be copied to the `declaration` directory.