### PR TITLE
chore: update changelog post dfx 0.11.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,13 +3,15 @@
 
 = UNRELEASED
 
-= 0.11.0
-
 == DFX
 
 === feat: Use `+--locked+` for Rust canisters
 
 `+dfx build+`, in Rust canisters, now uses the `+--locked+` flag when building with Cargo. To offset this, `+dfx new --type rust+` now runs `+cargo update+` on the resulting project.
+
+= 0.11.0
+
+== DFX
 
 === feat: renamed canisters in new projects to <project>_frontend and <project>_backend
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,6 +3,8 @@
 
 = UNRELEASED
 
+= 0.11.0
+
 == DFX
 
 === feat: renamed canisters in new projects to <project>_frontend and <project>_backend


### PR DESCRIPTION
Just updates the changelog so that changes after dfx 0.11.0 go in the right place