### PR TITLE
fix: Provide useful error when `provisional_create_canister_with_cycles` 404s

### DIFF
--- a/e2e/tests-dfx/create.bash
+++ b/e2e/tests-dfx/create.bash
@@ -230,3 +230,8 @@ teardown() {
     assert_command dfx --identity alice canister create --all --controller alice --controller bob
 }
 
+@test "canister-create on mainnet without wallet does not propagate the 404" {
+    dfx_start
+    assert_command_fail dfx deploy --network ic --no-wallet
+    assert_match 'dfx ledger create-canister'
+}

--- a/e2e/tests-dfx/create.bash
+++ b/e2e/tests-dfx/create.bash
@@ -231,7 +231,6 @@ teardown() {
 }
 
 @test "canister-create on mainnet without wallet does not propagate the 404" {
-    dfx_start
     assert_command_fail dfx deploy --network ic --no-wallet
     assert_match 'dfx ledger create-canister'
 }

--- a/src/dfx/src/lib/operations/canister/create_canister.rs
+++ b/src/dfx/src/lib/operations/canister/create_canister.rs
@@ -93,7 +93,9 @@ pub async fn create_canister(
                         .call_and_wait(waiter_with_timeout(timeout))
                         .await;
                     if let Err(AgentError::HttpError(HttpErrorPayload { status: 404, .. })) = &res {
-                        bail!("Cannot ledgerlessly create a canister on this network without a wallet (did you mean `dfx ledger create-canister`?)")
+                        bail!("In order to create a canister on this network, you must use a wallet in order to allocate cycles to the new canister. \
+                            To do this, remove the --no-wallet argument and try again. It is also possible to create a canister on this network \
+                            using `dfx ledger create-canister`, but doing so will not associate the created canister with any of the canisters in your project.")
                     }
                     res.context("Canister creation call failed.")?.0
                 }


### PR DESCRIPTION
Currently, `dfx deploy --network ic --no-wallet` or `dfx canister --network ic create --no-wallet` provides this amazingly unhelpful error message:

```
Error: The replica returned an HTTP Error: Http Error: status 404 Not Found, content type "text/html", content: <html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx/1.21.3</center>
</body>
</html>
```

This catches the specific case of 404 on canister creation and provides a more useful error message.