### PR TITLE
chore: removed unused field MotokoCanisterInfo.has_frontend

### DIFF
--- a/src/dfx/src/lib/canister_info/motoko.rs
+++ b/src/dfx/src/lib/canister_info/motoko.rs
@@ -16,7 +16,6 @@ pub struct MotokoCanisterInfo {
 
     packtool: Option<String>,
     moc_args: Option<String>,
-    has_frontend: bool,
 }
 
 impl MotokoCanisterInfo {
@@ -49,9 +48,6 @@ impl MotokoCanisterInfo {
     }
     pub fn get_args(&self) -> &Option<String> {
         &self.moc_args
-    }
-    pub fn has_frontend(&self) -> bool {
-        self.has_frontend
     }
 }
 
@@ -93,7 +89,6 @@ impl CanisterInfoFactory for MotokoCanisterInfo {
             output_assets_root,
             packtool: info.get_packtool().clone(),
             moc_args: info.get_args().clone(),
-            has_frontend: info.get_extra_value("frontend").is_some(),
         })
     }
 }


### PR DESCRIPTION
dfx used to use this field decide whether or not to inject assets into a Motoko canister, but nothing references it anymore.