### PR TITLE
chore: add script to update motoko

### DIFF
--- a/.github/CONTRIBUTING.adoc
+++ b/.github/CONTRIBUTING.adoc
@@ -93,6 +93,15 @@ To update the replica to a given $SHA from the dfinity repo, execute the followi
 ./scripts/update-replica.sh $SHA
 ----
 
+=== Updating Motoko
+
+To update Motoko to a given $VERSION from the motoko and motoko-base repos, execute the following:
+[source,bash]
+----
+# Requires niv to run. To install niv, run nix-env -iA nixpkgs.niv
+./scripts/update-motoko.sh $VERSION
+----
+
 === Licenses
 
 https://hydra.oregon.dfinity.build/latest/dfinity-ci-build/sdk/licenses.dfx.x86_64-linux/licenses.dfinity-sdk-dfx.html[Latest licenses of all dependencies of dfx (build for x86_64-linux)].

--- a/scripts/update-motoko.sh
+++ b/scripts/update-motoko.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+#   $1 not set   ||   not running in repo root
+if [ -z ${1+x} ] || [ ! -f ./scripts/write-dfx-asset-sources.sh ]; then
+    echo "Usage: run ./scripts/update-motoko.sh <version-to-update-to> in repo root"
+    exit 1
+fi
+
+VERSION=$1
+echo "Updating sources to version ${VERSION}"
+niv update motoko-base
+niv update motoko-base-tarball -a version=$VERSION
+niv update motoko-x86_64-darwin -a version=$VERSION
+niv update motoko-x86_64-linux -a version=$VERSION
+
+echo "Writing asset sources"
+./scripts/write-dfx-asset-sources.sh
+
+echo "Done. Don't forget to update CHANGELOG.adoc"


### PR DESCRIPTION
# Description

Adds a script to update Motoko, so that it's easier to make PRs for that

# How Has This Been Tested?

`./scripts/update-motoko.sh 0.6.28` and then inspect diff

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] (n/a) I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
