### PR TITLE
refactor: optimize from ic-wasm

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,12 @@
 
 == DFX
 
+=== refactor: optimize from ic-wasm
+
+Optimize Rust canister WASM module via ic-wasm library instead of ic-cdk-optimizer.
+
+The actual optimization kept the same.
+
 === fix: Use default setting for BTC adapter idle seconds
 
 A lower threshold was no longer necessary.

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,7 +9,7 @@
 
 Optimize Rust canister WASM module via ic-wasm library instead of ic-cdk-optimizer.
 
-The actual optimization kept the same.
+The actual optimization was kept the same.
 
 === fix: Use default setting for BTC adapter idle seconds
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "binaryen"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783bea139d75b6a565b13fab54d12ec4d58724a9458598ad7283d578f4f8777a"
+dependencies = [
+ "binaryen-sys",
+]
+
+[[package]]
+name = "binaryen-sys"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e9636d01b92f2df45dce29c35a9e3724687c1055bb4472fb4b829cc4a5a561"
+dependencies = [
+ "cc",
+ "cmake",
+ "heck 0.3.3",
+ "regex",
+]
+
+[[package]]
 name = "binread"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +783,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1568,6 +1598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+
+[[package]]
 name = "group"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1732,12 @@ name = "humanize-rs"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "016b02deb8b0c415d8d56a6f0ab265e50c22df61194e37f9be75ed3a722de8a6"
+
+[[package]]
+name = "humansize"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
 name = "humantime"
