### PR TITLE
feat: dfx start and dfx replica: launch ic-btc-adapter when so configured

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -129,6 +129,7 @@ jobs:
       - name: Run e2e test
         # rust tests sometimes fail with a 30-minute timeout
         run: |
+          echo "shellopts are $SHELLOPTS"
           set +e
           timeout 300 bats "e2e/$E2E_TEST"
           TESTRESULT=$?

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -128,7 +128,14 @@ jobs:
           export
       - name: Run e2e test
         # rust tests sometimes fail with a 30-minute timeout
-        run: timeout 2100 bats "e2e/$E2E_TEST"
+        run: |
+          timeout 300 bats "e2e/$E2E_TEST"
+          TESTRESULT=$?
+          if [ $? -eq 124 ]; then
+            echo "Test timed out.  Sometimes this means bats was waiting for a process to exit.  Process list:"
+            ps
+          fi
+          exit "$TESTRESULT"
 
   aggregate:
     name: e2e:required

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -131,7 +131,8 @@ jobs:
         run: |
           timeout 300 bats "e2e/$E2E_TEST"
           TESTRESULT=$?
-          if [ "$TESTRESULT" -eq 124 ]; then
+          echo "testresult is $TESTRESULT"
+          if [ $TESTRESULT -eq 124 ]; then
             echo "Test timed out.  Sometimes this means bats was waiting for a process to exit.  Process list:"
             ps
           fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           echo "shellopts are $SHELLOPTS"
           set +e
-          timeout 300 bats "e2e/$E2E_TEST"
+          timeout 2100 bats "e2e/$E2E_TEST"
           TESTRESULT=$?
           echo "testresult is $TESTRESULT"
           if [ $TESTRESULT -eq 124 ]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -129,6 +129,7 @@ jobs:
       - name: Run e2e test
         # rust tests sometimes fail with a 30-minute timeout
         run: |
+          set +e
           timeout 300 bats "e2e/$E2E_TEST"
           TESTRESULT=$?
           echo "testresult is $TESTRESULT"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-11, ubuntu-20.04 ]
+        os: [ macos-10.15, macos-11, ubuntu-20.04 ]
         rust: [ '1.58.1' ]
         binary_path: [ 'target/release' ]
     steps:
@@ -67,7 +67,7 @@ jobs:
         # ubuntu-18.04 not supported due to:
         #     /home/runner/.cache/dfinity/versions/0.8.3-34-g36e39809/ic-starter:
         #     /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found
-        os: [ macos-11, ubuntu-20.04 ]
+        os: [ macos-10.15, macos-11, ubuntu-20.04 ]
         rust: [ '1.58.1' ]
     steps:
       - uses: actions/checkout@v1
@@ -99,22 +99,7 @@ jobs:
     needs: [ build_dfx, list_tests ]
     strategy:
       fail-fast: false
-      matrix: {
-        "test": [
-            "dfx/bitcoin",
-        ],
-        "backend": [
-            "replica"
-        ],
-        "os": [
-            "macos-11",
-            "ubuntu-20.04"
-        ],
-        "rust": [
-            "1.58.1"
-        ]
-      }
-
+      matrix: ${{fromJson(needs.list_tests.outputs.matrix)}}
     env:
       E2E_TEST: tests-${{ matrix.test }}.bash
     steps:
@@ -143,17 +128,7 @@ jobs:
           export
       - name: Run e2e test
         # rust tests sometimes fail with a 30-minute timeout
-        run: |
-          echo "shellopts are $SHELLOPTS"
-          set +e
-          timeout 300 bats "e2e/$E2E_TEST"
-          TESTRESULT=$?
-          echo "testresult is $TESTRESULT"
-          if [ $TESTRESULT -eq 124 ]; then
-            echo "Test timed out.  Sometimes this means bats was waiting for a process to exit.  Process list:"
-            ps
-          fi
-          exit "$TESTRESULT"
+        run: timeout 2100 bats "e2e/$E2E_TEST"
 
   aggregate:
     name: e2e:required

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-10.15, macos-11, ubuntu-20.04 ]
+        os: [ macos-11, ubuntu-20.04 ]
         rust: [ '1.58.1' ]
         binary_path: [ 'target/release' ]
     steps:
@@ -67,7 +67,7 @@ jobs:
         # ubuntu-18.04 not supported due to:
         #     /home/runner/.cache/dfinity/versions/0.8.3-34-g36e39809/ic-starter:
         #     /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found
-        os: [ macos-10.15, macos-11, ubuntu-20.04 ]
+        os: [ macos-11, ubuntu-20.04 ]
         rust: [ '1.58.1' ]
     steps:
       - uses: actions/checkout@v1
@@ -99,7 +99,22 @@ jobs:
     needs: [ build_dfx, list_tests ]
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.list_tests.outputs.matrix)}}
+      matrix: {
+        "test": [
+            "dfx/bitcoin",
+        ],
+        "backend": [
+            "replica"
+        ],
+        "os": [
+            "macos-11",
+            "ubuntu-20.04"
+        ],
+        "rust": [
+            "1.58.1"
+        ]
+      }
+
     env:
       E2E_TEST: tests-${{ matrix.test }}.bash
     steps:
@@ -131,7 +146,7 @@ jobs:
         run: |
           echo "shellopts are $SHELLOPTS"
           set +e
-          timeout 2100 bats "e2e/$E2E_TEST"
+          timeout 300 bats "e2e/$E2E_TEST"
           TESTRESULT=$?
           echo "testresult is $TESTRESULT"
           if [ $TESTRESULT -eq 124 ]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           timeout 300 bats "e2e/$E2E_TEST"
           TESTRESULT=$?
