### PR TITLE
refactor: CanisterIdStore::new

### DIFF
--- a/src/dfx/src/commands/bootstrap.rs
+++ b/src/dfx/src/commands/bootstrap.rs
@@ -119,7 +119,7 @@ pub fn exec(env: &dyn Environment, opts: BootstrapOpts) -> DfxResult {
                 env.get_logger().clone(),
                 build_output_root,
                 network_descriptor,
-                config.get_project_root().to_path_buf(),
+                config,
                 env.get_temp_dir().to_path_buf(),
                 webserver_bind,
             )?;

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -330,7 +330,7 @@ pub fn exec(
             env.get_logger().clone(),
             build_output_root,
             network_descriptor,
-            config.get_project_root().to_path_buf(),
+            config,
             env.get_temp_dir().to_path_buf(),
             webserver_bind,
         )?;

--- a/src/dfx/src/lib/models/canister_id_store.rs
+++ b/src/dfx/src/lib/models/canister_id_store.rs
@@ -1,4 +1,4 @@
-use crate::config::dfinity::NetworkType;
+use crate::config::dfinity::{Config, NetworkType};
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::network::network_descriptor::NetworkDescriptor;
@@ -9,6 +9,7 @@ use fn_error_context::context;
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 type CanisterName = String;
 type NetworkName = String;
@@ -33,27 +34,22 @@ pub struct CanisterIdStore {
 impl CanisterIdStore {
     #[context("Failed to load canister id store.")]
     pub fn for_env(env: &dyn Environment) -> DfxResult<Self> {
-        let network_descriptor = env.get_network_descriptor();
-        let config = env.get_config();
-        let project_root = config.map(|c| c.get_project_root().to_path_buf());
-        let project_root = project_root.as_deref();
-        let store =
-            CanisterIdStore::for_network(network_descriptor, project_root, env.get_temp_dir())?;
-
-        let remote_ids = get_remote_ids(env)?;
-
-        Ok(CanisterIdStore {
-            remote_ids,
-            ..store
-        })
+        CanisterIdStore::new(
+            env.get_network_descriptor(),
+            env.get_config(),
+            env.get_temp_dir(),
+        )
     }
 
     #[context("Failed to load canister id store for network '{}'.", network_descriptor.name)]
-    pub fn for_network(
+    pub fn new(
         network_descriptor: &NetworkDescriptor,
-        project_root: Option<&Path>,
+        config: Option<Arc<Config>>,
         project_temp_dir: &Path,
     ) -> DfxResult<Self> {
+        let project_root = config.as_ref().map(|c| c.get_project_root().to_path_buf());
+        let project_root = project_root.as_deref();
+        let remote_ids = get_remote_ids(config)?;
         let path = match network_descriptor {
             NetworkDescriptor {
                 r#type: NetworkType::Persistent,
@@ -72,7 +68,7 @@ impl CanisterIdStore {
             network_descriptor: network_descriptor.clone(),
             path,
             ids,
-            remote_ids: None,
+            remote_ids,
         })
     }
 
@@ -187,8 +183,8 @@ impl CanisterIdStore {
 }
 
 #[context("Failed to get remote ids.")]
-fn get_remote_ids(env: &dyn Environment) -> DfxResult<Option<CanisterIds>> {
-    let config = if let Some(cfg) = env.get_config() {
+fn get_remote_ids(config: Option<Arc<Config>>) -> DfxResult<Option<CanisterIds>> {
+    let config = if let Some(cfg) = config {
         cfg
     } else {
         return Ok(None);


### PR DESCRIPTION
# Description

Add/refactor `CanisterIdStore::new` to make it possible to create a CanisterIdStore, with mappings for remote canister ids, without having to construct an AgentEnvironment.

See https://github.com/dfinity/sdk/pull/2375 for an example of where one might want to do this.

# How Has This Been Tested?

Covered by existing e2e tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] (no need) I have edited the CHANGELOG accordingly.
- [x] (n/a) I have made corresponding changes to the documentation.