@@ -1867,12 +1909,14 @@ dependencies = [
 [[package]]
 name = "ic-wasm"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f30356f66151c27e681c22b9775466e409bc52f1f7aad3ce9c2f7566492358"
+source = "git+https://github.com/dfinity/ic-wasm?branch=lwshang/optimize#5deb5c580f96d5350065ffe690ce37e4d12e0e44"
 dependencies = [
  "anyhow",
+ "binaryen",
  "candid",
  "clap",
+ "humansize",
+ "wabt",
  "walrus",
 ]
 
@@ -3906,6 +3950,29 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wabt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bef93d5e6c81a293bccf107cf43aa47239382f455ba14869d36695d8963b9c"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wabt-sys",
+]
+
+[[package]]
+name = "wabt-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a4e043159f63e16986e713e9b5e1c06043df4848565bf672e27c523864c7791"
+dependencies = [
+ "cc",
+ "cmake",
+ "glob",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,10 +1912,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41e494b1607f1d7b1e07041e711dd6b15e885edbc7802d02eb7fd3ad70ee5e06"
 dependencies = [
- "anyhow",
  "binaryen",
  "candid",
- "clap",
  "humansize",
  "wabt",
  "walrus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "ic-wasm"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic-wasm?branch=lwshang/optimize#5deb5c580f96d5350065ffe690ce37e4d12e0e44"
+source = "git+https://github.com/dfinity/ic-wasm?branch=lwshang/optimize#f532ceec1d40d4b8c4d63e3f15b040ed2e54abc9"
 dependencies = [
  "anyhow",
  "binaryen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,8 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "ic-wasm"
-version = "0.1.2"
-source = "git+https://github.com/dfinity/ic-wasm?branch=lwshang/optimize#f532ceec1d40d4b8c4d63e3f15b040ed2e54abc9"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e494b1607f1d7b1e07041e711dd6b15e885edbc7802d02eb7fd3ad70ee5e06"
 dependencies = [
  "anyhow",
  "binaryen",

--- a/e2e/tests-dfx/rust.bash
+++ b/e2e/tests-dfx/rust.bash
@@ -3,8 +3,6 @@
 
 load ../utils/_
 
-[ -e "${assets:?}/installed/bin/ic-cdk-optimizer" ] || cargo install ic-cdk-optimizer --root "$assets/installed" &> /dev/null
-
 setup() {
     standard_setup
 }
@@ -21,10 +19,8 @@ teardown() {
     dfx_start
     dfx canister create --all
     assert_command dfx build hello
-    assert_match "ic-cdk-optimizer not installed"
-    export PATH="$assets/installed/bin/:$PATH"
     assert_command dfx build hello
-    assert_match "Executing: ic-cdk-optimizer"
+    assert_match "Optimizing WASM module."
     assert_command dfx canister install hello
     assert_command dfx canister call hello greet dfinity
     assert_match '("Hello, dfinity!")'
@@ -33,7 +29,6 @@ teardown() {
 @test "rust canister can resolve dependencies" {
     dfx_new_rust rust_deps
     install_asset rust_deps
-    export PATH="$assets/installed/bin/:$PATH"
     dfx_start
     assert_command dfx deploy
     assert_command dfx canister call multiply_deps read
@@ -48,7 +43,6 @@ teardown() {
     dfx_new_rust
     CARGO_TARGET_DIR="$(echo -ne '\x81')"
     export CARGO_TARGET_DIR
-    export PATH="$assets/installed/bin/:$PATH"
     dfx_start
     assert_command dfx deploy
     assert_command dfx canister call e2e_project greet dfinity

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -42,7 +42,7 @@ futures = "0.3.21"
 garcon = { version = "0.2", features = ["async"] }
 hex = {version = "0.4.2", features = ["serde"] }
 ic-types = "0.3.0"
-ic-wasm = "0.1.0"
+ic-wasm = { git = "https://github.com/dfinity/ic-wasm", branch = "lwshang/optimize", features = ["exe", "optimize"]}
 indicatif = "0.16.0"
 itertools = "0.10.3"
 lazy-init = "0.5.0"

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -42,7 +42,7 @@ futures = "0.3.21"
 garcon = { version = "0.2", features = ["async"] }
 hex = {version = "0.4.2", features = ["serde"] }
 ic-types = "0.3.0"
-ic-wasm = { version = "0.1.3", features = ["optimize"]}
+ic-wasm = { version = "0.1.3", default-features = false, features = ["optimize"]}
 indicatif = "0.16.0"
 itertools = "0.10.3"
 lazy-init = "0.5.0"

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -42,7 +42,7 @@ futures = "0.3.21"
 garcon = { version = "0.2", features = ["async"] }
 hex = {version = "0.4.2", features = ["serde"] }
 ic-types = "0.3.0"
-ic-wasm = { git = "https://github.com/dfinity/ic-wasm", branch = "lwshang/optimize", features = ["exe", "optimize"]}
+ic-wasm = { version = "0.1.3", features = ["optimize"]}
 indicatif = "0.16.0"
 itertools = "0.10.3"
 lazy-init = "0.5.0"

--- a/src/dfx/src/lib/builders/rust.rs
+++ b/src/dfx/src/lib/builders/rust.rs
@@ -12,7 +12,7 @@ use anyhow::{anyhow, bail, Context};
 use fn_error_context::context;
 use ic_types::principal::Principal as CanisterId;
 use serde::Deserialize;
-use slog::{info, o, warn};
+use slog::{info, o};
 use std::path::PathBuf;
 use std::process::Command;
 use std::process::Stdio;
@@ -100,38 +100,14 @@ impl CanisterBuilder for RustBuilder {
         );
         let output = cargo.output().context("Failed to run 'cargo build'.")?;
 
-        if Command::new("ic-cdk-optimizer")
-            .arg("--version")
-            .output()
-            .is_ok()
-        {
-            let mut optimizer = Command::new("ic-cdk-optimizer");
-            let wasm_path = rust_info.get_output_wasm_path();
-            optimizer
-                .stdout(Stdio::inherit())
-                .stderr(Stdio::inherit())
-                .arg("-o")
-                .arg(wasm_path)
-                .arg(wasm_path);
-            // The optimized wasm overwrites the original wasm.
-            // Because the `get_output_wasm_path` must give the same path,
-            // no matter optimized or not.
-            info!(
-                self.logger,
-                "Executing: ic-cdk-optimizer -o {0} {0}",
-                wasm_path.display()
-            );
-            if !matches!(optimizer.status(), Ok(status) if status.success()) {
-                warn!(self.logger, "Failed to run ic-cdk-optimizer.");
-            }
-        } else {
-            warn!(
-                self.logger,
-                "ic-cdk-optimizer not installed, the output WASM module is not optimized in size.
-Run `cargo install ic-cdk-optimizer` to install it.
-                "
-            );
-        }
+        let wasm_path = rust_info.get_output_wasm_path();
+        let wasm = std::fs::read(wasm_path).expect("Could not read the WASM module.");
+        let wasm_optimized =
+            ic_wasm::optimize::optimize(&wasm).map_err(|e| anyhow!(e.to_string()))?;
+        // The optimized wasm overwrites the original wasm.
+        // Because the `get_output_wasm_path` must give the same path,
+        // no matter optimized or not.
+        std::fs::write(wasm_path, wasm_optimized).expect("Could not write optimized WASM module.");
 
         if !output.status.success() {
             bail!("Failed to compile the rust package: {}", package);

--- a/src/dfx/src/lib/builders/rust.rs
+++ b/src/dfx/src/lib/builders/rust.rs
@@ -100,6 +100,7 @@ impl CanisterBuilder for RustBuilder {
         );
         let output = cargo.output().context("Failed to run 'cargo build'.")?;
 
+        info!(self.logger, "Optimizing WASM module.");
         let wasm_path = rust_info.get_output_wasm_path();
         let wasm = std::fs::read(wasm_path).expect("Could not read the WASM module.");
         let wasm_optimized =


### PR DESCRIPTION
# Description

Optimize rust canister wasm module via ic-wasm library instead of ic-cdk-optimizer.
This might make CI faster.

# How Has This Been Tested?

`dfx build` in a default rust canister project. The optimized wasm was the same w/o this refactor.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
