### PR TITLE
refactor: reduce callers of CanisterIdStore::for_network()

### DIFF
--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -67,7 +67,7 @@ pub async fn exec(
     fetch_root_key_if_needed(env).await?;
 
     let mode = InstallMode::from_str(opts.mode.as_str()).map_err(|err| anyhow!(err))?;
-    let canister_id_store = CanisterIdStore::for_env(env)?;
+    let mut canister_id_store = CanisterIdStore::for_env(env)?;
     let network = env.get_network_descriptor();
 
     if mode == InstallMode::Reinstall && (opts.canister.is_none() || opts.all) {
@@ -119,6 +119,7 @@ pub async fn exec(
             install_canister(
                 env,
                 agent,
+                &mut canister_id_store,
                 &canister_info,
                 &install_args,
                 mode,
@@ -158,6 +159,7 @@ pub async fn exec(
                 install_canister(
                     env,
                     agent,
+                    &mut canister_id_store,
                     &canister_info,
                     &install_args,
                     mode,

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -147,7 +147,7 @@ fn display_urls(env: &dyn Environment) -> DfxResult {
     let mut frontend_urls = BTreeMap::new();
     let mut candid_urls: BTreeMap<&String, Url> = BTreeMap::new();
 
-    let ui_canister_id = named_canister::get_ui_canister_id(network);
+    let ui_canister_id = named_canister::get_ui_canister_id(&canister_id_store);
 
     if let Some(canisters) = &config.get_config().canisters {
         for (canister_name, canister_config) in canisters {

--- a/src/dfx/src/lib/migrate.rs
+++ b/src/dfx/src/lib/migrate.rs
@@ -47,7 +47,7 @@ pub async fn migrate(env: &dyn Environment, network: &NetworkDescriptor, fix: bo
     };
     did_migrate |= migrate_wallet(env, agent, &wallet, fix).await?;
     if let Some(canisters) = &config.canisters {
-        let store = CanisterIdStore::for_network(network)?;
+        let store = CanisterIdStore::for_env(env)?;
         for name in canisters.keys() {
             if !config.is_remote_canister(name, &network.name)? {
                 if let Some(id) = store.find(name) {

--- a/src/dfx/src/lib/named_canister.rs
+++ b/src/dfx/src/lib/named_canister.rs
@@ -4,7 +4,6 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::models::canister_id_store::CanisterIdStore;
-use crate::lib::network::network_descriptor::NetworkDescriptor;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::lib::waiter::waiter_with_timeout;
 use crate::util;
@@ -23,14 +22,14 @@ const UI_CANISTER: &str = "__Candid_UI";
 #[context("Failed to install candid UI canister.")]
 pub async fn install_ui_canister(
     env: &dyn Environment,
-    network: &NetworkDescriptor,
+    id_store: &mut CanisterIdStore,
     some_canister_id: Option<Principal>,
 ) -> DfxResult<Principal> {
-    let mut id_store = CanisterIdStore::for_network(network)?;
+    let network = env.get_network_descriptor();
     if id_store.find(UI_CANISTER).is_some() {
         return Err(anyhow!(
             "UI canister already installed on {} network",
-            network.name
+            network.name,
         ));
     }
     fetch_root_key_if_needed(env).await?;
@@ -85,7 +84,6 @@ pub async fn install_ui_canister(
     );
     Ok(canister_id)
 }
-pub fn get_ui_canister_id(network: &NetworkDescriptor) -> Option<Principal> {
-    let id_store = CanisterIdStore::for_network(network).ok()?;
+pub fn get_ui_canister_id(id_store: &CanisterIdStore) -> Option<Principal> {
     id_store.find(UI_CANISTER)
 }

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -221,7 +221,7 @@ async fn install_canisters(
         .get_agent()
         .ok_or_else(|| anyhow!("Cannot find dfx configuration file in the current working directory. Did you forget to create one?"))?;
 
-    let canister_id_store = CanisterIdStore::for_env(env)?;
+    let mut canister_id_store = CanisterIdStore::for_env(env)?;
 
     for canister_name in canister_names {
         let (install_mode, installed_module_hash) = if force_reinstall {
@@ -258,6 +258,7 @@ async fn install_canisters(
         install_canister(
             env,
             agent,
+            &mut canister_id_store,
             &canister_info,
             &install_args,
             install_mode,

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -4,6 +4,7 @@ use crate::lib::error::DfxResult;
 use crate::lib::identity::identity_utils::CallSender;
 use crate::lib::identity::Identity;
 use crate::lib::installers::assets::post_install_store_assets;
+use crate::lib::models::canister_id_store::CanisterIdStore;
 use crate::lib::named_canister;
 use crate::lib::waiter::waiter_with_timeout;
 use crate::util::assets::wallet_wasm;
@@ -28,6 +29,7 @@ use std::time::Duration;
 pub async fn install_canister(
     env: &dyn Environment,
     agent: &Agent,
+    canister_id_store: &mut CanisterIdStore,
     canister_info: &CanisterInfo,
     args: &[u8],
     mode: InstallMode,
@@ -38,8 +40,8 @@ pub async fn install_canister(
 ) -> DfxResult {
     let log = env.get_logger();
     let network = env.get_network_descriptor();
-    if !network.is_ic && named_canister::get_ui_canister_id(network).is_none() {
-        named_canister::install_ui_canister(env, network, None).await?;
+    if !network.is_ic && named_canister::get_ui_canister_id(canister_id_store).is_none() {
+        named_canister::install_ui_canister(env, canister_id_store, None).await?;
     }
 
     let canister_id = canister_info.get_canister_id()?;


### PR DESCRIPTION
# Description

This changes leaves two callers of `CanisterIdStore::for_network()`:
- CanisterIdStore::for_env()
- webserver::candid() (which we will soon remove altogether)

This also reduces the number of CanisterIdStore instantiations during `dfx deploy` and `dfx canister install --all`, though that doesn't matter as much.

# How Has This Been Tested?

Covered by existing e2e tests.


