### PR TITLE
refactor: standard setup and teardown for mode_reinstall, upgrade_check

### DIFF
--- a/e2e/tests-dfx/mode_reinstall.bash
+++ b/e2e/tests-dfx/mode_reinstall.bash
@@ -3,20 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    x=$(mktemp -d -t dfx-e2e-XXXXXXXX)
-    export DFX_CACHE_ROOT="$x"
-    export DFX_CONFIG_ROOT="$x"
-    cd "$x" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
 
     dfx_new hello
 }
 
 teardown() {
     dfx_stop
-    rm -rf "$DFX_CACHE_ROOT"
-    rm -rf "$DFX_CONFIG_ROOT"
+
+    standard_teardown
 }
 
 @test "install --mode=reinstall --all fails" {

--- a/e2e/tests-dfx/upgrade_check.bash
+++ b/e2e/tests-dfx/upgrade_check.bash
@@ -3,20 +3,15 @@
 load ../utils/_
 
 setup() {
-    # We want to work from a temporary directory, different for every test.
-    x=$(mktemp -d -t dfx-e2e-XXXXXXXX)
-    export DFX_CACHE_ROOT="$x"
-    export DFX_CONFIG_ROOT="$x"
-    cd "$x" || exit
-    export RUST_BACKTRACE=1
+    standard_setup
 
     dfx_new hello
 }
 
 teardown() {
     dfx_stop
-    rm -rf "$DFX_CACHE_ROOT"
-    rm -rf "$DFX_CONFIG_ROOT"
+
+    standard_teardown
 }
 
 @test "safe upgrade by adding a new stable variable" {


### PR DESCRIPTION
Two test files were still doing their own setup and teardown.  In particular, this means they didn't set up an isolated $HOME directory.

