### PR TITLE
chore: make identity commands less verbose

### DIFF
--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -344,7 +344,7 @@ teardown() {
 @test "identity: import" {
     openssl ecparam -name secp256k1 -genkey -out identity.pem
     assert_command dfx identity import --disable-encryption alice identity.pem
-    assert_match 'Created identity: "alice".' "$stderr"
+    assert_match 'Imported identity: "alice".' "$stderr"
     assert_command diff identity.pem "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
     assert_eq ""
 }
@@ -353,14 +353,14 @@ teardown() {
     openssl ecparam -name secp256k1 -genkey -out identity.pem
     openssl ecparam -name secp256k1 -genkey -out identity2.pem
     assert_command dfx identity import --disable-encryption alice identity.pem
-    assert_match 'Created identity: "alice".' "$stderr"
+    assert_match 'Imported identity: "alice".' "$stderr"
     dfx identity use alice
     PRINCIPAL_1="$(dfx identity get-principal)"
 
     assert_command_fail dfx identity import --disable-encryption alice identity2.pem
     assert_match "Identity already exists."
     assert_command dfx identity import --disable-encryption --force alice identity2.pem
-    assert_match 'Created identity: "alice".'
+    assert_match 'Imported identity: "alice".'
     PRINCIPAL_2="$(dfx identity get-principal)"
 
     assert_neq "$PRINCIPAL_1" "$PRINCIPAL_2"
@@ -369,7 +369,7 @@ teardown() {
 @test "identity: import default" {
     assert_command dfx identity new --disable-encryption alice
     assert_command dfx identity import --disable-encryption bob "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
-    assert_match 'Created identity: "bob".' "$stderr"
+    assert_match 'Imported identity: "bob".' "$stderr"
     assert_command diff "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem" "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.pem"
     assert_eq ""
 }

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -121,7 +121,6 @@ teardown() {
     assert_match 'alice anonymous default'
 
     assert_command dfx identity remove alice
-    assert_match 'Removing identity "alice".' "$stderr"
     assert_match 'Removed identity "alice".' "$stderr"
     assert_command_fail cat "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
 
@@ -181,7 +180,6 @@ teardown() {
     local key="$x"
 
     assert_command dfx identity rename alice bob
-    assert_match 'Renaming identity "alice" to "bob".' "$stderr"
     assert_match 'Renamed identity "alice" to "bob".' "$stderr"
 
     assert_command dfx identity list

--- a/src/dfx/src/commands/identity/import.rs
+++ b/src/dfx/src/commands/identity/import.rs
@@ -34,6 +34,6 @@ pub fn exec(env: &dyn Environment, opts: ImportOpts) -> DfxResult {
         disable_encryption: opts.disable_encryption,
     };
     IdentityManager::new(env)?.create_new_identity(name, params, opts.force)?;
-    info!(log, r#"Created identity: "{}"."#, name);
+    info!(log, r#"Imported identity: "{}"."#, name);
     Ok(())
 }

--- a/src/dfx/src/commands/identity/remove.rs
+++ b/src/dfx/src/commands/identity/remove.rs
@@ -16,7 +16,6 @@ pub fn exec(env: &dyn Environment, opts: RemoveOpts) -> DfxResult {
     let name = opts.identity.as_str();
 
     let log = env.get_logger();
-    info!(log, r#"Removing identity "{}"."#, name);
 
     IdentityManager::new(env)?.remove(name)?;
 

--- a/src/dfx/src/commands/identity/rename.rs
+++ b/src/dfx/src/commands/identity/rename.rs
@@ -20,7 +20,6 @@ pub fn exec(env: &dyn Environment, opts: RenameOpts) -> DfxResult {
     let to = opts.to.as_str();
 
     let log = env.get_logger();
-    info!(log, r#"Renaming identity "{}" to "{}"."#, from, to);
 
     let mut identity_manager = IdentityManager::new(env)?;
     let renamed_default = identity_manager.rename(env, from, to)?;


### PR DESCRIPTION
# Description

Identity commands are very verbose for their speed. Removing superfluous info messages.

Fixes [SDK-430](https://dfinity.atlassian.net/browse/SDK-430)

# How Has This Been Tested?

CI adapted

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
