### PR TITLE
fix: Fix more spurious configuration errors

### DIFF
--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -58,7 +58,6 @@ pub async fn exec(
     opts: CanisterInstallOpts,
     call_sender: &CallSender,
 ) -> DfxResult {
-    let config = env.get_config_or_anyhow()?;
     let agent = env
         .get_agent()
         .ok_or_else(|| anyhow!("Cannot get HTTP client from environment."))?;
@@ -75,9 +74,10 @@ pub async fn exec(
     }
 
     if let Some(canister) = opts.canister.as_deref() {
-        if config
+        let config = env.get_config();
+        if config.as_ref().map_or(Ok(false), |config| config
             .get_config()
-            .is_remote_canister(canister, &network.name)?
+            .is_remote_canister(canister, &network.name))?
         {
             bail!("Canister '{}' is a remote canister on network '{}', and cannot be installed from here.", canister, &network.name)
         }
@@ -86,7 +86,9 @@ pub async fn exec(
             Principal::from_text(canister).or_else(|_| canister_id_store.get(canister))?;
         let arguments = opts.argument.as_deref();
         let arg_type = opts.argument_type.as_deref();
-        let canister_info = CanisterInfo::load(&config, canister, Some(canister_id));
+        let canister_info = config.as_ref()
+            .ok_or_else(|| anyhow!("Cannot find dfx configuration file in the current working directory. Did you forget to create one?"))
+            .and_then(|config| CanisterInfo::load(&config, canister, Some(canister_id)));
         if let Some(wasm_path) = opts.wasm {
             // streamlined version, we can ignore most of the environment
             let install_args = blob_from_arguments(arguments, None, arg_type, &None)?;
@@ -125,7 +127,7 @@ pub async fn exec(
         }
     } else if opts.all {
         // Install all canisters.
-
+        let config = env.get_config_or_anyhow()?;
         if let Some(canisters) = &config.get_config().canisters {
             for canister in canisters.keys() {
                 if config

--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -75,10 +75,11 @@ pub async fn exec(
 
     if let Some(canister) = opts.canister.as_deref() {
         let config = env.get_config();
-        if config.as_ref().map_or(Ok(false), |config| config
-            .get_config()
-            .is_remote_canister(canister, &network.name))?
-        {
+        if config.as_ref().map_or(Ok(false), |config| {
+            config
+                .get_config()
+                .is_remote_canister(canister, &network.name)
+        })? {
             bail!("Canister '{}' is a remote canister on network '{}', and cannot be installed from here.", canister, &network.name)
         }
 
@@ -88,7 +89,7 @@ pub async fn exec(
         let arg_type = opts.argument_type.as_deref();
         let canister_info = config.as_ref()
             .ok_or_else(|| anyhow!("Cannot find dfx configuration file in the current working directory. Did you forget to create one?"))
-            .and_then(|config| CanisterInfo::load(&config, canister, Some(canister_id)));
+            .and_then(|config| CanisterInfo::load(config, canister, Some(canister_id)));
         if let Some(wasm_path) = opts.wasm {
             // streamlined version, we can ignore most of the environment
             let install_args = blob_from_arguments(arguments, None, arg_type, &None)?;

--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -75,11 +75,12 @@ pub async fn exec(
 
     if let Some(canister) = opts.canister.as_deref() {
         let config = env.get_config();
-        if config.as_ref().map_or(Ok(false), |config| {
+        let is_remote = config.as_ref().map_or(Ok(false), |config| {
             config
                 .get_config()
                 .is_remote_canister(canister, &network.name)
-        })? {
+        })?;
+        if is_remote {
             bail!("Canister '{}' is a remote canister on network '{}', and cannot be installed from here.", canister, &network.name)
         }
 

--- a/src/dfx/src/commands/canister/status.rs
+++ b/src/dfx/src/commands/canister/status.rs
@@ -63,14 +63,13 @@ pub async fn exec(
     opts: CanisterStatusOpts,
     call_sender: &CallSender,
 ) -> DfxResult {
-    let config = env.get_config_or_anyhow()?;
-
     fetch_root_key_if_needed(env).await?;
     let timeout = expiry_duration();
 
     if let Some(canister) = opts.canister.as_deref() {
         canister_status(env, canister, timeout, call_sender).await
     } else if opts.all {
+        let config = env.get_config_or_anyhow()?;
         if let Some(canisters) = &config.get_config().canisters {
             for canister in canisters.keys() {
                 canister_status(env, canister, timeout, call_sender).await?;


### PR DESCRIPTION
Same story as #2169, this time with `dfx canister install` (applicable primarily with `--wasm`) and `dfx canister status`.

Fixes #2050.