### PR TITLE
docs: contributing: cargo just works

### DIFF
--- a/.github/CONTRIBUTING.adoc
+++ b/.github/CONTRIBUTING.adoc
@@ -2,137 +2,62 @@
 
 == Developing `dfx`
 
-Run `nix-shell` in the root directory of this repo to bring the right version
-of `rustc` and `cargo` into scope.
-
-Inside the shell use `cargo` to build and test the Rust packages (crates).
+Use `cargo` with the relevant link:../rust-toolchain.toml[rust toolchain] like any other Rust project.
 
 [source,bash]
 ----
-sdk $ nix-shell
-[nix-shell:~/d/sdk]$ cargo build
-[nix-shell:~/d/sdk]$ cargo test
+sdk $ cargo build
+sdk $ cargo test
 ----
 
-Open a second window to run `dfx`, since we usually run it in a different
-subdirectory and running it does not require a `nix-shell`.
+Then use `cargo run` or the method of your choice to run `dfx`.
 
 [source,bash]
 ----
 sdk $ alias dfx=$(pwd)/target/debug/dfx
 sdk $ dfx --version
-dfx 0.5.7-1-gad81116
+dfx 0.9.1-63-gd7020bbb
 ----
 
-=== Other Development Workflows
+=== End-to-End Tests
 
-==== Running End-to-End Tests Locally
+==== Setup
+
+. Install bats and bats-support 0.3.0.  See the CI provisioning scripts for examples:
+** link:../scripts/workflows/provision-linux.sh[Linux]
+** link:../scripts/workflows/provision-darwin.sh[Darwin]
+. Export `BATSLIB` to your bats-support directory, typically:
++
+[source, bash]
+----
+$ export BATSLIB=/usr/local/lib/bats-support
+----
+. Build dfx and add its target directory to your path:
++
+[source, bash]
+----
+sdk $ cargo build
+sdk $ export PATH="$(pwd)/target/debug:$PATH"
+----
+
+==== Running End-to-End Tests
 
 [source,bash]
 ----
