### PR TITLE
test: add e2e test for inter-canister calls

### DIFF
--- a/e2e/assets/inter/Cargo.toml
+++ b/e2e/assets/inter/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = [
+    "src/counter_rs",
+    "src/inter_rs",
+    "src/inter2_rs",
+]

--- a/e2e/assets/inter/dfx.json
+++ b/e2e/assets/inter/dfx.json
@@ -1,0 +1,48 @@
+{
+  "version": 1,
+  "canisters": {
+    "counter_rs": {
+      "type": "rust",
+      "package": "counter_rs",
+      "candid": "src/counter_rs/counter.did"
+    },
+    "counter_mo": {
+      "type": "motoko",
+      "main": "src/counter_mo/main.mo"
+    },
+    "inter_rs": {
+      "type": "rust",
+      "package": "inter_rs",
+      "candid": "src/inter_rs/lib.did",
+      "dependencies": [
+        "counter_mo"
+      ]
+    },
+    "inter_mo": {
+      "type": "motoko",
+      "main": "src/inter_mo/main.mo"
+    },
+    "inter2_rs": {
+      "type": "rust",
+      "package": "inter2_rs",
+      "candid": "src/inter2_rs/lib.did",
+      "dependencies": [
+        "inter_mo"
+      ]
+    },
+    "inter2_mo": {
+      "type": "motoko",
+      "main": "src/inter2_mo/main.mo"
+    }
+  },
+  "defaults": {
+    "build": {
+      "output": "canisters/"
+    },
+    "start": {
+      "address": "127.0.0.1",
+      "port": 8000,
+      "serve_root": "canisters/eeoo/assets"
+    }
+  }
+}

--- a/e2e/assets/inter/patch.bash
+++ b/e2e/assets/inter/patch.bash
@@ -1,0 +1,1 @@
+#nothing to do

--- a/e2e/assets/inter/src/counter_mo/main.mo
+++ b/e2e/assets/inter/src/counter_mo/main.mo
@@ -1,0 +1,15 @@
+actor Counter {
+    var cell : Nat = 0;
+
+    public func inc() : async () {
+        cell += 1;
+    };
+
+    public query func read() : async Nat {
+        cell
+    };
+
+    public func write(n: Nat) : async () {
+        cell := n;
+    };
+}

