### PR TITLE
fix: add src/declarations to .gitignore for new projects

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,8 @@
 
 == DFX
 
+=== fix: Added src/declarations to .gitignore for new projects
+
 === feat: deprecate `+dfx config+` for removal
 
 The `+dfx config+` command has several issues and is ultimately a poor replacement for https://stedolan.github.io/jq/[`+jq+`]. The command is being deprecated, and will be removed in a later release; we recommend switching to `+jq+` or similar tools (e.g. `+ConvertTo-Json+` in PowerShell, `+to json+` in nushell, etc.)

--- a/src/dfx/assets/new_project_motoko_files/__dot__gitignore
+++ b/src/dfx/assets/new_project_motoko_files/__dot__gitignore
@@ -10,6 +10,9 @@
 # dfx temporary files
 .dfx/
 
+# generated files
+src/declarations/
+
 # frontend code
 node_modules/
 dist/

--- a/src/dfx/assets/new_project_rust_files/__dot__gitignore
+++ b/src/dfx/assets/new_project_rust_files/__dot__gitignore
@@ -10,6 +10,9 @@
 # dfx temporary files
 .dfx/
 
+# generated files
+src/declarations/
+
 # rust
 target/
 


### PR DESCRIPTION
# Description

Files in `src/declarations` are for use by IDEs, not meant to be edited, and generated from sources so not needed to be added to source control, so add them to .gitignore for new projects.

# How Has This Been Tested?

Tested locally
```
[~/] $ dfx new decl && cd decl
[~/decl] $ dfx start --background
[~/decl] $ dfx deploy
[~/decl] $ git status
On branch master
nothing to commit, working tree clean
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] (n/a) I have made corresponding changes to the documentation.