-sdk $ nix-shell -A e2e-tests.shell .
-[nix-shell:~/d/sdk]$ cd e2e
-[nix-shell:~/d/sdk]$ bats tests-dfx/*.bash
+sdk $ bats e2e/tests-dfx/*.bash
+sdk $ bats e2e/tests-replica/*.bash
 ----
 
-==== Running End-to-End Tests Locally Against Reference IC
+==== Running End-to-End Tests Against Reference IC
 
 This runs the end-to-end tests against the
-https://github.com/dfinity-lab/ic-ref[reference implementation of the Internet Computer].
+https://github.com/dfinity/ic-hs[reference implementation of the Internet Computer].
 
 [source,bash]
 ----
-sdk $ nix-shell -A e2e-tests-ic-ref.shell .
-[nix-shell:~/d/sdk]$ cd e2e
-[nix-shell:~/d/sdk]$ bats tests-dfx/*.bash
+sdk $ USE_IC_REF=1 bats e2e/tests-dfx/*.bash
+sdk $ USE_IC_REF=1 bats e2e/tests-replica/*.bash
 ----
-
-==== Running `dfx` in a Debugger
-
-While there are many OS/IDE variants where this can work, this document provides
-a specific example in order to make the instructions easier to follow.
-
-The key is to use a `nix-shell` to provide the `DFX_ASSETS` environment variable for `dfx`.
-
-This example assumes that your git workspaces are under `~/d` and
-your `dfx` workspaces are under `~/w`, but they can be anywhere.
-
-===== Debugging `dfx` in JetBrains IDEs on OSX
-
-. Install https://www.rust-lang.org/tools/install[Rust]
-
-. Switch to the version of the rust toolchain from the https://github.com/dfinity-lab/common/blob/master/nix/overlays/rust.nix#L12[common repo]
-+
-[source,bash]
-----
-$ rustup toolchain install 1.41.1
-$ rustup default 1.41.1
-----
-+
-. Install https://www.jetbrains.com/idea/[IDEA Ultimate] or https://www.jetbrains.com/clion/[CLion], and the Rust plugin.
-
-. Install https://brew.sh/[Homebrew] and required packages:
-+
-[source,bash]
-----
-$ brew install openssl cmake
-----
-
-. Start a `nix-shell` and obtain `DFX_ASSETS`.
-+
-Leave this `nix-shell` open.
-+
-[source,bash]
-----
-sdk $ nix-shell
-[nix-shell:~/d/sdk]$ echo $DFX_ASSETS
-/nix/store/g419n569py1gas7642q9jf5vh19xzp3y-dfx-assets
-----
-
-. Launch your IDE and then `File | Open... | ~/d/sdk/Cargo.toml`
-You should briefly see a small popup that says `Using rustup`.
-
-. In the Project window, navigate to `src/dfx/src/main.rs` and right-click `Run 'Run dfx'`
-+
-It will build, but fail to run with an error like this:
-+
-----
-thread 'main' panicked at 'Cannot find DFX_ASSETS: NotPresent', src/libcore/result.rs:1188:5
-----
-
-. Fix the Run/Debug Configuration
-+
-By default, it will be set up to run `dfx` without parameters
-in the `sdk` workspace directory.
-+
-We'll set up a configuration to run `dfx new <project>`, which we can duplicate
-and alter for other commands, by making these changes:
-+
-* Change the `Name` field to indicate which command we are running
-* Specify the `--manifest-path` for `cargo run`
-* Add command-line arguments for `dfx`
-* Provide the `DFX_ASSETS` environment variable
-* Change the working directory to where we want to run `dfx`
-+
-Before:
-+
-----
-Name: Run dfx
-Command: run --package dfx --bin dfx
-Environment variables:
-Working directory: <home>/d/sdk
-----
-+
-After:
-+
-----
-Name: dfx new dfxdebug
-Command: run --manifest-path <home>/d/sdk/Cargo.toml --package dfx --bin dfx new someproject
-Environment variables: DFX_ASSETS=<DFX_ASSETS path from nix-shell>
-Working directory: <home>/w
-----
-
-. Run or set breakpoints and debug.
 
 == Conventional Commits
 
@@ -155,39 +80,6 @@ What that means is your PR title should start with one of the following prefix:
   and will be ignored.
 * `release:`. Your PR is for tagging a release and should be ignored, but will be
   a break point for the log history when doing release notes.
-
-== Documentation
-
-https://hydra.oregon.dfinity.build/latest/dfinity-ci-build/sdk/dfx.doc.x86_64-linux/dfx/index.html[Latest cargo docs].
-
-== Building without Nix
-
-The build script in this repo requires an environment variable to point to the asset directory
-that is to be bundled. That asset directory is normally built as a nix dependency to building
-DFX.
-
-If you aren't changing the assets themselves (ie. you're just fixing a bug in dfx), and you
-already have the latest DFX installed, it's probably safe (but not always) to use the cache
-folder installed on your computer as the asset directory.
-
-You can do this with the follow command:
-
-[source,bash]
-----
-export DFX_ASSETS=$(dfx cache show)
-cargo build
-----
-
-Please note that this will work, but result in a bigger output (dfx itself is part of the cache
-but not the asset), and that if the installed cache is out of sync with your branch it might
-result in incompatibilities. This is normally enough to run unit tests and compilation though.
-
-== CI
-
-To run the CI job manually run either:
-
-[source,bash]
-nix-build ci/ci.nix -A dfx[.x86_64-linux|.x86_64-darwin]
 
 == Dependencies
 


### PR DESCRIPTION
# Description

We don't need nix in order to build dfx anymore, and `cargo build` just works now.

Updated the contributing docs to say how to build dfx and how to run end to end tests without nix.
