### PR TITLE
fix: install script: use either of shasum or sha256sum

### DIFF
--- a/public/install/999_footer.sh
+++ b/public/install/999_footer.sh
@@ -159,9 +159,10 @@ main() {
     if [ -n "${_dfx_sha256_filename}" ]; then
         log "Checking integrity of tarball..."
         ensure downloader "$_dfx_sha256_url" "${_dir}/${_dfx_sha256_filename}"
-        ensure pushd "${_dir}" >/dev/null
-        ensure $SHASUM -c "${_dfx_sha256_filename}"
-        ensure popd >/dev/null
+        (
+            ensure cd "${_dir}" >/dev/null
+            ensure $SHASUM -c "${_dfx_sha256_filename}"
+        )
     fi
     tar -xf "$_dfx_archive" -O >"$_dfx_file"
     ensure chmod u+x "$_dfx_file"

--- a/public/install/999_footer.sh
+++ b/public/install/999_footer.sh
@@ -103,7 +103,13 @@ main() {
     need_cmd mktemp
     need_cmd chmod
     need_cmd mkdir
-    need_cmd shasum
+    if check_cmd sha256sum; then
+        SHASUM=sha256sum
+    elif check_cmd shasum; then
+        SHASUM=shasum
+    else
+        err "need 'shasum' or 'sha256sum' (neither command found)"
+    fi
     need_cmd rm
     need_cmd tar
     need_cmd gzip
@@ -154,7 +160,7 @@ main() {
         log "Checking integrity of tarball..."
         ensure downloader "$_dfx_sha256_url" "${_dir}/${_dfx_sha256_filename}"
         ensure pushd "${_dir}" >/dev/null
-        ensure shasum -c "${_dfx_sha256_filename}"
+        ensure $SHASUM -c "${_dfx_sha256_filename}"
         ensure popd >/dev/null
     fi
     tar -xf "$_dfx_archive" -O >"$_dfx_file"


### PR DESCRIPTION
# Description

On Linux systems, `shasum` may not be available, and even if it is, it depends on perl being installed.
On OSX, `sha256sum` isn't installed by default, but can be by homebrew.

Use whichever is available, favoring sha256sum.

Also, pushd and popd aren't available in sh, so use a subshell.

# How Has This Been Tested?

Tested manually.
