### PR TITLE
chore: Revert "feat: Add additional logging from bitcoin canister in replica."

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,10 +5,6 @@
 
 == DFX
 
-=== feat: Add additional logging from bitcoin canister in replica.
-
-Configures the replica to emit additional logging from the bitcoin canister whenever the bitcoin feature is enabled. This helps show useful information to developers, such as the bitcoin height that the replica currently sees.
-
 === feat: renamed canisters in new projects to <project>_frontend and <project>_backend
 
 The names of canisters created for new projects have changed.

--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -318,10 +318,6 @@ fn replica_start_thread(
                     socket_path.to_str().unwrap_or_default(),
                 ]);
             }
-
-            // Show debug logs from the bitcoin canister.
-            // This helps developers see, for example, the current tip height.
-            cmd.args(&["--debug-overrides", "ic_btc_canister::heartbeat"]);
         }
         if config.canister_http_adapter.enabled {
             cmd.args(&["--subnet-features", "http_requests"]);


### PR DESCRIPTION
Reverts dfinity/sdk#2318

This change is preventing us from updating to the latest hotfix replica (example: https://github.com/dfinity/sdk/pull/2341 and [build failure](https://github.com/dfinity/sdk/runs/7326295725?check_suite_focus=true#step:8:1357)).  Will re-incorporate this change when future replica releases support it.