### PR TITLE
test: widen e2e timeout to account for rust test timeouts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,8 +127,8 @@ jobs:
           fi
           export
       - name: Run e2e test
-        # rust tests sometimes fail with a 30-minute timeout
-        run: timeout 2100 bats "e2e/$E2E_TEST"
+        # rust tests sometimes fail with a 35-minute timeout
+        run: timeout 2700 bats "e2e/$E2E_TEST"
 
   aggregate:
     name: e2e:required


### PR DESCRIPTION
The rust e2e tests sometimes time out after 35 minutes.  This PR widens the timeout to 45 minutes.  This is too long, but we will soon remove the `ic-cdk-optimizer` step, which will reduce the test time substantially.  In the meantime, having to manually rerun failed tests frequently is worse.
