### PR TITLE
fix: Use bitcoin regtest rather than bitcoin testnet

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -69,6 +69,11 @@ a dfx process that is starting.
 
 dfx ping now uses the anonymous identity, and no longer requires dfx.json to be present.
 
+=== fix: Initialize replica with bitcoin regtest flag
+
+When the bitcoin feature is enabled, dfx was launching the replica with the "bitcoin_testnet" feature.
+The correct feature to use is "bitcoin_regtest".
+
 == Dependencies
 
 == Motoko

--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -309,7 +309,7 @@ fn replica_start_thread(
             cmd.args(&["--http-port", &port.to_string()]);
         }
         if config.btc_adapter.enabled {
-            cmd.args(&["--subnet-features", "bitcoin_testnet"]);
+            cmd.args(&["--subnet-features", "bitcoin_regtest"]);
             if let Some(socket_path) = config.btc_adapter.socket_path {
                 cmd.args(&[
                     "--bitcoin-testnet-uds-path",


### PR DESCRIPTION
Copied from https://github.com/dfinity/sdk/pull/2243
