### PR TITLE
fix: removes copyplugin

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,11 @@
 
 == DFX
 
+=== fix: Webpack config no longer uses CopyPlugin
+
+Dfx already points to the asset canister's assets directory, and copying to disk could sometimes
+lead to an annoying "too many open files" error.
+
 === fix: HSMs are once again supported on Linux
 
 On Linux, dfx 0.10.0 failed any operation with an HSM with the following error:

--- a/src/dfx/assets/new_project_node_files/package.json
+++ b/src/dfx/assets/new_project_node_files/package.json
@@ -16,7 +16,6 @@
     "@dfinity/principal": "{js_agent_version}",
     "assert": "2.0.0",
     "buffer": "6.0.3",
-    "copy-webpack-plugin": "^9.0.1",
     "events": "3.3.0",
     "html-webpack-plugin": "5.5.0",
     "process": "0.11.10",

--- a/src/dfx/assets/new_project_node_files/webpack.config.js
+++ b/src/dfx/assets/new_project_node_files/webpack.config.js
@@ -2,7 +2,6 @@ const path = require("path");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
-const CopyPlugin = require("copy-webpack-plugin");
 
 function initCanisterEnv() {
   let localCanisters, prodCanisters;
@@ -85,14 +84,6 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: path.join(__dirname, asset_entry),
       cache: false,
-    }),
-    new CopyPlugin({
-      patterns: [
-        {
-          from: path.join(__dirname, "src", frontendDirectory, "assets"),
-          to: path.join(__dirname, "dist", frontendDirectory),
-        },
-      ],
     }),
     new webpack.EnvironmentPlugin({
       NODE_ENV: "development",


### PR DESCRIPTION
# Description

CopyPlugin was redundant and leading to 'too many open files' message, as dfx.json already is configured to pull assets from the frontend assets directory


# How Has This Been Tested?

manually tested the changes locally

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
