### PR TITLE
chore: Add `vendored-openssl` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.20.0+1.1.1o"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92892c4f87d56e376e469ace79f1128fdaded07646ddf73aa0be4706ff712dec"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,6 +2469,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -109,3 +109,6 @@ env_logger = "0.9"
 proptest = "1.0"
 mockito = "0.31.0"
 tempfile = "3.1.0"
+
+[features]
+vendored-openssl = ["openssl/vendored"]


### PR DESCRIPTION
This adds a feature flag so you can run `cargo build --features vendored-openssl` to quickly change the compilation mode without needing to edit Cargo.toml. Useful both for development, and for building from source on e.g. Alpine. 