### PR TITLE
chore: updates webpack dependencies

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,10 @@
 
 == DFX
 
+=== chore: updates webpack dependencies for dfx new project
+
+Resolves an issue where `+webpack-cli+` was was breaking when users tried to run `+npm start+` in a fresh project. For affected users of 0.10.1, you can resolve this issue manually by running `+npm install webpack@latest webpack-cli@latest terser-webpack-plugin@latest+`.
+
 === feat: Support for new ledger notify function
 
 Ledger 7424ea8 deprecates the existing `+notify+` function with a switch parameter between creating and topping up a canister, and introduces two

--- a/src/dfx/assets/new_project_node_files/package.json
+++ b/src/dfx/assets/new_project_node_files/package.json
@@ -20,10 +20,10 @@
     "html-webpack-plugin": "5.5.0",
     "process": "0.11.10",
     "stream-browserify": "3.0.0",
-    "terser-webpack-plugin": "5.2.5",
+    "terser-webpack-plugin": "^5.3.3",
     "util": "0.12.4",
-    "webpack": "5.72.0",
-    "webpack-cli": "4.9.2",
+    "webpack": "^5.73.0",
+    "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.8.1"
   },
   "engines": {


### PR DESCRIPTION
# Description

Resolves an issue with running `npm start` in a fresh project, leading to the message 
```
TypeError: cli.isMultipleCompiler is not a function 
```

Fixes SDK-541

# How Has This Been Tested?

Run locally with a new project

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
