### PR TITLE
fix: dfx start should detect if dfx is already running

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,7 @@
 dfx will once again display 'dfx is already running' if dfx is already running,
 rather than 'Address already in use'.
 
-As a side effect, after `dfx start` failed to notice that dfx was already running,
+As a consequence, after `dfx start` failed to notice that dfx was already running,
 it would replace .dfx/pid with an empty file.  Later invocations of `dfx stop`
 would display no output and return a successful exit code, but leave dfx running.
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,15 @@
 
 == DFX
 
+=== fix: dfx start will once again notice if dfx is already running
+
+dfx will once again display 'dfx is already running' if dfx is already running,
+rather than 'Address already in use'.
+
+As a side effect, after `dfx start` failed to notice that dfx was already running,
+it would replace .dfx/pid with an empty file.  Later invocations of `dfx stop`
+would display no output and return a successful exit code, but leave dfx running.
+
 === feat: dfx deploy --upgrade-unchanged or dfx canister install --mode upgrade --upgrade-unchanged
 
 When upgrading a canister, `dfx deploy` and `dfx canister install` skip installing the .wasm

--- a/e2e/tests-dfx/start.bash
+++ b/e2e/tests-dfx/start.bash
@@ -156,3 +156,11 @@ teardown() {
     assert_match "subnet_type: System"
 
 }
+
+@test "dfx start detects if dfx is already running" {
+    dfx_new hello
+    dfx_start
+
+    assert_command_fail dfx start
+    assert_match "dfx is already running"
+}

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -322,7 +322,8 @@ fn check_previous_process_running(dfx_pid_path: &Path) -> DfxResult<()> {
         if let Ok(s) = std::fs::read_to_string(&dfx_pid_path) {
             if let Ok(pid) = s.parse::<Pid>() {
                 // If we find the pid in the file, we tell the user and don't start!
-                let system = System::new();
+                let mut system = System::new();
+                system.refresh_processes();
                 if let Some(_process) = system.process(pid) {
                     bail!("dfx is already running.");
                 }


### PR DESCRIPTION
# Description

While writing other tests, I noticed that `dfx start` outputs "Address already in use" instead of "dfx is already running" if dfx is already running.

It turned out that dfx start wasn't actually checking the process list, because the newer version of `system` that we're using requires a call to update the process list.

Worse, it would overwrite `.dfx/pid` with an empty file, then fail with `Address is already in use`, meaning `dfx stop` would later not know which pid to signal.

Fixes # https://dfinity.atlassian.net/browse/SDK-424

# How Has This Been Tested?

Added an e2e test.

Before
```
$ dfx start --background && dfx start
...

Apr 18 10:19:32.478 INFO Starting server. Listening on http://127.0.0.1:8000/
Error: Address already in use (os error 48)
$ dfx stop
$ dfx start
Error: Address already in use (os error 48)
```

After
```
$ dfx start --background && dfx start
...
Apr 18 10:24:06.743 INFO Starting server. Listening on http://127.0.0.1:8000/
Error: dfx is already running.
$ dfx stop
Apr 18 17:24:33.285 INFO Caught SIGTERM
Stopping the replica...
Stopped.                                                                                                                                                                                                     
Stopping icx-proxy...
Stopped.
$ dfx start
...
 Apr 18 10:26:02.361 INFO Starting server. Listening on http://127.0.0.1:8000/
```


# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] (not needed) I have made corresponding changes to the documentation.
