### PR TITLE
chore: upgrate to agent-rs 0.18.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,15 @@
 
 == DFX
 
+=== feat: assets are no longer copied from source directories before being uploaded to asset canister
+
+Assets are now uploaded directly from their source directories, rather than first being copied
+to an output directory.
+
+If you're using `dfx deploy`, you won't see any change in functionality.  If you're running
+`dfx canister install --mode=upgrade`, changed files in asset source directories will
+be detected and uploaded even without an intervening `dfx build`.
+
 === fix: remove deprecated candid path environment variable
 
 The environment variable format `+CANISTER_CANDID_{name}+`, used in Rust projects, was deprecated in 0.9.2, to be unified with the variables `+CANISTER_CANDID_PATH_{name}+` which are used in other project types. It has now been removed. Note that you will need to update `+ic-cdk-macros+` if you use the `+#[import]+` macro.
@@ -83,11 +92,15 @@ dfx ping now uses the anonymous identity, and no longer requires dfx.json to be 
 
 == Dependencies
 
-== Motoko
+=== Rust Agent
+
+Updated agent-rs to 0.18.0
+
+=== Motoko
 
 Updated Motoko from 0.6.28 to 0.6.29.
 
-== Replica
+=== Replica
 
 Updated replica to elected commit 92e6b0ed36cdc9322a3588f46a8c8c7cc567e143.
 This incorporates the following executed proposals:
@@ -99,7 +112,7 @@ This incorporates the following executed proposals:
 * https://dashboard.internetcomputer.org/proposal/63228[63228]
 * https://dashboard.internetcomputer.org/proposal/62143[62143]
 
-== ic-ref
+=== ic-ref
 
 Updated ic-ref to 0.0.1-173cbe84
  - add ic0.performance_counter system interface

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,16 +1758,18 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.17.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=d170b0dd0fb87d741f642981fc1220ef448aeffb#d170b0dd0fb87d741f642981fc1220ef448aeffb"
+version = "0.18.0"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=fef27d1c1dc7b82ec903c8a256a38d3e488dc31b#fef27d1c1dc7b82ec903c8a256a38d3e488dc31b"
 dependencies = [
  "async-trait",
  "base32",
  "base64",
  "byteorder",
+ "futures-util",
  "garcon",
  "hex",
  "http",
+ "http-body",
  "hyper-rustls",
  "ic-types",
  "k256",
@@ -1791,8 +1793,8 @@ dependencies = [
 
 [[package]]
 name = "ic-asset"
-version = "0.17.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=d170b0dd0fb87d741f642981fc1220ef448aeffb#d170b0dd0fb87d741f642981fc1220ef448aeffb"
+version = "0.18.0"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=fef27d1c1dc7b82ec903c8a256a38d3e488dc31b#fef27d1c1dc7b82ec903c8a256a38d3e488dc31b"
 dependencies = [
  "anyhow",
  "candid",
@@ -1814,8 +1816,8 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.17.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=d170b0dd0fb87d741f642981fc1220ef448aeffb#d170b0dd0fb87d741f642981fc1220ef448aeffb"
+version = "0.18.0"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=fef27d1c1dc7b82ec903c8a256a38d3e488dc31b#fef27d1c1dc7b82ec903c8a256a38d3e488dc31b"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1843,8 +1845,8 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.17.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=d170b0dd0fb87d741f642981fc1220ef448aeffb#d170b0dd0fb87d741f642981fc1220ef448aeffb"
+version = "0.18.0"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=fef27d1c1dc7b82ec903c8a256a38d3e488dc31b#fef27d1c1dc7b82ec903c8a256a38d3e488dc31b"
 dependencies = [
  "async-trait",
  "candid",
@@ -3010,6 +3012,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,24 +4,24 @@ members = [
 ]
 
 [patch.crates-io.ic-agent]
-version = "0.17.0"
+version = "0.18.0"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "d170b0dd0fb87d741f642981fc1220ef448aeffb"
+rev = "fef27d1c1dc7b82ec903c8a256a38d3e488dc31b"
 
 [patch.crates-io.ic-asset]
-version = "0.17.0"
+version = "0.18.0"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "d170b0dd0fb87d741f642981fc1220ef448aeffb"
+rev = "fef27d1c1dc7b82ec903c8a256a38d3e488dc31b"
 
 [patch.crates-io.ic-identity-hsm]
-version = "0.17.0"
+version = "0.18.0"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "d170b0dd0fb87d741f642981fc1220ef448aeffb"
+rev = "fef27d1c1dc7b82ec903c8a256a38d3e488dc31b"
 
 [patch.crates-io.ic-utils]
-version = "0.17.0"
+version = "0.18.0"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "d170b0dd0fb87d741f642981fc1220ef448aeffb"
+rev = "fef27d1c1dc7b82ec903c8a256a38d3e488dc31b"
 
 [profile.dev.package.argon2]
 opt-level = 3

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -88,25 +88,25 @@ wasmparser = "0.86.0"
 which = "4.2.5"
 
 [dependencies.ic-agent]
-version = "0.17.0"
+version = "0.18.0"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "d170b0dd0fb87d741f642981fc1220ef448aeffb"
+rev = "fef27d1c1dc7b82ec903c8a256a38d3e488dc31b"
 features = ["reqwest"]
 
 [dependencies.ic-asset]
-version = "0.17.0"
+version = "0.18.0"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "d170b0dd0fb87d741f642981fc1220ef448aeffb"
+rev = "fef27d1c1dc7b82ec903c8a256a38d3e488dc31b"
 
 [dependencies.ic-identity-hsm]
-version = "0.17.0"
+version = "0.18.0"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "d170b0dd0fb87d741f642981fc1220ef448aeffb"
+rev = "fef27d1c1dc7b82ec903c8a256a38d3e488dc31b"
 
 [dependencies.ic-utils]
-version = "0.17.0"
+version = "0.18.0"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "d170b0dd0fb87d741f642981fc1220ef448aeffb"
+rev = "fef27d1c1dc7b82ec903c8a256a38d3e488dc31b"
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/src/dfx/src/lib/canister_info/assets.rs
+++ b/src/dfx/src/lib/canister_info/assets.rs
@@ -11,7 +11,6 @@ pub struct AssetsCanisterInfo {
 
     output_wasm_path: PathBuf,
     output_idl_path: PathBuf,
-    output_assets_path: PathBuf,
 }
 
 impl AssetsCanisterInfo {
@@ -23,9 +22,6 @@ impl AssetsCanisterInfo {
     }
     pub fn get_output_idl_path(&self) -> &Path {
         self.output_idl_path.as_path()
-    }
-    pub fn get_output_assets_path(&self) -> &Path {
-        self.output_assets_path.as_path()
     }
 
     #[context("Failed to assert source paths.")]
@@ -72,14 +68,12 @@ impl CanisterInfoFactory for AssetsCanisterInfo {
 
         let output_wasm_path = output_root.join(Path::new("assetstorage.wasm"));
         let output_idl_path = output_wasm_path.with_extension("did");
-        let output_assets_path = output_root.join(Path::new("assets"));
 
         Ok(AssetsCanisterInfo {
             input_root,
             source_paths,
             output_wasm_path,
             output_idl_path,
-            output_assets_path,
         })
     }
 }


### PR DESCRIPTION
# Description

No longer copies asset source directory contents to an output directory.  Now synchronizes assets directly from asset source directories.

This is to support upcoming changes that place asset configuration files alongside asset files.

# How Has This Been Tested?

Covered by existing e2e tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] (n/a) I have made corresponding changes to the documentation.
