### PR TITLE
fix: identities with configured wallets are not broken anymore and re…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,14 @@
 
 Most errors that happen within dfx are now reported in much more detail. No more plain `File not found` without explanation what even was attempted.
 
+=== fix: identities with configured wallets are removed only when using the --drop-wallets flag
+
+When an identity has a configured wallet, dfx no longer breaks the identity without actually removing it.
+Instead, if the --drop-wallets flag is specified, it properly removes everything and logs what wallets were linked,
+and when the flag is not specified, it does not remove anything.
+
+The behavior for identities without any configured wallets is unchanged.
+
 === feat: bitcoin integration: dfx now generates the bitcoin adapter config file
 
 dfx command-line parameters for bitcoin integration:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,7 +9,7 @@
 
 Most errors that happen within dfx are now reported in much more detail. No more plain `File not found` without explanation what even was attempted.
 
-=== fix: identities with configured wallets are removed only when using the --drop-wallets flag
+=== fix: identities with configured wallets are not broken anymore and removed only when using the --drop-wallets flag
 
 When an identity has a configured wallet, dfx no longer breaks the identity without actually removing it.
 Instead, if the --drop-wallets flag is specified, it properly removes everything and logs what wallets were linked,

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -133,6 +133,7 @@ teardown() {
 }
 
 @test "identity remove: only remove identities with configured wallet if --drop-wallets is specified" {
+    # There's no replica running, and no real wallet.  This is just a valid principal.
     WALLET="rwlgt-iiaaa-aaaaa-aaaaa-cai"
     assert_command dfx identity new --disable-encryption alice
     assert_command dfx identity use alice

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -132,6 +132,17 @@ teardown() {
     assert_command_fail dfx identity remove charlie
 }
 
+@test "identity remove: only remove identities with configured wallet if --drop-wallets is specified" {
+    WALLET="rwlgt-iiaaa-aaaaa-aaaaa-cai"
+    assert_command dfx identity new --disable-encryption alice
+    assert_command dfx identity use alice
+    assert_command dfx identity --network ic set-wallet --force "$WALLET"
+    assert_command dfx identity use default
+    assert_command_fail dfx identity remove alice
+    assert_match "$WALLET"
+    assert_command dfx identity remove alice --drop-wallets
+}
+
 @test "identity remove: cannot remove the non-default active identity" {
     assert_command dfx identity new --disable-encryption alice
     assert_command dfx identity use alice

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -139,8 +139,9 @@ teardown() {
     assert_command dfx identity --network ic set-wallet --force "$WALLET"
     assert_command dfx identity use default
     assert_command_fail dfx identity remove alice
-    assert_match "$WALLET"
+    assert_match "identity 'alice' on network 'ic' has wallet $WALLET"
     assert_command dfx identity remove alice --drop-wallets
+    assert_match "identity 'alice' on network 'ic' has wallet $WALLET"
 }
 
 @test "identity remove: cannot remove the non-default active identity" {

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -139,6 +139,7 @@ teardown() {
     assert_command dfx identity --network ic set-wallet --force "$WALLET"
     assert_command dfx identity use default
     assert_command_fail dfx identity remove alice
+    # make sure the configured wallet is displayed
     assert_match "identity 'alice' on network 'ic' has wallet $WALLET"
     assert_command dfx identity remove alice --drop-wallets
     assert_match "identity 'alice' on network 'ic' has wallet $WALLET"

--- a/src/dfx/src/commands/identity/remove.rs
+++ b/src/dfx/src/commands/identity/remove.rs
@@ -10,6 +10,10 @@ use slog::info;
 pub struct RemoveOpts {
     /// The identity to remove.
     identity: String,
+
+    /// Required if the identity has wallets configured so that users do not accidentally lose access to wallets.
+    #[clap(long)]
+    drop_wallets: bool,
 }
 
 pub fn exec(env: &dyn Environment, opts: RemoveOpts) -> DfxResult {
@@ -17,7 +21,7 @@ pub fn exec(env: &dyn Environment, opts: RemoveOpts) -> DfxResult {
 
     let log = env.get_logger();
 
-    IdentityManager::new(env)?.remove(name)?;
+    IdentityManager::new(env)?.remove(name, opts.drop_wallets, Some(log))?;
 
     info!(log, r#"Removed identity "{}"."#, name);
     Ok(())

--- a/src/dfx/src/commands/identity/set_wallet.rs
+++ b/src/dfx/src/commands/identity/set_wallet.rs
@@ -25,7 +25,6 @@ pub struct SetWalletOpts {
 
 pub fn exec(env: &dyn Environment, opts: SetWalletOpts, network: Option<String>) -> DfxResult {
     let agent_env = create_agent_environment(env, network.clone())?;
-    let config = env.get_config_or_anyhow()?;
     let env = &agent_env;
     let log = env.get_logger();
 
@@ -42,6 +41,7 @@ pub fn exec(env: &dyn Environment, opts: SetWalletOpts, network: Option<String>)
     let canister_id = match Principal::from_text(canister_name) {
         Ok(id) => id,
         Err(_) => {
+            let config = env.get_config_or_anyhow()?;
             let canister_id = CanisterIdStore::for_env(env)?.get(canister_name)?;
             let canister_info = CanisterInfo::load(&config, canister_name, Some(canister_id))?;
             canister_info.get_canister_id()?

--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -252,12 +252,12 @@ impl IdentityManager {
 
         let wallet_config_file = self.get_persistent_wallet_config_file(name);
         if wallet_config_file.exists() {
+            if let Some(logger) = display_linked_wallets_to {
+                DfxIdentity::display_linked_wallets(logger, &wallet_config_file)?;
+            }
             if drop_wallets {
                 remove_identity_file(&wallet_config_file)?;
             } else {
-                if let Some(logger) = display_linked_wallets_to {
-                    DfxIdentity::display_linked_wallets(logger, &wallet_config_file)?;
-                }
                 bail!("If you want to remove an identity with configured wallets, please use the --drop-wallets flag.")
             }
         }

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -318,7 +318,7 @@ impl Identity {
 
     /// Logs all wallets that are configured in a WalletGlobalConfig.
     #[context("Failed while trying to display configured wallets in {}.", wallet_config.to_string_lossy())]
-    pub fn display_linked_wallets(logger: &Logger, wallet_config: &PathBuf) -> DfxResult {
+    pub fn display_linked_wallets(logger: &Logger, wallet_config: &Path) -> DfxResult {
         let config = Identity::load_wallet_config(wallet_config)?;
         info!(
             logger,


### PR DESCRIPTION
…moved only when using the --drop-wallets flag

# Description

```
WALLET="rwlgt-iiaaa-aaaaa-aaaaa-cai"
dfx identity new --disable-encryption alice
dfx identity use alice
dfx identity --network ic set-wallet --force "$WALLET"
dfx identity use default
dfx identity remove alice
```
This removes the identity pem file, but leaves the wallets.json config in the identity folder. Removing the id fails, but the id is not usable anymore.

Solution: `dfx identity remove alice` only removes alice iff it has no wallets configured. Otherwise, it will display the wallets and a message to include `--drop-wallets` in order to remove the identity. If `--drop-wallets` is added (`dfx identity remove alice --drop-wallets`), then the identity is removed.

Fixes [error report on the forum](https://forum.dfinity.org/t/cannot-remove-identity-directory/12910)

# How Has This Been Tested?

Added an e2e test for this scenario.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
