### PR TITLE
fix: Remove false error from deposit-cycles

### DIFF
--- a/e2e/tests-dfx/wallet.bash
+++ b/e2e/tests-dfx/wallet.bash
@@ -184,3 +184,11 @@ teardown() {
     ALICE_WALLET=$(dfx --identity alice identity get-wallet)
     dfx wallet send "$ALICE_WALLET" 1
 }
+
+@test "dfx canister deposit-cycles succeeds on a canister the caller does not own" {
+    dfx_new hello
+    dfx_start
+    dfx identity new alice --disable-encryption
+    dfx --identity alice deploy --no-wallet hello
+    assert_command dfx canister --wallet "$(dfx identity get-wallet)" deposit-cycles 1 hello
+}

--- a/src/dfx/src/commands/canister/deposit_cycles.rs
+++ b/src/dfx/src/commands/canister/deposit_cycles.rs
@@ -46,12 +46,15 @@ async fn deposit_cycles(
 
     canister::deposit_cycles(env, canister_id, timeout, call_sender, cycles).await?;
 
-    let status = canister::get_canister_status(env, canister_id, timeout, call_sender).await?;
-
-    info!(
-        log,
-        "Deposited {} cycles, updated balance: {} cycles", cycles, status.cycles
-    );
+    let status = canister::get_canister_status(env, canister_id, timeout, call_sender).await;
+    if let Ok(status) = status {
+        info!(
+            log,
+            "Deposited {} cycles, updated balance: {} cycles", cycles, status.cycles
+        );
+    } else {
+        info!(log, "Deposited {cycles} cycles.");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
`dfx canister deposit-cycles` attempts to get the new balance so it can log it, and propagates any errors. This means that if it successfully deposited cycles to a canister it can't query because it doesn't own, it will visually fail with an error while the transaction proceeded just fine. This removes that behavior.