### PR TITLE
fix: use debug formatter for principals that fail to parse

### DIFF
--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -100,7 +100,7 @@ async fn delete_canister(
         match withdraw_cycles_to_canister {
             Some(ref target_canister_id) => {
                 Some(Principal::from_text(target_canister_id).with_context(|| {
-                    format!("Failed to read canister id {}.", target_canister_id)
+                    format!("Failed to read canister id {:?}.", target_canister_id)
                 })?)
             }
             None => match call_sender {
@@ -127,7 +127,7 @@ async fn delete_canister(
     let dank_target_principal = match withdraw_cycles_to_dank_principal {
         None => principal,
         Some(principal) => Principal::from_text(&principal)
-            .with_context(|| format!("Failed to read principal {}.", &principal))?,
+            .with_context(|| format!("Failed to read principal {:?}.", &principal))?,
     };
     fetch_root_key_if_needed(env).await?;
 

--- a/src/dfx/src/commands/canister/send.rs
+++ b/src/dfx/src/commands/canister/send.rs
@@ -46,7 +46,7 @@ pub async fn exec(
         .context("Failed to create transport object.")?;
     let content = hex::decode(&message.content).context("Failed to decode message content.")?;
     let canister_id = Principal::from_text(message.canister_id.clone())
-        .with_context(|| format!("Failed to parse canister id {}.", message.canister_id))?;
+        .with_context(|| format!("Failed to parse canister id {:?}.", message.canister_id))?;
 
     if opts.status {
         if message.call_type.clone().as_str() != "update" {

--- a/src/dfx/src/commands/ledger/create_canister.rs
+++ b/src/dfx/src/commands/ledger/create_canister.rs
@@ -63,7 +63,7 @@ pub async fn exec(env: &dyn Environment, opts: CreateCanisterOpts) -> DfxResult 
 
     let controller = Principal::from_text(&opts.controller).with_context(|| {
         format!(
-            "Failed to parse {} as controller principal.",
+            "Failed to parse {:?} as controller principal.",
             &opts.controller
         )
     })?;

--- a/src/dfx/src/commands/ledger/notify/create_canister.rs
+++ b/src/dfx/src/commands/ledger/notify/create_canister.rs
@@ -23,7 +23,7 @@ pub async fn exec(env: &dyn Environment, opts: NotifyCreateOpts) -> DfxResult {
     let block_height = opts.block_height.parse::<u64>().unwrap();
     let controller = Principal::from_text(&opts.controller).with_context(|| {
         format!(
-            "Failed to parse {} as destination principal.",
+            "Failed to parse {:?} as destination principal.",
             opts.controller
         )
     })?;

--- a/src/dfx/src/commands/ledger/notify/top_up.rs
+++ b/src/dfx/src/commands/ledger/notify/top_up.rs
@@ -23,7 +23,7 @@ pub async fn exec(env: &dyn Environment, opts: NotifyTopUpOpts) -> DfxResult {
     let block_height = opts.block_height.parse::<u64>().unwrap();
     let canister = Principal::from_text(&opts.canister).with_context(|| {
         format!(
-            "Failed to parse {} as destination principal.",
+            "Failed to parse {:?} as destination principal.",
             opts.canister
         )
     })?;

--- a/src/dfx/src/commands/ledger/top_up.rs
+++ b/src/dfx/src/commands/ledger/top_up.rs
@@ -63,7 +63,7 @@ pub async fn exec(env: &dyn Environment, opts: TopUpOpts) -> DfxResult {
 
     let to = Principal::from_text(&opts.canister).with_context(|| {
         format!(
-            "Failed to parse {} as target canister principal.",
+            "Failed to parse {:?} as target canister principal.",
             &opts.canister
         )
     })?;

--- a/src/dfx/src/commands/wallet/add_controller.rs
+++ b/src/dfx/src/commands/wallet/add_controller.rs
@@ -16,7 +16,7 @@ pub struct AddControllerOpts {
 pub async fn exec(env: &dyn Environment, opts: AddControllerOpts) -> DfxResult {
     let controller = Principal::from_text(&opts.controller).with_context(|| {
         format!(
-            "Failed to parse {} as controller principal.",
+            "Failed to parse {:?} as controller principal.",
             opts.controller
         )
     })?;

--- a/src/dfx/src/commands/wallet/authorize.rs
+++ b/src/dfx/src/commands/wallet/authorize.rs
@@ -14,8 +14,12 @@ pub struct AuthorizeOpts {
 }
 
 pub async fn exec(env: &dyn Environment, opts: AuthorizeOpts) -> DfxResult {
-    let custodian = Principal::from_text(&opts.custodian)
-        .with_context(|| format!("Failed to parse {} as custodian principal.", opts.custodian))?;
+    let custodian = Principal::from_text(&opts.custodian).with_context(|| {
+        format!(
+            "Failed to parse {:?} as custodian principal.",
+            opts.custodian
+        )
+    })?;
     wallet_update(env, "authorize", custodian).await?;
     println!("Authorized {} as a custodian.", custodian);
     Ok(())

--- a/src/dfx/src/commands/wallet/deauthorize.rs
+++ b/src/dfx/src/commands/wallet/deauthorize.rs
@@ -14,8 +14,12 @@ pub struct DeauthorizeOpts {
 }
 
 pub async fn exec(env: &dyn Environment, opts: DeauthorizeOpts) -> DfxResult {
-    let custodian = Principal::from_text(&opts.custodian)
-        .with_context(|| format!("Failed to parse {} as custodian principal.", opts.custodian))?;
+    let custodian = Principal::from_text(&opts.custodian).with_context(|| {
+        format!(
+            "Failed to parse {:?} as custodian principal.",
+            opts.custodian
+        )
+    })?;
     wallet_update(env, "deauthorize", custodian).await?;
     println!("Deauthorized {} as a custodian.", opts.custodian);
     Ok(())

--- a/src/dfx/src/commands/wallet/remove_controller.rs
+++ b/src/dfx/src/commands/wallet/remove_controller.rs
@@ -16,7 +16,7 @@ pub struct RemoveControllerOpts {
 pub async fn exec(env: &dyn Environment, opts: RemoveControllerOpts) -> DfxResult {
     let controller = Principal::from_text(&opts.controller).with_context(|| {
         format!(
-            "Failed to parse {} as controller principal.",
+            "Failed to parse {:?} as controller principal.",
             opts.controller
         )
     })?;

--- a/src/dfx/src/commands/wallet/send.rs
+++ b/src/dfx/src/commands/wallet/send.rs
@@ -30,7 +30,7 @@ pub async fn exec(env: &dyn Environment, opts: SendOpts) -> DfxResult {
     }
     let canister = Principal::from_text(&opts.destination).with_context(|| {
         format!(
-            "Failed to parse {} as destination principal.",
+            "Failed to parse {:?} as destination principal.",
             &opts.destination
         )
     })?;

--- a/src/dfx/src/lib/identity/identity_utils.rs
+++ b/src/dfx/src/lib/identity/identity_utils.rs
@@ -21,7 +21,7 @@ pub async fn call_sender(_env: &dyn Environment, wallet: &Option<String>) -> Dfx
     let sender = if let Some(id) = wallet {
         CallSender::Wallet(
             Principal::from_text(&id)
-                .with_context(|| format!("Failed to read principal from {}.", id))?,
+                .with_context(|| format!("Failed to read principal from {:?}.", id))?,
         )
     } else {
         CallSender::SelectedId


### PR DESCRIPTION
Use `{:?}` to display any special characters in a principal that failed to parse
