### PR TITLE
fix: Error if nonzero cycles are passed without a wallet proxy

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,10 @@
 
 == DFX
 
+=== fix: Error if nonzero cycles are passed without a wallet proxy
+
+Previously, `dfx canister call --with-cycles 1` would silently ignore the `--with-cycles` argument as the DFX principal has no way to pass cycles and the call must be forwarded through the wallet. Now it will error instead of silently ignoring it. To forward a call through the wallet, use `--wallet $(dfx identity get-wallet)`, or `--wallet $(dfx identity --network ic get-wallet)` for mainnet.
+
 === feat: Configure subnet type of local replica
 
 The local replica sets its parameters according to the subnet type defined in defaults.replica.subnet_type, defaulting to 'application' when none is specified.

--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -63,6 +63,6 @@ teardown() {
 @test "call with cycles" {
     dfx_start
     dfx deploy --all
-    assert_command_fail dfx canister call hello '' --with-cycles 100
-    assert_command dfx canister --wallet "$(dfx identity get-wallet)" call hello '' --with-cycles 100
+    assert_command_fail dfx canister call hello greet '' --with-cycles 100
+    assert_command dfx canister --wallet "$(dfx identity get-wallet)" call hello greet '' --with-cycles 100
 }

--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -62,7 +62,7 @@ teardown() {
 
 @test "call with cycles" {
     dfx_start
-    dfx deploy --all
+    dfx deploy
     assert_command_fail dfx canister call hello greet '' --with-cycles 100
     assert_command dfx canister --wallet "$(dfx identity get-wallet)" call hello greet '' --with-cycles 100
 }

--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -59,3 +59,10 @@ teardown() {
     dfx canister install hello
     assert_command dfx canister call hello recurse 100
 }
+
+@test "call with cycles" {
+    dfx_start
+    dfx deploy --all
+    assert_command_fail dfx canister call hello '' --with-cycles 100
+    assert_command dfx canister --wallet "$(dfx identity get-wallet)" call hello '' --with-cycles 100
+}

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -224,7 +224,7 @@ pub async fn exec(
         .map_or(0_u64, |amount| amount.parse::<u64>().unwrap());
 
     if call_sender == &CallSender::SelectedId && cycles != 0 {
-        bail!("Cannot provide cycles without proxying through the wallet (did you mean to use `canister --wallet`?)");
+        bail!("Cannot provide cycles without proxying through the wallet (did you mean to use `canister --wallet <wallet id> call`?)");
     }
 
     if is_query {

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -223,6 +223,10 @@ pub async fn exec(
         .as_deref()
         .map_or(0_u64, |amount| amount.parse::<u64>().unwrap());
 
+    if call_sender == &CallSender::SelectedId && cycles != 0 {
+        bail!("Cannot provide cycles without proxying through the wallet (did you mean to use `canister --wallet`?)");
+    }
+
     if is_query {
         let blob = match call_sender {
             CallSender::SelectedId => {


### PR DESCRIPTION
`--with-cycles <n!=0>` is only valid in a call if it is proxying through the wallet.