### PR TITLE
feat: dfx deploy --upgrade-unchanged to upgrade wasm even if it did not changed

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,13 @@
 
 == DFX
 
+=== feat: dfx deploy --upgrade-unchanged or dfx canister install --mode upgrade --upgrade-unchanged
+
+When upgrading a canister, `dfx deploy` and `dfx canister install` skip installing the .wasm
+if the wasm hash did not change.  This avoids a round trip through stable memory for all
+assets on every dfx deploy, for example.  By passing this argument, dfx will instead
+install the wasm even if its hash matches the already-installed wasm.
+
 === feat: Introduce DFX_CACHE_ROOT environment variable
 
 A new environment variable, `DFX_CACHE_ROOT`, has been introduced to allow setting the cache root directory to a different location than the configuration root directory. Previously `DFX_CONFIG_ROOT` was repurposed for this which only allowed one location to be set for both the cache and configuration root directories.

--- a/e2e/tests-dfx/deploy.bash
+++ b/e2e/tests-dfx/deploy.bash
@@ -14,6 +14,16 @@ teardown() {
     standard_teardown
 }
 
+@test "deploy --upgrade-unchanged upgrades even if the .wasm did not change" {
+    dfx_start
+    assert_command dfx deploy
+
+    assert_command dfx deploy
+    assert_match "Module hash.*is already installed"
+
+    assert_command dfx deploy --upgrade-unchanged
+    assert_not_match "Module hash.*is already installed"
+}
 
 @test "deploy without arguments sets wallet and self as the controllers" {
     dfx_start

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -14,6 +14,20 @@ teardown() {
     standard_teardown
 }
 
+@test "canister install --upgrade-unchanged upgrades even if the .wasm did not change" {
+    dfx_start
+    dfx canister create --all
+    dfx build
+
+    assert_command dfx canister install --all
+
+    assert_command dfx canister install --all --mode upgrade
+    assert_match "Module hash.*is already installed"
+
+    assert_command dfx canister install --all --mode upgrade --upgrade-unchanged
+    assert_not_match "Module hash.*is already installed"
+}
+
 @test "install fails if no argument is provided" {
     [ "$USE_IC_REF" ] && skip "skipped for ic-ref"
 

--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -34,6 +34,10 @@ pub struct CanisterInstallOpts {
         possible_values(&["install", "reinstall", "upgrade"]))]
     mode: String,
 
+    /// Upgrade the canister even if the .wasm did not change.
+    #[clap(long)]
+    upgrade_unchanged: bool,
+
     /// Specifies the argument to pass to the method.
     #[clap(long)]
     argument: Option<String>,
@@ -93,6 +97,7 @@ pub async fn exec(
             timeout,
             call_sender,
             installed_module_hash,
+            opts.upgrade_unchanged,
         )
         .await
     } else if opts.all {
@@ -130,6 +135,7 @@ pub async fn exec(
                     timeout,
                     call_sender,
                     installed_module_hash,
+                    opts.upgrade_unchanged,
                 )
                 .await?;
             }

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -47,6 +47,10 @@ pub struct DeployOpts {
     possible_values(&["reinstall"]))]
     mode: Option<String>,
 
+    /// Upgrade the canister even if the .wasm did not change.
+    #[clap(long)]
+    upgrade_unchanged: bool,
+
     /// Override the compute network to connect to. By default, the local network is used.
     /// A valid URL (starting with `http:` or `https:`) can be used here, and a special
     /// ephemeral network will be created specifically for this request. E.g.
@@ -123,6 +127,7 @@ pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
         argument,
         argument_type,
         force_reinstall,
+        opts.upgrade_unchanged,
         timeout,
         with_cycles,
         &call_sender,

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -28,6 +28,7 @@ pub async fn deploy_canisters(
     argument: Option<&str>,
     argument_type: Option<&str>,
     force_reinstall: bool,
+    upgrade_unchanged: bool,
     timeout: Duration,
     with_cycles: Option<&str>,
     call_sender: &CallSender,
@@ -98,6 +99,7 @@ pub async fn deploy_canisters(
         argument,
         argument_type,
         force_reinstall,
+        upgrade_unchanged,
         timeout,
         call_sender,
     )
@@ -203,6 +205,7 @@ async fn install_canisters(
     argument: Option<&str>,
     argument_type: Option<&str>,
     force_reinstall: bool,
+    upgrade_unchanged: bool,
     timeout: Duration,
     call_sender: &CallSender,
 ) -> DfxResult {
@@ -255,6 +258,7 @@ async fn install_canisters(
             timeout,
             call_sender,
             installed_module_hash,
+            upgrade_unchanged,
         )
         .await?;
     }

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -30,6 +30,7 @@ pub async fn install_canister(
     timeout: Duration,
     call_sender: &CallSender,
     installed_module_hash: Option<Vec<u8>>,
+    upgrade_unchanged: bool,
 ) -> DfxResult {
     let network = env.get_network_descriptor().unwrap();
     if !network.is_ic && named_canister::get_ui_canister_id(network).is_none() {
@@ -122,6 +123,7 @@ YOU WILL LOSE ALL DATA IN THE CANISTER.");
 
     if mode == InstallMode::Upgrade
         && wasm_module_already_installed(&wasm_module, installed_module_hash.as_deref())
+        && !upgrade_unchanged
     {
         println!(
             "Module hash {} is already installed.",


### PR DESCRIPTION
# Description

Make it so it's possible to "upgrade" a canister's wasm even if the wasm hash did not change.  This has been asked for in order to be able to re-run the upgrade path repeatedly (even though the code didn't change).

Also applies to dfx canister install --mode=upgrade --upgrade-unchanged

# How Has This Been Tested?

Through end-to-end tests, and by running `dfx deploy --upgrade-unchanged` and `dfx install --all --mode=upgrade --upgrade-unchanged`

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [] I have made corresponding changes to the documentation.

closes #2015 