-          if [ $? -eq 124 ]; then
+          if [ "$TESTRESULT" -eq 124 ]; then
             echo "Test timed out.  Sometimes this means bats was waiting for a process to exit.  Process list:"
             ps
           fi

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -52,6 +52,18 @@ If you want to get your identity out of dfx, you can use `dfx identity export id
 When something went wrong during identity creation, the identity was not listed as existing.
 But when trying to create an identity with that name, it was considered to be already existing.
 
+=== feat: dfx start and dfx replica can now launch the ic-btc-adapter process
+
+Added command-line parameter:
+    dfx start --btc-adapter-config <path>
+    dfx replica --btc-adapter-config <path>
+
+Defaults to value from dfx.json: .defaults.bitcoin.btc_adapter_config
+
+If set, dfx start/replica will launch the ic-btc-adapter process.
+
+The rest of this isn't hooked up yet.
+
 == updating dependencies
 
 Updated to version 0.14.0 of agent-rs

--- a/e2e/assets/bitcoin/patch.bash
+++ b/e2e/assets/bitcoin/patch.bash
@@ -1,0 +1,5 @@
+# shellcheck disable=SC2094
+cat <<<"$(jq '.defaults.bitcoin.btc_adapter_config="'"$(pwd)/testnet.config.json"'"' dfx.json)" >dfx.json
+# unix socket domain names can only be so long.  An attempt to use $(pwd) here resulted in this error:
+# path must be shorter than libc::sockaddr_un.sun_path
+cat <<<"$(jq '.incoming_source.Path="'"/tmp/e2e-ic-btc-adapter.$$.socket"'"' testnet.config.json)" >testnet.config.json

--- a/e2e/assets/bitcoin/testnet.config.json
+++ b/e2e/assets/bitcoin/testnet.config.json
@@ -1,0 +1,13 @@
+{
+  "network": "testnet",
+  "dns_seeds": [
+    "testnet-seed.bitcoin.jonasschnelli.ch",
+    "seed.tbtc.petertodd.org",
+    "seed.testnet.bitcoin.sprovoost.nl",
+    "testnet-seed.bluematt.me"
+  ],
+  "incoming_source": {
+    "Path": "<filled in during test>"
+  },
+  "ipv6_only": true
+}

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -73,6 +73,8 @@ teardown() {
 @test "dfx restarts replica when ic-btc-adapter restarts (replica and bootstrap)" {
     [ "$USE_IC_REF" ] && skip "skip for ic-ref"
 
+    skip
+
     # pass (uname -a | grep Darwin) && (echo "exit at start" && exit 1)
 
     dfx_new hello
@@ -121,8 +123,4 @@ teardown() {
 
     assert_command dfx canister call hello greet '("Omega")'
     assert_eq '("Hello, Omega!")'
-
-    ps || "no output from ps"
-    echo "pass"
-    exit 0
 }

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -66,7 +66,7 @@ teardown() {
 
     ID=$(dfx canister id hello_assets)
 
-    (uname -a | grep Darwin) && (echo "exit at L69" && exit 1)
+    # pass (uname -a | grep Darwin) && (echo "exit at L69" && exit 1)
 
     timeout 15s sh -c \
       "until curl --fail http://localhost:\$(cat .dfx/webserver-port)/sample-asset.txt?canisterId=$ID; do echo waiting for icx-proxy to restart; sleep 1; done" \
@@ -115,7 +115,7 @@ teardown() {
       || (echo "replica did not restart" && ps aux && exit 1)
     wait_until_replica_healthy
 
-    (uname -a | grep Darwin) && (echo "exit at L118" && exit 1)
+    # pass (uname -a | grep Darwin) && (echo "exit at L118" && exit 1)
 
     # Sometimes initially get an error like:
     #     IC0304: Attempt to execute a message on canister <>> which contains no Wasm module

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -95,6 +95,7 @@ teardown() {
     timeout 15s sh -c \
       "until curl --fail -o /dev/null http://localhost:$(cat .dfx/replica-configuration/replica-1.port)/api/v2/status; do echo waiting for icx-proxy to restart; sleep 1; done" \
       || (echo "replica did not restart" && ps aux && exit 1)
+    # shellcheck disable=SC2094
     cat <<<"$(jq .networks.local.bind=\"127.0.0.1:"$(cat .dfx/replica-configuration/replica-1.port)"\" dfx.json)" >dfx.json
 
     timeout 15s sh -c \

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -12,7 +12,7 @@ teardown() {
     bitcoin-cli -regtest stop
 
     standard_teardown
-    # dfx_stop_replica_and_bootstrap
+    dfx_stop_replica_and_bootstrap
 
     # created in bitcoin/patch.bash
     rm -f "/tmp/e2e-ic-btc-adapter.$$.socket"

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -47,7 +47,7 @@ teardown() {
     assert_process_exits "$BTC_ADAPTER_PID" 15s
     assert_process_exits "$REPLICA_PID" 15s
 
-    (uname -a | grep Darwin) && (echo "exit at L50" && exit 1)
+    # pass (uname -a | grep Darwin) && (echo "exit at L50" && exit 1)
 
     timeout 15s sh -c \
       'until dfx ping; do echo waiting for replica to restart; sleep 1; done' \
@@ -65,6 +65,8 @@ teardown() {
     assert_eq '("Hello, Omega!")'
 
     ID=$(dfx canister id hello_assets)
+
+    (uname -a | grep Darwin) && (echo "exit at L69" && exit 1)
 
     timeout 15s sh -c \
       "until curl --fail http://localhost:\$(cat .dfx/webserver-port)/sample-asset.txt?canisterId=$ID; do echo waiting for icx-proxy to restart; sleep 1; done" \
@@ -98,7 +100,7 @@ teardown() {
     assert_process_exits "$BTC_ADAPTER_PID" 15s
     assert_process_exits "$REPLICA_PID" 15s
 
-    (uname -a | grep Darwin) && (echo "exit at L101" && exit 1)
+    # pass (uname -a | grep Darwin) && (echo "exit at L101" && exit 1)
 
     timeout 15s sh -x -c \
       "until curl --fail --verbose -o /dev/null http://localhost:\$(cat .dfx/replica-configuration/replica-1.port)/api/v2/status; do echo \"waiting for replica to restart on port \$(cat .dfx/replica-configuration/replica-1.port)\"; sleep 1; done" \
@@ -112,6 +114,8 @@ teardown() {
       'until dfx ping; do echo waiting for replica to restart; sleep 1; done' \
       || (echo "replica did not restart" && ps aux && exit 1)
     wait_until_replica_healthy
+
+    (uname -a | grep Darwin) && (echo "exit at L118" && exit 1)
 
     # Sometimes initially get an error like:
     #     IC0304: Attempt to execute a message on canister <>> which contains no Wasm module

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -63,7 +63,7 @@ teardown() {
     ID=$(dfx canister id hello_assets)
 
     timeout 15s sh -c \
-      "until curl --fail http://localhost:$(cat .dfx/webserver-port)/sample-asset.txt?canisterId=$ID; do echo waiting for icx-proxy to restart; sleep 1; done" \
+      "until curl --fail http://localhost:\$(cat .dfx/webserver-port)/sample-asset.txt?canisterId=$ID; do echo waiting for icx-proxy to restart; sleep 1; done" \
       || (echo "icx-proxy did not restart" && ps aux && exit 1)
 
     assert_command curl --fail http://localhost:"$(cat .dfx/webserver-port)"/sample-asset.txt?canisterId="$ID"
@@ -93,7 +93,7 @@ teardown() {
     assert_process_exits "$REPLICA_PID" 15s
 
     timeout 15s sh -x -c \
-      "until curl --fail --verbose -o /dev/null http://localhost:$(cat .dfx/replica-configuration/replica-1.port)/api/v2/status; do echo \"waiting for replica to restart on port $(cat .dfx/replica-configuration/replica-1.port)\"; sleep 1; done" \
+      "until curl --fail --verbose -o /dev/null http://localhost:\$(cat .dfx/replica-configuration/replica-1.port)/api/v2/status; do echo \"waiting for replica to restart on port \$(cat .dfx/replica-configuration/replica-1.port)\"; sleep 1; done" \
       || (echo "replica did not restart" && echo "last replica port was $(cat .dfx/replica-configuration/replica-1.port)" && ps aux && exit 1)
     # shellcheck disable=SC2094
     cat <<<"$(jq .networks.local.bind=\"127.0.0.1:"$(cat .dfx/replica-configuration/replica-1.port)"\" dfx.json)" >dfx.json

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -122,7 +122,6 @@ teardown() {
     assert_command dfx canister call hello greet '("Omega")'
     assert_eq '("Hello, Omega!")'
 
-
-    ps
+    ps || "no output from ps"
     exit 0
 }

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -12,6 +12,7 @@ teardown() {
     bitcoin-cli -regtest stop
 
     standard_teardown
+    # dfx_stop_replica_and_bootstrap
 
     # created in bitcoin/patch.bash
     rm -f "/tmp/e2e-ic-btc-adapter.$$.socket"
@@ -25,8 +26,6 @@ teardown() {
 
 @test "dfx restarts replica when ic-btc-adapter restarts" {
     [ "$USE_IC_REF" ] && skip "skip for ic-ref"
-
-    # pass (uname -a | grep Darwin) && (echo "exit at start" && exit 1)
 
     dfx_new hello
     install_asset bitcoin
@@ -47,8 +46,6 @@ teardown() {
     assert_process_exits "$BTC_ADAPTER_PID" 15s
     assert_process_exits "$REPLICA_PID" 15s
 
-    # pass (uname -a | grep Darwin) && (echo "exit at L50" && exit 1)
-
     timeout 15s sh -c \
       'until dfx ping; do echo waiting for replica to restart; sleep 1; done' \
       || (echo "replica did not restart" && ps aux && exit 1)
@@ -65,8 +62,6 @@ teardown() {
     assert_eq '("Hello, Omega!")'
 
     ID=$(dfx canister id hello_assets)
-
-    # pass (uname -a | grep Darwin) && (echo "exit at L69" && exit 1)
 
     timeout 15s sh -c \
       "until curl --fail http://localhost:\$(cat .dfx/webserver-port)/sample-asset.txt?canisterId=$ID; do echo waiting for icx-proxy to restart; sleep 1; done" \
@@ -115,7 +110,7 @@ teardown() {
       || (echo "replica did not restart" && ps aux && exit 1)
     wait_until_replica_healthy
 
-    # pass (uname -a | grep Darwin) && (echo "exit at L118" && exit 1)
+    # (uname -a | grep Darwin) && (echo "exit at L118" && exit 1)
 
     # Sometimes initially get an error like:
     #     IC0304: Attempt to execute a message on canister <>> which contains no Wasm module

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -26,7 +26,7 @@ teardown() {
 @test "dfx restarts replica when ic-btc-adapter restarts" {
     [ "$USE_IC_REF" ] && skip "skip for ic-ref"
 
-    (uname -a | grep Darwin) && (echo "exit at start" && exit 1)
+    # pass (uname -a | grep Darwin) && (echo "exit at start" && exit 1)
 
     dfx_new hello
     install_asset bitcoin
@@ -46,6 +46,8 @@ teardown() {
     kill -KILL "$BTC_ADAPTER_PID"
     assert_process_exits "$BTC_ADAPTER_PID" 15s
     assert_process_exits "$REPLICA_PID" 15s
+
+    (uname -a | grep Darwin) && (echo "exit at L50" && exit 1)
 
     timeout 15s sh -c \
       'until dfx ping; do echo waiting for replica to restart; sleep 1; done' \
@@ -74,7 +76,7 @@ teardown() {
 @test "dfx restarts replica when ic-btc-adapter restarts (replica and bootstrap)" {
     [ "$USE_IC_REF" ] && skip "skip for ic-ref"
 
-    (uname -a | grep Darwin) && (echo "exit at start" && exit 1)
+    # pass (uname -a | grep Darwin) && (echo "exit at start" && exit 1)
 
     dfx_new hello
     install_asset bitcoin
@@ -95,6 +97,8 @@ teardown() {
     kill -KILL "$BTC_ADAPTER_PID"
     assert_process_exits "$BTC_ADAPTER_PID" 15s
     assert_process_exits "$REPLICA_PID" 15s
+
+    (uname -a | grep Darwin) && (echo "exit at L101" && exit 1)
 
     timeout 15s sh -x -c \
       "until curl --fail --verbose -o /dev/null http://localhost:\$(cat .dfx/replica-configuration/replica-1.port)/api/v2/status; do echo \"waiting for replica to restart on port \$(cat .dfx/replica-configuration/replica-1.port)\"; sleep 1; done" \

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -123,5 +123,6 @@ teardown() {
     assert_eq '("Hello, Omega!")'
 
     ps || "no output from ps"
+    echo "pass"
     exit 0
 }

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -26,6 +26,8 @@ teardown() {
 @test "dfx restarts replica when ic-btc-adapter restarts" {
     [ "$USE_IC_REF" ] && skip "skip for ic-ref"
 
+    (uname -a | grep Darwin) && (echo "exit at start" && exit 1)
+
     dfx_new hello
     install_asset bitcoin
     dfx_start
@@ -71,6 +73,8 @@ teardown() {
 
 @test "dfx restarts replica when ic-btc-adapter restarts (replica and bootstrap)" {
     [ "$USE_IC_REF" ] && skip "skip for ic-ref"
+
+    (uname -a | grep Darwin) && (echo "exit at start" && exit 1)
 
     dfx_new hello
     install_asset bitcoin

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -110,7 +110,7 @@ teardown() {
       || (echo "replica did not restart" && ps aux && exit 1)
     wait_until_replica_healthy
 
-    # (uname -a | grep Darwin) && (echo "exit at L118" && exit 1)
+    # pass (uname -a | grep Darwin) && (echo "exit at L118" && exit 1)
 
     # Sometimes initially get an error like:
     #     IC0304: Attempt to execute a message on canister <>> which contains no Wasm module
@@ -121,4 +121,9 @@ teardown() {
 
     assert_command dfx canister call hello greet '("Omega")'
     assert_eq '("Hello, Omega!")'
+
+
+    echo "force failure"
+    ps
+    exit 1
 }

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -2,6 +2,8 @@
 
 load ../utils/_
 
+# All tests in this file are skipped for ic-ref.  See scripts/workflows/e2e-matrix.py
+
 setup() {
     standard_setup
 
@@ -26,8 +28,6 @@ teardown() {
 }
 
 @test "dfx restarts replica when ic-btc-adapter restarts" {
-    [ "$USE_IC_REF" ] && skip "skip for ic-ref"
-
     dfx_new hello
     install_asset bitcoin
     dfx_start
@@ -72,10 +72,6 @@ teardown() {
 }
 
 @test "dfx restarts replica when ic-btc-adapter restarts (replica and bootstrap)" {
-    [ "$USE_IC_REF" ] && skip "skip for ic-ref"
-
-    # pass (uname -a | grep Darwin) && (echo "exit at start" && exit 1)
-
     dfx_new hello
     install_asset bitcoin
     dfx_start_replica_and_bootstrap
@@ -96,8 +92,6 @@ teardown() {
     assert_process_exits "$BTC_ADAPTER_PID" 15s
     assert_process_exits "$REPLICA_PID" 15s
 
-    # pass (uname -a | grep Darwin) && (echo "exit at L101" && exit 1)
-
     timeout 15s sh -x -c \
       "until curl --fail --verbose -o /dev/null http://localhost:\$(cat .dfx/replica-configuration/replica-1.port)/api/v2/status; do echo \"waiting for replica to restart on port \$(cat .dfx/replica-configuration/replica-1.port)\"; sleep 1; done" \
       || (echo "replica did not restart" && echo "last replica port was $(cat .dfx/replica-configuration/replica-1.port)" && ps aux && exit 1)
@@ -110,8 +104,6 @@ teardown() {
       'until dfx ping; do echo waiting for replica to restart; sleep 1; done' \
       || (echo "replica did not restart" && ps aux && exit 1)
     wait_until_replica_healthy
-
-    # pass (uname -a | grep Darwin) && (echo "exit at L118" && exit 1)
 
     # Sometimes initially get an error like:
     #     IC0304: Attempt to execute a message on canister <>> which contains no Wasm module

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -11,8 +11,8 @@ setup() {
 teardown() {
     bitcoin-cli -regtest stop
 
-    standard_teardown
     dfx_stop_replica_and_bootstrap
+    standard_teardown
 
     # created in bitcoin/patch.bash
     rm -f "/tmp/e2e-ic-btc-adapter.$$.socket"
@@ -123,7 +123,6 @@ teardown() {
     assert_eq '("Hello, Omega!")'
 
 
-    echo "force failure"
     ps
-    exit 1
+    exit 0
 }

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -11,6 +11,7 @@ setup() {
 teardown() {
     bitcoin-cli -regtest stop
 
+    dfx_stop
     dfx_stop_replica_and_bootstrap
     standard_teardown
 
@@ -26,8 +27,6 @@ teardown() {
 
 @test "dfx restarts replica when ic-btc-adapter restarts" {
     [ "$USE_IC_REF" ] && skip "skip for ic-ref"
-
-    skip
 
     dfx_new hello
     install_asset bitcoin
@@ -74,8 +73,6 @@ teardown() {
 
 @test "dfx restarts replica when ic-btc-adapter restarts (replica and bootstrap)" {
     [ "$USE_IC_REF" ] && skip "skip for ic-ref"
-
-    skip
 
     # pass (uname -a | grep Darwin) && (echo "exit at start" && exit 1)
 

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -27,6 +27,8 @@ teardown() {
 @test "dfx restarts replica when ic-btc-adapter restarts" {
     [ "$USE_IC_REF" ] && skip "skip for ic-ref"
 
+    skip
+
     dfx_new hello
     install_asset bitcoin
     dfx_start

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -92,8 +92,8 @@ teardown() {
     assert_process_exits "$BTC_ADAPTER_PID" 15s
     assert_process_exits "$REPLICA_PID" 15s
 
-    timeout 15s sh -c \
-      "until curl --fail -o /dev/null http://localhost:$(cat .dfx/replica-configuration/replica-1.port)/api/v2/status; do echo waiting for replica to restart; sleep 1; done" \
+    timeout 15s sh -x -c \
+      "until curl --fail --verbose -o /dev/null http://localhost:$(cat .dfx/replica-configuration/replica-1.port)/api/v2/status; do echo waiting for replica to restart (port $(cat .dfx/replica-configuration/replica-1.port)); sleep 1; done" \
       || (echo "replica did not restart" && echo "last replica port was $(cat .dfx/replica-configuration/replica-1.port)" && ps aux && exit 1)
     # shellcheck disable=SC2094
     cat <<<"$(jq .networks.local.bind=\"127.0.0.1:"$(cat .dfx/replica-configuration/replica-1.port)"\" dfx.json)" >dfx.json

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -93,7 +93,7 @@ teardown() {
     assert_process_exits "$REPLICA_PID" 15s
 
     timeout 15s sh -x -c \
-      "until curl --fail --verbose -o /dev/null http://localhost:$(cat .dfx/replica-configuration/replica-1.port)/api/v2/status; do echo waiting for replica to restart (port $(cat .dfx/replica-configuration/replica-1.port)); sleep 1; done" \
+      "until curl --fail --verbose -o /dev/null http://localhost:$(cat .dfx/replica-configuration/replica-1.port)/api/v2/status; do echo \"waiting for replica to restart on port $(cat .dfx/replica-configuration/replica-1.port)\"; sleep 1; done" \
       || (echo "replica did not restart" && echo "last replica port was $(cat .dfx/replica-configuration/replica-1.port)" && ps aux && exit 1)
     # shellcheck disable=SC2094
     cat <<<"$(jq .networks.local.bind=\"127.0.0.1:"$(cat .dfx/replica-configuration/replica-1.port)"\" dfx.json)" >dfx.json

--- a/e2e/tests-dfx/start.bash
+++ b/e2e/tests-dfx/start.bash
@@ -82,7 +82,7 @@ teardown() {
     ID=$(dfx canister id hello_assets)
 
     timeout 15s sh -c \
-      "until curl --fail http://localhost:$(cat .dfx/webserver-port)/sample-asset.txt?canisterId=$ID; do echo waiting for icx-proxy to restart; sleep 1; done" \
+      "until curl --fail http://localhost:\$(cat .dfx/webserver-port)/sample-asset.txt?canisterId=$ID; do echo waiting for icx-proxy to restart; sleep 1; done" \
       || (echo "icx-proxy did not restart" && ps aux && exit 1)
 
     assert_command curl --fail http://localhost:"$(cat .dfx/webserver-port)"/sample-asset.txt?canisterId="$ID"
@@ -127,7 +127,7 @@ teardown() {
     ID=$(dfx canister id hello_assets)
 
     timeout 15s sh -c \
-      "until curl --fail http://localhost:$(cat .dfx/webserver-port)/sample-asset.txt?canisterId=$ID; do echo waiting for icx-proxy to restart; sleep 1; done" \
+      "until curl --fail http://localhost:\$(cat .dfx/webserver-port)/sample-asset.txt?canisterId=$ID; do echo waiting for icx-proxy to restart; sleep 1; done" \
       || (echo "icx-proxy did not restart" && ps aux && exit 1)
 
     assert_command curl --fail http://localhost:"$(cat .dfx/webserver-port)"/sample-asset.txt?canisterId="$ID"

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -185,13 +185,10 @@ dfx_start_replica_and_bootstrap() {
         local replica_port=$(cat ${dfx_config_root}/replica-1.port)
 
     fi
-    local webserver_port=$(cat .dfx/webserver-port)
-
     # Overwrite the default networks.local.bind 127.0.0.1:8000 with allocated port
     cat <<<$(jq .networks.local.bind=\"127.0.0.1:${replica_port}\" dfx.json) >dfx.json
 
     printf "Replica Configured Port: %s\n" "${replica_port}"
-    printf "Webserver Configured Port: %s\n" "${webserver_port}"
 
     timeout 5 sh -c \
         "until nc -z localhost ${replica_port}; do echo waiting for replica; sleep 1; done" \
@@ -213,6 +210,9 @@ dfx_start_replica_and_bootstrap() {
 
     local proxy_port=$(cat .dfx/proxy-port)
     printf "Proxy Configured Port: %s\n", "${proxy_port}"
+
+    local webserver_port=$(cat .dfx/webserver-port)
+    printf "Webserver Configured Port: %s\n", "${webserver_port}"
 }
 
 # Start the replica in the background.

--- a/scripts/workflows/e2e-matrix.py
+++ b/scripts/workflows/e2e-matrix.py
@@ -18,7 +18,13 @@ matrix = {
     'test': test,
     'backend': [ 'ic-ref', 'replica' ],
     'os': [ 'macos-11', 'ubuntu-20.04' ],
-    'rust': [ '1.58.1' ]
+    'rust': [ '1.58.1' ],
+    'exclude': [
+        {
+            'backend': 'ic-ref',
+            'test': 'dfx/bitcoin'
+        }
+    ]
 }
 
 print(json.dumps(matrix))

--- a/src/dfx/src/actors/btc_adapter.rs
+++ b/src/dfx/src/actors/btc_adapter.rs
@@ -1,0 +1,247 @@
+use crate::actors::btc_adapter::signals::{BtcAdapterReady, BtcAdapterReadySubscribe};
+use crate::actors::shutdown::{wait_for_child_or_receiver, ChildOrReceiver};
+use crate::actors::shutdown_controller::signals::outbound::Shutdown;
+use crate::actors::shutdown_controller::signals::ShutdownSubscribe;
+use crate::actors::shutdown_controller::ShutdownController;
+use crate::lib::error::{DfxError, DfxResult};
+use actix::{
+    Actor, ActorContext, ActorFutureExt, Addr, AsyncContext, Context, Handler, Recipient,
+    ResponseActFuture, Running, WrapFuture,
+};
+use anyhow::anyhow;
+use crossbeam::channel::{unbounded, Receiver, Sender};
+use garcon::{Delay, Waiter};
+use slog::{debug, info, Logger};
+use std::path::{Path, PathBuf};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+pub mod signals {
+    use actix::prelude::*;
+
+    #[derive(Message)]
+    #[rtype(result = "()")]
+    pub struct BtcAdapterReady {}
+
+    #[derive(Message)]
+    #[rtype(result = "()")]
+    pub struct BtcAdapterReadySubscribe(pub Recipient<BtcAdapterReady>);
+}
+
+#[derive(Clone)]
+pub struct Config {
+    pub btc_adapter_path: PathBuf,
+
+    pub config_path: PathBuf,
+    pub socket_path: Option<PathBuf>,
+    pub shutdown_controller: Addr<ShutdownController>,
+    pub btc_adapter_pid_file_path: PathBuf,
+
+    pub logger: Option<Logger>,
+}
+
+/// An actor for the ic-btc-adapter process.  Publishes information about
+/// the process starting or restarting, so that other processes can reconnect.
+pub struct BtcAdapter {
+    config: Config,
+
+    stop_sender: Option<Sender<()>>,
+    thread_join: Option<JoinHandle<()>>,
+
+    ready: bool,
+    ready_subscribers: Vec<Recipient<BtcAdapterReady>>,
+
+    logger: Logger,
+}
+
+impl BtcAdapter {
+    pub fn new(config: Config) -> Self {
+        let logger =
+            (config.logger.clone()).unwrap_or_else(|| Logger::root(slog::Discard, slog::o!()));
+        BtcAdapter {
+            config,
+            stop_sender: None,
+            thread_join: None,
+            ready: false,
+            ready_subscribers: Vec::new(),
+            logger,
+        }
+    }
+
+    fn wait_for_socket(socket_path: &Path) -> DfxResult {
+        let mut waiter = Delay::builder()
+            .throttle(Duration::from_millis(100))
+            .timeout(Duration::from_secs(30))
+            .build();
+
+        waiter.start();
+        loop {
+            if socket_path.exists() {
+                return Ok(());
+            }
+            waiter
+                .wait()
+                .map_err(|err| anyhow!("Cannot start btc-adapter: {:?}", err))?;
+        }
+    }
+
+    fn start_btc_adapter(&mut self, addr: Addr<Self>) -> DfxResult {
+        let logger = self.logger.clone();
+
+        let (sender, receiver) = unbounded();
+
+        let handle = btc_adapter_start_thread(logger, self.config.clone(), addr, receiver)?;
+
+        self.thread_join = Some(handle);
+        self.stop_sender = Some(sender);
+        Ok(())
+    }
+
+    fn send_ready_signal(&self) {
+        for sub in &self.ready_subscribers {
+            let _ = sub.do_send(BtcAdapterReady {});
+        }
+    }
+}
+
+impl Actor for BtcAdapter {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        self.start_btc_adapter(ctx.address())
+            .expect("Could not start btc-adapter");
+
+        self.config
+            .shutdown_controller
+            .do_send(ShutdownSubscribe(ctx.address().recipient::<Shutdown>()));
+    }
+
+    fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
+        info!(self.logger, "Stopping btc-adapter...");
+        if let Some(sender) = self.stop_sender.take() {
+            let _ = sender.send(());
+        }
+
+        if let Some(join) = self.thread_join.take() {
+            let _ = join.join();
+        }
+
+        info!(self.logger, "Stopped.");
+        Running::Stop
+    }
+}
+
+impl Handler<signals::BtcAdapterReady> for BtcAdapter {
+    type Result = ();
+
+    fn handle(&mut self, _msg: signals::BtcAdapterReady, _ctx: &mut Self::Context) -> Self::Result {
+        self.ready = true;
+        self.send_ready_signal();
+    }
+}
+
+impl Handler<BtcAdapterReadySubscribe> for BtcAdapter {
+    type Result = ();
+
+    fn handle(&mut self, msg: BtcAdapterReadySubscribe, _: &mut Self::Context) {
+        // If the adapter is already ready, let the new subscriber know! Yeah!
+        if self.ready {
+            let _ = msg.0.do_send(BtcAdapterReady {});
+        }
+
+        self.ready_subscribers.push(msg.0);
+    }
+}
+
+impl Handler<Shutdown> for BtcAdapter {
+    type Result = ResponseActFuture<Self, Result<(), ()>>;
+
+    fn handle(&mut self, _msg: Shutdown, _ctx: &mut Self::Context) -> Self::Result {
+        Box::pin(
+            async {}
+                .into_actor(self) // converts future to ActorFuture
+                .map(|_, _act, ctx| {
+                    ctx.stop();
+                    Ok(())
+                }),
+        )
+    }
+}
+
+fn btc_adapter_start_thread(
+    logger: Logger,
+    config: Config,
+    addr: Addr<BtcAdapter>,
+    receiver: Receiver<()>,
+) -> DfxResult<std::thread::JoinHandle<()>> {
+    let thread_handler = move || {
+        // Use a Waiter for waiting for the file to be created.
+        let mut waiter = Delay::builder()
+            .throttle(Duration::from_millis(1000))
+            .exponential_backoff(Duration::from_secs(1), 1.2)
+            .build();
+        waiter.start();
+
+        let btc_adapter_path = config.btc_adapter_path.as_os_str();
+        let mut cmd = std::process::Command::new(btc_adapter_path);
+        cmd.arg(&config.config_path.to_string_lossy().to_string());
+
+        cmd.stdout(std::process::Stdio::inherit());
+        cmd.stderr(std::process::Stdio::inherit());
+
+        let mut done = false;
+        while !done {
+            if let Some(socket_path) = &config.socket_path {
+                if socket_path.exists() {
+                    std::fs::remove_file(socket_path).expect("Could not remove btc-adapter socket");
+                }
+            }
+            let last_start = std::time::Instant::now();
+            debug!(logger, "Starting ic-btc-adapter...");
+            let mut child = cmd.spawn().expect("Could not start ic-btc-adapter.");
+
+            std::fs::write(&config.btc_adapter_pid_file_path, "")
+                .expect("Could not write to btc-adapter-pid file.");
+            std::fs::write(&config.btc_adapter_pid_file_path, child.id().to_string())
+                .expect("Could not write to btc-adapter-pid file.");
+
+            if let Some(socket_path) = &config.socket_path {
+                BtcAdapter::wait_for_socket(socket_path)
+                    .expect("btc adapter socket was not created");
+            }
+            addr.do_send(signals::BtcAdapterReady {});
+
+            // This waits for the child to stop, or the receiver to receive a message.
+            // We don't restart the adapter if done = true.
+            match wait_for_child_or_receiver(&mut child, &receiver) {
+                ChildOrReceiver::Receiver => {
+                    debug!(logger, "Got signal to stop. Killing btc-adapter process...");
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    done = true;
+                }
+                ChildOrReceiver::Child => {
+                    debug!(logger, "ic-btc-adapter process failed.");
+                    // Reset waiter if last start was over 2 seconds ago, and do not wait.
+                    if std::time::Instant::now().duration_since(last_start)
+                        >= Duration::from_secs(2)
+                    {
+                        debug!(
+                            logger,
+                            "Last ic-btc-adapter seemed to have been healthy, not waiting..."
+                        );
+                        waiter.start();
+                    } else {
+                        // Wait before we start it again.
+                        let _ = waiter.wait();
+                    }
+                }
+            }
+        }
+    };
+
+    std::thread::Builder::new()
+        .name("btc-adapter-actor".to_owned())
+        .spawn(thread_handler)
+        .map_err(DfxError::from)
+}

--- a/src/dfx/src/commands/replica.rs
+++ b/src/dfx/src/commands/replica.rs
@@ -1,14 +1,16 @@
-use crate::actors::shutdown_controller::ShutdownController;
-use crate::actors::{start_emulator_actor, start_replica_actor, start_shutdown_controller};
+use crate::actors::{
+    start_btc_adapter_actor, start_emulator_actor, start_replica_actor, start_shutdown_controller,
+};
 use crate::config::dfinity::ConfigDefaultsReplica;
 use crate::error_invalid_argument;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::replica_config::{HttpHandlerConfig, ReplicaConfig};
 
-use actix::Addr;
+use crate::commands::start::get_btc_adapter_socket_path;
 use clap::Parser;
 use std::default::Default;
+use std::path::PathBuf;
 
 /// Starts a local Internet Computer replica.
 #[derive(Parser)]
@@ -20,10 +22,18 @@ pub struct ReplicaOpts {
     /// Runs a dedicated emulator instead of the replica
     #[clap(long)]
     emulator: bool,
+
+    /// Runs the bitcoin adapter (not supported with emulator)
+    #[clap(long, conflicts_with("emulator"))]
+    btc_adapter_config: Option<PathBuf>,
 }
 
 /// Gets the configuration options for the Internet Computer replica.
-fn get_config(env: &dyn Environment, opts: ReplicaOpts) -> DfxResult<ReplicaConfig> {
+fn get_config(
+    env: &dyn Environment,
+    opts: ReplicaOpts,
+    btc_adapter_socket: Option<PathBuf>,
+) -> DfxResult<ReplicaConfig> {
     let config = get_config_from_file(env);
     let port = get_port(&config, opts.port)?;
     let mut http_handler: HttpHandlerConfig = Default::default();
@@ -40,6 +50,10 @@ fn get_config(env: &dyn Environment, opts: ReplicaOpts) -> DfxResult<ReplicaConf
     let mut replica_config =
         ReplicaConfig::new(&env.get_state_dir(), config.subnet_type.unwrap_or_default());
     replica_config.http_handler = http_handler;
+
+    if let Some(btc_adapter_socket) = btc_adapter_socket {
+        replica_config = replica_config.with_btc_adapter_socket(btc_adapter_socket);
+    }
     Ok(replica_config)
 }
 
@@ -63,27 +77,59 @@ fn get_port(config: &ConfigDefaultsReplica, port: Option<String>) -> DfxResult<u
         .map_err(|err| error_invalid_argument!("Invalid port number: {}", err))
 }
 
-fn start_replica(
-    env: &dyn Environment,
-    opts: ReplicaOpts,
-    shutdown_controller: Addr<ShutdownController>,
-) -> DfxResult {
-    let replica_config = get_config(env, opts)?;
-    start_replica_actor(env, replica_config, shutdown_controller)?;
-    Ok(())
-}
-
 /// Start the Internet Computer locally. Spawns a proxy to forward and
 /// manage browser requests. Responsible for running the network (one
 /// replica at the moment) and the proxy.
 pub fn exec(env: &dyn Environment, opts: ReplicaOpts) -> DfxResult {
     let system = actix::System::new();
+
+    let btc_adapter_pid_file_path = env.get_temp_dir().join("ic-btc-adapter-pid");
+    std::fs::write(&btc_adapter_pid_file_path, "")?;
+
     system.block_on(async move {
         let shutdown_controller = start_shutdown_controller(env)?;
         if opts.emulator {
             start_emulator_actor(env, shutdown_controller)?;
         } else {
-            start_replica(env, opts, shutdown_controller)?;
+            let config = env.get_config_or_anyhow()?;
+            let btc_adapter_config = opts.btc_adapter_config.clone();
+            let btc_adapter_config: Option<PathBuf> = btc_adapter_config.or_else(|| {
+                config
+                    .get_config()
+                    .get_defaults()
+                    .bitcoin
+                    .as_ref()
+                    .and_then(|x| x.btc_adapter_config.clone())
+            });
+
+            let btc_adapter_socket_path = btc_adapter_config
+                .as_ref()
+                .map(|btc_adapter_config| get_btc_adapter_socket_path(btc_adapter_config))
+                .transpose()?
+                .flatten();
+
+            let btc_adapter_ready_subscribe = btc_adapter_config
+                .as_ref()
+                .map(|btc_adapter_config| {
+                    start_btc_adapter_actor(
+                        env,
+                        btc_adapter_config.clone(),
+                        btc_adapter_socket_path.clone(),
+                        shutdown_controller.clone(),
+                        btc_adapter_pid_file_path,
+                    )
+                    .map(|x| x.recipient())
+                })
+                .transpose()?;
+
+            let replica_config = get_config(env, opts, btc_adapter_socket_path)?;
+
+            start_replica_actor(
+                env,
+                replica_config,
+                shutdown_controller,
+                btc_adapter_ready_subscribe,
+            )?;
         }
         DfxResult::Ok(())
     })?;

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -14,14 +14,15 @@ use std::path::{Path, PathBuf};
 pub const CONFIG_FILE_NAME: &str = "dfx.json";
 
 const EMPTY_CONFIG_DEFAULTS: ConfigDefaults = ConfigDefaults {
-    bitcoind: None,
+    bitcoin: None,
     bootstrap: None,
     build: None,
     replica: None,
 };
 
-const EMPTY_CONFIG_DEFAULTS_BITCOIND: ConfigDefaultsBitcoind =
-    ConfigDefaultsBitcoind { port: None };
+const EMPTY_CONFIG_DEFAULTS_BITCOIN: ConfigDefaultsBitcoin = ConfigDefaultsBitcoin {
+    btc_adapter_config: None,
+};
 
 const EMPTY_CONFIG_DEFAULTS_BOOTSTRAP: ConfigDefaultsBootstrap = ConfigDefaultsBootstrap {
     ip: None,
@@ -84,8 +85,8 @@ pub struct CanisterDeclarationsConfig {
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct ConfigDefaultsBitcoind {
-    pub port: Option<u16>,
+pub struct ConfigDefaultsBitcoin {
+    pub btc_adapter_config: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -192,7 +193,7 @@ pub enum Profile {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ConfigDefaults {
-    pub bitcoind: Option<ConfigDefaultsBitcoind>,
+    pub bitcoin: Option<ConfigDefaultsBitcoin>,
     pub bootstrap: Option<ConfigDefaultsBootstrap>,
     pub build: Option<ConfigDefaultsBuild>,
     pub replica: Option<ConfigDefaultsReplica>,
@@ -239,10 +240,10 @@ impl ConfigDefaultsBuild {
 }
 
 impl ConfigDefaults {
-    pub fn get_bitcoind(&self) -> &ConfigDefaultsBitcoind {
-        match &self.bitcoind {
+    pub fn get_bitcoin(&self) -> &ConfigDefaultsBitcoin {
+        match &self.bitcoin {
             Some(x) => x,
-            None => &EMPTY_CONFIG_DEFAULTS_BITCOIND,
+            None => &EMPTY_CONFIG_DEFAULTS_BITCOIN,
         }
     }
     pub fn get_bootstrap(&self) -> &ConfigDefaultsBootstrap {

--- a/src/dfx/src/lib/replica_config.rs
+++ b/src/dfx/src/lib/replica_config.rs
@@ -17,6 +17,11 @@ pub struct HttpHandlerConfig {
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct BtcAdapterConfig {
+    pub socket_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ArtifactPoolConfig {
     pub consensus_pool_path: PathBuf,
 }
@@ -38,6 +43,7 @@ pub struct ReplicaConfig {
     pub crypto: CryptoConfig,
     pub artifact_pool: ArtifactPoolConfig,
     pub subnet_type: ReplicaSubnetType,
+    pub btc_adapter: BtcAdapterConfig,
 }
 
 impl ReplicaConfig {
@@ -57,6 +63,7 @@ impl ReplicaConfig {
                 consensus_pool_path: state_root.join("consensus_pool"),
             },
             subnet_type,
+            btc_adapter: BtcAdapterConfig { socket_path: None },
         }
     }
 
@@ -70,6 +77,12 @@ impl ReplicaConfig {
     pub fn with_random_port(&mut self, write_port_to: &Path) -> Self {
         self.http_handler.port = None;
         self.http_handler.write_port_to = Some(write_port_to.to_path_buf());
+        let config = &*self;
+        config.clone()
+    }
+
+    pub fn with_btc_adapter_socket(&mut self, socket_path: PathBuf) -> Self {
+        self.btc_adapter.socket_path = Some(socket_path);
         let config = &*self;
         config.clone()
     }


### PR DESCRIPTION
# Description

`dfx start` and `dfx replica` now launch the `ic-btc-adapter` binary, if either the `--btc-adapter-config <path>` parameter is passed, or the `.defaults.bitcoin.btc_adapter_config` field is set in dfx.json.

If a unix domain socket path is configured (`.incoming_source.Path` in the btc adapter config file), dfx will:
- delete this file before launching ic-btc-adapter,
- wait to launch replica until after this file exists (meaning ic-btc-adapter is listening on the unix domain socket).

If the ic-btc-adapter process exits (crashes), dfx will relaunch it, in the same way that it relaunches icx-proxy if the replica restarts.

Fixes https://dfinity.atlassian.net/browse/SDK-352

Gathering the docs changes here, but not opening a PR until the ic-starter work is done: https://github.com/dfinity/docs/tree/ericswanson/sdk-349-dfx-btc-integration

# How Has This Been Tested?

Through e2e tests, and by running `dfx start` and `dfx replica` with the new argument manually.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] (See above) I have made corresponding changes to the documentation.
