### PR TITLE
fix: Support a custom target dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 result*
+e2e/assets/installed/
 
 # Building
 build/

--- a/e2e/tests-dfx/rust.bash
+++ b/e2e/tests-dfx/rust.bash
@@ -45,7 +45,8 @@ teardown() {
 
 @test "rust canister can have nonstandard target dir location" {
     dfx_new_rust
-    export CARGO_TARGET_DIR="$(echo -ne '\x81')"
+    CARGO_TARGET_DIR="$(echo -ne '\x81')"
+    export CARGO_TARGET_DIR
     dfx_start
     assert_command dfx deploy
     assert_command dfx canister call e2e_project greet dfinity

--- a/e2e/tests-dfx/rust.bash
+++ b/e2e/tests-dfx/rust.bash
@@ -42,3 +42,11 @@ teardown() {
     assert_command dfx canister call rust_deps read
     assert_match '(9 : nat)'
 }
+
+@test "rust canister can have nonstandard target dir location" {
+    dfx_new_rust
+    export CARGO_TARGET_DIR="$(echo -ne '\x81')"
+    dfx_start
+    assert_command dfx deploy
+    assert_command dfx canister call e2e_project greet dfinity
+}

--- a/e2e/tests-dfx/rust.bash
+++ b/e2e/tests-dfx/rust.bash
@@ -4,6 +4,7 @@ load ../utils/_
 
 setup() {
     standard_setup
+    export PATH="$HOME/.cargo/bin/:$PATH"
 }
 
 teardown() {
@@ -20,8 +21,6 @@ teardown() {
     assert_command dfx build hello
     assert_match "ic-cdk-optimizer not installed"
     cargo install ic-cdk-optimizer
-    # shellcheck disable=SC2030
-    export PATH="$HOME/.cargo/bin/:$PATH"
     assert_command dfx build hello
     assert_match "Executing: ic-cdk-optimizer"
     assert_command dfx canister install hello

--- a/e2e/tests-dfx/rust.bash
+++ b/e2e/tests-dfx/rust.bash
@@ -1,10 +1,12 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
 
 load ../utils/_
 
+[ -e "${assets:?}/installed/bin/ic-cdk-optimizer" ] || cargo install ic-cdk-optimizer --root "$assets/installed" &> /dev/null
+
 setup() {
     standard_setup
-    export PATH="$HOME/.cargo/bin/:$PATH"
 }
 
 teardown() {
@@ -20,7 +22,7 @@ teardown() {
     dfx canister create --all
     assert_command dfx build hello
     assert_match "ic-cdk-optimizer not installed"
-    cargo install ic-cdk-optimizer
+    export PATH="$assets/installed/bin/:$PATH"
     assert_command dfx build hello
     assert_match "Executing: ic-cdk-optimizer"
     assert_command dfx canister install hello
@@ -31,7 +33,7 @@ teardown() {
 @test "rust canister can resolve dependencies" {
     dfx_new_rust rust_deps
     install_asset rust_deps
-
+    export PATH="$assets/installed/bin/:$PATH"
     dfx_start
     assert_command dfx deploy
     assert_command dfx canister call multiply_deps read
@@ -46,6 +48,7 @@ teardown() {
     dfx_new_rust
     CARGO_TARGET_DIR="$(echo -ne '\x81')"
     export CARGO_TARGET_DIR
+    export PATH="$assets/installed/bin/:$PATH"
     dfx_start
     assert_command dfx deploy
     assert_command dfx canister call e2e_project greet dfinity

--- a/src/dfx/src/lib/canister_info/rust.rs
+++ b/src/dfx/src/lib/canister_info/rust.rs
@@ -1,6 +1,9 @@
 use crate::lib::canister_info::{CanisterInfo, CanisterInfoFactory};
 use crate::lib::error::DfxResult;
+use anyhow::{bail, Context};
+use serde::Deserialize;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 pub struct RustCanisterInfo {
     package: String,
@@ -28,13 +31,26 @@ impl CanisterInfoFactory for RustCanisterInfo {
     }
 
     fn create(info: &CanisterInfo) -> DfxResult<Self> {
+        #[derive(Deserialize)]
+        struct Project {
+            target_directory: PathBuf,
+        }
+        let metadata = Command::new("cargo")
+            .args(["metadata", "--no-deps", "--format-version=1"])
+            .stderr(Stdio::inherit())
+            .stdout(Stdio::piped())
+            .output()
+            .context("Failed to run `cargo metadata`")?;
+        if !metadata.status.success() {
+            bail!("`cargo metadata` was unsuccessful");
+        }
+        let Project { target_directory } = serde_json::from_slice(&metadata.stdout)
+            .context("Failed to read metadata from `cargo metadata`")?;
         let package = info.get_extra::<String>("package")?;
 
         let workspace_root = info.get_workspace_root();
-        let output_wasm_path = workspace_root.join(format!(
-            "target/wasm32-unknown-unknown/release/{}.wasm",
-            package
-        ));
+        let output_wasm_path =
+            target_directory.join(format!("wasm32-unknown-unknown/release/{package}.wasm"));
         let candid = if let Some(remote_candid) = info.get_remote_candid_if_remote() {
             PathBuf::from(remote_candid)
         } else {


### PR DESCRIPTION
Cargo supports alternate locations for the build artifacts than `./target`, configured through e.g. `$CARGO_TARGET_DIR`. This changes the artifact path from a hardcoded assumption of `./target` to the configured path via `cargo metadata`.