### PR TITLE
feat: look up running webserver port

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,10 @@
 
 == DFX
 
+=== feat: dfx will look up the port of the running webserver from .dfx/webserver-port, if present
+
+After `dfx start --host 127.0.0.1:0`, the dfx webserver will listen on an ephemeral port.  It stores the port value in .dfx/webserver-port.  dfx will now look for this file, and if a port is contained within, use that port to connect to the dfx webserver.
+
 === fix: dfx commands once again work from any subdirectory of a dfx project
 
 Running `dfx deploy`, `dfx canister id`, `dfx canister call` and so forth work as expected

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -99,8 +99,10 @@ set_default_bitcoin_enabled() {
     timeout 15s sh -x -c \
       "until curl --fail --verbose -o /dev/null http://localhost:\$(cat .dfx/replica-configuration/replica-1.port)/api/v2/status; do echo \"waiting for replica to restart on port \$(cat .dfx/replica-configuration/replica-1.port)\"; sleep 1; done" \
       || (echo "replica did not restart" && echo "last replica port was $(get_replica_port)" && ps aux && exit 1)
-    # shellcheck disable=SC2094
-    cat <<<"$(jq .networks.local.bind=\"127.0.0.1:"$(get_replica_port)"\" dfx.json)" >dfx.json
+
+    # unfortunately bootstrap will never know about the new replica port.  This makes dfx bypass bootstrap:
+    overwrite_webserver_port "$(get_replica_port)"
+
     echo "dfx.json configured for new replica:"
     cat dfx.json
 

--- a/e2e/tests-dfx/canister_http.bash
+++ b/e2e/tests-dfx/canister_http.bash
@@ -89,8 +89,9 @@ set_default_canister_http_enabled() {
     timeout 15s sh -x -c \
       "until curl --fail --verbose -o /dev/null http://localhost:\$(cat .dfx/replica-configuration/replica-1.port)/api/v2/status; do echo \"waiting for replica to restart on port \$(cat .dfx/replica-configuration/replica-1.port)\"; sleep 1; done" \
       || (echo "replica did not restart" && echo "last replica port was $(get_replica_port)" && ps aux && exit 1)
-    # shellcheck disable=SC2094
-    cat <<<"$(jq .networks.local.bind=\"127.0.0.1:"$(get_replica_port)"\" dfx.json)" >dfx.json
+
+    # unfortunately bootstrap will never know about the new replica port. This makes dfx bypass bootstrap:
+    overwrite_webserver_port "$(get_replica_port)"
 
     timeout 15s sh -c \
       'until dfx ping; do echo waiting for replica to restart; sleep 1; done' \

--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -37,8 +37,7 @@ setup() {
     while true
     do
         MITM_PORT=$(python3 "${BATS_TEST_DIRNAME}/../utils/get_ephemeral_port.py")
-        # shellcheck disable=SC2094
-        cat <<<"$(jq '.networks.local.bind="127.0.0.1:'"$MITM_PORT"'"' dfx.json)" >dfx.json
+        overwrite_webserver_port "$MITM_PORT"
 
         mitmdump -p "$MITM_PORT" --mode "reverse:http://$BACKEND"  "$MODIFY_BODY_ARG" '/~s/Hello,/Hullo,' &
         MITMDUMP_PID=$!

--- a/e2e/tests-dfx/ping.bash
+++ b/e2e/tests-dfx/ping.bash
@@ -67,8 +67,10 @@ teardown() {
     [ "$USE_IC_REF" ] && skip "skipped for ic-ref"
 
     dfx_start --host 127.0.0.1:12345
-    # dfx_start overwrites local bind with provided port arg, set it back to default
-    assert_command dfx config networks.local.bind '"127.0.0.1:8000"'
+
+    # Make dfx use the port from configuration:
+    rm .dfx/webserver-port
+
     # shellcheck disable=SC2094
     cat <<<"$(jq '.networks.arbitrary.providers=["http://127.0.0.1:12345"]' dfx.json)" >dfx.json
 
@@ -76,7 +78,7 @@ teardown() {
     assert_match "\"ic_api_version\""
 
     assert_command_fail dfx ping
-    # this port won't match the ephemeral port that the ic ref picked
+    # this port won't match the ephemeral port that the replica picked
     # shellcheck disable=SC2094
     cat <<<"$(jq '.networks.arbitrary.providers=["127.0.0.1:22113"]' dfx.json)" >dfx.json
     assert_command_fail dfx ping arbitrary

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -111,10 +111,6 @@ dfx_start() {
 
         test -f .dfx/ic-ref.port
         local port=$(cat .dfx/ic-ref.port)
-
-        # Overwrite the default networks.local.bind 127.0.0.1:8000 with allocated port
-        local webserver_port=$(cat .dfx/webserver-port)
-        cat <<<$(jq .networks.local.bind=\"127.0.0.1:${webserver_port}\" dfx.json) >dfx.json
     else
         # Bats creates a FD 3 for test output, but child processes inherit it and Bats will
         # wait for it to close. Because `dfx start` leaves child processes running, we need
@@ -129,11 +125,9 @@ dfx_start() {
         printf "Configuration Root for DFX: %s\n" "${dfx_config_root}"
         test -f ${dfx_config_root}/replica-1.port
         local port=$(cat ${dfx_config_root}/replica-1.port)
-
-        # Overwrite the default networks.local.bind 127.0.0.1:8000 with allocated port
-        local webserver_port=$(cat .dfx/webserver-port)
-        cat <<<$(jq .networks.local.bind=\"127.0.0.1:${webserver_port}\" dfx.json) >dfx.json
     fi
+
+    local webserver_port=$(cat .dfx/webserver-port)
 
     printf "Replica Configured Port: %s\n" "${port}"
     printf "Webserver Configured Port: %s\n" "${webserver_port}"
@@ -277,6 +271,9 @@ use_wallet_wasm() {
 
 get_webserver_port() {
   cat ".dfx/webserver-port"
+}
+overwrite_webserver_port() {
+  echo "$1" >".dfx/webserver-port"
 }
 
 get_replica_pid() {

--- a/src/dfx/src/commands/bootstrap.rs
+++ b/src/dfx/src/commands/bootstrap.rs
@@ -2,7 +2,7 @@ use crate::config::dfinity::{ConfigDefaults, ConfigDefaultsBootstrap};
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::network::network_descriptor::NetworkDescriptor;
-use crate::lib::provider::get_network_descriptor;
+use crate::lib::provider::{get_network_descriptor, LocalBindDetermination};
 use crate::lib::webserver::run_webserver;
 use crate::util::get_reusable_socket_addr;
 
@@ -51,7 +51,11 @@ pub fn exec(env: &dyn Environment, opts: BootstrapOpts) -> DfxResult {
     let base_config_bootstrap = config_defaults.get_bootstrap().to_owned();
     let config_bootstrap = apply_arguments(&base_config_bootstrap, env, opts.clone())?;
 
-    let network_descriptor = get_network_descriptor(env.get_config(), opts.network)?;
+    let network_descriptor = get_network_descriptor(
+        env.get_config(),
+        opts.network,
+        LocalBindDetermination::AsConfigured,
+    )?;
     let build_output_root = config.get_temp_path().join(network_descriptor.name.clone());
     let build_output_root = build_output_root.join("canisters");
     let icx_proxy_pid_file_path = env.get_temp_dir().join("icx-proxy-pid");

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -12,7 +12,7 @@ use crate::util::get_reusable_socket_addr;
 
 use crate::actors::icx_proxy::IcxProxyConfig;
 use crate::lib::network::local_server_descriptor::LocalServerDescriptor;
-use crate::lib::provider::get_network_descriptor;
+use crate::lib::provider::{get_network_descriptor, LocalBindDetermination};
 use crate::lib::webserver::run_webserver;
 use actix::Recipient;
 use anyhow::{anyhow, bail, Context, Error};
@@ -163,7 +163,8 @@ pub fn exec(
     }: StartOpts,
 ) -> DfxResult {
     let config = env.get_config_or_anyhow()?;
-    let network_descriptor = get_network_descriptor(env.get_config(), None)?;
+    let network_descriptor =
+        get_network_descriptor(env.get_config(), None, LocalBindDetermination::AsConfigured)?;
     let local_server_descriptor = network_descriptor.local_server_descriptor()?;
     let temp_dir = env.get_temp_dir();
     let build_output_root = temp_dir.join(&network_descriptor.name).join("canisters");

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -512,7 +512,8 @@ impl Config {
         Ok(Config::from_slice(path.to_path_buf(), &content)?)
     }
 
-    fn from_dir(working_dir: &Path) -> DfxResult<Option<Config>> {
+    #[context("Failed to read config from directory {}.", working_dir.to_string_lossy())]
+    pub fn from_dir(working_dir: &Path) -> DfxResult<Option<Config>> {
         let path = Config::resolve_config_path(working_dir)?;
         let maybe_config = path.map(|path| Config::from_file(&path)).transpose()?;
         Ok(maybe_config)


### PR DESCRIPTION
# Description

If `--host <addr>:0` is passed to `dfx start`, the dfx (icx-proxy) webserver will listen on an ephemeral port.  However, dfx will not connect to the running server unless dfx.json is first modified to reflect the dynamically-allocated port.

This shows up in the e2e test suite: after `dfx start`, the setup functions alter dfx.json.  Reviewers can see this in `_.bash`, which no longer alters dfx.json after `dfx start`.

In the upcoming system-wide dfx server changes, in many (if not most) cases there will not be a `local` network entry in dfx.json (project or shared) at all.  This means that tests would have to add a local network entry, which would change the conditions of the test.

`dfx start` also stores the port of the running webserver port in `.dfx/webserver-port`.  This PR makes dfx use this port if it is present in this file.

Before
```
$ dfx start --background --host 127.0.0.1:0
...
 Jun 28 20:31:11.687 INFO Starting server. Listening on http://127.0.0.1:56492/
$ dfx ping
Error: Failed while waiting for agent status.
Caused by: Failed while waiting for agent status.
  An error happened during communication with the replica: error sending request for url (http://127.0.0.1:8000/api/v2/status): error trying to connect: tcp connect error: Connection refused (os error 61)
```
After
```
$ dfx start --background --host 127.0.0.1:0
...
 Jun 28 20:34:03.216 INFO Starting server. Listening on http://127.0.0.1:56532/
$ dfx ping
{
  "ic_api_version": "0.18.0"  "impl_hash": "c01380c5c40891089bf295c7bc91ab157a9b8fff0417415239b54037d6211ab8"  "impl_version": "0.8.0"  "replica_health_status": "healthy"  "root_key": [48, 129, 130, 48, 29, 6, 13, 43, 6, 1, 4, 1, 130, 220, 124, 5, 3, 1, 2, 1, 6, 12, 43, 6, 1, 4, 1, 130, 220, 124, 5, 3, 2, 1, 3, 97, 0, 180, 206, 190, 177, 185, 147, 165, 78, 12, 208, 18, 119, 8, 66, 132, 236, 216, 108, 190, 216, 85, 33, 212, 189, 232, 225, 32, 34, 234, 3, 107, 114, 199, 222, 88, 36, 207, 179, 18, 247, 163, 58, 187, 114, 95, 237, 96, 83, 11, 243, 212, 39, 65, 107, 123, 73, 44, 248, 98, 24, 99, 39, 237, 202, 80, 163, 172, 163, 224, 137, 108, 82, 126, 255, 144, 125, 6, 243, 59, 47, 84, 194, 130, 114, 73, 224, 93, 38, 219, 136, 217, 248, 251, 104, 163, 222]
```

# How Has This Been Tested?

Covered by e2e tests and new unit tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] (n/a) I have made corresponding changes to the documentation.
