### PR TITLE
feat: Use null as default value for opt arguments

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,20 @@
 
 == DFX
 
+=== feat: Use null as default value for opt arguments
+
+
+Before this, `deploy`ing a canister with an `opt Foo` init argument without specifying an `--argument` would lead to an error:
+
+```
+$ dfx deploy
+Error: Invalid data: Expected arguments but found none.
+```
+
+With this change, this isn't an error anymore, but instead `null` is passed as a value. In general, if the user does _not_ provide an `--argument`, and if the init method expects only `opt` arguments, then `dfx` will supply `null` for each argument.
+
+Note in particular that this does not try to match `opt` arguments for heterogeneous (`opt`/non-`opt`) signatures. Note moreover that this only impacts a case that would previously error out, so no existing (working) workflows should be affected.
+
 === feat: dfx canister call --candid <path to candid file> ...
 
 Allows one to provide the .did file for calls to an arbitrary canister.

--- a/src/dfx/src/util/mod.rs
+++ b/src/dfx/src/util/mod.rs
@@ -166,14 +166,16 @@ pub fn blob_from_arguments(
                     } else if func.args.is_empty() {
                         use candid::Encode;
                         Encode!()
-                    } else if func.args.iter().all(|t| match t { Type::Opt(_) => true, _ => false }) {
+                    } else if func.args.iter().all(|t| match t {
+                        Type::Opt(_) => true,
+                        _ => false,
+                    }) {
                         // If the user provided no arguments, and if all the expected arguments are
                         // optional, then use null values.
                         let nulls = vec![IDLValue::Null; func.args.len()];
                         let args = IDLArgs::new(&nulls);
                         args.to_bytes_with_types(env, &func.args)
-                    }
-                    else if let Some(random) = random {
+                    } else if let Some(random) = random {
                         let random = if random.is_empty() {
                             eprintln!("Random schema is empty, using any random value instead.");
                             "{=}"

--- a/src/dfx/src/util/mod.rs
+++ b/src/dfx/src/util/mod.rs
@@ -166,7 +166,14 @@ pub fn blob_from_arguments(
                     } else if func.args.is_empty() {
                         use candid::Encode;
                         Encode!()
-                    } else if let Some(random) = random {
+                    } else if func.args.iter().all(|t| match t { Type::Opt(_) => true, _ => false }) {
+                        // If the user provided no arguments, and if all the expected arguments are
+                        // optional, then use null values.
+                        let nulls = vec![IDLValue::Null; func.args.len()];
+                        let args = IDLArgs::new(&nulls);
+                        args.to_bytes_with_types(env, &func.args)
+                    }
+                    else if let Some(random) = random {
                         let random = if random.is_empty() {
                             eprintln!("Random schema is empty, using any random value instead.");
                             "{=}"

--- a/src/dfx/src/util/mod.rs
+++ b/src/dfx/src/util/mod.rs
@@ -166,10 +166,7 @@ pub fn blob_from_arguments(
                     } else if func.args.is_empty() {
                         use candid::Encode;
                         Encode!()
-                    } else if func.args.iter().all(|t| match t {
-                        Type::Opt(_) => true,
-                        _ => false,
-                    }) {
+                    } else if func.args.iter().all(|t| matches!(t, Type::Opt(_))) {
                         // If the user provided no arguments, and if all the expected arguments are
                         // optional, then use null values.
                         let nulls = vec![IDLValue::Null; func.args.len()];


### PR DESCRIPTION
# Description

Before this commit, `deploy`ing a canister with an `opt Foo` init
argument without specifying an `--argument` would lead to an error:

```
$ dfx deploy
Error: Invalid data: Expected arguments but found none.
```

With this change, this isn't an error anymore, but instead `null` is
passed as a value. In general, if the user does _not_ provide an
`--argument`, and if the init method expects only `opt` arguments, then
`dfx` will supply `null` for each argument.

Note in particular that this does not try to match `opt` arguments for
heterogeneous (`opt`/non-`opt`) signatures. Note moreover that this only
impacts a case that would previously error out, so no existing (working)
workflows should be affected.

# How Has This Been Tested?

I've only manually tested this with a canister that expected a single `opt` init argument.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
