### PR TITLE
chore: try to reduce identity export test flakiness

### DIFF
--- a/e2e/assets/expect_scripts/import_export_identity_with_password.exp
+++ b/e2e/assets/expect_scripts/import_export_identity_with_password.exp
@@ -29,20 +29,31 @@ while {1} {
 		}
 		timeout {
 			puts stderr "Not asked for a password when creating new identity!"
-			exit 1
+			exit 2
 		}
 	}
 }
 
-# use 'bash -c' to use output redirection
-spawn bash -c "dfx identity export alice > export.pem"
-expect {
-	"Please enter a passphrase for your identity: " {
-		send -- "testpassword\r"
+while {1} {
+	# use 'bash -c' to use output redirection
+	spawn bash -c "dfx identity export alice > export.pem"
+	expect {
+		"Please enter a passphrase for your identity: " {
+			send -- "testpassword\r"
+		}
+		timeout {
+			puts stderr "Not asked for a password when exporting encrypted identity!"
+			exit 3
+		}
 	}
-	timeout {
-		puts stderr "Not asked for a password when exporting encrypted identity!"
-		exit 1
-	}
+	expect {
+		"Failed during decryption." {
+			expect eof
+		}
+		"Decryption complete." {
+			expect eof {
+				break
+			}
+		}
+	}	
 }
-expect eof


### PR DESCRIPTION
# Description

The test 'import and export identity with a password are inverse operations' is too flaky. This tries to make it less so.

# How Has This Been Tested?

IME it only fails in CI. Just have to observe it a few times.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
