### PR TITLE
feat: Enable threshold ecdsa signature

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,11 @@
 
 == DFX
 
+=== feat: Enable threshold ecdsa signature
+
+ECDSA signature signing is now enabled by default in new projects, or by running `dfx start --clean`.
+A test key id "Secp256k1:dfx_test_key" is ready to be used by locally created canisters.
+
 === fix: Use default setting for BTC adapter idle seconds
 
 A lower threshold was no longer necessary.

--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -304,6 +304,8 @@ fn replica_start_thread(
             "rocksdb",
             "--subnet-type",
             &config.subnet_type.as_ic_starter_string(),
+            "--ecdsa-keyid",
+            "Secp256k1:dfx-local-key",
         ]);
         if let Some(port) = port {
             cmd.args(&["--http-port", &port.to_string()]);

--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -305,7 +305,7 @@ fn replica_start_thread(
             "--subnet-type",
             &config.subnet_type.as_ic_starter_string(),
             "--ecdsa-keyid",
-            "Secp256k1:dfx-local-key",
+            "Secp256k1:dfx_test_key",
         ]);
         if let Some(port) = port {
             cmd.args(&["--http-port", &port.to_string()]);


### PR DESCRIPTION
Turn on ECDSA signature signing by default with a test key named "Secp256k1:dfx_test_key".

# Description

This enables developers to use threshold ECDSA system APIs when deploying code in a local dev environment.

# How Has This Been Tested?

It has been tested manually to be working.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.