### PR TITLE
feat: JS language bindings by default configure the HttpAgent to generate a Nonce for updates.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,45 @@
 = dfx changelog
 :doctype: book
 
+= 0.9.4
+
+== DFX
+
+=== JS language bindings: createActor now by default configures the HttpAgent to generate a Nonce for updates, ensuring uniqueness
+
+*Important*: It is necessary to run `dfx generate` to update bindings in order for this change to take effect.
+
+Prior to this change, near-simultaneous update calls to a method with the same argument values could be submitted to
+the replica as identical requests.  In some cases the ingress_expiry field would differ, in other cases not.
+
+For example, the following calls could return all the same values:
+
+[source, javascript]
+----
+const val = await Promise.all([
+    dd.inc(),
+    dd.inc(),
+    dd.inc(),
+    dd.inc()
+    ]);
+----
+given this canister code:
+[source, motoko]
+----
+public func inc() : async Nat {
+  counter += 1;
+  counter
+};
+----
+
+Now, by default, the createActor() method in the JS language bindings configures the HttpAgent to generate a nonce, effectively:
+[source, javascript]
+----
+    agent.addTransform(makeNonceTransform(makeNonce));
+----
+This behavior can be controlled by the `useNonceForUpdates` and `nonceFn` options to `createActor`.
+
+
 = 0.9.3
 
 == DFX

--- a/src/dfx/assets/language_bindings/canister.js
+++ b/src/dfx/assets/language_bindings/canister.js
@@ -17,7 +17,7 @@ export const canisterId = process.env.{canister_name_uppercase}_CANISTER_ID;
   const agent = new HttpAgent({ ...options?.agentOptions });
   if(useNonceForUpdates) {
     // By default we will set a unique nonce so that update calls with
-    // the same parameters will be made unique through that unique nonce.
+    // the same parameter values will be distinguishable from one another.
     agent.addTransform(makeNonceTransform(nonceFn??makeNonce));
   }
 


### PR DESCRIPTION
Must run `dfx generate` for this change to take effect in a project.

See https://forum.dfinity.org/t/calling-a-counter-multiple-times-asynchronously-with-promise-all-gives-the-same-value-each-time/11618/2

Fixes https://dfinity.atlassian.net/browse/SDK-390