### PR TITLE
fix: dfx canister update-settings <canister id>

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,8 @@ As a consequence, after `dfx start` failed to notice that dfx was already runnin
 it would replace .dfx/pid with an empty file.  Later invocations of `dfx stop`
 would display no output and return a successful exit code, but leave dfx running.
 
+=== fix: dfx canister update-settings works if passed a canister id, even if that canister id is unknown to the project
+
 === feat: dfx deploy --upgrade-unchanged or dfx canister install --mode upgrade --upgrade-unchanged
 
 When upgrading a canister, `dfx deploy` and `dfx canister install` skip installing the .wasm

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,7 +18,10 @@ As a consequence, after `dfx start` failed to notice that dfx was already runnin
 it would replace .dfx/pid with an empty file.  Later invocations of `dfx stop`
 would display no output and return a successful exit code, but leave dfx running.
 
-=== fix: dfx canister update-settings works if passed a canister id, even if that canister id is unknown to the project
+=== fix: dfx canister update-settings <canister id> works even if the canister id is not known to the project.
+
+This makes the behavior match the usage text of the command:
+`<CANISTER> Specifies the canister name or id to update. You must specify either canister name/id or the --all option`
 
 === feat: dfx deploy --upgrade-unchanged or dfx canister install --mode upgrade --upgrade-unchanged
 

