### PR TITLE
fix: specifying ic provider with a trailing slash is recognised correctly

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -48,6 +48,10 @@ dfx command-line parameters for canister http requests integration:
 This defaults to the following value in dfx.json:
     .defaults.canister_http.enabled
 
+=== fix: specifying ic provider with a trailing slash is recognised correctly
+
+Specifying the network provider as `https://ic0.app/` instead of `https://ic0.app` is now recognised as the real IC network.
+
 === Binary cache
 
 Added ic-canister-http-adapter to the binary cache.

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -56,6 +56,7 @@ pub struct ConfigCanistersCanisterRemote {
 
 const DEFAULT_LOCAL_BIND: &str = "127.0.0.1:8000";
 pub const DEFAULT_IC_GATEWAY: &str = "https://ic0.app";
+pub const DEFAULT_IC_GATEWAY_TRAILING_SLASH: &str = "https://ic0.app/";
 
 /// A Canister configuration in the dfx.json config file.
 /// It only contains a type; everything else should be infered using the

--- a/src/dfx/src/lib/network/network_descriptor.rs
+++ b/src/dfx/src/lib/network/network_descriptor.rs
@@ -35,21 +35,22 @@ mod test {
     #[test]
     fn ic_by_netname() {
         assert!(NetworkDescriptor::is_ic("ic", &vec![]));
+        assert!(NetworkDescriptor::is_ic(DEFAULT_IC_GATEWAY, &vec![]));
+        assert!(NetworkDescriptor::is_ic(
+            DEFAULT_IC_GATEWAY_TRAILING_SLASH,
+            &vec![]
+        ));
     }
 
     #[test]
     fn ic_by_provider() {
         assert!(NetworkDescriptor::is_ic(
             "not_ic",
-            &vec!["https://ic0.app".to_string()]
+            &vec![DEFAULT_IC_GATEWAY.to_string()]
         ));
-    }
-
-    #[test]
-    fn ic_by_provider_trailing_slash() {
         assert!(NetworkDescriptor::is_ic(
             "not_ic",
-            &vec!["https://ic0.app/".to_string()]
+            &vec![DEFAULT_IC_GATEWAY_TRAILING_SLASH.to_string()]
         ));
     }
 
@@ -71,7 +72,7 @@ mod test {
         assert!(!NetworkDescriptor::is_ic(
             "not_ic",
             &vec![
-                "https://ic0.app".to_string(),
+                DEFAULT_IC_GATEWAY.to_string(),
                 "some_other_provider".to_string()
             ]
         ));

--- a/src/dfx/src/lib/network/network_descriptor.rs
+++ b/src/dfx/src/lib/network/network_descriptor.rs
@@ -1,5 +1,5 @@
 use crate::config::dfinity::NetworkType;
-use crate::config::dfinity::DEFAULT_IC_GATEWAY;
+use crate::config::dfinity::{DEFAULT_IC_GATEWAY, DEFAULT_IC_GATEWAY_TRAILING_SLASH};
 
 #[derive(Clone, Debug)]
 pub struct NetworkDescriptor {
@@ -13,9 +13,17 @@ impl NetworkDescriptor {
     // Determines whether the provided connection is the official IC or not.
     #[allow(clippy::ptr_arg)]
     pub fn is_ic(network_name: &str, providers: &Vec<String>) -> bool {
-        let name_match = network_name == "ic" || network_name == DEFAULT_IC_GATEWAY;
-        let provider_match =
-            { providers.len() == 1 && providers.get(0).unwrap() == "https://ic0.app" };
+        let name_match = network_name == "ic"
+            || network_name == DEFAULT_IC_GATEWAY
+            || network_name == DEFAULT_IC_GATEWAY_TRAILING_SLASH;
+        let provider_match = {
+            providers.len() == 1
+                && match providers.get(0).unwrap().as_str() {
+                    DEFAULT_IC_GATEWAY => true,
+                    DEFAULT_IC_GATEWAY_TRAILING_SLASH => true,
+                    _ => false,
+                }
+        };
         name_match || provider_match
     }
 }
@@ -34,6 +42,14 @@ mod test {
         assert!(NetworkDescriptor::is_ic(
             "not_ic",
             &vec!["https://ic0.app".to_string()]
+        ));
+    }
+
+    #[test]
+    fn ic_by_provider_trailing_slash() {
+        assert!(NetworkDescriptor::is_ic(
+            "not_ic",
+            &vec!["https://ic0.app/".to_string()]
         ));
     }
 


### PR DESCRIPTION
# Description

User writes `https://ic0.app/` instead of `https://ic0.app`. Dfx does not recognise the provider with a trailing slash as the real IC and tries to create a UI canister.

Fixes [this problem a user encountered](https://forum.dfinity.org/t/deploy-an-app-twice-on-the-ic-staging-env/5661/29).

# How Has This Been Tested?

Added a unit test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
