### PR TITLE
fix: when failing to convert a string to a principal, include the string in context

### DIFF
--- a/src/dfx/src/commands/ledger/create_canister.rs
+++ b/src/dfx/src/commands/ledger/create_canister.rs
@@ -53,6 +53,7 @@ pub async fn exec(env: &dyn Environment, opts: CreateCanisterOpts) -> DfxResult 
 
     let fee = opts
         .fee
+        .as_ref()
         .map_or(Ok(TRANSACTION_FEE), |v| {
             ICPTs::from_str(&v).map_err(|err| anyhow!(err))
         })
@@ -60,8 +61,12 @@ pub async fn exec(env: &dyn Environment, opts: CreateCanisterOpts) -> DfxResult 
 
     let memo = Memo(MEMO_CREATE_CANISTER);
 
-    let controller =
-        Principal::from_text(opts.controller).context("Failed to parse controller principal.")?;
+    let controller = Principal::from_text(&opts.controller).with_context(|| {
+        format!(
+            "Failed to parse {} as controller principal.",
+            &opts.controller
+        )
+    })?;
 
     let agent = env
         .get_agent()

--- a/src/dfx/src/commands/ledger/create_canister.rs
+++ b/src/dfx/src/commands/ledger/create_canister.rs
@@ -55,7 +55,7 @@ pub async fn exec(env: &dyn Environment, opts: CreateCanisterOpts) -> DfxResult 
         .fee
         .as_ref()
         .map_or(Ok(TRANSACTION_FEE), |v| {
-            ICPTs::from_str(&v).map_err(|err| anyhow!(err))
+            ICPTs::from_str(v).map_err(|err| anyhow!(err))
         })
         .context("Failed to determine fee.")?;
 

