### PR TITLE
refactor: Identity::wallet_canister_id returns DfxResult<Option<Principal>>

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,12 @@
 
 == DFX
 
+=== fix: dfx wallet upgrade: improved error message if there is no wallet to upgrade
+
+= 0.11.1
+
+== DFX
+
 === fix: dfx now only adds candid:service metadata to custom canisters that have at least one build step
 
 This way, if a canister uses a premade canister wasm, dfx will use it as-is.

--- a/e2e/tests-dfx/wallet.bash
+++ b/e2e/tests-dfx/wallet.bash
@@ -170,3 +170,8 @@ teardown() {
     dfx --identity alice deploy --no-wallet hello_backend
     assert_command dfx canister --wallet "$(dfx identity get-wallet)" deposit-cycles 1 hello_backend
 }
+
+@test "detects if there is no wallet to upgrade" {
+    assert_command_fail dfx wallet upgrade
+    assert_match "There is no wallet defined for identity 'default' on network 'local'. Nothing to do."
+}

--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -114,10 +114,7 @@ async fn delete_canister(
                         .expect("No selected identity.")
                         .to_string();
                     // If there is no wallet, then do not attempt to withdraw the cycles.
-                    match Identity::wallet_canister_id(env, network, &identity_name) {
-                        Ok(canister_id) => Some(canister_id),
-                        Err(_) => None,
-                    }
+                    Identity::wallet_canister_id(env, network, &identity_name)?
                 }
             },
         }

--- a/src/dfx/src/commands/wallet/upgrade.rs
+++ b/src/dfx/src/commands/wallet/upgrade.rs
@@ -21,7 +21,16 @@ pub async fn exec(env: &dyn Environment, _opts: UpgradeOpts) -> DfxResult {
     // Network descriptor will always be set.
     let network = env.get_network_descriptor();
 
-    let canister_id = Identity::wallet_canister_id(env, network, &identity_name)?;
+    let canister_id =
+        if let Some(principal) = Identity::wallet_canister_id(env, network, &identity_name)? {
+            principal
+        } else {
+            bail!(
+                "There is no wallet defined for identity '{}' on network '{}'.  Nothing to do.",
+                identity_name,
+                &network.name
+            );
+        };
 
     let agent = env
         .get_agent()

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -564,8 +564,8 @@ impl Identity {
         name: &str,
         create: bool,
     ) -> DfxResult<Principal> {
-        match Identity::wallet_canister_id(env, network, name) {
-            Err(_) => {
+        match Identity::wallet_canister_id(env, network, name)? {
+            None => {
                 // If the network is not the IC, we ignore the error and create a new wallet for the identity.
                 if !network.is_ic || create {
                     Identity::create_wallet(env, network, name, None).await
@@ -577,7 +577,7 @@ impl Identity {
                     - Configure a wallet for this identity/network combination: 'dfx identity --network <network name> set-wallet <wallet id>'.".to_string())).context("Wallet not configured.")
                 }
             }
-            x => x,
+            Some(principal) => Ok(principal),
         }
     }
 
@@ -586,31 +586,19 @@ impl Identity {
         env: &dyn Environment,
         network: &NetworkDescriptor,
         name: &str,
-    ) -> DfxResult<Principal> {
+    ) -> DfxResult<Option<Principal>> {
         let wallet_path = Identity::get_wallet_config_file(env, network, name)?;
         if !wallet_path.exists() {
-            return Err(anyhow!(
-                "Failed to find wallet file {}.",
-                wallet_path.to_string_lossy()
-            ));
+            return Ok(None);
         }
 
         let config = Identity::load_wallet_config(&wallet_path)?;
 
-        let wallet_network = config.identities.get(name).ok_or_else(|| {
-            anyhow!(
-                "Could not find wallet for \"{}\" on \"{}\" network.",
-                name,
-                network.name.clone()
-            )
-        })?;
-        Ok(*wallet_network.networks.get(&network.name).ok_or_else(|| {
-            anyhow!(
-                "Could not find wallet for \"{}\" on \"{}\" network.",
-                name,
-                network.name.clone()
-            )
-        })?)
+        let maybe_wallet_principal = config
+            .identities
+            .get(name)
+            .and_then(|wallet_network| wallet_network.networks.get(&network.name).cloned());
+        Ok(maybe_wallet_principal)
     }
 
     #[context("Failed to construct wallet canister caller.")]

--- a/src/dfx/src/lib/migrate.rs
+++ b/src/dfx/src/lib/migrate.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Context, Error};
+use anyhow::{bail, Context, Error};
 use candid::{CandidType, Deserialize, Principal};
 use ic_agent::{Agent, Identity as _};
 use ic_utils::{
@@ -34,8 +34,12 @@ pub async fn migrate(env: &dyn Environment, network: &NetworkDescriptor, fix: bo
     let mut mgr = IdentityManager::new(env)?;
     let ident = mgr.instantiate_selected_identity()?;
     let mut did_migrate = false;
-    let wallet = Identity::wallet_canister_id(env, network, ident.name())
-        .map_err(|_| anyhow!("No wallet found; nothing to do"))?;
+    let wallet = if let Some(principal) = Identity::wallet_canister_id(env, network, ident.name())?
+    {
+        principal
+    } else {
+        bail!("No wallet found; nothing to do");
+    };
     let wallet = if let Ok(wallet) = WalletCanister::create(agent, wallet).await {
         wallet
     } else {


### PR DESCRIPTION
# Description

If there's no `wallets.json` file, or if `wallets.json` doesn't have a wallet id for a given identity/network, this isn't an error.  It instead means there's no wallet for that identity on that network.

Actual errors could be things like permissions errors, or malformed json.

This PR changes `Identity::wallet_canister_id` to return `DfxResult<Option<Principal>>`.

As can be seen in the PR, most callers discard any error details and assume that any error means that there was no wallet.  But we should report things like permissions problems or malformed errors as errors.

# How Has This Been Tested?

Added an e2e test.

before
```
$ dfx --identity alice wallet upgrade
Error: Failed to get wallet canister id for identity 'alice' on network 'local'.
Caused by: Failed to get wallet canister id for identity 'alice' on network 'local'.
  Could not find wallet for "alice" on "local" network.
```

after
```
$ dfx --identity alice wallet upgrade
Error: There is no wallet defined for identity 'alice' on network 'local'.  Nothing to do.
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] (n/a) I have made corresponding changes to the documentation.
