### PR TITLE
fix: now builds on Apple M1

### DIFF
--- a/scripts/prepare-dfx-assets.sh
+++ b/scripts/prepare-dfx-assets.sh
@@ -18,7 +18,8 @@ function cleanup {
 }
 trap cleanup EXIT
 
-MACHINE=$(uname -m) # ex: x86_64
+# We use x86_64 even on Apple M1 (arm64), though rosetta
+MACHINE=x86_64
 case "$OSTYPE" in
     darwin*)  PLATFORM="darwin" ;;
     linux*)   PLATFORM="linux" ;;

--- a/scripts/prepare-dfx-assets.sh
+++ b/scripts/prepare-dfx-assets.sh
@@ -18,7 +18,7 @@ function cleanup {
 }
 trap cleanup EXIT
 
-# We use x86_64 even on Apple M1 (arm64), though rosetta
+# We use x86_64 even on Apple M1 (arm64), through rosetta
 MACHINE=x86_64
 case "$OSTYPE" in
     darwin*)  PLATFORM="darwin" ;;


### PR DESCRIPTION
# Description

We always use x86_64 prebuilt binaries with rosetta

# How Has This Been Tested?

`cargo build` on an M1 machine

