### PR TITLE
feat: Allow users to configure logging level of bitcoin adapter

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,20 @@
 
 == DFX
 
+=== feat: Allow users to configure logging level of bitcoin adapter
+
+The bitcoin adapter's logging can be very verbose if debug logging is enabled, making it difficult to make sense of what's going on. On the other hand, these logs are useful for triaging problems.
+
+To get the best of both worlds, this commit adds support for an additional configuration option in dfx.json:
+
+    "bitcoin": {
+      "enabled": true,
+      "nodes": ["127.0.0.1:18444"],
+      "log_level": "info" <------- users can now configure the log level
+    }
+
+By default, a log level of "info" is used, which is relatively quiet. Users can change it to "debug" for more verbose logging.
+
 === chore: update Candid UI canister with commit bffa0ae3c416e8aa3c92c33722a6b1cb31d0f1c3
 
 This includes the following changes:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,7 +9,7 @@
 
 The bitcoin adapter's logging can be very verbose if debug logging is enabled, making it difficult to make sense of what's going on. On the other hand, these logs are useful for triaging problems.
 
-To get the best of both worlds, this commit adds support for an additional configuration option in dfx.json:
+To get the best of both worlds, this release adds support for an additional configuration option in dfx.json:
 
     "bitcoin": {
       "enabled": true,

--- a/src/dfx/src/commands/replica.rs
+++ b/src/dfx/src/commands/replica.rs
@@ -4,7 +4,6 @@ use crate::actors::{
 };
 use crate::config::dfinity::ConfigDefaultsReplica;
 use crate::error_invalid_argument;
-use crate::lib::bitcoin::adapter::config::Level;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::replica_config::{HttpHandlerConfig, ReplicaConfig};

--- a/src/dfx/src/commands/replica.rs
+++ b/src/dfx/src/commands/replica.rs
@@ -4,6 +4,7 @@ use crate::actors::{
 };
 use crate::config::dfinity::ConfigDefaultsReplica;
 use crate::error_invalid_argument;
+use crate::lib::bitcoin::adapter::config::Level;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::replica_config::{HttpHandlerConfig, ReplicaConfig};

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -435,6 +435,7 @@ pub fn configure_btc_adapter_if_enabled(
     nodes: Vec<SocketAddr>,
 ) -> DfxResult<Option<bitcoin::adapter::Config>> {
     let enable = enable_bitcoin || !nodes.is_empty() || config.get_defaults().get_bitcoin().enabled;
+    let log_level = config.get_defaults().get_bitcoin().log_level;
 
     if !enable {
         return Ok(None);
@@ -446,7 +447,7 @@ pub fn configure_btc_adapter_if_enabled(
         (_, _) => bitcoin::adapter::config::default_nodes(),
     };
 
-    let config = write_btc_adapter_config(uds_holder_path, config_path, nodes)?;
+    let config = write_btc_adapter_config(uds_holder_path, config_path, nodes, log_level)?;
     Ok(Some(config))
 }
 
@@ -486,10 +487,11 @@ fn write_btc_adapter_config(
     uds_holder_path: &Path,
     config_path: &Path,
     nodes: Vec<SocketAddr>,
+    log_level: bitcoin::adapter::config::Level,
 ) -> DfxResult<bitcoin::adapter::Config> {
     let socket_path = get_persistent_socket_path(uds_holder_path, "ic-btc-adapter-socket")?;
 
-    let adapter_config = bitcoin::adapter::Config::new(nodes, socket_path);
+    let adapter_config = bitcoin::adapter::Config::new(nodes, socket_path, log_level);
 
     let contents = serde_json::to_string_pretty(&adapter_config)
         .context("Unable to serialize btc adapter configuration to json")?;

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -487,7 +487,7 @@ fn write_btc_adapter_config(
     uds_holder_path: &Path,
     config_path: &Path,
     nodes: Vec<SocketAddr>,
-    log_level: bitcoin::adapter::config::Level,
+    log_level: bitcoin::adapter::config::BitcoinAdapterLogLevel,
 ) -> DfxResult<bitcoin::adapter::Config> {
     let socket_path = get_persistent_socket_path(uds_holder_path, "ic-btc-adapter-socket")?;
 

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+use crate::lib::bitcoin::adapter::config::Level;
 use crate::lib::error::{BuildError, DfxError, DfxResult};
 use crate::util::SerdeVec;
 use crate::{error_invalid_argument, error_invalid_config, error_invalid_data};
@@ -26,6 +27,7 @@ const EMPTY_CONFIG_DEFAULTS: ConfigDefaults = ConfigDefaults {
 const EMPTY_CONFIG_DEFAULTS_BITCOIN: ConfigDefaultsBitcoin = ConfigDefaultsBitcoin {
     enabled: false,
     nodes: None,
+    log_level: Level::Info,
 };
 
 const EMPTY_CONFIG_DEFAULTS_CANISTER_HTTP: ConfigDefaultsCanisterHttp =
@@ -103,6 +105,10 @@ pub struct ConfigDefaultsBitcoin {
     /// Addresses of nodes to connect to (in case discovery from seeds is not possible/sufficient)
     #[serde(default)]
     pub nodes: Option<Vec<SocketAddr>>,
+
+    /// The logging level of the adapter (e.g. "info", "debug", "error", etc.)
+    #[serde(default)]
+    pub log_level: Level,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use crate::lib::bitcoin::adapter::config::Level;
+use crate::lib::bitcoin::adapter::config::BitcoinAdapterLogLevel;
 use crate::lib::error::{BuildError, DfxError, DfxResult};
 use crate::util::SerdeVec;
 use crate::{error_invalid_argument, error_invalid_config, error_invalid_data};
@@ -27,7 +27,7 @@ const EMPTY_CONFIG_DEFAULTS: ConfigDefaults = ConfigDefaults {
 const EMPTY_CONFIG_DEFAULTS_BITCOIN: ConfigDefaultsBitcoin = ConfigDefaultsBitcoin {
     enabled: false,
     nodes: None,
-    log_level: Level::Info,
+    log_level: BitcoinAdapterLogLevel::Info,
 };
 
 const EMPTY_CONFIG_DEFAULTS_CANISTER_HTTP: ConfigDefaultsCanisterHttp =
@@ -108,7 +108,7 @@ pub struct ConfigDefaultsBitcoin {
 
     /// The logging level of the adapter (e.g. "info", "debug", "error", etc.)
     #[serde(default)]
-    pub log_level: Level,
+    pub log_level: BitcoinAdapterLogLevel,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -804,7 +804,7 @@ mod tests {
             &ConfigDefaultsBitcoin {
                 enabled: true,
                 nodes: Some(vec![SocketAddr::from_str("127.0.0.1:18444").unwrap()]),
-                log_level: Level::Info
+                log_level: BitcoinAdapterLogLevel::Info
             }
         );
     }

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -830,7 +830,7 @@ mod tests {
             &ConfigDefaultsBitcoin {
                 enabled: true,
                 nodes: Some(vec![SocketAddr::from_str("127.0.0.1:18444").unwrap()]),
-                log_level: Level::Info // A default log level of "info" is assumed
+                log_level: BitcoinAdapterLogLevel::Info // A default log level of "info" is assumed
             }
         );
     }
@@ -856,7 +856,7 @@ mod tests {
             &ConfigDefaultsBitcoin {
                 enabled: true,
                 nodes: None,
-                log_level: Level::Debug
+                log_level: BitcoinAdapterLogLevel::Debug
             }
         );
     }

--- a/src/dfx/src/lib/bitcoin/adapter/config.rs
+++ b/src/dfx/src/lib/bitcoin/adapter/config.rs
@@ -36,10 +36,10 @@ impl Default for IncomingSource {
     }
 }
 
-/// Represents the log level.
+/// Represents the log level of the bitcoin adapter.
 #[derive(Clone, Debug, Serialize, Deserialize, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum Level {
+pub enum BitcoinAdapterLogLevel {
     Critical,
     Error,
     Warning,
@@ -48,31 +48,31 @@ pub enum Level {
     Trace,
 }
 
-impl FromStr for Level {
+impl FromStr for BitcoinAdapterLogLevel {
     type Err = String;
 
-    fn from_str(input: &str) -> Result<Level, Self::Err> {
+    fn from_str(input: &str) -> Result<BitcoinAdapterLogLevel, Self::Err> {
         match input {
-            "critical" => Ok(Level::Critical),
-            "error" => Ok(Level::Error),
-            "warning" => Ok(Level::Warning),
-            "info" => Ok(Level::Info),
-            "debug" => Ok(Level::Debug),
-            "trace" => Ok(Level::Trace),
+            "critical" => Ok(BitcoinAdapterLogLevel::Critical),
+            "error" => Ok(BitcoinAdapterLogLevel::Error),
+            "warning" => Ok(BitcoinAdapterLogLevel::Warning),
+            "info" => Ok(BitcoinAdapterLogLevel::Info),
+            "debug" => Ok(BitcoinAdapterLogLevel::Debug),
+            "trace" => Ok(BitcoinAdapterLogLevel::Trace),
             other => Err(format!("Unknown log level: {}", other)),
         }
     }
 }
 
-impl Default for Level {
+impl Default for BitcoinAdapterLogLevel {
     fn default() -> Self {
-        Level::Info
+        BitcoinAdapterLogLevel::Info
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct LoggerConfig {
-    level: Level,
+    level: BitcoinAdapterLogLevel,
 }
 
 /// This struct contains configuration options for the BTC Adapter.
@@ -95,7 +95,11 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new(nodes: Vec<SocketAddr>, uds_path: PathBuf, log_level: Level) -> Config {
+    pub fn new(
+        nodes: Vec<SocketAddr>,
+        uds_path: PathBuf,
+        log_level: BitcoinAdapterLogLevel,
+    ) -> Config {
         Config {
             network: String::from("regtest"),
             nodes,

--- a/src/dfx/src/lib/bitcoin/adapter/config.rs
+++ b/src/dfx/src/lib/bitcoin/adapter/config.rs
@@ -37,7 +37,7 @@ impl Default for IncomingSource {
 }
 
 /// Represents the log level.
-#[derive(Clone, Debug, Serialize, Deserialize, Copy)]
+#[derive(Clone, Debug, Serialize, Deserialize, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Level {
     Critical,


### PR DESCRIPTION
# Description

The bitcoin adapter's logging can be very verbose if `debug` logging is enabled, making it difficult to make sense of what's going on. On the other hand, these logs are useful for triaging problems.

To get the best of both worlds, this commit adds support for an additional configuration option in `dfx.json`:

```
  "defaults": {
    "bitcoin": {
      "enabled": true,
      "nodes": ["127.0.0.1:18444"],
      "log_level": "info" <------- users can now configure the log level
    },
```

By default, a log level of "info" is used, which is relatively quiet. Users can change it to "debug" for more verbose logging.

# How Has This Been Tested?

I ran `dfx start` with various configurations of `dfx.json` and verified from the logs that the bitcoin adapter gets initialized with the expected log level.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
