### PR TITLE
build: allow use of a local version of icx-proxy  when building

### DIFF
--- a/scripts/prepare-dfx-assets.sh
+++ b/scripts/prepare-dfx-assets.sh
@@ -93,7 +93,11 @@ download_ic_ref() {
 }
 
 download_icx_proxy() {
-    download_tarball "icx-proxy"
+    if [ -z "$DFX_CARGO_BUILD_ICX_PROXY_PATH" ]; then
+        download_tarball "icx-proxy"
+    else
+        cp "$DFX_CARGO_BUILD_ICX_PROXY_PATH" "$BINARY_CACHE_TEMP_DIR"
+    fi
     chmod 0500 "$BINARY_CACHE_TEMP_DIR/icx-proxy"
 }
 


### PR DESCRIPTION
# Description

At the moment, all of files for icx-proxy releases report 404 on attempt to download.  This change allows for use of a local binary instead of downloading one.

Example
```
$ DFX_CARGO_BUILD_ICX_PROXY_PATH=/Users/ericswanson/build-archive/icx-proxy/0.10.0/icx-proxy cargo build
```

# How Has This Been Tested?

Tested locally.  All CI tests will still fail.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
