### PR TITLE
fix: Support direct custom build script

### DIFF
--- a/e2e/assets/custom_canister/build.sh
+++ b/e2e/assets/custom_canister/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo CUSTOM_CANISTER2_BUILD_DONE

--- a/e2e/assets/custom_canister/dfx.json
+++ b/e2e/assets/custom_canister/dfx.json
@@ -6,6 +6,12 @@
       "candid": "main.did",
       "wasm": "main.wasm",
       "build": "echo CUSTOM_CANISTER_BUILD_DONE"
+    },
+    "custom2": {
+      "type": "custom",
+      "candid": "main.did",
+      "wasm": "main.wasm",
+      "build": "build.sh"
     }
   },
   "defaults": {

--- a/e2e/tests-dfx/build.bash
+++ b/e2e/tests-dfx/build.bash
@@ -128,11 +128,14 @@ teardown() {
   install_asset custom_canister
   dfx_start
   dfx canister create --all
-  assert_command dfx build
+  assert_command dfx build custom
   assert_match "CUSTOM_CANISTER_BUILD_DONE"
+  assert_command dfx build custom2
+  assert_match "CUSTOM_CANISTER2_BUILD_DONE"
 
   dfx canister install --all
   assert_command dfx canister call custom fromQuery
+  assert_command dfx canister call custom2 fromQuery
 }
 
 @test "build succeeds with network parameter" {

--- a/src/dfx/src/lib/builders/custom.rs
+++ b/src/dfx/src/lib/builders/custom.rs
@@ -190,7 +190,7 @@ impl CanisterBuilder for CustomBuilder {
 fn run_command(args: Vec<String>, vars: &[super::Env<'_>]) -> DfxResult<()> {
     let (command_name, arguments) = args.split_first().unwrap();
     let command_path = Path::new(command_name);
-    let mut cmd = if arguments.len() == 0
+    let mut cmd = if arguments.is_empty()
         && command_path.components().count() == 1
         && command_path.exists()
     {


### PR DESCRIPTION
Addresses SDK-476. Currently, `type:custom`'s `build` flag obeys shell rules, i.e. `"script.sh"` does not work and requires `"./script.sh"`. This changes the behavior to support the specific case of `"script.sh"`, but *not* `"script.sh --args"`, for the same reason as the shell disallows it in the first place.