### PR TITLE
test: reduce e2e test timeout to 30 minutes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,8 +127,7 @@ jobs:
           fi
           export
       - name: Run e2e test
-        # rust tests sometimes fail with a 35-minute timeout
-        run: timeout 2700 bats "e2e/$E2E_TEST"
+        run: timeout 1800 bats "e2e/$E2E_TEST"
 
   aggregate:
     name: e2e:required


### PR DESCRIPTION
The rust e2e tests are now taking <25 minutes