--- a/e2e/assets/inter/src/counter_rs/Cargo.toml
+++ b/e2e/assets/inter/src/counter_rs/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "counter_rs"
+version = "0.1.0"
+authors = ["Hans Larsen <hans@larsen.online>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+path = "lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+candid = "0.7.4"
+ic-cdk = { version = "0.5" }
+ic-cdk-macros = { version = "0.5" }
+lazy_static = "1.4.0"

--- a/e2e/assets/inter/src/counter_rs/counter.did
+++ b/e2e/assets/inter/src/counter_rs/counter.did
@@ -1,0 +1,5 @@
+service : {
+  "inc": () -> ();
+  "read": () -> (nat) query;
+  "write": (nat) -> ();
+}

--- a/e2e/assets/inter/src/counter_rs/lib.rs
+++ b/e2e/assets/inter/src/counter_rs/lib.rs
@@ -1,0 +1,32 @@
+use ic_cdk::{
+    api::call::ManualReply,
+    export::{candid, Principal},
+};
+use ic_cdk_macros::*;
+use std::cell::{Cell, RefCell};
+
+thread_local! {
+    static COUNTER: RefCell<candid::Nat> = RefCell::new(candid::Nat::from(0));
+    static OWNER: Cell<Principal> = Cell::new(Principal::from_slice(&[]));
+}
+
+#[init]
+fn init() {
+    OWNER.with(|owner| owner.set(ic_cdk::api::caller()));
+}
+
+#[update]
+fn inc() -> () {
+    ic_cdk::println!("{:?}", OWNER.with(|owner| owner.get()));
+    COUNTER.with(|counter| *counter.borrow_mut() += 1u64);
+}
+
+#[query(manual_reply = true)]
+fn read() -> ManualReply<candid::Nat> {
+    COUNTER.with(|counter| ManualReply::one(counter))
+}
+
+#[update]
+fn write(input: candid::Nat) -> () {
+    COUNTER.with(|counter| *counter.borrow_mut() = input);
+}

--- a/e2e/assets/inter/src/inter2_mo/main.mo
+++ b/e2e/assets/inter/src/inter2_mo/main.mo
@@ -1,0 +1,15 @@
+import CounterRs "canister:inter_rs";
+
+actor Counter {
+    public func inc() : async () {
+        await CounterRs.inc()
+    };
+
+    public func read() : async Nat {
+        await CounterRs.read()
+    };
+
+    public func write(n: Nat) : async () {
+        await CounterRs.write(n)
+    };
+}

--- a/e2e/assets/inter/src/inter2_rs/Cargo.toml
+++ b/e2e/assets/inter/src/inter2_rs/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "inter2_rs"
+version = "0.1.0"
+authors = ["Hans Larsen <hans@larsen.online>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+path = "lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+candid = "0.7.4"
+ic-cdk = { version = "*" }
+ic-cdk-macros = { version = "*" }

--- a/e2e/assets/inter/src/inter2_rs/lib.did
+++ b/e2e/assets/inter/src/inter2_rs/lib.did
@@ -1,0 +1,5 @@
+service : {
+  "inc": () -> ();
+  "read": () -> (nat);
+  "write": (nat) -> ();
+}

--- a/e2e/assets/inter/src/inter2_rs/lib.rs
+++ b/e2e/assets/inter/src/inter2_rs/lib.rs
@@ -1,0 +1,20 @@
+use ic_cdk::export::candid;
+use ic_cdk_macros::*;
+
+#[import(canister = "inter_mo")]
+struct CounterCanister;
+
+#[update]
+async fn read() -> candid::Nat {
+    CounterCanister::read().await.0
+}
+
+#[update]
+async fn inc() -> () {
+    CounterCanister::inc().await
+}
+
+#[update]
+async fn write(input: candid::Nat) -> () {
+    CounterCanister::write(input).await
+}

--- a/e2e/assets/inter/src/inter_mo/main.mo
+++ b/e2e/assets/inter/src/inter_mo/main.mo
@@ -1,0 +1,15 @@
+import CounterRs "canister:counter_rs";
+
+actor Counter {
+    public func inc() : async () {
+        await CounterRs.inc()
+    };
+
+    public func read() : async Nat {
+        await CounterRs.read()
+    };
+
+    public func write(n: Nat) : async () {
+        await CounterRs.write(n)
+    };
+}

--- a/e2e/assets/inter/src/inter_rs/Cargo.toml
+++ b/e2e/assets/inter/src/inter_rs/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "inter_rs"
+version = "0.1.0"
+authors = ["Hans Larsen <hans@larsen.online>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+path = "lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+candid = "0.7.4"
+ic-cdk = { version = "*" }
+ic-cdk-macros = { version = "*" }

--- a/e2e/assets/inter/src/inter_rs/lib.did
+++ b/e2e/assets/inter/src/inter_rs/lib.did
@@ -1,0 +1,5 @@
+service : {
+  "inc": () -> ();
+  "read": () -> (nat);
+  "write": (nat) -> ();
+}

--- a/e2e/assets/inter/src/inter_rs/lib.rs
+++ b/e2e/assets/inter/src/inter_rs/lib.rs
@@ -1,0 +1,20 @@
+use ic_cdk::export::candid;
+use ic_cdk_macros::*;
+
+#[import(canister = "counter_mo")]
+struct CounterCanister;
+
+#[update]
+async fn read() -> candid::Nat {
+    CounterCanister::read().await.0
+}
+
+#[update]
+async fn inc() -> () {
+    CounterCanister::inc().await
+}
+
+#[update]
+async fn write(input: candid::Nat) -> () {
+    CounterCanister::write(input).await
+}

--- a/e2e/tests-dfx/inter.bash
+++ b/e2e/tests-dfx/inter.bash
@@ -2,6 +2,8 @@
 
 load ../utils/_
 
+[ -e "${assets:?}/installed/bin/ic-cdk-optimizer" ] || cargo install ic-cdk-optimizer --root "$assets/installed" &> /dev/null
+
 setup() {
     standard_setup
 }
@@ -16,6 +18,7 @@ teardown() {
     dfx_new_rust inter
     install_asset inter
     dfx_start
+    export PATH="$assets/installed/bin/:$PATH"
     dfx deploy
 
     # calling motoko canister from rust canister

--- a/e2e/tests-dfx/inter.bash
+++ b/e2e/tests-dfx/inter.bash
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+load ../utils/_
+
+setup() {
+    standard_setup
+}
+
+teardown() {
+    dfx_stop
+    dfx_stop_replica_and_bootstrap
+    standard_teardown
+}
+
+@test "inter-canister calls" {
+    dfx_new_rust inter
+    install_asset inter
+    dfx_start
+    dfx deploy
+
+    # calling motoko canister from rust canister
+    assert_command dfx canister call inter_rs read
+    assert_match '(0 : nat)'
+    assert_command dfx canister call inter_rs inc
+    assert_command dfx canister call inter_rs read
+    assert_match '(1 : nat)'
+    assert_command dfx canister call inter_rs write '(5)'
+    assert_command dfx canister call inter_rs read
+    assert_match '(5 : nat)'
+
+    # calling rust canister from motoko canister
+    assert_command dfx canister call inter_mo write '(0)'
+    assert_command dfx canister call inter_mo read
+    assert_match '(0 : nat)'
+    assert_command dfx canister call inter_mo inc
+    assert_command dfx canister call inter_mo read
+    assert_match '(1 : nat)'
+    assert_command dfx canister call inter_mo write '(6)'
+    assert_command dfx canister call inter_mo read
+    assert_match '(6 : nat)'
+
+    # calling rust canister from rust canister, trough motoko canisters
+    assert_command dfx canister call inter2_rs write '(0)'
+    assert_command dfx canister call inter2_rs read
+    assert_match '(0 : nat)'
+    assert_command dfx canister call inter2_rs inc
+    assert_command dfx canister call inter2_rs read
+    assert_match '(1 : nat)'
+    assert_command dfx canister call inter2_rs write '(7)'
+    assert_command dfx canister call inter2_rs read
+    assert_match '(7 : nat)'
+
+    # calling motoko canister from motoko canister, trough rust canisters
+    assert_command dfx canister call inter2_mo write '(0)'
+    assert_command dfx canister call inter2_mo read
+    assert_match '(0 : nat)'
+    assert_command dfx canister call inter2_mo inc
+    assert_command dfx canister call inter2_mo read
+    assert_match '(1 : nat)'
+    assert_command dfx canister call inter2_mo write '(8)'
+    assert_command dfx canister call inter2_mo read
+    assert_match '(8 : nat)'
+}


### PR DESCRIPTION
Implements [SDK-158](https://dfinity.atlassian.net/browse/SDK-158).

# Description

Testing inter-canister calls:
- calling motoko canister from rust canister
- calling rust canister from motoko canister
- calling rust canister from rust canister, trough motoko canisters
- calling motoko canister from motoko canister, trough rust canisters

based on: https://github.com/dfinity/cdk-rs/tree/a639e75d31bae959d4dc12f8b6e3e282d55e997b/examples/counter

# How Has This Been Tested?

```console
bats e2e/tests-dfx/inter.bash
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly. (n/a)
- [x] I have made corresponding changes to the documentation.
