### PR TITLE
fix: use `dfinity-bot` instead of `github bot` to avoid signing CLA in GHA workflow

### DIFF
--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -71,6 +71,7 @@ jobs:
     - name: create Pull Request, with CHANGELOG.adoc entry suggestion 
       uses: actions/github-script@v6
       with:
+        github-token: ${{ secrets.NIV_UPDATER_TOKEN }} # act on behalf of https://github.com/dfinity-bot 
         script: |
           const { repo, owner } = context.repo;
 


### PR DESCRIPTION
# Description

Use https://github.com/dfinity-bot to create the PR produced by `.github/workflows/update-replica-version.yml` workflow. This will help avoid asking GitHub Bot to sign CLA (example https://github.com/dfinity/sdk/pull/2379).
Fixes/continuation of: https://github.com/dfinity/sdk/pull/2377

# How Has This Been Tested?

forked and tested there

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
