### PR TITLE
fix: make sure dfx can load dfx.json with a custom canister with no build step

### DIFF
--- a/e2e/assets/custom_canister/dfx.json
+++ b/e2e/assets/custom_canister/dfx.json
@@ -12,6 +12,11 @@
       "candid": "main.did",
       "wasm": "main.wasm",
       "build": "build.sh"
+    },
+    "custom3": {
+      "type": "custom",
+      "candid": "main.did",
+      "wasm": "main.wasm"
     }
   },
   "defaults": {

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -776,7 +776,7 @@ impl<'de> Visitor<'de> for PropertiesVisitor {
                 source: source.ok_or_else(|| missing_field("source"))?,
             },
             Some("custom") => CanisterTypeProperties::Custom {
-                build: build.ok_or_else(|| missing_field("build"))?,
+                build: build.unwrap_or_default()?,
                 candid: candid.ok_or_else(|| missing_field("candid"))?,
                 wasm: wasm.ok_or_else(|| missing_field("wasm"))?,
             },

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -776,7 +776,7 @@ impl<'de> Visitor<'de> for PropertiesVisitor {
                 source: source.ok_or_else(|| missing_field("source"))?,
             },
             Some("custom") => CanisterTypeProperties::Custom {
-                build: build.unwrap_or_default()?,
+                build: build.unwrap_or_default(),
                 candid: candid.ok_or_else(|| missing_field("candid"))?,
                 wasm: wasm.ok_or_else(|| missing_field("wasm"))?,
             },


### PR DESCRIPTION
# Description

Adds a test for https://github.com/dfinity/sdk/pull/2351, and updates the custom deserializer to use a default for the `build` field.

There's no change to the changelog, because this is covered by an existing entry, in the current `UNRELEASED` section.

# How Has This Been Tested?

Updated an existing e2e test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
