### PR TITLE
feat: pass uds socket path to ic-starter for btc adapter.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,7 +19,7 @@ These default to values from dfx.json:
 
 The --bitcoin-node parameter, if specified on the command line, implies --enable-bitcoin.
 
-If --enable-bitcoin or .defaults.bitcoin.enabled is set, then dfx start/replica will launch the ic-btc-adapter process. and configure the replica to communicate with it.
+If --enable-bitcoin or .defaults.bitcoin.enabled is set, then dfx start/replica will launch the ic-btc-adapter process and configure the replica to communicate with it.
 
 === Binary cache
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,7 +19,7 @@ These default to values from dfx.json:
 
 The --bitcoin-node parameter, if specified on the command line, implies --enable-bitcoin.
 
-If --enable-bitcoin or .defaults.bitcoin.enabled is set, then dfx start/replica will launch the ic-btc-adapter process.
+If --enable-bitcoin or .defaults.bitcoin.enabled is set, then dfx start/replica will launch the ic-btc-adapter process. and configure the replica to communicate with it.
 
 === Binary cache
 

--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -266,8 +266,14 @@ fn replica_start_thread(
         if let Some(port) = port {
             cmd.args(&["--http-port", &port.to_string()]);
         }
-        if config.btc_adapter.socket_path.is_some() {
+        if config.btc_adapter.enabled {
             cmd.args(&["--subnet-features", "bitcoin_testnet_feature"]);
+            if let Some(socket_path) = config.btc_adapter.socket_path {
+                cmd.args(&[
+                    "--bitcoin-testnet-uds-path",
+                    socket_path.to_str().unwrap_or_default(),
+                ]);
+            }
         }
 
         if let Some(write_port_to) = &write_port_to {

--- a/src/dfx/src/commands/replica.rs
+++ b/src/dfx/src/commands/replica.rs
@@ -11,7 +11,6 @@ use crate::commands::start::{configure_btc_adapter_if_enabled, empty_writable_pa
 use clap::Parser;
 use std::default::Default;
 use std::net::SocketAddr;
-use std::path::PathBuf;
 
 /// Starts a local Internet Computer replica.
 #[derive(Parser)]
@@ -34,11 +33,7 @@ pub struct ReplicaOpts {
 }
 
 /// Gets the configuration options for the Internet Computer replica.
-fn get_config(
-    env: &dyn Environment,
-    opts: ReplicaOpts,
-    btc_adapter_socket: Option<PathBuf>,
-) -> DfxResult<ReplicaConfig> {
+fn get_config(env: &dyn Environment, opts: ReplicaOpts) -> DfxResult<ReplicaConfig> {
     let config = get_config_from_file(env);
     let port = get_port(&config, opts.port)?;
     let mut http_handler: HttpHandlerConfig = Default::default();
@@ -56,9 +51,6 @@ fn get_config(
         ReplicaConfig::new(&env.get_state_dir(), config.subnet_type.unwrap_or_default());
     replica_config.http_handler = http_handler;
 
-    if let Some(btc_adapter_socket) = btc_adapter_socket {
-        replica_config = replica_config.with_btc_adapter_socket(btc_adapter_socket);
-    }
     Ok(replica_config)
 }
 
@@ -109,7 +101,7 @@ pub fn exec(env: &dyn Environment, opts: ReplicaOpts) -> DfxResult {
             start_emulator_actor(env, shutdown_controller)?;
         } else {
             let (btc_adapter_ready_subscribe, btc_adapter_socket_path) =
-                if let Some(btc_adapter_config) = btc_adapter_config {
+                if let Some(ref btc_adapter_config) = btc_adapter_config {
                     let socket_path = btc_adapter_config.get_socket_path();
                     let ready_subscribe = start_btc_adapter_actor(
                         env,
@@ -124,7 +116,13 @@ pub fn exec(env: &dyn Environment, opts: ReplicaOpts) -> DfxResult {
                     (None, None)
                 };
 
-            let replica_config = get_config(env, opts, btc_adapter_socket_path)?;
+            let mut replica_config = get_config(env, opts)?;
+            if btc_adapter_config.is_some() {
+                replica_config = replica_config.with_btc_adapter_enabled();
+                if let Some(btc_adapter_socket) = btc_adapter_socket_path {
+                    replica_config = replica_config.with_btc_adapter_socket(btc_adapter_socket);
+                }
+            }
 
             start_replica_actor(
                 env,

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -196,7 +196,7 @@ pub fn exec(
             emulator.recipient()
         } else {
             let (btc_adapter_ready_subscribe, btc_adapter_socket_path) =
-                if let Some(btc_adapter_config) = btc_adapter_config {
+                if let Some(ref btc_adapter_config) = btc_adapter_config {
                     let socket_path = btc_adapter_config.get_socket_path();
                     let ready_subscribe = start_btc_adapter_actor(
                         env,
@@ -224,8 +224,11 @@ pub fn exec(
                 .unwrap_or_default();
             let mut replica_config = ReplicaConfig::new(&env.get_state_dir(), subnet_type)
                 .with_random_port(&replica_port_path);
-            if let Some(btc_adapter_socket) = btc_adapter_socket_path {
-                replica_config = replica_config.with_btc_adapter_socket(btc_adapter_socket);
+            if btc_adapter_config.is_some() {
+                replica_config = replica_config.with_btc_adapter_enabled();
+                if let Some(btc_adapter_socket) = btc_adapter_socket_path {
+                    replica_config = replica_config.with_btc_adapter_socket(btc_adapter_socket);
+                }
             }
 
             let replica = start_replica_actor(

--- a/src/dfx/src/lib/replica_config.rs
+++ b/src/dfx/src/lib/replica_config.rs
@@ -18,6 +18,7 @@ pub struct HttpHandlerConfig {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct BtcAdapterConfig {
+    pub enabled: bool,
     pub socket_path: Option<PathBuf>,
 }
 
@@ -63,27 +64,71 @@ impl ReplicaConfig {
                 consensus_pool_path: state_root.join("consensus_pool"),
             },
             subnet_type,
-            btc_adapter: BtcAdapterConfig { socket_path: None },
+            btc_adapter: BtcAdapterConfig {
+                enabled: false,
+                socket_path: None,
+            },
         }
     }
 
     #[allow(dead_code)]
-    pub fn with_port(&mut self, port: u16) -> &mut Self {
-        self.http_handler.port = Some(port);
-        self.http_handler.write_port_to = None;
-        self
+    pub fn with_port(self, port: u16) -> Self {
+        ReplicaConfig {
+            http_handler: self.http_handler.with_port(port),
+            ..self
+        }
     }
 
-    pub fn with_random_port(&mut self, write_port_to: &Path) -> Self {
-        self.http_handler.port = None;
-        self.http_handler.write_port_to = Some(write_port_to.to_path_buf());
-        let config = &*self;
-        config.clone()
+    pub fn with_random_port(self, write_port_to: &Path) -> Self {
+        ReplicaConfig {
+            http_handler: self.http_handler.with_random_port(write_port_to),
+            ..self
+        }
     }
 
-    pub fn with_btc_adapter_socket(&mut self, socket_path: PathBuf) -> Self {
-        self.btc_adapter.socket_path = Some(socket_path);
-        let config = &*self;
-        config.clone()
+    pub fn with_btc_adapter_enabled(self) -> Self {
+        ReplicaConfig {
+            btc_adapter: self.btc_adapter.with_enabled(),
+            ..self
+        }
+    }
+
+    pub fn with_btc_adapter_socket(self, socket_path: PathBuf) -> Self {
+        ReplicaConfig {
+            btc_adapter: self.btc_adapter.with_socket_path(socket_path),
+            ..self
+        }
+    }
+}
+
+impl BtcAdapterConfig {
+    pub fn with_enabled(self) -> Self {
+        BtcAdapterConfig {
+            enabled: true,
+            ..self
+        }
+    }
+
+    pub fn with_socket_path(self, socket_path: PathBuf) -> Self {
+        BtcAdapterConfig {
+            socket_path: Some(socket_path),
+            ..self
+        }
+    }
+}
+
+impl HttpHandlerConfig {
+    pub fn with_port(self, port: u16) -> Self {
+        HttpHandlerConfig {
+            port: Some(port),
+            write_port_to: None,
+        }
+    }
+
+    pub fn with_random_port(self, write_port_to: &Path) -> Self {
+        HttpHandlerConfig {
+            port: None,
+            write_port_to: Some(write_port_to.to_path_buf()),
+        }
     }
 }


### PR DESCRIPTION
Also made the ReplicaConfig `.with_*` methods consistent with each other.

Fixes https://dfinity.atlassian.net/browse/SDK-452
