### PR TITLE
build: make release script work without nix-shell

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -154,38 +154,35 @@ validate_default_project() {
 build_release_branch() {
 
     announce "Building branch $BRANCH for release $NEW_DFX_VERSION"
-    NIX_COMMAND=$(envsubst <<"EOF"
-        set -e
 
-        echo "Cleaning up cargo build files..."
-        $DRY_RUN_ECHO cargo clean --release
+    echo "Cleaning up cargo build files..."
+    $DRY_RUN_ECHO cargo clean --release
 
-        echo "Switching to branch: $BRANCH"
-        $DRY_RUN_ECHO git switch -c $BRANCH
+    echo "Switching to branch: $BRANCH"
+    $DRY_RUN_ECHO git switch -c "$BRANCH"
 
-        echo "Updating version in src/dfx/Cargo.toml"
-        # update first version in src/dfx/Cargo.toml to be NEW_DFX_VERSION
-        sed -i '0,/^version = ".*"/s//version = "$NEW_DFX_VERSION"/' src/dfx/Cargo.toml
+    echo "Updating version in src/dfx/Cargo.toml"
+    # update first version in src/dfx/Cargo.toml to be NEW_DFX_VERSION
+    # shellcheck disable=SC2094
+    cat <<<"$(awk 'NR==1,/^version = ".*"/{sub(/^version = ".*"/, "version = \"'"$NEW_DFX_VERSION"'\"")} 1' <src/dfx/Cargo.toml)" >src/dfx/Cargo.toml
 
-        echo "Building dfx with cargo."
-        cargo build --release --locked
+    echo "Building dfx with cargo."
+    # not --locked, because Cargo.lock needs to be updated with the new version
+    # we already checked that it builds with --locked, when building the release candidate.
+    cargo build --release
 
-        echo "Appending version to public/manifest.json"
-        # Append the new version to `public/manifest.json` by appending it to the `versions` list.
-        cat <<<$(jq --indent 4 '.versions += ["$NEW_DFX_VERSION"]' public/manifest.json) >public/manifest.json
+    echo "Appending version to public/manifest.json"
+    # Append the new version to `public/manifest.json` by appending it to the `versions` list.
+    # shellcheck disable=SC2094
+    cat <<<"$(jq --indent 4 '.versions += ["'"$NEW_DFX_VERSION"'"]' public/manifest.json)" >public/manifest.json
 
-        echo "Creating release branch: $BRANCH"
-        $DRY_RUN_ECHO git add -u
-        $DRY_RUN_ECHO git commit --signoff --message "chore: Release $NEW_DFX_VERSION"
-        $DRY_RUN_ECHO git push origin $BRANCH
+    echo "Creating release branch: $BRANCH"
+    $DRY_RUN_ECHO git add -u
+    $DRY_RUN_ECHO git commit --signoff --message "chore: Release $NEW_DFX_VERSION"
+    $DRY_RUN_ECHO git push origin "$BRANCH"
 
-        echo "Please open a pull request to the $FINAL_RELEASE_BRANCH branch, review and approve it, then merge it manually."
-        echo "  (The automerge-squash label will not work because the PR is not to the master branch)"
-EOF
-    )
-    # echo "$NIX_COMMAND"
-    echo "Starting nix-shell."
-    nix-shell --option extra-binary-caches https://cache.dfinity.systems --command "$NIX_COMMAND"
+    echo "Please open a pull request to the $FINAL_RELEASE_BRANCH branch, review and approve it, then merge it manually."
+    echo "  (The automerge-squash label will not work because the PR is not to the master branch)"
 
     wait_for_response 'PR merged'
 }
@@ -193,29 +190,21 @@ EOF
 tag_release_commit() {
     announce 'Tagging release commit'
 
-    NIX_COMMAND=$(envsubst <<"EOF"
-        set -e
+    echo "Switching to the release branch."
+    $DRY_RUN_ECHO git switch "$FINAL_RELEASE_BRANCH"
 
-        echo "Switching to the release branch."
-        $DRY_RUN_ECHO git switch "$FINAL_RELEASE_BRANCH"
+    echo "Pulling the remote branch"
+    $DRY_RUN_ECHO git pull
 
-        echo "Pulling the remote branch"
-        $DRY_RUN_ECHO git pull
+    echo "Creating a new tag $NEW_DFX_VERSION"
+    $DRY_RUN_ECHO git tag --annotate "$NEW_DFX_VERSION" --message "Release: $NEW_DFX_VERSION"
 
-        echo "Creating a new tag $NEW_DFX_VERSION"
-        $DRY_RUN_ECHO git tag --annotate $NEW_DFX_VERSION --message "Release: $NEW_DFX_VERSION"
+    echo "Displaying tags"
+    git log -1
+    git describe --always
 
-        echo "Displaying tags"
-        git log -1
-        git describe --always
-
-        echo "Pushing tag $NEW_DFX_VERSION"
-        $DRY_RUN_ECHO git push origin $NEW_DFX_VERSION
-
-EOF
-)
-
-    nix-shell --option extra-binary-caches https://cache.dfinity.systems --command "$NIX_COMMAND"
+    echo "Pushing tag $NEW_DFX_VERSION"
+    $DRY_RUN_ECHO git push origin "$NEW_DFX_VERSION"
 }
 
 {


### PR DESCRIPTION
# Description

Make it so the build script no longer requires nix to be installed.

At one point, I had a problem: how to update the first `version =` line in Cargo.toml.  "I know, I'll use sed," I thought.  Well, whichever version of sed nix bundles worked, but sed on OSX had other ideas.  Anyway, you know the rest of the story.  This PR makes the script use `awk` instead.

# How Has This Been Tested?

```
DRY_RUN=1 ./scripts/release.sh 9.8.7-beta.1
```
