### PR TITLE
feat: dfx deploy shows frontend and candid urls

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,8 @@
 
 == DFX
 
+=== feat: dfx deploy now displays URLs for the frontend and candid interface
+
 === dfx.json
 
 In preparation for BTC integration, added configuration for the bitcoind port:

--- a/e2e/tests-dfx/frontend.bash
+++ b/e2e/tests-dfx/frontend.bash
@@ -14,6 +14,26 @@ teardown() {
     standard_teardown
 }
 
+@test "dfx deploy shows a url for the frontend and for the candid interface" {
+    dfx_start
+    PORT=$(cat .dfx/webserver-port)
+
+    assert_command dfx deploy
+    CANDID_UI_ID=$(dfx canister id __Candid_UI)
+    APP_ID=$(dfx canister id e2e_project)
+    ASSETS_ID=$(dfx canister id e2e_project_assets)
+    assert_match "e2e_project: http://127.0.0.1:$PORT/\?canisterId=$CANDID_UI_ID&id=$APP_ID"
+    assert_match "e2e_project_assets: http://127.0.0.1:$PORT/\?canisterId=$ASSETS_ID"
+
+    # the urls are a little nicer if the bind address is localhost:8000 rather than 127.0.0.1:8000
+    # shellcheck disable=SC2094
+    cat <<<"$(jq '.networks.local.bind="localhost:'"$PORT"'"' dfx.json)" >dfx.json
+
+    assert_command dfx deploy
+    assert_match "e2e_project: http://$CANDID_UI_ID.localhost:$PORT/\?id=$APP_ID"
+    assert_match "e2e_project_assets: http://$ASSETS_ID.localhost:$PORT/"
+}
+
 @test "dfx start serves a frontend with static assets" {
     skip "Need a build of @dfinity/agent that works with HTTP Query"
     dfx_start

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -3,15 +3,26 @@ use crate::lib::identity::identity_utils::{call_sender, CallSender};
 use crate::lib::operations::canister::deploy_canisters;
 use crate::lib::provider::create_agent_environment;
 use crate::lib::root_key::fetch_root_key_if_needed;
-use crate::lib::{environment::Environment, identity::Identity};
+use crate::lib::{environment::Environment, identity::Identity, named_canister};
 use crate::util::clap::validators::cycle_amount_validator;
 use crate::util::expiry_duration;
+use std::collections::BTreeMap;
 
+use crate::lib::canister_info::CanisterInfo;
+use crate::lib::models::canister_id_store::CanisterIdStore;
+use crate::lib::network::network_descriptor::NetworkDescriptor;
 use anyhow::{anyhow, bail};
 use clap::Parser;
+use console::Style;
+use ic_types::Principal;
 use ic_utils::interfaces::management_canister::builders::InstallMode;
+use slog::info;
 use std::str::FromStr;
 use tokio::runtime::Runtime;
+use url::Host::Domain;
+use url::Url;
+
+const MAINNET_CANDID_INTERFACE_PRINCIPAL: &str = "a4gq6-oaaaa-aaaab-qaa4q-cai";
 
 /// Deploys all or a specific canister from the code in your project. By default, all canisters are deployed.
 #[derive(Parser)]
@@ -116,5 +127,88 @@ pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
         with_cycles,
         &call_sender,
         create_call_sender,
-    ))
+    ))?;
+
+    display_urls(&env)
+}
+
+fn display_urls(env: &dyn Environment) -> DfxResult {
+    let config = env.get_config_or_anyhow()?;
+    let network: &NetworkDescriptor = env.get_network_descriptor().unwrap();
+    let log = env.get_logger();
+    let canister_id_store = CanisterIdStore::for_env(env)?;
+
+    let mut frontend_urls = BTreeMap::new();
+    let mut candid_urls: BTreeMap<&String, Url> = BTreeMap::new();
+
+    let ui_canister_id = named_canister::get_ui_canister_id(network);
+
+    if let Some(canisters) = &config.get_config().canisters {
+        for (canister_name, canister_config) in canisters {
+            if config
+                .get_config()
+                .is_remote_canister(canister_name, &network.name)?
+            {
+                continue;
+            }
+            let canister_id = Principal::from_text(canister_name)
+                .or_else(|_| canister_id_store.get(canister_name))?;
+            let canister_info = CanisterInfo::load(&config, canister_name, Some(canister_id))?;
+            let is_frontend = canister_config.extras.get("frontend").is_some();
+
+            if is_frontend {
+                let mut url = Url::parse(&network.providers[0])?;
+
+                if let Some(Domain(domain)) = url.host() {
+                    let host = format!("{}.{}", canister_id, domain);
+                    url.set_host(Some(&host))?;
+                } else {
+                    let query = format!("canisterId={}", canister_id);
+                    url.set_query(Some(&query));
+                };
+                frontend_urls.insert(canister_name, url);
+            }
+
+            if canister_info.get_type() != "assets" {
+                if network.is_ic {
+                    let url = format!(
+                        "https://{}.raw.ic0.app/?id={}",
+                        MAINNET_CANDID_INTERFACE_PRINCIPAL, canister_id
+                    );
+                    candid_urls.insert(canister_name, Url::parse(&url)?);
+                } else if let Some(ui_canister_id) = ui_canister_id {
+                    let mut url = Url::parse(&network.providers[0])?;
+                    if let Some(Domain(domain)) = url.host() {
+                        let host = format!("{}.{}", ui_canister_id, domain);
+                        let query = format!("id={}", canister_id);
+                        url.set_host(Some(&host))?;
+                        url.set_query(Some(&query));
+                    } else {
+                        let query = format!("canisterId={}&id={}", ui_canister_id, canister_id);
+                        url.set_query(Some(&query));
+                    }
+                    candid_urls.insert(canister_name, url);
+                };
+            }
+        }
+    }
+
+    if !frontend_urls.is_empty() || !candid_urls.is_empty() {
+        info!(log, "URLs:");
+        let green = Style::new().green();
+        if !frontend_urls.is_empty() {
+            info!(log, "  Frontend:");
+            for (name, url) in frontend_urls {
+                info!(log, "    {}: {}", name, green.apply_to(url));
+            }
+        }
+        if !candid_urls.is_empty() {
+            info!(log, "  Candid:");
+            for (name, url) in candid_urls {
+                info!(log, "    {}: {}", name, green.apply_to(url));
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -153,7 +153,7 @@ fn display_urls(env: &dyn Environment) -> DfxResult {
             }
             let canister_id = match Principal::from_text(canister_name) {
                 Ok(principal) => Some(principal),
-                Err(_) => canister_id_store.find(canister_name)
+                Err(_) => canister_id_store.find(canister_name),
             };
             if let Some(canister_id) = canister_id {
                 let canister_info = CanisterInfo::load(&config, canister_name, Some(canister_id))?;


### PR DESCRIPTION
Example output for local deploy, if dfx.json has `127.0.0.1:8000` as the bind address, which is the default:
```
$ dfx deploy
...
Committing batch.
Deployed canisters.
URLs:
  Frontend:
    dd_assets: http://127.0.0.1:8000/?canisterId=rdmx6-jaaaa-aaaaa-aaadq-cai
  Candid:
    dd: http://127.0.0.1:8000/?canisterId=qoctq-giaaa-aaaaa-aaaea-cai&id=renrk-eyaaa-aaaaa-aaada-cai
```

Example output for local deploy, if dfx.json has `localhost:8000` as the bind address:
```
$ dfx deploy
...
Deployed canisters.
URLs:
  Frontend:
    dd_assets: http://ryjl3-tyaaa-aaaaa-aaaba-cai.localhost:8000/
  Candid:
    dd: http://r7inp-6aaaa-aaaaa-aaabq-cai.localhost:8000/?id=rrkah-fqaaa-aaaaa-aaaaq-cai
```

Example mainnet output:
```
$ dfx --identity mainnet deploy --network ic
...
Committing batch.
Deployed canisters.
URLs:
  Frontend:
    mainnet_assets: https://zrrcc-3aaaa-aaaai-abzkq-cai.ic0.app/
  Candid:
    mainnet: https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.ic0.app/?id=zwqew-wyaaa-aaaai-abzka-cai
```