### PR TITLE
refactor: e2e dfx_start_replica_and_bootstrap into separate functions

### DIFF
--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -14,7 +14,8 @@ teardown() {
     bitcoin-cli -regtest stop
 
     dfx_stop
-    dfx_stop_replica_and_bootstrap
+    stop_dfx_replica
+    stop_dfx_bootstrap
     standard_teardown
 }
 
@@ -76,7 +77,8 @@ set_default_bitcoin_enabled() {
 @test "dfx restarts replica when ic-btc-adapter restarts (replica and bootstrap)" {
     dfx_new hello
     set_default_bitcoin_enabled
-    dfx_start_replica_and_bootstrap
+    dfx_replica
+    dfx_bootstrap
 
     install_asset greet
     assert_command dfx deploy
@@ -128,7 +130,8 @@ set_default_bitcoin_enabled() {
 
 @test "dfx replica --bitcoin-node <node> implies --enable-bitcoin" {
     dfx_new hello
-    dfx_start_replica_and_bootstrap "--bitcoin-node" "127.0.0.1:18444"
+    dfx_replica "--bitcoin-node" "127.0.0.1:18444"
+    dfx_bootstrap
 
     assert_file_not_empty .dfx/ic-btc-adapter-pid
 }
@@ -145,7 +148,7 @@ set_default_bitcoin_enabled() {
 @test "dfx replica --enable-bitcoin with no other configuration succeeds" {
     dfx_new hello
 
-    dfx_start_replica_and_bootstrap --enable-bitcoin
+    dfx_replica --enable-bitcoin
 
     assert_file_not_empty .dfx/ic-btc-adapter-pid
 }
@@ -163,7 +166,7 @@ set_default_bitcoin_enabled() {
     dfx_new hello
     set_default_bitcoin_enabled
 
-    dfx_start_replica_and_bootstrap
+    dfx_replica
 
     assert_file_not_empty .dfx/ic-btc-adapter-pid
 }
@@ -185,7 +188,8 @@ set_default_bitcoin_enabled() {
 @test "dfx replica+bootstrap with both bitcoin and canister http enabled" {
     dfx_new hello
 
-    dfx_start_replica_and_bootstrap --enable-bitcoin --enable-canister-http
+    dfx_replica --enable-bitcoin --enable-canister-http
+    dfx_bootstrap
 
     assert_file_not_empty .dfx/ic-btc-adapter-pid
     assert_file_not_empty .dfx/ic-canister-http-adapter-pid

--- a/e2e/tests-dfx/bootstrap.bash
+++ b/e2e/tests-dfx/bootstrap.bash
@@ -9,14 +9,16 @@ setup() {
 }
 
 teardown() {
-    dfx_stop_replica_and_bootstrap
+    stop_dfx_replica
+    stop_dfx_bootstrap
 
     standard_teardown
 }
 
 @test "bootstrap fetches candid file" {
 
-    dfx_start_replica_and_bootstrap
+    dfx_replica
+    dfx_bootstrap
 
     dfx canister create --all
     dfx build
@@ -40,7 +42,8 @@ teardown() {
 }
 
 @test "bootstrap supports http requests" {
-    dfx_start_replica_and_bootstrap
+    dfx_replica
+    dfx_bootstrap
 
     dfx canister create --all
     dfx build

--- a/e2e/tests-dfx/canister_http.bash
+++ b/e2e/tests-dfx/canister_http.bash
@@ -10,7 +10,8 @@ setup() {
 
 teardown() {
     dfx_stop
-    dfx_stop_replica_and_bootstrap
+    stop_dfx_replica
+    stop_dfx_bootstrap
     standard_teardown
 }
 
@@ -66,7 +67,8 @@ set_default_canister_http_enabled() {
 @test "dfx restarts replica when ic-canister-http-adapter restarts - replica and bootstrap" {
     dfx_new hello
     set_default_canister_http_enabled
-    dfx_start_replica_and_bootstrap
+    dfx_replica
+    dfx_bootstrap
 
     install_asset greet
     assert_command dfx deploy
@@ -117,7 +119,7 @@ set_default_canister_http_enabled() {
 @test "dfx replica --enable-canister-http with no other configuration succeeds" {
     dfx_new hello
 
-    dfx_start_replica_and_bootstrap --enable-canister-http
+    dfx_replica --enable-canister-http
 
     assert_file_not_empty .dfx/ic-canister-http-adapter-pid
 }
@@ -135,7 +137,7 @@ set_default_canister_http_enabled() {
     dfx_new hello
     set_default_canister_http_enabled
 
-    dfx_start_replica_and_bootstrap
+    dfx_replica
 
     assert_file_not_empty .dfx/ic-canister-http-adapter-pid
 }

--- a/e2e/tests-dfx/inter.bash
+++ b/e2e/tests-dfx/inter.bash
@@ -10,7 +10,8 @@ setup() {
 
 teardown() {
     dfx_stop
-    dfx_stop_replica_and_bootstrap
+    stop_dfx_replica
+    stop_dfx_bootstrap
     standard_teardown
 }
 

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -150,7 +150,7 @@ wait_until_replica_healthy() {
 }
 
 # Start the replica in the background.
-dfx_start_replica_and_bootstrap() {
+dfx_replica() {
     dfx_patchelf
     if [ "$USE_IC_REF" ]
     then
@@ -193,7 +193,9 @@ dfx_start_replica_and_bootstrap() {
         || (echo "could not connect to replica on port ${replica_port}" && exit 1)
 
     wait_until_replica_healthy
+}
 
+dfx_bootstrap() {
     # This only works because we use the network by name
     #    (implicitly: --network local)
     # If we passed --network http://127.0.0.1:${replica_port}
@@ -216,11 +218,16 @@ dfx_start_replica_and_bootstrap() {
     printf "Webserver Configured Port: %s\n", "${webserver_port}"
 }
 
-# Start the replica in the background.
-dfx_stop_replica_and_bootstrap() {
+# Stop the `dfx replica` process that is running in the background.
+stop_dfx_replica() {
     [ "$DFX_REPLICA_PID" ] && kill -TERM "$DFX_REPLICA_PID"
+    unset DFX_REPLICA_PID
+}
 
+# Stop the `dfx bootstrap` process that is running in the background
+stop_dfx_bootstrap() {
     [ "$DFX_BOOTSTRAP_PID" ] && kill -TERM "$DFX_BOOTSTRAP_PID"
+    unset DFX_BOOTSTRAP_PID
 }
 
 # Stop the replica and verify it is very very stopped.


### PR DESCRIPTION


# Description

This is to facilitate starting and stopping them individually in tests.

A few tests only needed the replica, so they no longer also start bootstrap.

# How Has This Been Tested?

Covered by e2e tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] (n/a) I have edited the CHANGELOG accordingly.
- [x] (n/a) I have made corresponding changes to the documentation.