--- a/src/dfx/src/commands/ledger/notify/create_canister.rs
+++ b/src/dfx/src/commands/ledger/notify/create_canister.rs
@@ -21,8 +21,12 @@ pub struct NotifyCreateOpts {
 pub async fn exec(env: &dyn Environment, opts: NotifyCreateOpts) -> DfxResult {
     // validated by e8s_validator
     let block_height = opts.block_height.parse::<u64>().unwrap();
-    let controller =
-        Principal::from_text(opts.controller).context("Failed to parse destination principal.")?;
+    let controller = Principal::from_text(&opts.controller).with_context(|| {
+        format!(
+            "Failed to parse {} as destination principal.",
+            opts.controller
+        )
+    })?;
 
     let agent = env
         .get_agent()

--- a/src/dfx/src/commands/ledger/notify/top_up.rs
+++ b/src/dfx/src/commands/ledger/notify/top_up.rs
@@ -21,8 +21,12 @@ pub struct NotifyTopUpOpts {
 pub async fn exec(env: &dyn Environment, opts: NotifyTopUpOpts) -> DfxResult {
     // validated by e8s_validator
     let block_height = opts.block_height.parse::<u64>().unwrap();
-    let canister =
-        Principal::from_text(opts.canister).context("Failed to parse destination principal.")?;
+    let canister = Principal::from_text(&opts.canister).with_context(|| {
+        format!(
+            "Failed to parse {} as destination principal.",
+            opts.canister
+        )
+    })?;
 
     let agent = env
         .get_agent()

--- a/src/dfx/src/commands/ledger/top_up.rs
+++ b/src/dfx/src/commands/ledger/top_up.rs
@@ -55,7 +55,7 @@ pub async fn exec(env: &dyn Environment, opts: TopUpOpts) -> DfxResult {
         .fee
         .as_ref()
         .map_or(Ok(TRANSACTION_FEE), |v| {
-            ICPTs::from_str(&v).map_err(|err| anyhow!(err))
+            ICPTs::from_str(v).map_err(|err| anyhow!(err))
         })
         .context("Failed to determine fee.")?;
 

--- a/src/dfx/src/commands/ledger/top_up.rs
+++ b/src/dfx/src/commands/ledger/top_up.rs
@@ -53,6 +53,7 @@ pub async fn exec(env: &dyn Environment, opts: TopUpOpts) -> DfxResult {
 
     let fee = opts
         .fee
+        .as_ref()
         .map_or(Ok(TRANSACTION_FEE), |v| {
             ICPTs::from_str(&v).map_err(|err| anyhow!(err))
         })
@@ -60,8 +61,12 @@ pub async fn exec(env: &dyn Environment, opts: TopUpOpts) -> DfxResult {
 
     let memo = Memo(MEMO_TOP_UP_CANISTER);
 
-    let to = Principal::from_text(opts.canister)
-        .context("Failed to parse target canister principal.")?;
+    let to = Principal::from_text(&opts.canister).with_context(|| {
+        format!(
+            "Failed to parse {} as target canister principal.",
+            &opts.canister
+        )
+    })?;
 
     let agent = env
         .get_agent()

--- a/src/dfx/src/commands/wallet/add_controller.rs
+++ b/src/dfx/src/commands/wallet/add_controller.rs
@@ -14,8 +14,12 @@ pub struct AddControllerOpts {
 }
 
 pub async fn exec(env: &dyn Environment, opts: AddControllerOpts) -> DfxResult {
-    let controller =
-        Principal::from_text(opts.controller).context("Failed to parse controller principal.")?;
+    let controller = Principal::from_text(&opts.controller).with_context(|| {
+        format!(
+            "Failed to parse {} as controller principal.",
+            opts.controller
+        )
+    })?;
     wallet_update(env, "add_controller", controller).await?;
     println!("Added {} as a controller.", controller);
     Ok(())

--- a/src/dfx/src/commands/wallet/authorize.rs
+++ b/src/dfx/src/commands/wallet/authorize.rs
@@ -14,8 +14,8 @@ pub struct AuthorizeOpts {
 }
 
 pub async fn exec(env: &dyn Environment, opts: AuthorizeOpts) -> DfxResult {
-    let custodian =
-        Principal::from_text(opts.custodian).context("Failed to parse custodian principal.")?;
+    let custodian = Principal::from_text(&opts.custodian)
+        .with_context(|| format!("Failed to parse {} as custodian principal.", opts.custodian))?;
     wallet_update(env, "authorize", custodian).await?;
     println!("Authorized {} as a custodian.", custodian);
     Ok(())

--- a/src/dfx/src/commands/wallet/deauthorize.rs
+++ b/src/dfx/src/commands/wallet/deauthorize.rs
@@ -14,8 +14,8 @@ pub struct DeauthorizeOpts {
 }
 
 pub async fn exec(env: &dyn Environment, opts: DeauthorizeOpts) -> DfxResult {
-    let custodian =
-        Principal::from_text(&opts.custodian).context("Failed to parse custodian principal.")?;
+    let custodian = Principal::from_text(&opts.custodian)
+        .with_context(|| format!("Failed to parse {} as custodian principal.", opts.custodian))?;
     wallet_update(env, "deauthorize", custodian).await?;
     println!("Deauthorized {} as a custodian.", opts.custodian);
     Ok(())

--- a/src/dfx/src/commands/wallet/remove_controller.rs
+++ b/src/dfx/src/commands/wallet/remove_controller.rs
@@ -14,8 +14,12 @@ pub struct RemoveControllerOpts {
 }
 
 pub async fn exec(env: &dyn Environment, opts: RemoveControllerOpts) -> DfxResult {
-    let controller =
-        Principal::from_text(opts.controller).context("Failed to parse controller principal.")?;
+    let controller = Principal::from_text(&opts.controller).with_context(|| {
+        format!(
+            "Failed to parse {} as controller principal.",
+            opts.controller
+        )
+    })?;
     wallet_update(env, "remove_controller", controller).await?;
     println!("Removed {} as a controller.", controller);
     Ok(())

--- a/src/dfx/src/commands/wallet/send.rs
+++ b/src/dfx/src/commands/wallet/send.rs
@@ -28,8 +28,12 @@ pub async fn exec(env: &dyn Environment, opts: SendOpts) -> DfxResult {
         canister: Principal,
         amount: u128,
     }
-    let canister = Principal::from_text(&opts.destination)
-        .context("Failed to parse destination principal.")?;
+    let canister = Principal::from_text(&opts.destination).with_context(|| {
+        format!(
+            "Failed to parse {} as destination principal.",
+            &opts.destination
+        )
+    })?;
     // amount has been validated by cycle_amount_validator
     let amount = opts.amount.parse::<u128>().unwrap();
     let res = get_wallet(env)


### PR DESCRIPTION
Just to make it easier to find out what wasn't recognized as a principal
