### PR TITLE
fix: make CanisterIdStore struct members private

### DIFF
--- a/src/dfx/src/lib/models/canister_id_store.rs
+++ b/src/dfx/src/lib/models/canister_id_store.rs
@@ -18,9 +18,14 @@ type CanisterIds = BTreeMap<CanisterName, NetworkNametoCanisterId>;
 
 #[derive(Clone, Debug)]
 pub struct CanisterIdStore {
-    pub network_descriptor: NetworkDescriptor,
-    pub path: PathBuf,
-    pub ids: CanisterIds,
+    network_descriptor: NetworkDescriptor,
+    path: PathBuf,
+
+    // Only the canister ids read from/written to canister-ids.json
+    // which does not include remote canister ids
+    ids: CanisterIds,
+
+    // Remote ids read from dfx.json, never written to canister_ids.json
     remote_ids: Option<CanisterIds>,
 }
 


### PR DESCRIPTION
I don't think these ever needed to be public, but they sure don't now.