### PR TITLE
feat: `--from-subaccount` flag on ledger commands

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,6 +3,12 @@
 
 = UNRELEASED
 
+== DFX
+
+=== feat: `+--from-subaccount+`
+
+Previously, the ledger commands assumed all transfers were made from the default subaccount for the identity principal. This feature adds a `+--from-subaccount+` flag to `+dfx ledger transfer+`, `+dfx ledger create-canister+`, and `+dfx ledger top-up+`, to enable making transfers from a selected subaccount. A `+--subaccount+` flag is also added to `+dfx ledger balance+` for convenience. Subaccounts are expected as 64-character hex-strings (i.e. 32 bytes).
+
 = 0.10.1
 
 == DFX

--- a/e2e/tests-dfx/ledger.bash
+++ b/e2e/tests-dfx/ledger.bash
@@ -18,7 +18,7 @@ setup() {
 
     "${NNS_ARTIFACTS}/ic-nns-init" \
       --url "$NNS_URL" \
-      --initialize-ledger-with-test-accounts 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 22ca7edac648b814e81d7946e8bacea99280e07c5f51a04ba7a38009d8ad8e89\
+      --initialize-ledger-with-test-accounts 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 22ca7edac648b814e81d7946e8bacea99280e07c5f51a04ba7a38009d8ad8e89 5a94fe181e9d411c58726cb87cbf2d016241b6c350bc3330e4869ca76e54ecbc\
       --wasm-dir "$NNS_ARTIFACTS"
 }
 
@@ -50,11 +50,40 @@ teardown() {
     assert_command dfx ledger balance
     assert_match "10100.00000000 ICP"
 
-    assert_command dfx ledger transfer --icp 100 --e8s 1 --memo 2 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 # to bob
+    assert_command dfx ledger transfer --icp 100 --e8s 1 --memo 2 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 # to alice
     assert_match "Transfer sent at BlockHeight:"
 
     # The sender(bob) paid transaction fee which is 0.0001 ICP
     # 10100 - 100 - 0.0001 - 0.00000001 = 9999.99989999
     assert_command dfx ledger balance
     assert_match "9999.99989999 ICP"
+}
+
+@test "ledger subaccounts" {
+    subacct=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+    assert_command dfx --identity bob ledger account-id --subaccount "$subacct"
+    assert_match 5a94fe181e9d411c58726cb87cbf2d016241b6c350bc3330e4869ca76e54ecbc
+
+    dfx identity use alice
+    assert_command dfx ledger balance
+    assert_match "10000.00000000 ICP"
+    assert_command dfx ledger transfer --amount 100 --memo 1 5a94fe181e9d411c58726cb87cbf2d016241b6c350bc3330e4869ca76e54ecbc # to bob+subacct 
+    assert_match "Transfer sent at BlockHeight:"
+    assert_command dfx ledger balance
+    assert_match "9899.99990000 ICP"
+
+    dfx identity use bob
+    assert_command dfx ledger balance
+    assert_match "10000.00000000 ICP"
+    assert_command dfx ledger balance --subaccount "$subacct"
+    assert_match "10100.00000000 ICP"
+    
+    assert_command dfx ledger transfer --amount 100 --memo 2 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 --from-subaccount "$subacct" # to alice
+    assert_match "Transfer sent at BlockHeight"
+    assert_command dfx ledger balance
+    assert_match "10000.00000000 ICP"
+    assert_command dfx ledger balance --subaccount "$subacct"
+    assert_match "9999.99990000 ICP"
+    assert_command dfx --identity alice ledger balance
+    assert_match "9999.99990000 ICP"
 }

--- a/src/dfx/src/commands/ledger/account_id.rs
+++ b/src/dfx/src/commands/ledger/account_id.rs
@@ -4,7 +4,6 @@ use crate::lib::models::canister_id_store::CanisterIdStore;
 use crate::lib::nns_types::account_identifier::{AccountIdentifier, Subaccount};
 use anyhow::{anyhow, Context};
 use ic_types::Principal;
