### PR TITLE
chore: stabilize mitmproxy tests

### DIFF
--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -35,11 +35,11 @@ setup() {
         MITMDUMP_PID=$!
 
         if timeout 5 sh -c "until nc -z localhost $MITM_PORT; do echo waiting for mitmdump; sleep 1; done"; then
+            break
+        else
             echo "mitmdump did not start on port $MITM_PORT"
             pkill -P $MITMDUMP_PID
             kill $MITMDUMP_PID
-        else
-            break
         fi
     done
 }

--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -42,7 +42,6 @@ setup() {
             break
         fi
     done
-    exit 1
 }
 
 teardown() {

--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -14,15 +14,6 @@ setup() {
 
     BACKEND="$(jq -r .networks.local.bind dfx.json)"
 
-    # In github workflows, at the time of this writing, we get:
-    #     macos-latest: mitmproxy 7.0.4
-    #     ubuntu-latest: mitmproxy 4.x
-    if [ "$(mitmdump --version | grep Mitmproxy | cut -d ' ' -f 2 | cut -c 1-2)" = "4." ]; then
-        MODIFY_BODY_ARG="--replacements"
-    else
-        MODIFY_BODY_ARG="--modify-body"
-    fi
-
     # Sometimes, something goes wrong with mitmdump's initialization.
     # It reports that it is listening, and the `nc` call succeeds,
     # but it does not actually respond to requests.
@@ -40,14 +31,14 @@ setup() {
         # shellcheck disable=SC2094
         cat <<<"$(jq '.networks.local.bind="127.0.0.1:'"$MITM_PORT"'"' dfx.json)" >dfx.json
 
-        mitmdump -p "$MITM_PORT" --mode "reverse:http://$BACKEND"  "$MODIFY_BODY_ARG" '/~s/Hello,/Hullo,' &
+        mitmdump -p "$MITM_PORT" --mode "reverse:http://$BACKEND"  "--modify-body" '/~s/Hello,/Hullo,' &
         MITMDUMP_PID=$!
 
         timeout 5 sh -c \
             "until nc -z localhost $MITM_PORT; do echo waiting for mitmdump; sleep 1; done" \
             || (echo "mitmdump did not start on port $MITM_PORT" && exit 1)
 
-        if timeout 10 dfx ping; then
+        if nc -z localhost $MITM_PORT; then
             break
         fi
 

--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -38,7 +38,7 @@ setup() {
             "until nc -z localhost $MITM_PORT; do echo waiting for mitmdump; sleep 1; done" \
             || (echo "mitmdump did not start on port $MITM_PORT" && exit 1)
 
-        if nc -z localhost $MITM_PORT; then
+        if nc -z localhost "$MITM_PORT"; then
             break
         fi
 

--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -48,6 +48,7 @@ setup() {
             || (echo "mitmdump did not start on port $MITM_PORT" && exit 1)
 
         if nc -z localhost "$MITM_PORT"; then
+        echo "nc found a connection at $MITM_PORT. exit mitmdump start loop"
             break
         fi
 

--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -34,16 +34,15 @@ setup() {
         mitmdump -p "$MITM_PORT" --mode "reverse:http://$BACKEND"  "--modify-body" '/~s/Hello,/Hullo,' &
         MITMDUMP_PID=$!
 
-        timeout 5 sh -c \
-            "until nc -z localhost $MITM_PORT; do echo waiting for mitmdump; sleep 1; done" \
-            || (echo "mitmdump did not start on port $MITM_PORT" && exit 1)
-
-        if nc -z localhost "$MITM_PORT"; then
+        if timeout 5 sh -c "until nc -z localhost $MITM_PORT; do echo waiting for mitmdump; sleep 1; done"; then
+            echo "mitmdump did not start on port $MITM_PORT"
+            pkill -P $MITMDUMP_PID
+            kill $MITMDUMP_PID
+        else
             break
         fi
-
-        kill -9 $MITMDUMP_PID
     done
+    exit 1
 }
 
 teardown() {

--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -34,13 +34,15 @@ setup() {
         mitmdump -p "$MITM_PORT" --mode "reverse:http://$BACKEND"  "--modify-body" '/~s/Hello,/Hullo,' &
         MITMDUMP_PID=$!
 
-        if timeout 5 sh -c "until nc -z localhost $MITM_PORT; do echo waiting for mitmdump; sleep 1; done"; then
+        timeout 5 sh -c \
+            "until nc -z localhost $MITM_PORT; do echo waiting for mitmdump; sleep 1; done" \
+            || (echo "mitmdump did not start on port $MITM_PORT" && exit 1)
+
+        if timeout 10 dfx ping; then
             break
-        else
-            echo "mitmdump did not start on port $MITM_PORT"
-            pkill -P $MITMDUMP_PID
-            kill $MITMDUMP_PID
         fi
+
+        kill -9 $MITMDUMP_PID
     done
 }
 

--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -14,6 +14,15 @@ setup() {
 
     BACKEND="$(jq -r .networks.local.bind dfx.json)"
 
+    # In github workflows, at the time of this writing, we get:
+    #     macos-latest: mitmproxy 7.0.4
+    #     ubuntu-latest: mitmproxy 4.x
+    if [ "$(mitmdump --version | grep Mitmproxy | cut -d ' ' -f 2 | cut -c 1-2)" = "4." ]; then
+        MODIFY_BODY_ARG="--replacements"
+    else
+        MODIFY_BODY_ARG="--modify-body"
+    fi
+
     # Sometimes, something goes wrong with mitmdump's initialization.
     # It reports that it is listening, and the `nc` call succeeds,
     # but it does not actually respond to requests.
@@ -31,7 +40,7 @@ setup() {
         # shellcheck disable=SC2094
         cat <<<"$(jq '.networks.local.bind="127.0.0.1:'"$MITM_PORT"'"' dfx.json)" >dfx.json
 
-        mitmdump -p "$MITM_PORT" --mode "reverse:http://$BACKEND"  "--modify-body" '/~s/Hello,/Hullo,' &
+        mitmdump -p "$MITM_PORT" --mode "reverse:http://$BACKEND"  "$MODIFY_BODY_ARG" '/~s/Hello,/Hullo,' &
         MITMDUMP_PID=$!
 
         timeout 5 sh -c \

--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -48,7 +48,7 @@ setup() {
             || (echo "mitmdump did not start on port $MITM_PORT" && exit 1)
 
         if nc -z localhost "$MITM_PORT"; then
-        echo "nc found a connection at $MITM_PORT. exit mitmdump start loop"
+        echo "nc found a connection at $MITM_PORT. exiting mitmdump start loop"
             break
         fi
 


### PR DESCRIPTION
# Description

mitmproxy starts unreliably. This should fix the retry-logic to actually retry starting mitmproxy.

Fixes no particular issue, but makes e2e/certificate tests less flaky.

# How Has This Been Tested?

All on CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
