### PR TITLE
feat: dfx canister call --candid <path to candid file> ...

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,10 @@
 
 == DFX
 
+=== feat: dfx canister call --candid <path to candid file> ...
+
+Allows one to provide the .did file for calls to an arbitrary canister.
+
 === feat: Install arbitrary wasm into canisters
 
 You no longer need a DFX project setup with a build task to install an already-built wasm module into a canister ID. The new `+--wasm <path>+` flag to `+dfx canister install+` will bypass project configuration and install the wasm module at `+<path>+`. A DFX project setup is still recommended for general use; this should mostly be used for installing pre-built canisters. Note that DFX will also not perform its usual checks for API/ABI/stable-memory compatibility in this mode.

--- a/e2e/assets/call/call.mo
+++ b/e2e/assets/call/call.mo
@@ -1,0 +1,8 @@
+actor Call {
+
+  public query func make_struct(a: Text, b: Text) : async { c: Text; d: Text; } {
+    let result = { c = a; d = b; };
+    result
+  };
+
+}

--- a/e2e/assets/call/patch.bash
+++ b/e2e/assets/call/patch.bash
@@ -1,0 +1,1 @@
+dfx config canisters/hello/main call.mo

--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -14,6 +14,27 @@ teardown() {
     standard_teardown
 }
 
+@test "call --candid <path to candid file>" {
+    install_asset call
+    cat dfx.json
+
+    dfx_start
+    dfx deploy
+    assert_command dfx canister call hello make_struct '("A", "B")'
+    assert_eq '(record { c = "A"; d = "B" })'
+
+    CANISTER_ID=$(dfx canister id hello)
+    rm .dfx/local/canister_ids.json
+
+    # if no candid file known, then no field names
+    assert_command dfx canister call "$CANISTER_ID" make_struct '("A", "B")'
+    assert_eq '(record { 99 = "A"; 100 = "B" })'
+
+    # if passing the candid file, field names available
+    assert_command dfx canister call --candid .dfx/local/canisters/hello/hello.did "$CANISTER_ID" make_struct '("A", "B")'
+    assert_eq '(record { c = "A"; d = "B" })'
+}
+
 @test "call subcommand accepts canister identifier as canister name" {
     install_asset greet
     dfx_start

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -19,6 +19,7 @@ use ic_utils::interfaces::management_canister::MgmtMethod;
 use ic_utils::interfaces::wallet::{CallForwarder, CallResult};
 use ic_utils::interfaces::WalletCanister;
 use std::option::Option;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 /// Calls a method on a deployed canister.
@@ -65,6 +66,11 @@ pub struct CanisterCallOpts {
     /// Deducted from the wallet.
     #[clap(long, validator(cycle_amount_validator))]
     with_cycles: Option<String>,
+
+    /// Provide the .did file with which to decode the response.  Overrides value from dfx.json
+    /// for project canisters.
+    #[clap(long)]
+    candid: Option<PathBuf>,
 }
 
 #[derive(Clone, CandidType, Deserialize)]
@@ -195,6 +201,7 @@ pub async fn exec(
             get_local_cid_and_candid_path(env, callee_canister, Some(canister_id))?
         }
     };
+    let maybe_candid_path = opts.candid.or(maybe_candid_path);
 
     let is_management_canister = canister_id == CanisterId::management_canister();
 


### PR DESCRIPTION
# Description

If you use `dfx canister call` to call a canister that is not in your dfx project, dfx doesn't know the candid definition and its output can be hard to read.  This PR adds a command-line argument to allow for specification of the .did file.

Before
```
$ dfx canister call $(dfx identity get-wallet) get_events 
(
  vec { record { 23_515 = 49_296 : nat32; 1_191_829_844 = variant { 2_171_739_429 = 
record { 25_979 = principal "rrkah-fqaaa-aaaaa-aaaaq-cai"; 3_573_748_184 = 1 : nat64; 
4_293_698_680 = 0 : nat64;} }; 2_781_795_542 = 1_650_500_230_310_218_000 : nat64;}; record { 23_515 = 49_297 : nat32; 1_
```

After
```
$ dfx canister call --candid ~/d/sdk/src/distributed/wallet.did $(dfx identity get-wallet) get_events '(opt record {})'
(
  vec { record { id = 50_397 : nat32; kind = variant { CyclesSent = record { to = principal "rrkah-fqaaa-aaaaa-aaaaq-cai"; 
amount = 1 : nat64; refund = 0 : nat64;} }; timestamp = 1_650_500_308_906_654_000 : nat64;}; 
record { id = 50_398 : nat32; kind = variant { CyclesSent = record { to = principal "rrkah-fqaaa-aaaaa-aaaaq-cai"; amount = 1 : nat64; refund = 0 : nat64;} }; timestamp = 1_650_500_308_906_654_000 : nat64;}; record { id
```

Related docs PR: https://github.com/dfinity/docs/pull/739

# How Has This Been Tested?

Added an e2e test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