-use std::convert::TryFrom;
 
 use clap::Parser;
 
@@ -21,20 +20,10 @@ pub struct AccountIdOpts {
 
     #[clap(long, value_name = "SUBACCOUNT")]
     /// Subaccount identifier (64 character long hex string).
-    pub subaccount: Option<String>,
+    pub subaccount: Option<Subaccount>,
 }
 
 pub async fn exec(env: &dyn Environment, opts: AccountIdOpts) -> DfxResult {
-    let subaccount = match opts.subaccount {
-        Some(sub_hex) => {
-            let sub_bytes = hex::decode(&sub_hex)
-                .with_context(|| format!("Subaccount '{}' is not a valid hex string", sub_hex))?;
-            let sub = Subaccount::try_from(&sub_bytes[..])
-                .with_context(|| format!("Subaccount '{}' is not 64 characters long", sub_hex))?;
-            Some(sub)
-        }
-        None => None,
-    };
     let principal = if let Some(principal) = opts.of_principal {
         if opts.of_canister.is_some() {
             return Err(anyhow!(
@@ -49,6 +38,6 @@ pub async fn exec(env: &dyn Environment, opts: AccountIdOpts) -> DfxResult {
         env.get_selected_identity_principal()
             .context("No identity is selected")?
     };
-    println!("{}", AccountIdentifier::new(principal, subaccount));
+    println!("{}", AccountIdentifier::new(principal, opts.subaccount));
     Ok(())
 }

--- a/src/dfx/src/commands/ledger/balance.rs
+++ b/src/dfx/src/commands/ledger/balance.rs
@@ -1,7 +1,7 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::ledger_types::{AccountBalanceArgs, MAINNET_LEDGER_CANISTER_ID};
-use crate::lib::nns_types::account_identifier::AccountIdentifier;
+use crate::lib::nns_types::account_identifier::{AccountIdentifier, Subaccount};
 use crate::lib::nns_types::icpts::ICPTs;
 
 use anyhow::{anyhow, Context};
@@ -18,6 +18,10 @@ pub struct BalanceOpts {
     /// Specifies an AccountIdentifier to get the balance of
     of: Option<String>,
 
+    /// Subaccount of the selected identity to get the balance of 
+    #[clap(long, conflicts_with("of"))]
+    subaccount: Option<Subaccount>,
+
     /// Canister ID of the ledger canister.
     #[clap(long)]
     ledger_canister_id: Option<Principal>,
@@ -27,10 +31,11 @@ pub async fn exec(env: &dyn Environment, opts: BalanceOpts) -> DfxResult {
     let sender = env
         .get_selected_identity_principal()
         .expect("Selected identity not instantiated.");
+    let subacct = opts.subaccount;
     let acc_id = opts
         .of
         .map_or_else(
-            || Ok(AccountIdentifier::new(sender, None)),
+            || Ok(AccountIdentifier::new(sender, subacct)),
             |v| AccountIdentifier::from_str(&v),
         )
         .map_err(|err| anyhow!(err))?;

--- a/src/dfx/src/commands/ledger/balance.rs
+++ b/src/dfx/src/commands/ledger/balance.rs
@@ -18,7 +18,7 @@ pub struct BalanceOpts {
     /// Specifies an AccountIdentifier to get the balance of
     of: Option<String>,
 
-    /// Subaccount of the selected identity to get the balance of 
+    /// Subaccount of the selected identity to get the balance of
     #[clap(long, conflicts_with("of"))]
     subaccount: Option<Subaccount>,
 

--- a/src/dfx/src/commands/ledger/create_canister.rs
+++ b/src/dfx/src/commands/ledger/create_canister.rs
@@ -20,6 +20,9 @@ pub struct CreateCanisterOpts {
     /// Specify the controller of the new canister
     controller: String,
 
+    /// Subaccount to withdraw from
+    from_subaccount: Option<Subaccount>,
+
     /// ICP to mint into cycles and deposit into destination canister
     /// Can be specified as a Decimal with the fractional portion up to 8 decimal places
     /// i.e. 100.012
@@ -64,7 +67,16 @@ pub async fn exec(env: &dyn Environment, opts: CreateCanisterOpts) -> DfxResult 
         .map_or(Ok(TRANSACTION_FEE), |v| ICPTs::from_str(&v))
         .map_err(|err| anyhow!(err))?;
 
-    let result = transfer_and_notify(env, memo, amount, fee, to_subaccount, max_fee).await?;
+    let result = transfer_and_notify(
+        env,
+        memo,
+        amount,
+        fee,
+        opts.from_subaccount,
+        to_subaccount,
+        max_fee,
+    )
+    .await?;
 
     match result {
         CyclesResponse::CanisterCreated(v) => {

--- a/src/dfx/src/commands/ledger/mod.rs
+++ b/src/dfx/src/commands/ledger/mod.rs
@@ -112,6 +112,7 @@ pub async fn transfer(
     memo: Memo,
     amount: ICPTs,
     fee: ICPTs,
+    from_subaccount: Option<Subaccount>,
     to: AccountIdBlob,
 ) -> DfxResult<BlockHeight> {
     let timestamp_nanos = SystemTime::now()
@@ -137,7 +138,7 @@ pub async fn transfer(
                     memo,
                     amount,
                     fee,
-                    from_subaccount: None,
+                    from_subaccount,
                     to,
                     created_at_time: Some(TimeStamp { timestamp_nanos }),
                 })
@@ -176,6 +177,7 @@ async fn transfer_and_notify(
     memo: Memo,
     amount: ICPTs,
     fee: ICPTs,
+    from_subaccount: Option<Subaccount>,
     to_subaccount: Option<Subaccount>,
     max_fee: ICPTs,
 ) -> DfxResult<CyclesResponse> {
@@ -187,7 +189,16 @@ async fn transfer_and_notify(
 
     let to = AccountIdentifier::new(MAINNET_CYCLE_MINTER_CANISTER_ID, to_subaccount).to_address();
 
-    let block_height = transfer(agent, &MAINNET_LEDGER_CANISTER_ID, memo, amount, fee, to).await?;
+    let block_height = transfer(
+        agent,
+        &MAINNET_LEDGER_CANISTER_ID,
+        memo,
+        amount,
+        fee,
+        from_subaccount,
+        to,
+    )
+    .await?;
 
     println!("Transfer sent at BlockHeight: {}", block_height);
 
@@ -197,7 +208,7 @@ async fn transfer_and_notify(
             Encode!(&NotifyCanisterArgs {
                 block_height,
                 max_fee,
-                from_subaccount: None,
+                from_subaccount,
                 to_canister: MAINNET_CYCLE_MINTER_CANISTER_ID,
                 to_subaccount,
             })

--- a/src/dfx/src/commands/ledger/notify.rs
+++ b/src/dfx/src/commands/ledger/notify.rs
@@ -30,6 +30,10 @@ pub struct NotifyOpts {
     #[clap(validator(e8s_validator))]
     block_height: String,
 
+    /// Subaccount that the transfer was made from.
+    #[clap(long)]
+    from_subaccount: Option<Subaccount>,
+
     /// Specify the principal of the destination, either a canister id or a user principal.
     /// If the send transaction was for `create-canister`, specify the `controller` here.
     /// If the send transacction was for `top-up`, specify the `canister` here.
@@ -66,7 +70,7 @@ pub async fn exec(env: &dyn Environment, opts: NotifyOpts) -> DfxResult {
             Encode!(&NotifyCanisterArgs {
                 block_height,
                 max_fee,
-                from_subaccount: None,
+                from_subaccount: opts.from_subaccount,
                 to_canister: MAINNET_CYCLE_MINTER_CANISTER_ID,
                 to_subaccount,
             })

--- a/src/dfx/src/commands/ledger/top_up.rs
+++ b/src/dfx/src/commands/ledger/top_up.rs
@@ -20,6 +20,9 @@ pub struct TopUpOpts {
     /// Specify the canister id to top up
     canister: String,
 
+    /// Subaccount to withdraw from
+    from_subaccount: Option<Subaccount>,
+
     /// ICP to mint into cycles and deposit into destination canister
     /// Can be specified as a Decimal with the fractional portion up to 8 decimal places
     /// i.e. 100.012
@@ -65,7 +68,16 @@ pub async fn exec(env: &dyn Environment, opts: TopUpOpts) -> DfxResult {
         .map_or(Ok(TRANSACTION_FEE), |v| ICPTs::from_str(&v))
         .map_err(|err| anyhow!(err))?;
 
-    let result = transfer_and_notify(env, memo, amount, fee, to_subaccount, max_fee).await?;
+    let result = transfer_and_notify(
+        env,
+        memo,
+        amount,
+        fee,
+        opts.from_subaccount,
+        to_subaccount,
+        max_fee,
+    )
+    .await?;
 
     match result {
         CyclesResponse::ToppedUp(()) => {

--- a/src/dfx/src/commands/ledger/transfer.rs
+++ b/src/dfx/src/commands/ledger/transfer.rs
@@ -2,7 +2,7 @@ use crate::commands::ledger::{get_icpts_from_args, transfer};
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::ledger_types::{Memo, MAINNET_LEDGER_CANISTER_ID};
-use crate::lib::nns_types::account_identifier::AccountIdentifier;
+use crate::lib::nns_types::account_identifier::{AccountIdentifier, Subaccount};
 use crate::lib::nns_types::icpts::{ICPTs, TRANSACTION_FEE};
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::util::clap::validators::{e8s_validator, icpts_amount_validator, memo_validator};
@@ -17,6 +17,10 @@ use std::str::FromStr;
 pub struct TransferOpts {
     /// AccountIdentifier of transfer destination.
     to: String,
+
+    /// Subaccount to transfer from.
+    #[clap(long)]
+    from_subaccount: Option<Subaccount>,
 
     /// ICPs to transfer to the destination AccountIdentifier
     /// Can be specified as a Decimal with the fractional portion up to 8 decimal places
@@ -78,7 +82,16 @@ pub async fn exec(env: &dyn Environment, opts: TransferOpts) -> DfxResult {
         .ledger_canister_id
         .unwrap_or(MAINNET_LEDGER_CANISTER_ID);
 
-    let block_height = transfer(agent, &canister_id, memo, amount, fee, to).await?;
+    let block_height = transfer(
+        agent,
+        &canister_id,
+        memo,
+        amount,
+        fee,
+        opts.from_subaccount,
+        to,
+    )
+    .await?;
 
     println!("Transfer sent at BlockHeight: {}", block_height);
 

--- a/src/dfx/src/lib/nns_types/account_identifier.rs
+++ b/src/dfx/src/lib/nns_types/account_identifier.rs
@@ -4,6 +4,7 @@
 // dfinity-lab/dfinity@25999dd54d29c24edb31483801bddfd8c1d780c8
 // https://github.com/dfinity-lab/dfinity/blob/master/rs/rosetta-api/canister/src/account_identifier.rs
 
+use anyhow::Context;
 use candid::CandidType;
 use ic_types::principal::Principal;
 use openssl::sha::Sha224;
@@ -188,5 +189,16 @@ impl TryFrom<&[u8]> for Subaccount {
 
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
         slice.try_into().map(Subaccount)
+    }
+}
+
+impl FromStr for Subaccount {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let hex = hex::decode(s)
+            .with_context(|| format!("Subaccount {s:?} is not a valid hex string."))?;
+        Self::try_from(&hex[..])
+            .with_context(|| format!("Subaccount {s:?} is not 64 characters long"))
     }
 }


### PR DESCRIPTION
Addresses SDK-508. dfx allows one to calculate ledger addresses for subaccounts, but has no way to send tokens from a subaccount. This adds a `--from-subaccount` flag to the four relevant ledger commands, as well as a `--subaccount` flag to `dfx ledger balance` for convenience.