### PR TITLE
refactor: Environment.get_network_descriptor() returns a ref, not an option

### DIFF
--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -75,14 +75,13 @@ pub async fn exec(
     let with_cycles = opts.with_cycles.as_deref();
 
     let config_interface = config.get_config();
-    let network = env.get_network_descriptor().unwrap();
+    let network = env.get_network_descriptor();
 
     let proxy_sender;
     if !opts.no_wallet && !matches!(call_sender, CallSender::Wallet(_)) {
         let wallet = Identity::get_or_create_wallet_canister(
             env,
-            env.get_network_descriptor()
-                .expect("Couldn't get the network descriptor"),
+            env.get_network_descriptor(),
             env.get_selected_identity().expect("No selected identity"),
             false,
         )

--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -106,7 +106,7 @@ async fn delete_canister(
             None => match call_sender {
                 CallSender::Wallet(wallet_id) => Some(*wallet_id),
                 CallSender::SelectedId => {
-                    let network = env.get_network_descriptor().unwrap();
+                    let network = env.get_network_descriptor();
                     let agent_env = create_agent_environment(env, Some(network.name.clone()))?;
                     let identity_name = agent_env
                         .get_selected_identity()

--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -68,7 +68,7 @@ pub async fn exec(
 
     let mode = InstallMode::from_str(opts.mode.as_str()).map_err(|err| anyhow!(err))?;
     let canister_id_store = CanisterIdStore::for_env(env)?;
-    let network = env.get_network_descriptor().unwrap();
+    let network = env.get_network_descriptor();
 
     if mode == InstallMode::Reinstall && (opts.canister.is_none() || opts.all) {
         bail!("The --mode=reinstall is only valid when specifying a single canister, because reinstallation destroys all data in the canister.");

--- a/src/dfx/src/commands/canister/sign.rs
+++ b/src/dfx/src/commands/canister/sign.rs
@@ -120,7 +120,6 @@ pub async fn exec(
 
     let network = env
         .get_network_descriptor()
-        .expect("Cannot get network descriptor from environment.")
         .providers
         .first()
         .expect("Cannot get network provider (url).")

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -111,8 +111,7 @@ pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
     let create_call_sender = if !opts.no_wallet && !matches!(call_sender, CallSender::Wallet(_)) {
         let wallet = runtime.block_on(Identity::get_or_create_wallet_canister(
             &env,
-            env.get_network_descriptor()
-                .expect("Couldn't get the network descriptor"),
+            env.get_network_descriptor(),
             env.get_selected_identity().expect("No selected identity"),
             false,
         ))?;
@@ -141,7 +140,7 @@ pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
 
 fn display_urls(env: &dyn Environment) -> DfxResult {
     let config = env.get_config_or_anyhow()?;
-    let network: &NetworkDescriptor = env.get_network_descriptor().unwrap();
+    let network: &NetworkDescriptor = env.get_network_descriptor();
     let log = env.get_logger();
     let canister_id_store = CanisterIdStore::for_env(env)?;
 

--- a/src/dfx/src/commands/diagnose.rs
+++ b/src/dfx/src/commands/diagnose.rs
@@ -17,7 +17,6 @@ pub struct DiagnoseOpts {
 pub fn exec(env: &dyn Environment, opts: DiagnoseOpts) -> DfxResult {
     let env = create_agent_environment(env, opts.network)?;
     let runtime = Runtime::new().expect("Unable to create a runtime");
-    runtime
-        .block_on(async { migrate(&env, env.get_network_descriptor().unwrap(), false).await })?;
+    runtime.block_on(async { migrate(&env, env.get_network_descriptor(), false).await })?;
     Ok(())
 }

--- a/src/dfx/src/commands/fix.rs
+++ b/src/dfx/src/commands/fix.rs
@@ -18,6 +18,6 @@ pub struct FixOpts {
 pub fn exec(env: &dyn Environment, opts: FixOpts) -> DfxResult {
     let env = create_agent_environment(env, opts.network)?;
     let runtime = Runtime::new().expect("Failed to create runtime");
-    runtime.block_on(async { migrate(&env, env.get_network_descriptor().unwrap(), true).await })?;
+    runtime.block_on(async { migrate(&env, env.get_network_descriptor(), true).await })?;
     Ok(())
 }

--- a/src/dfx/src/commands/wallet/mod.rs
+++ b/src/dfx/src/commands/wallet/mod.rs
@@ -91,7 +91,7 @@ where
         .expect("No selected identity.")
         .to_string();
     // Network descriptor will always be set.
-    let network = env.get_network_descriptor().unwrap();
+    let network = env.get_network_descriptor();
     let wallet =
         Identity::get_or_create_wallet_canister(env, network, &identity_name, false).await?;
 
@@ -128,7 +128,7 @@ async fn get_wallet(env: &dyn Environment) -> DfxResult<WalletCanister<'_>> {
         .expect("No selected identity.")
         .to_string();
     // Network descriptor will always be set.
-    let network = env.get_network_descriptor().unwrap();
+    let network = env.get_network_descriptor();
     fetch_root_key_if_needed(env).await?;
     let wallet =
         Identity::get_or_create_wallet_canister(env, network, &identity_name, false).await?;

--- a/src/dfx/src/commands/wallet/upgrade.rs
+++ b/src/dfx/src/commands/wallet/upgrade.rs
@@ -19,7 +19,7 @@ pub async fn exec(env: &dyn Environment, _opts: UpgradeOpts) -> DfxResult {
         .to_string();
 
     // Network descriptor will always be set.
-    let network = env.get_network_descriptor().unwrap();
+    let network = env.get_network_descriptor();
 
     let canister_id = Identity::wallet_canister_id(env, network, &identity_name)?;
 

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -188,7 +188,7 @@ impl Environment for EnvironmentImpl {
     fn get_network_descriptor(&self) -> &NetworkDescriptor {
         // It's not valid to call get_network_descriptor on an EnvironmentImpl.
         // All of the places that call this have an AgentEnvironment anyway.
-        panic!("NetworkDescriptor only available from an AgentEnvironment");
+        unreachable!("NetworkDescriptor only available from an AgentEnvironment");
     }
 
     fn get_logger(&self) -> &slog::Logger {

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -43,7 +43,7 @@ pub trait Environment {
     fn get_agent<'a>(&'a self) -> Option<&'a Agent>;
 
     #[allow(clippy::needless_lifetimes)]
-    fn get_network_descriptor<'a>(&'a self) -> Option<&'a NetworkDescriptor>;
+    fn get_network_descriptor<'a>(&'a self) -> &'a NetworkDescriptor;
 
     fn get_logger(&self) -> &slog::Logger;
     fn new_spinner(&self, message: Cow<'static, str>) -> ProgressBar;
@@ -185,10 +185,10 @@ impl Environment for EnvironmentImpl {
         None
     }
 
-    fn get_network_descriptor(&self) -> Option<&NetworkDescriptor> {
-        // create an AgentEnvironment explicitly, in order to specify network and agent.
-        // See install, build for examples.
-        None
+    fn get_network_descriptor(&self) -> &NetworkDescriptor {
+        // It's not valid to call get_network_descriptor on an EnvironmentImpl.
+        // All of the places that call this have an AgentEnvironment anyway.
+        panic!("NetworkDescriptor only available from an AgentEnvironment");
     }
 
     fn get_logger(&self) -> &slog::Logger {
@@ -290,8 +290,8 @@ impl<'a> Environment for AgentEnvironment<'a> {
         Some(&self.agent)
     }
 
-    fn get_network_descriptor(&self) -> Option<&NetworkDescriptor> {
-        Some(&self.network_descriptor)
+    fn get_network_descriptor(&self) -> &NetworkDescriptor {
+        &self.network_descriptor
     }
 
     fn get_logger(&self) -> &slog::Logger {

--- a/src/dfx/src/lib/models/canister_id_store.rs
+++ b/src/dfx/src/lib/models/canister_id_store.rs
@@ -33,7 +33,7 @@ pub struct CanisterIdStore {
 impl CanisterIdStore {
     #[context("Failed to load canister id store.")]
     pub fn for_env(env: &dyn Environment) -> DfxResult<Self> {
-        let network_descriptor = env.get_network_descriptor().expect("no network descriptor");
+        let network_descriptor = env.get_network_descriptor();
         let store = CanisterIdStore::for_network(network_descriptor)?;
 
         let remote_ids = get_remote_ids(env)?;

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -43,7 +43,7 @@ pub async fn deploy_canisters(
         .ok_or_else(|| anyhow!("Cannot find dfx configuration file in the current working directory. Did you forget to create one?"))?;
     let initial_canister_id_store = CanisterIdStore::for_env(env)?;
 
-    let network = env.get_network_descriptor().unwrap();
+    let network = env.get_network_descriptor();
 
     let canisters_to_build = canister_with_dependencies(&config, some_canister)?;
 

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -37,7 +37,7 @@ pub async fn install_canister(
     upgrade_unchanged: bool,
 ) -> DfxResult {
     let log = env.get_logger();
-    let network = env.get_network_descriptor().unwrap();
+    let network = env.get_network_descriptor();
     if !network.is_ic && named_canister::get_ui_canister_id(network).is_none() {
         named_canister::install_ui_canister(env, network, None).await?;
     }

--- a/src/dfx/src/lib/root_key.rs
+++ b/src/dfx/src/lib/root_key.rs
@@ -10,11 +10,7 @@ pub async fn fetch_root_key_if_needed(env: &dyn Environment) -> DfxResult {
         .get_agent()
         .ok_or_else(|| anyhow!("Cannot get HTTP client from environment."))?;
 
-    if !env
-        .get_network_descriptor()
-        .expect("no network descriptor")
-        .is_ic
-    {
+    if !env.get_network_descriptor().is_ic {
         agent
             .fetch_root_key()
             .await
@@ -31,11 +27,7 @@ pub async fn fetch_root_key_or_anyhow(env: &dyn Environment) -> DfxResult {
         .get_agent()
         .ok_or_else(|| anyhow!("Cannot get HTTP client from environment."))?;
 
-    if !env
-        .get_network_descriptor()
-        .expect("no network descriptor")
-        .is_ic
-    {
+    if !env.get_network_descriptor().is_ic {
         agent
             .fetch_root_key()
             .await


### PR DESCRIPTION
# Description

This eliminates a bunch of unwrap() and expect() calls that can never trigger, because the Environment in question is always an AgentEnvironment anyway.  In practice, Environment::get_network_descriptor can never be called, so it now calls `unreachable!()`.

This is preliminary work for system-wide dfx start

# How Has This Been Tested?

e2e tests will cover it

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] (not needed) I have edited the CHANGELOG accordingly.
- [x] (not needed) I have made corresponding changes to the documentation.
