### PR TITLE
chore: update mergify config for hydra removal, GH-based license check

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,12 +3,11 @@ queue_rules:
     conditions:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
-      - status-success=hydra:dfinity-ci-build:evaluation
-      - status-success=hydra:dfinity-ci-build:sdk:required
       - status-success=audit:required
       - status-success=e2e:required
       - status-success=fmt:required
       - status-success=lint:required
+      - status-success=license-check:required
       - status-success=prepare-dfx-assets:required
       - base=master
       - label=automerge-squash
@@ -18,12 +17,11 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
-      - status-success=hydra:dfinity-ci-build:evaluation
-      - status-success=hydra:dfinity-ci-build:sdk:required
       - status-success=audit:required
       - status-success=e2e:required
       - status-success=fmt:required
       - status-success=lint:required
+      - status-success=license-check:required
       - status-success=prepare-dfx-assets:required
       - base=master
       - label=automerge-squash

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,8 +6,8 @@ queue_rules:
       - status-success=audit:required
       - status-success=e2e:required
       - status-success=fmt:required
-      - status-success=lint:required
       - status-success=license-check:required
+      - status-success=lint:required
       - status-success=prepare-dfx-assets:required
       - base=master
       - label=automerge-squash
@@ -20,8 +20,8 @@ pull_request_rules:
       - status-success=audit:required
       - status-success=e2e:required
       - status-success=fmt:required
-      - status-success=lint:required
       - status-success=license-check:required
+      - status-success=lint:required
       - status-success=prepare-dfx-assets:required
       - base=master
       - label=automerge-squash


### PR DESCRIPTION
Hydra no longer reports (or checks) any statuses, so remove these from the mergify config

Also, add the `license-check:required` (cargo deny) step

