### PR TITLE
build: Use versioned motoko-base tarball rather than copying from a repo clone

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -151,6 +151,16 @@
         "url": "https://github.com/dfinity/motoko-base/archive/6f80c49d0f708c11d95895893ef3237cc7b05234.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "motoko-base-tarball": {
+        "builtin": false,
+        "description": "The Motoko base library",
+        "owner": "dfinity",
+        "sha256": "1kd05ayp9s3v6y44il5p3f2gmmq9fhcragkiymjlxmwsfxqrd9qy",
+        "type": "tarball",
+        "url": "https://github.com/dfinity/motoko/releases/download/0.6.27/motoko-base-library.tar.gz",
+        "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-base-library.tar.gz",
+        "version": "0.6.27"
+    },
     "motoko-x86_64-darwin": {
         "builtin": false,
         "sha256": "1qqg7nha7f2llmx4vjc8f0yxh422dg5srrzrykh40pmz71w5mlbg",

--- a/scripts/dfx-asset-sources.sh
+++ b/scripts/dfx-asset-sources.sh
@@ -39,3 +39,5 @@ SANDBOX_LAUNCHER_X86_64_LINUX_SHA256="8391a2f103a46073db7aa7f2b6b973e8e3795e2f03
 SANDBOX_LAUNCHER_X86_64_LINUX_URL="https://download.dfinity.systems/blessed/ic/dcb2d23dfcd9de200f235110e618713cc884cb19/sdk-release/x86_64-linux/sandbox_launcher.gz"
 MOTOKO_BASE_BRANCH="next-moc"
 MOTOKO_BASE_REV="6f80c49d0f708c11d95895893ef3237cc7b05234"
+MOTOKO_BASE_TARBALL_URL="https://github.com/dfinity/motoko/releases/download/0.6.27/motoko-base-library.tar.gz"
+MOTOKO_BASE_TARBALL_SHA256="1ea79671779ad74e65f5713e95197409d7fa841bb7d04888377be874bd2aa0cd"

--- a/scripts/dfx-asset-sources.sh
+++ b/scripts/dfx-asset-sources.sh
@@ -37,7 +37,5 @@ SANDBOX_LAUNCHER_X86_64_DARWIN_SHA256="3e45b2285189ac85b0f846dfb80b25bfe6ccebda8
 SANDBOX_LAUNCHER_X86_64_DARWIN_URL="https://download.dfinity.systems/blessed/ic/dcb2d23dfcd9de200f235110e618713cc884cb19/sdk-release/x86_64-darwin/sandbox_launcher.gz"
 SANDBOX_LAUNCHER_X86_64_LINUX_SHA256="8391a2f103a46073db7aa7f2b6b973e8e3795e2f037c6916034e31734c966be8"
 SANDBOX_LAUNCHER_X86_64_LINUX_URL="https://download.dfinity.systems/blessed/ic/dcb2d23dfcd9de200f235110e618713cc884cb19/sdk-release/x86_64-linux/sandbox_launcher.gz"
-MOTOKO_BASE_BRANCH="next-moc"
-MOTOKO_BASE_REV="6f80c49d0f708c11d95895893ef3237cc7b05234"
 MOTOKO_BASE_TARBALL_URL="https://github.com/dfinity/motoko/releases/download/0.6.27/motoko-base-library.tar.gz"
 MOTOKO_BASE_TARBALL_SHA256="1ea79671779ad74e65f5713e95197409d7fa841bb7d04888377be874bd2aa0cd"

--- a/scripts/prepare-dfx-assets.sh
+++ b/scripts/prepare-dfx-assets.sh
@@ -13,7 +13,12 @@ DFX_ASSETS_TEMP_DIR=$(mktemp -d)
 BINARY_CACHE_TEMP_DIR=$(mktemp -d)
 DOWNLOAD_TEMP_DIR=$(mktemp -d)
 
+echo "DFX_ASSETS_TEMP_DIR is $DFX_ASSETS_TEMP_DIR"
+echo "BINARY_CACHE_TEMP_DIR is $BINARY_CACHE_TEMP_DIR"
+echo "DOWNLOAD_TEMP_DIR is $DOWNLOAD_TEMP_DIR"
+
 function cleanup {
+    echo
     rm -rf "$DFX_ASSETS_TEMP_DIR" "$BINARY_CACHE_TEMP_DIR" "$DOWNLOAD_TEMP_DIR"
 }
 trap cleanup EXIT
@@ -123,7 +128,35 @@ copy_motoko_base_from_clone() {
     )
 }
 