--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -129,17 +129,17 @@ pub async fn exec(
         let compute_allocation = get_compute_allocation(
             opts.compute_allocation.clone(),
             config_interface,
-            canister_name,
+            Some(canister_name),
         )?;
         let memory_allocation = get_memory_allocation(
             opts.memory_allocation.clone(),
             config_interface,
-            canister_name,
+            Some(canister_name),
         )?;
         let freezing_threshold = get_freezing_threshold(
             opts.freezing_threshold.clone(),
             config_interface,
-            canister_name,
+            Some(canister_name),
         )?;
         create_canister(
             env,
@@ -176,17 +176,17 @@ pub async fn exec(
                 let compute_allocation = get_compute_allocation(
                     opts.compute_allocation.clone(),
                     config_interface,
-                    canister_name,
+                    Some(canister_name),
                 )?;
                 let memory_allocation = get_memory_allocation(
                     opts.memory_allocation.clone(),
                     config_interface,
-                    canister_name,
+                    Some(canister_name),
                 )?;
                 let freezing_threshold = get_freezing_threshold(
                     opts.freezing_threshold.clone(),
                     config_interface,
-                    canister_name,
+                    Some(canister_name),
                 )?;
                 create_canister(
                     env,

--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -81,23 +81,22 @@ pub async fn exec(
             .or_else(|_| canister_id_store.get(canister_name_or_id))?;
         let textual_cid = canister_id.to_text();
         let canister_name = canister_id_store
-            .get_name(&textual_cid)
-            .ok_or_else(|| anyhow!("Cannot find canister name for id '{}'.", textual_cid))?;
+            .get_name(&textual_cid);
 
         let compute_allocation = get_compute_allocation(
             opts.compute_allocation.clone(),
             config_interface,
-            canister_name,
+            canister_name.as_deref().map(|x| &**x),
         )?;
         let memory_allocation = get_memory_allocation(
             opts.memory_allocation.clone(),
             config_interface,
-            canister_name,
+            canister_name.as_deref().map(|x| &**x),
         )?;
         let freezing_threshold = get_freezing_threshold(
             opts.freezing_threshold.clone(),
             config_interface,
-            canister_name,
+            canister_name.as_deref().map(|x| &**x),
         )?;
         if let Some(added) = &opts.add_controller {
             let status = get_canister_status(env, canister_id, timeout, call_sender).await?;
@@ -141,17 +140,17 @@ pub async fn exec(
                 let compute_allocation = get_compute_allocation(
                     opts.compute_allocation.clone(),
                     config_interface,
-                    canister_name,
+                    Some(canister_name),
                 )?;
                 let memory_allocation = get_memory_allocation(
                     opts.memory_allocation.clone(),
                     config_interface,
-                    canister_name,
+                    Some(canister_name),
                 )?;
                 let freezing_threshold = get_freezing_threshold(
                     opts.freezing_threshold.clone(),
                     config_interface,
-                    canister_name,
+                    Some(canister_name),
                 )?;
                 if let Some(added) = &opts.add_controller {
                     let status =

--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -80,8 +80,7 @@ pub async fn exec(
         let canister_id = CanisterId::from_text(canister_name_or_id)
             .or_else(|_| canister_id_store.get(canister_name_or_id))?;
         let textual_cid = canister_id.to_text();
-        let canister_name = canister_id_store
-            .get_name(&textual_cid);
+        let canister_name = canister_id_store.get_name(&textual_cid);
 
         let compute_allocation = get_compute_allocation(
             opts.compute_allocation.clone(),

--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -80,22 +80,22 @@ pub async fn exec(
         let canister_id = CanisterId::from_text(canister_name_or_id)
             .or_else(|_| canister_id_store.get(canister_name_or_id))?;
         let textual_cid = canister_id.to_text();
-        let canister_name = canister_id_store.get_name(&textual_cid);
+        let canister_name = canister_id_store.get_name(&textual_cid).map(|x| &**x);
 
         let compute_allocation = get_compute_allocation(
             opts.compute_allocation.clone(),
             config_interface,
-            canister_name.as_deref().map(|x| &**x),
+            canister_name,
         )?;
         let memory_allocation = get_memory_allocation(
             opts.memory_allocation.clone(),
             config_interface,
-            canister_name.as_deref().map(|x| &**x),
+            canister_name,
         )?;
         let freezing_threshold = get_freezing_threshold(
             opts.freezing_threshold.clone(),
             config_interface,
-            canister_name.as_deref().map(|x| &**x),
+            canister_name,
         )?;
         if let Some(added) = &opts.add_controller {
             let status = get_canister_status(env, canister_id, timeout, call_sender).await?;

--- a/src/dfx/src/lib/ic_attributes/mod.rs
+++ b/src/dfx/src/lib/ic_attributes/mod.rs
@@ -25,11 +25,10 @@ pub fn get_compute_allocation(
         (None, Some(canister_name)) => config_interface.get_compute_allocation(canister_name)?,
         (None, None) => None,
     };
-    Ok(compute_allocation
-        .map(|arg| {
-            ComputeAllocation::try_from(arg.parse::<u64>().unwrap())
-                .expect("Compute Allocation must be a percentage.")
-        }))
+    Ok(compute_allocation.map(|arg| {
+        ComputeAllocation::try_from(arg.parse::<u64>().unwrap())
+            .expect("Compute Allocation must be a percentage.")
+    }))
 }
 
 pub fn get_memory_allocation(
@@ -42,11 +41,10 @@ pub fn get_memory_allocation(
         (None, Some(canister_name)) => config_interface.get_memory_allocation(canister_name)?,
         (None, None) => None,
     };
-    Ok(memory_allocation
-        .map(|arg| {
-            MemoryAllocation::try_from(u64::try_from(arg.parse::<Bytes>().unwrap().size()).unwrap())
-                .expect("Memory allocation must be between 0 and 2^48 (i.e 256TB), inclusively.")
-        }))
+    Ok(memory_allocation.map(|arg| {
+        MemoryAllocation::try_from(u64::try_from(arg.parse::<Bytes>().unwrap().size()).unwrap())
+            .expect("Memory allocation must be between 0 and 2^48 (i.e 256TB), inclusively.")
+    }))
 }
 
 pub fn get_freezing_threshold(
@@ -59,9 +57,8 @@ pub fn get_freezing_threshold(
         (None, Some(canister_name)) => config_interface.get_freezing_threshold(canister_name)?,
         (None, None) => None,
     };
-    Ok(freezing_threshold
-        .map(|arg| {
-            FreezingThreshold::try_from(arg.parse::<u128>().unwrap())
-                .expect("Must be a value between 0 and 2^64-1 inclusive.")
-        }))
+    Ok(freezing_threshold.map(|arg| {
+        FreezingThreshold::try_from(arg.parse::<u128>().unwrap())
+            .expect("Must be a value between 0 and 2^64-1 inclusive.")
+    }))
 }

--- a/src/dfx/src/lib/ic_attributes/mod.rs
+++ b/src/dfx/src/lib/ic_attributes/mod.rs
@@ -18,10 +18,14 @@ pub struct CanisterSettings {
 pub fn get_compute_allocation(
     compute_allocation: Option<String>,
     config_interface: &ConfigInterface,
-    canister_name: &str,
+    canister_name: Option<&str>,
 ) -> DfxResult<Option<ComputeAllocation>> {
+    let compute_allocation = match (compute_allocation, canister_name) {
+        (Some(compute_allocation), _) => Some(compute_allocation),
+        (None, Some(canister_name)) => config_interface.get_compute_allocation(canister_name)?,
+        (None, None) => None,
+    };
     Ok(compute_allocation
-        .or(config_interface.get_compute_allocation(canister_name)?)
         .map(|arg| {
             ComputeAllocation::try_from(arg.parse::<u64>().unwrap())
                 .expect("Compute Allocation must be a percentage.")
@@ -31,10 +35,14 @@ pub fn get_compute_allocation(
 pub fn get_memory_allocation(
     memory_allocation: Option<String>,
     config_interface: &ConfigInterface,
-    canister_name: &str,
+    canister_name: Option<&str>,
 ) -> DfxResult<Option<MemoryAllocation>> {
+    let memory_allocation = match (memory_allocation, canister_name) {
+        (Some(memory_allocation), _) => Some(memory_allocation),
+        (None, Some(canister_name)) => config_interface.get_memory_allocation(canister_name)?,
+        (None, None) => None,
+    };
     Ok(memory_allocation
-        .or(config_interface.get_memory_allocation(canister_name)?)
         .map(|arg| {
             MemoryAllocation::try_from(u64::try_from(arg.parse::<Bytes>().unwrap().size()).unwrap())
                 .expect("Memory allocation must be between 0 and 2^48 (i.e 256TB), inclusively.")
@@ -44,10 +52,14 @@ pub fn get_memory_allocation(
 pub fn get_freezing_threshold(
     freezing_threshold: Option<String>,
     config_interface: &ConfigInterface,
-    canister_name: &str,
+    canister_name: Option<&str>,
 ) -> DfxResult<Option<FreezingThreshold>> {
+    let freezing_threshold = match (freezing_threshold, canister_name) {
+        (Some(freezing_threshold), _) => Some(freezing_threshold),
+        (None, Some(canister_name)) => config_interface.get_freezing_threshold(canister_name)?,
+        (None, None) => None,
+    };
     Ok(freezing_threshold
-        .or(config_interface.get_freezing_threshold(canister_name)?)
         .map(|arg| {
             FreezingThreshold::try_from(arg.parse::<u128>().unwrap())
                 .expect("Must be a value between 0 and 2^64-1 inclusive.")


### PR DESCRIPTION
# Description

`dfx canister update-settings <canister id>` would fail unless the canister id corresponded to a named canister in the project.  This PR makes it so the command works for any canister id (as long as you are the controller)

Fixes https://dfinity.atlassian.net/browse/SDK-438

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation (this makes the behavior match the existing documentation)
