### PR TITLE
fix: broken icx-proxy in nix builds

### DIFF
--- a/assets.nix
+++ b/assets.nix
@@ -2,12 +2,6 @@
 , distributed-canisters ? import ./distributed-canisters.nix { inherit pkgs; }
 }:
 let
-  icx-proxy-standalone = pkgs.lib.standaloneRust {
-    drv = pkgs.icx-proxy;
-    exename = "icx-proxy";
-    usePackager = false;
-  };
-  icx-proxy-bin = pkgs.sources."icx-proxy-${pkgs.system}";
   replica-bin = pkgs.sources."replica-${pkgs.system}";
   canister-sandbox-bin = pkgs.sources."canister-sandbox-${pkgs.system}";
   sandbox-launcher-bin = pkgs.sources."sandbox-launcher-${pkgs.system}";
@@ -15,7 +9,6 @@ let
   looseBinaryCache = pkgs.runCommandNoCCLocal "loose-binary-cache" {} ''
     mkdir -p $out
 
-    gunzip <${icx-proxy-bin} >$out/icx-proxy
     gunzip <${replica-bin} >$out/replica
     gunzip <${canister-sandbox-bin} >$out/canister_sandbox
     gunzip <${sandbox-launcher-bin} >$out/sandbox_launcher
@@ -25,6 +18,7 @@ let
     cp ${pkgs.motoko}/bin/mo-ide $out
     cp ${pkgs.motoko}/bin/moc $out
     cp ${pkgs.ic-ref}/bin/* $out
+    cp ${pkgs.icx-proxy}/bin/icx-proxy $out
   '';
 in
 pkgs.runCommandNoCCLocal "assets" {} ''

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -45,15 +45,6 @@ let
                 ++ self.lib.optional self.stdenv.isDarwin pkgs.libiconv;
                 override = attrs: { OPENSSL_STATIC = "1"; };
               };
-              icx-proxy = self.naersk.buildPackage {
-                name = "icx-proxy";
-                root = self.sources.icx-proxy;
-                cargoBuildOptions = x: x ++ [ "-p" "icx-proxy" ];
-                cargoTestOptions = x: x ++ [ "-p" "icx-proxy" ];
-                buildInputs = [ self.pkgsStatic.openssl self.pkg-config ]
-                ++ self.lib.optional self.stdenv.isDarwin pkgs.libiconv;
-                override = attrs: { OPENSSL_STATIC = "1"; };
-              };
               dfinity =
                 (import self.sources.dfinity { inherit (self) system; }).dfinity.rs;
               napalm = self.callPackage self.sources.napalm {
@@ -68,6 +59,12 @@ let
               '';
               motoko = pkgs.runCommandNoCCLocal "motoko" {
                 src = self.sources."motoko-${self.system}";
+              } ''
+                mkdir -p $out/bin
+                tar -C $out/bin -xf $src
+              '';
+              icx-proxy = pkgs.runCommandNoCCLocal "icx-proxy" {
+                src = self.sources."icx-proxy-${pkgs.system}";
               } ''
                 mkdir -p $out/bin
                 tar -C $out/bin -xf $src


### PR DESCRIPTION
The .tar form of the release binary tarball (.tar.gz) was being included as the icx-proxy binary, rather than the contained icx-proxy binary.

Before:
```
$ ( export DFX_CONFIG_ROOT="$(mktemp -d)"; DFX="$(nix-build ./dfx.nix -A build)/bin/dfx" ; "$DFX" cache install ; $("$DFX" cache show)/icx-proxy --help )
  Version v0.9.2 installed successfully.
zsh: exec format error: /var/folders/vl/2fdfs_116pb82rzcb_s779d80000gn/T/tmp.b2PPAA85/.cache/dfinity/versions/0.9.2/icx-proxy
```

After:
```
$ ( export DFX_CONFIG_ROOT="$(mktemp -d)"; DFX="$(nix-build ./dfx.nix -A build)/bin/dfx" ; "$DFX" cache install ; $("$DFX" cache show)/icx-proxy --help )
building '/nix/store/l2h140b9849clcimy1s2rnmjam4ygv8x-git-ls-files.drv'...
  Version v0.9.2 installed successfully.
icx-proxy 0.8.1
DFINITY Stiftung <sdk@dfinity.org>

USAGE:
    icx-proxy [OPTIONS]

...
```