### PR TITLE
feat: add command-line arg and dfx.json default to enable bitcoin feature

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -66,15 +66,20 @@ But when trying to create an identity with that name, it was considered to be al
 
 === feat: dfx start and dfx replica can now launch the ic-btc-adapter process
 
-Added command-line parameter:
-    dfx start --btc-adapter-config <path>
-    dfx replica --btc-adapter-config <path>
+Added command-line parameters:
+    dfx start   --enable-bitcoin --btc-adapter-config <path>
+    dfx replica --enable-bitcoin --btc-adapter-config <path>
 
-Defaults to value from dfx.json: .defaults.bitcoin.btc_adapter_config
+These default to values from dfx.json:
+    .defaults.bitcoin.btc_adapter_config
+    .defaults.bitcoin.enabled
 
-If set, dfx start/replica will launch the ic-btc-adapter process.
+The --btc-adapter-config parameter, if specified on the command line, implies --enable-bitcoin.
 
-The rest of this isn't hooked up yet.
+If --enable-bitcoin or .defaults.bitcoin.enabled is set, and a btc adapter configuration is specified,
+then dfx start/replica will launch the ic-btc-adapter process.
+
+This integration is not yet complete, pending upcoming functionality in ic-starter.
 
 == updating dependencies
 

--- a/e2e/assets/bitcoin/patch.bash
+++ b/e2e/assets/bitcoin/patch.bash
@@ -1,5 +1,3 @@
-# shellcheck disable=SC2094
-cat <<<"$(jq '.defaults.bitcoin.btc_adapter_config="'"$(pwd)/testnet.config.json"'"' dfx.json)" >dfx.json
 # unix socket domain names can only be so long.  An attempt to use $(pwd) here resulted in this error:
 # path must be shorter than libc::sockaddr_un.sun_path
 cat <<<"$(jq '.incoming_source.Path="'"/tmp/e2e-ic-btc-adapter.$$.socket"'"' testnet.config.json)" >testnet.config.json

--- a/e2e/utils/assertions.bash
+++ b/e2e/utils/assertions.bash
@@ -168,6 +168,18 @@ assert_file_exists() {
     fi
 }
 
+assert_file_not_empty() {
+    filename="$1"
+
+    assert_file_exists "$filename"
+
+    if [[ ! -s $filename ]]; then
+        echo "$filename is empty" \
+        | batslib_decorate "Empty file" \
+        | fail
+    fi
+}
+
 assert_file_not_exists() {
     filename="$1"
 

--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -266,6 +266,10 @@ fn replica_start_thread(
         if let Some(port) = port {
             cmd.args(&["--http-port", &port.to_string()]);
         }
+        if config.btc_adapter.socket_path.is_some() {
+            cmd.args(&["--subnet-features", "bitcoin_testnet_feature"]);
+        }
+
         if let Some(write_port_to) = &write_port_to {
             cmd.args(&[
                 "--http-port-file",

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -22,6 +22,7 @@ const EMPTY_CONFIG_DEFAULTS: ConfigDefaults = ConfigDefaults {
 
 const EMPTY_CONFIG_DEFAULTS_BITCOIN: ConfigDefaultsBitcoin = ConfigDefaultsBitcoin {
     btc_adapter_config: None,
+    enabled: false,
 };
 
 const EMPTY_CONFIG_DEFAULTS_BOOTSTRAP: ConfigDefaultsBootstrap = ConfigDefaultsBootstrap {
@@ -87,6 +88,14 @@ pub struct CanisterDeclarationsConfig {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ConfigDefaultsBitcoin {
     pub btc_adapter_config: Option<PathBuf>,
+
+    #[serde(default = "default_as_false")]
+    pub enabled: bool,
+}
+
+fn default_as_false() -> bool {
+    // sigh https://github.com/serde-rs/serde/issues/368
+    false
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]


### PR DESCRIPTION
# Description

Set the `bitcoin_testnet_feature` subnet feature if btc integration is enabled.

Add `dfx start --enable-bitcoin` and `dfx replica --enable-bitcoin` command-line arguments for enabling the bitcoin feature.  Note that passing `--btc-adapter-config <path>` on the command line implies these parameters are true.

Also added a dfx.json setting `.defaults.bitcoin.enabled` to control this behavior.

This way, you can set up the btc integration (configuration path) in defaults, without having it enabled all of the time, but can  enable it by running `dfx start --enable-bitcoin`, and it's also possible to set up dfx.json such that it's enabled with just `dfx start`.

Fixes # (unknown)

# How Has This Been Tested?

There are end-to-end tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
