### PR TITLE
chore: update changelog for changes post-0.10.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,8 @@
 = dfx changelog
 :doctype: book
 
+= UNRELEASED
+
 = 0.10.0
 
 == DFX


### PR DESCRIPTION
Adds a section to the changelog for entries that are made after the 0.10.0 release

