### PR TITLE
fix: HSM support on Linux build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,7 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
-      - 'test-[0-9]+.[0-9]+.[0-9]+'
-      - 'test-[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-[A-Za-z]+.[0-9]+'
 
 jobs:
   build_dfx:
@@ -19,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ '1.58.1' ]
-        target: [ x86_64-apple-darwin, x86_64-unknown-linux-musl ]
+        target: [ x86_64-apple-darwin, x86_64-unknown-linux-musl, x86_64-unknown-linux-gnu ]
         include:
           - os: macos-latest
             target: x86_64-apple-darwin
@@ -29,6 +27,11 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             binary_path: target/x86_64-unknown-linux-musl/release
+            name: x86_64-linux-musl
+            tar: tar
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary_path: target/x86_64-unknown-linux-gnu/release
             name: x86_64-linux
             tar: tar
     steps:
@@ -57,6 +60,18 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
         if: contains(matrix.os, 'macos')
+
+      - name: Build static-linked openssl
+        run: |
+          # https://github.com/rust-lang/cargo/issues/713#issuecomment-59597433
+          git clone git://git.openssl.org/openssl.git
+          cd openssl
+          ./config -fPIC --prefix=/usr/local --openssldir=/usr/local/ssl
+          make
+          make install
+          echo "OPENSSL_LIB_DIR=/usr/local/lib64" >> $GITHUB_ENV
+          echo "OPENSSL_INCLUDE_DIR=/usr/local/include" >> $GITHUB_ENV
+        if: contains(matrix.target, 'linux-gnu')
 
       - name: Linux hack (musl only)
         run: |
@@ -118,7 +133,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ '1.58.1' ]
-        name: [ 'x86_64-darwin', 'x86_64-linux' ]
+        name: [ 'x86_64-darwin', 'x86_64-linux', 'x86_64-linux-musl' ]
     steps:
       - name: Setup environment variables
         run: echo "VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
           cd openssl
           ./config -fPIC --prefix=/usr/local --openssldir=/usr/local/ssl
           make
-          make install
+          sudo make install
           echo "OPENSSL_LIB_DIR=/usr/local/lib64" >> $GITHUB_ENV
           echo "OPENSSL_INCLUDE_DIR=/usr/local/include" >> $GITHUB_ENV
         if: contains(matrix.target, 'linux-gnu')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Check dynamically-linked libraries (macos)
         run: |
           ACTUAL="$(otool -L ${{ matrix.binary_path }}/dfx | awk 'NR > 1{ print $1 }' | grep -v /System/Library/Frameworks | sort | awk -v d=" " '{s=(NR==1?s:s d)$0}END{printf "%s",s}')"
-          EXPECTED="/usr/lib/libSystem.B.dylib /usr/lib/libiconv.2.dylib X /usr/lib/libresolv.9.dylib"
+          EXPECTED="/usr/lib/libSystem.B.dylib /usr/lib/libiconv.2.dylib /usr/lib/libresolv.9.dylib"
           echo "Dynamically-linked libraries:"
           echo "  Actual:   $ACTUAL"
           echo "  Expected: $EXPECTED"
@@ -90,7 +90,7 @@ jobs:
       - name: Check dynamically-linked libraries (ubuntu)
         run: |
           ACTUAL="$(ldd ${{ matrix.binary_path }}/dfx | awk '{ print $1 }' | sort | awk -v d=" " '{s=(NR==1?s:s d)$0}END{printf "%s",s}')"
-          EXPECTED="(todo)"
+          EXPECTED="/lib64/ld-linux-x86-64.so.2 libc.so.6 libdl.so.2 libgcc_s.so.1 libm.so.6 libpthread.so.0 librt.so.1 linux-vdso.so.1"
           echo "Dynamically-linked libraries:"
           echo "  Actual:   $ACTUAL"
           echo "  Expected: $EXPECTED"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,18 +17,15 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ '1.58.1' ]
-        target: [ x86_64-apple-darwin, x86_64-unknown-linux-musl, x86_64-unknown-linux-gnu ]
+        # We build a dynamic-linked linux binary because otherwise HSM support fails with:
+        #   Error: IO: Dynamic loading not supported
+        target: [ x86_64-apple-darwin, x86_64-unknown-linux-gnu ]
         include:
           - os: macos-latest
             target: x86_64-apple-darwin
             binary_path: target/x86_64-apple-darwin/release
             name: x86_64-darwin
             tar: gtar
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            binary_path: target/x86_64-unknown-linux-musl/release
-            name: x86_64-linux-musl
-            tar: tar
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary_path: target/x86_64-unknown-linux-gnu/release
@@ -73,37 +70,34 @@ jobs:
           echo "OPENSSL_INCLUDE_DIR=/usr/local/include" >> $GITHUB_ENV
         if: contains(matrix.target, 'linux-gnu')
 