+download_motoko_base() {
+    echo "----download motoko base----"
+
+    URL=$MOTOKO_BASE_TARBALL_URL
+    SHA256=$MOTOKO_BASE_TARBALL_SHA256
+    DOWNLOAD_PATH="$DOWNLOAD_TEMP_DIR/motoko-base-tarball.tar.gz"
+
+    download_url_and_check_sha "$URL" "$SHA256" "$DOWNLOAD_PATH"
+
+    mkdir "$DOWNLOAD_TEMP_DIR/motoko-base"
+    tar -xkvf "$DOWNLOAD_PATH" -C "$DOWNLOAD_TEMP_DIR/motoko-base"
+    ls -lR "$DOWNLOAD_TEMP_DIR/motoko-base"
+    #chmod -R 0744 "$DOWNLOAD_TEMP_DIR/motoko-base"
+    cp -R "$DOWNLOAD_TEMP_DIR/motoko-base/src/" "$BINARY_CACHE_TEMP_DIR/base"
+    chmod -R 0744 "$DOWNLOAD_TEMP_DIR/motoko-base"
+    rm -rf "$DOWNLOAD_TEMP_DIR/motoko-base"
+
+    echo "**** 1"
+    ls -lR "$BINARY_CACHE_TEMP_DIR/base"
+    chmod 0755 "$BINARY_CACHE_TEMP_DIR/base"
+    find "$BINARY_CACHE_TEMP_DIR/base" -type f -print -exec touch {} \; -exec chmod 0644 {} \;
+    echo "**** 2"
+    ls -lR "$BINARY_CACHE_TEMP_DIR/base"
+    # chmod 0644 "$BINARY_CACHE_TEMP_DIR/base/*.mo"
+
+}
+
 add_binary_cache() {
+    download_motoko_base
     download_binary "ic-btc-adapter"
     download_binary "ic-canister-http-adapter"
     download_binary "replica"
@@ -133,7 +166,7 @@ add_binary_cache() {
     download_ic_ref
     download_icx_proxy
     download_motoko_binaries
-    copy_motoko_base_from_clone
+    #copy_motoko_base_from_clone
 
     tar -czf "$DFX_ASSETS_TEMP_DIR"/binary_cache.tgz -C "$BINARY_CACHE_TEMP_DIR" .
 }

--- a/scripts/prepare-dfx-assets.sh
+++ b/scripts/prepare-dfx-assets.sh
@@ -13,12 +13,7 @@ DFX_ASSETS_TEMP_DIR=$(mktemp -d)
 BINARY_CACHE_TEMP_DIR=$(mktemp -d)
 DOWNLOAD_TEMP_DIR=$(mktemp -d)
 
-echo "DFX_ASSETS_TEMP_DIR is $DFX_ASSETS_TEMP_DIR"
-echo "BINARY_CACHE_TEMP_DIR is $BINARY_CACHE_TEMP_DIR"
-echo "DOWNLOAD_TEMP_DIR is $DOWNLOAD_TEMP_DIR"
-
 function cleanup {
-    echo
     rm -rf "$DFX_ASSETS_TEMP_DIR" "$BINARY_CACHE_TEMP_DIR" "$DOWNLOAD_TEMP_DIR"
 }
 trap cleanup EXIT
@@ -112,51 +107,25 @@ download_motoko_binaries() {
     done
 }
 
-copy_motoko_base_from_clone() {
-    REV=$MOTOKO_BASE_REV
-    BRANCH=$MOTOKO_BASE_BRANCH
-
-    (
-        cd "$DOWNLOAD_TEMP_DIR" # ok technically we are not downloading
-
-        git clone -b "$BRANCH" --single-branch https://github.com/dfinity/motoko-base.git
-        (
-            cd motoko-base
-            git checkout "$REV"
-            cp -R src/ "$BINARY_CACHE_TEMP_DIR/base"
-        )
-    )
-}
-
 download_motoko_base() {
-    echo "----download motoko base----"
-
-    URL=$MOTOKO_BASE_TARBALL_URL
-    SHA256=$MOTOKO_BASE_TARBALL_SHA256
+    URL="$MOTOKO_BASE_TARBALL_URL"
+    SHA256="$MOTOKO_BASE_TARBALL_SHA256"
     DOWNLOAD_PATH="$DOWNLOAD_TEMP_DIR/motoko-base-tarball.tar.gz"
 
     download_url_and_check_sha "$URL" "$SHA256" "$DOWNLOAD_PATH"
 
     mkdir "$DOWNLOAD_TEMP_DIR/motoko-base"
     tar -xkvf "$DOWNLOAD_PATH" -C "$DOWNLOAD_TEMP_DIR/motoko-base"
-    ls -lR "$DOWNLOAD_TEMP_DIR/motoko-base"
-    #chmod -R 0744 "$DOWNLOAD_TEMP_DIR/motoko-base"
+
     cp -R "$DOWNLOAD_TEMP_DIR/motoko-base/src/" "$BINARY_CACHE_TEMP_DIR/base"
+    chmod 0755 "$BINARY_CACHE_TEMP_DIR/base"
+    find "$BINARY_CACHE_TEMP_DIR/base" -type f -exec touch {} \; -exec chmod 0644 {} \;
+
     chmod -R 0744 "$DOWNLOAD_TEMP_DIR/motoko-base"
     rm -rf "$DOWNLOAD_TEMP_DIR/motoko-base"
-
-    echo "**** 1"
-    ls -lR "$BINARY_CACHE_TEMP_DIR/base"
-    chmod 0755 "$BINARY_CACHE_TEMP_DIR/base"
-    find "$BINARY_CACHE_TEMP_DIR/base" -type f -print -exec touch {} \; -exec chmod 0644 {} \;
-    echo "**** 2"
-    ls -lR "$BINARY_CACHE_TEMP_DIR/base"
-    # chmod 0644 "$BINARY_CACHE_TEMP_DIR/base/*.mo"
-
 }
 
 add_binary_cache() {
-    download_motoko_base
     download_binary "ic-btc-adapter"
     download_binary "ic-canister-http-adapter"
     download_binary "replica"
@@ -166,7 +135,7 @@ add_binary_cache() {
     download_ic_ref
     download_icx_proxy
     download_motoko_binaries
-    #copy_motoko_base_from_clone
+    download_motoko_base
 
     tar -czf "$DFX_ASSETS_TEMP_DIR"/binary_cache.tgz -C "$BINARY_CACHE_TEMP_DIR" .
 }

--- a/scripts/write-dfx-asset-sources.sh
+++ b/scripts/write-dfx-asset-sources.sh
@@ -74,7 +74,5 @@ do
     done
 done
 
-write_var "motoko-base" "branch"
-write_var "motoko-base" "rev"
 write_url "motoko-base-tarball"
 write_sha256 "motoko-base-tarball"

--- a/scripts/write-dfx-asset-sources.sh
+++ b/scripts/write-dfx-asset-sources.sh
@@ -76,4 +76,6 @@ done
 
 write_var "motoko-base" "branch"
 write_var "motoko-base" "rev"
-
+write_url "motoko-base-tarball"
+#write_var "motoko-base-tarball" "version"
+write_sha256 "motoko-base-tarball"

--- a/scripts/write-dfx-asset-sources.sh
+++ b/scripts/write-dfx-asset-sources.sh
@@ -77,5 +77,4 @@ done
 write_var "motoko-base" "branch"
 write_var "motoko-base" "rev"
 write_url "motoko-base-tarball"
-#write_var "motoko-base-tarball" "version"
 write_sha256 "motoko-base-tarball"


### PR DESCRIPTION
# Description

Download the motoko-base library sources from the versioned tarball, rather than from a repo clone.

The `motoko-base` repo entry is still in nix/sources.json because our nix setup still uses it when it builds its version of dfx.

Fixes https://dfinity.atlassian.net/browse/SDK-217

# How Has This Been Tested?

e2e tests cover this, but I also ran before- and after- and verified that everything is the same, including permissions.

