### PR TITLE
fix: include ic-canister-http-adapter binary in binary cache

### DIFF
--- a/scripts/prepare-dfx-assets.sh
+++ b/scripts/prepare-dfx-assets.sh
@@ -124,6 +124,7 @@ copy_motoko_base_from_clone() {
 
 add_binary_cache() {
     download_binary "ic-btc-adapter"
+    download_binary "ic-canister-http-adapter"
     download_binary "replica"
     download_binary "canister_sandbox"
     download_binary "sandbox_launcher"


### PR DESCRIPTION
# Description

Previous PR neglected to actually add the binary, when built with `cargo build`

# How Has This Been Tested?

```
$ dfx-wip cache install
$ ls $(dfx-wip cache show)
base				ic-canister-http-adapter	libffi.8.dylib			mo-ide
canister_sandbox		ic-ref				libgmp.10.dylib			moc
dfx				ic-starter			libz.1.2.11.dylib		replica
ic-btc-adapter			icx-proxy			mo-doc				sandbox_launcher
```