-      - name: Linux hack (musl only)
-        run: |
-          echo "[toolchain]" >./rust-toolchain.toml
-          echo 'channel = "1.58.1"' >>./rust-toolchain.toml
-          echo 'components = ["rustfmt", "clippy"]' >>./rust-toolchain.toml
-        if: contains(matrix.target, 'linux-musl')
-
-      - name: Generate DFX_ASSETS (musl only)
-        run: |
-          ./scripts/prepare-dfx-assets.sh .dfx-assets
-          echo "DFX_ASSETS=$(pwd)/.dfx-assets" >> $GITHUB_ENV
-        if: contains(matrix.target, 'linux-musl')
-
-      - name: Linux build (musl)
-        uses: dfinity/rust-musl-action@master
-        with:
-          args: |
-            echo "[toolchain]" >./rust-toolchain.toml
-            echo 'channel = "1.58.1"' >>./rust-toolchain.toml
-            echo 'components = ["rustfmt", "clippy"]' >>./rust-toolchain.toml
-            rustup target add ${{ matrix.target }}
-
-            cargo clean --target ${{ matrix.target }} --release
-            cargo build --target ${{ matrix.target }} --locked --release
-        if: contains(matrix.target, 'linux-musl')
-
-      - name: Build (non-musl)
+      - name: Build
         run: |
           cargo clean --target ${{ matrix.target }} --release
           cargo build --target ${{ matrix.target }} --locked --release
-        if: contains(matrix.target, 'linux-musl') == false
+
+      - name: Check dynamically-linked libraries (macos)
+        run: |
+          ACTUAL="$(otool -L ${{ matrix.binary_path }}/dfx | awk 'NR > 1{ print $1 }' | grep -v /System/Library/Frameworks | sort | awk -v d=" " '{s=(NR==1?s:s d)$0}END{printf "%s",s}')"
+          EXPECTED="/usr/lib/libSystem.B.dylib /usr/lib/libiconv.2.dylib X /usr/lib/libresolv.9.dylib"
+          echo "Dynamically-linked libraries:"
+          echo "  Actual:   $ACTUAL"
+          echo "  Expected: $EXPECTED"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+              exit 1
+          fi
+        if: contains(matrix.os, 'macos')
+
+      - name: Check dynamically-linked libraries (ubuntu)
+        run: |
+          ACTUAL="$(ldd ${{ matrix.binary_path }}/dfx | awk '{ print $1 }' | sort | awk -v d=" " '{s=(NR==1?s:s d)$0}END{printf "%s",s}')"
+          EXPECTED="(todo)"
+          echo "Dynamically-linked libraries:"
+          echo "  Actual:   $ACTUAL"
+          echo "  Expected: $EXPECTED"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+              exit 1
+          fi
+        if: contains(matrix.os, 'ubuntu')
 
       - name: Strip binaries
         run: |
@@ -133,7 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ '1.58.1' ]
-        name: [ 'x86_64-darwin', 'x86_64-linux', 'x86_64-linux-musl' ]
+        name: [ 'x86_64-darwin', 'x86_64-linux' ]
     steps:
       - name: Setup environment variables
         run: echo "VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,13 @@
 
 == DFX
 
+=== fix: HSMs are once again supported on Linux
+
+On Linux, dfx 0.10.0 failed any operation with an HSM with the following error:
+    Error: IO: Dynamic loading not supported
+
+The fix was to once again dynamically-link the Linux build.
+
 === chore: add context to errors
 
 Most errors that happen within dfx are now reported in much more detail. No more plain `File not found` without explanation what even was attempted.


### PR DESCRIPTION
# Description

Build the Linux binary dynamically, as was done in dfx 0.9.3 and earlier, in order to avoid the following error when trying to use an HSM:
```
Error: IO: Dynamic loading not supported
```

Other changes to the workflow:
- manually build a static-linked openssl for the linux build
- allow words other than "beta" in the tag name
- removed the "test-#.#.#-*" tag allowance, because those wouldn't be a valid semver (and dfx would panic)
- verify the list of referenced dynamic libraries, to avoid post-release surprises.

Fixes https://dfinity.atlassian.net/browse/SDK-495 

# How Has This Been Tested?

Tested manually with an HSM.  Here's a sample release: https://github.com/dfinity/sdk/releases/tag/0.10.1-hsm.1

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] (n/a) I have made corresponding changes to the documentation.
