### PR TITLE
chore: port back from portal what was added for dfx 0.10.1 already

### DIFF
--- a/docs/cli-reference/dfx-identity.md
+++ b/docs/cli-reference/dfx-identity.md
@@ -252,7 +252,7 @@ You can use the following optional flags with the `dfx identity remove` command.
 | Flag              | Description                   |
 |-------------------|-------------------------------|
 | `-h`, `--help`    | Displays usage information.   |
-| `-V`, `--version` | Displays version information. |
+| `-V`, `--version` | Displays version information. || `--drop-wallets`  | Required if the identity has wallets configured so that users do not accidentally lose access to wallets.   |
 
 ### Arguments
 
@@ -277,6 +277,11 @@ Although you can delete the `default` identity if you have created other identit
 
     Identity error:
       Cannot delete the default identity
+
+If you have an identity with one or more wallets configured, it will only be deleted if you call it with `--drop-wallets`. This is made so that users don't accidentally lose access to their cycles wallets. If you try to delete an identity with at least one wallet configured, it will display the attached wallets like this:
+
+    This identity is connected to the following wallets:
+        identity 'mainnet' on network 'ic' has wallet rwlgt-iiaaa-aaaaa-aaaaa-cai
 
 ## dfx identity rename
 

--- a/docs/cli-reference/dfx-replica.md
+++ b/docs/cli-reference/dfx-replica.md
@@ -18,14 +18,17 @@ You can use the following optional flags with the `dfx replica` command.
 |-------------------|-------------------------------|
 | `-h`, `--help`    | Displays usage information.   |
 | `-V`, `--version` | Displays version information. |
+| `--enable-bitcoin`| Enables bitcoin integration.  |
+| `--enable-canister-http` | Enables canister HTTP requests. |
 
 ## Options
 
 You can use the following option with the `dfx replica` command.
 
-| Option        | Description                                                                   |
-|---------------|-------------------------------------------------------------------------------|
-| `--port port` | Specifies the port the local canister execution environment should listen to. |
+| Option                    | Description                                                                   |
+|---------------------------|-------------------------------------------------------------------------------|
+| `--port port`             | Specifies the port the local canister execution environment should listen to. |
+| `--bitcoin-node host:port` | Specifies the address of a bitcoind node.  Implies `--enable-bitcoin`. |
 
 ## Examples
 

--- a/docs/cli-reference/dfx-start.md
+++ b/docs/cli-reference/dfx-start.md
@@ -16,10 +16,12 @@ You can use the following optional flags with the `dfx start` command.
 
 | Flag              | Description                                                                                                                                                                                                                                  |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--background`    | Starts the local canister execution environment and web server processes in the background and waits for a reply before returning to the shell.                                                                                              |
-| `--clean`         | Starts the local canister execution environment and web server processes in a clean state by removing checkpoints from your project cache. You can use this flag to set your project cache to a new state when troubleshooting or debugging. |
-| `-h`, `--help`    | Displays usage information.                                                                                                                                                                                                                  |
-| `-V`, `--version` | Displays version information.                                                                                                                                                                                                                |
+| `--background`           | Starts the local canister execution environment and web server processes in the background and waits for a reply before returning to the shell.                                                                                              |
+| `--clean`                | Starts the local canister execution environment and web server processes in a clean state by removing checkpoints from your project cache. You can use this flag to set your project cache to a new state when troubleshooting or debugging. |
+| `--enable-bitcoin` | Enables bitcoin integration. |
+| `--enable-canister-http` | Enables canister HTTP requests. |
+| `-h`, `--help`           | Displays usage information.                                                                                                                                                                                                                  |
+| `-V`, `--version`        | Displays version information.                                                                                                                                                                                                                |
 
 ## Options
 
@@ -28,6 +30,7 @@ You can use the following option with the `dfx start` command.
 | Option        | Description                                                                                                       |
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | `--host host` | Specifies the host interface IP address and port number to bind the frontend to. The default is `127.0.0.1:8000`. |
+| `--bitcoin-node host:port` | Specifies the address of a bitcoind node. Implies `--enable-bitcoin`. |
 
 ## Examples
 

--- a/docs/cli-reference/dfx-wallet.md
+++ b/docs/cli-reference/dfx-wallet.md
@@ -204,6 +204,7 @@ You can use the following optional flags with the `dfx wallet balance` command.
 -------|---------
 |`-h`, `--help` |Displays usage information.
 |`-V`, `--version` |Displays version information.
+|`--precise` |Displays the exact balance, without scaling to trillions of cycles.
 
 ### Examples
 
@@ -216,7 +217,7 @@ dfx wallet balance
 This command displays the number of cycles in your cycles wallet. For example: 
 
 ```
-89000000000000 cycles.
+89.000 TC (trillion cycles).
 ```
 
 ## dfx wallet controllers
@@ -237,7 +238,6 @@ You can use the following optional flags with the `dfx wallet controllers` comma
 |Flag |Description
 |`-h`, `--help` |Displays usage information.
 |`-V`, `--version` |Displays version information.
-
 
 ### Examples
 


### PR DESCRIPTION
# Description

CLI reference moved back to this repo. This pulls back in what was added to the `dfx0.10.1` branch before it moved back here.

# How Has This Been Tested?

Docs. Not tested.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
