### PR TITLE
refactor: use AgentEnvironment.get_network_descriptor() rather than creating a second one

### DIFF
--- a/src/dfx/src/commands/identity/deploy_wallet.rs
+++ b/src/dfx/src/commands/identity/deploy_wallet.rs
@@ -1,7 +1,7 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::identity::Identity;
-use crate::lib::provider::{create_agent_environment, get_network_descriptor};
+use crate::lib::provider::create_agent_environment;
 use crate::lib::root_key::fetch_root_key_if_needed;
 
 use anyhow::bail;
@@ -26,7 +26,7 @@ pub fn exec(env: &dyn Environment, opts: DeployWalletOpts, network: Option<Strin
         .get_selected_identity()
         .expect("No selected identity.")
         .to_string();
-    let network = get_network_descriptor(&agent_env, network)?;
+    let network = agent_env.get_network_descriptor();
 
     let canister_id = opts.canister_id;
     match CanisterId::from_text(&canister_id) {

--- a/src/dfx/src/commands/identity/deploy_wallet.rs
+++ b/src/dfx/src/commands/identity/deploy_wallet.rs
@@ -17,7 +17,7 @@ pub struct DeployWalletOpts {
 }
 
 pub fn exec(env: &dyn Environment, opts: DeployWalletOpts, network: Option<String>) -> DfxResult {
-    let agent_env = create_agent_environment(env, network.clone())?;
+    let agent_env = create_agent_environment(env, network)?;
     let runtime = Runtime::new().expect("Unable to create a runtime");
 
     runtime.block_on(async { fetch_root_key_if_needed(&agent_env).await })?;
@@ -32,7 +32,7 @@ pub fn exec(env: &dyn Environment, opts: DeployWalletOpts, network: Option<Strin
     match CanisterId::from_text(&canister_id) {
         Ok(id) => {
             runtime.block_on(async {
-                Identity::create_wallet(&agent_env, &network, &identity_name, Some(id)).await?;
+                Identity::create_wallet(&agent_env, network, &identity_name, Some(id)).await?;
                 DfxResult::Ok(())
             })?;
         }

--- a/src/dfx/src/commands/identity/get_wallet.rs
+++ b/src/dfx/src/commands/identity/get_wallet.rs
@@ -12,7 +12,7 @@ use tokio::runtime::Runtime;
 pub struct GetWalletOpts {}
 
 pub fn exec(env: &dyn Environment, _opts: GetWalletOpts, network: Option<String>) -> DfxResult {
-    let agent_env = create_agent_environment(env, network.clone())?;
+    let agent_env = create_agent_environment(env, network)?;
     let runtime = Runtime::new().expect("Unable to create a runtime");
 
     runtime.block_on(async { fetch_root_key_if_needed(&agent_env).await })?;
@@ -26,7 +26,7 @@ pub fn exec(env: &dyn Environment, _opts: GetWalletOpts, network: Option<String>
     runtime.block_on(async {
         println!(
             "{}",
-            Identity::get_or_create_wallet(&agent_env, &network, &identity_name, false).await?
+            Identity::get_or_create_wallet(&agent_env, network, &identity_name, false).await?
         );
         DfxResult::Ok(())
     })?;

--- a/src/dfx/src/commands/identity/get_wallet.rs
+++ b/src/dfx/src/commands/identity/get_wallet.rs
@@ -1,7 +1,7 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::identity::Identity;
-use crate::lib::provider::{create_agent_environment, get_network_descriptor};
+use crate::lib::provider::create_agent_environment;
 use crate::lib::root_key::fetch_root_key_if_needed;
 
 use clap::Parser;
@@ -21,7 +21,7 @@ pub fn exec(env: &dyn Environment, _opts: GetWalletOpts, network: Option<String>
         .get_selected_identity()
         .expect("No selected identity.")
         .to_string();
-    let network = get_network_descriptor(&agent_env, network)?;
+    let network = agent_env.get_network_descriptor();
 
     runtime.block_on(async {
         println!(

--- a/src/dfx/src/commands/identity/set_wallet.rs
+++ b/src/dfx/src/commands/identity/set_wallet.rs
@@ -24,7 +24,7 @@ pub struct SetWalletOpts {
 }
 
 pub fn exec(env: &dyn Environment, opts: SetWalletOpts, network: Option<String>) -> DfxResult {
-    let agent_env = create_agent_environment(env, network.clone())?;
+    let agent_env = create_agent_environment(env, network)?;
     let env = &agent_env;
     let log = env.get_logger();
 
@@ -100,7 +100,7 @@ pub fn exec(env: &dyn Environment, opts: SetWalletOpts, network: Option<String>)
         network.name,
         canister_id
     );
-    Identity::set_wallet_id(env, &network, &identity_name, canister_id)?;
+    Identity::set_wallet_id(env, network, &identity_name, canister_id)?;
     info!(log, "Wallet set successfully.");
 
     Ok(())

--- a/src/dfx/src/commands/identity/set_wallet.rs
+++ b/src/dfx/src/commands/identity/set_wallet.rs
@@ -3,7 +3,7 @@ use crate::lib::environment::Environment;
 use crate::lib::error::{DfxError, DfxResult};
 use crate::lib::identity::Identity;
 use crate::lib::models::canister_id_store::CanisterIdStore;
-use crate::lib::provider::{create_agent_environment, get_network_descriptor};
+use crate::lib::provider::create_agent_environment;
 
 use anyhow::{anyhow, Context};
 use clap::Parser;
@@ -35,7 +35,7 @@ pub fn exec(env: &dyn Environment, opts: SetWalletOpts, network: Option<String>)
         .expect("No selected identity.")
         .to_string();
 
-    let network = get_network_descriptor(&agent_env, network)?;
+    let network = agent_env.get_network_descriptor();
 
     let canister_name = opts.canister_name.as_str();
     let canister_id = match Principal::from_text(canister_name) {


### PR DESCRIPTION
# Description

There were three places that created a new NetworkDescriptor rather than using the one already available from the AgentEnvironment.  This reduces the call points to get_network_descriptor() to the four places where it's actually required:
- create_agent_environment
- start, bootstrap, ping commands

# How Has This Been Tested?

Covered by e2e tests