### PR TITLE
refactor: motoko-base-tarball -> motoko-base

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -140,18 +140,6 @@
         "url_template": "https://github.com/dfinity/icx-proxy/releases/download/<tag>/binaries-linux.tar.gz"
     },
     "motoko-base": {
-        "branch": "next-moc",
-        "description": "The Motoko base library",
-        "homepage": null,
-        "owner": "dfinity",
-        "repo": "motoko-base",
-        "rev": "585671454aa0e92b73c64bf4b1dd6463885e6c51",
-        "sha256": "1sckvr53ja8390qzd4y81na7kxfmawlzj7z7iwn4yl9p3d1hcqc2",
-        "type": "tarball",
-        "url": "https://github.com/dfinity/motoko-base/archive/585671454aa0e92b73c64bf4b1dd6463885e6c51.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "motoko-base-tarball": {
         "builtin": false,
         "description": "The Motoko base library",
         "owner": "dfinity",

--- a/scripts/dfx-asset-sources.sh
+++ b/scripts/dfx-asset-sources.sh
@@ -37,5 +37,5 @@ SANDBOX_LAUNCHER_X86_64_DARWIN_SHA256="9ae1c566d283a324c65d64ef1722dfeec2a54f329
 SANDBOX_LAUNCHER_X86_64_DARWIN_URL="https://download.dfinity.systems/blessed/ic/3b5d893c0857c47715fc339112e5dd1dbfff77a8/sdk-release/x86_64-darwin/sandbox_launcher.gz"
 SANDBOX_LAUNCHER_X86_64_LINUX_SHA256="a6ff4900ab3b5d57ee07296b73180990e4605b0250a6eb046e714507042b7099"
 SANDBOX_LAUNCHER_X86_64_LINUX_URL="https://download.dfinity.systems/blessed/ic/3b5d893c0857c47715fc339112e5dd1dbfff77a8/sdk-release/x86_64-linux/sandbox_launcher.gz"
-MOTOKO_BASE_TARBALL_URL="https://github.com/dfinity/motoko/releases/download/0.6.28/motoko-base-library.tar.gz"
-MOTOKO_BASE_TARBALL_SHA256="ab8473c918bdbfe7a7380849790ebe3b459ed52de3ca5b9c1d0d72fcf54ec1d1"
+MOTOKO_BASE_URL="https://github.com/dfinity/motoko/releases/download/0.6.28/motoko-base-library.tar.gz"
+MOTOKO_BASE_SHA256="ab8473c918bdbfe7a7380849790ebe3b459ed52de3ca5b9c1d0d72fcf54ec1d1"

--- a/scripts/prepare-dfx-assets.sh
+++ b/scripts/prepare-dfx-assets.sh
@@ -108,8 +108,8 @@ download_motoko_binaries() {
 }
 
 download_motoko_base() {
-    URL="$MOTOKO_BASE_TARBALL_URL"
-    SHA256="$MOTOKO_BASE_TARBALL_SHA256"
+    URL="$MOTOKO_BASE_URL"
+    SHA256="$MOTOKO_BASE_SHA256"
     DOWNLOAD_PATH="$DOWNLOAD_TEMP_DIR/motoko-base-tarball.tar.gz"
 
     download_url_and_check_sha "$URL" "$SHA256" "$DOWNLOAD_PATH"

--- a/scripts/update-motoko.sh
+++ b/scripts/update-motoko.sh
@@ -10,8 +10,7 @@ fi
 
 VERSION=$1
 echo "Updating sources to version ${VERSION}"
-niv update motoko-base
-niv update motoko-base-tarball -a version=$VERSION
+niv update motoko-base -a version=$VERSION
 niv update motoko-x86_64-darwin -a version=$VERSION
 niv update motoko-x86_64-linux -a version=$VERSION
 

--- a/scripts/write-dfx-asset-sources.sh
+++ b/scripts/write-dfx-asset-sources.sh
@@ -103,5 +103,6 @@ do
     done
 done
 
-write_url "motoko-base-tarball"
-calculate_sha256 "motoko-base-tarball"
+write_url "motoko-base"
+calculate_sha256 "motoko-base"
+


### PR DESCRIPTION
In sources.json:
1. Remove motoko-base definition
2. Rename motoko-base-tarball to motoko-base

The motoko-base definition, which referenced the next-moc branch in the motoko-base repo, was no longer used.

No need for anything in the changelog because these are just internal references
