### PR TITLE
fix: always write .old.did under .dfx/

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,18 @@
 
 == DFX
 
+=== fix: dfx deploy and dfx canister install write .old.did files under .dfx/
+
+When dfx deploy and dfx canister install upgrade a canister, they ensure that the
+new candid interface is compatible with the previous candid interface.  They write
+a file with extension .old.did that contains the previous interface.  In some
+circumstances these files could be written in the project directory.  dfx now
+always writes them under the .dfx/ directory.
+
+= 0.11.1
+
+== DFX
+
 === fix: dfx now only adds candid:service metadata to custom canisters that have at least one build step
 
 This way, if a canister uses a premade canister wasm, dfx will use it as-is.

--- a/e2e/tests-dfx/build.bash
+++ b/e2e/tests-dfx/build.bash
@@ -149,6 +149,21 @@ teardown() {
   assert_command diff main.did installed.did
 }
 
+@test "upgrade check writes .old.did under .dfx" {
+  install_asset custom_canister
+  dfx_start
+  dfx deploy
+
+  echo yes | dfx deploy --mode=reinstall custom
+
+  # dfx intentionally leaves this file after creating it for comparison,
+  # so that the developer can look at the differences too.
+  # This test makes sure that the file is created under the .dfx/ directory,
+  # which is where other temporary / build artifacts go.
+  assert_file_not_exists ./main.old.did
+  assert_file_exists .dfx/local/canisters/custom/custom.old.did
+}
+
 @test "custom canister build script picks local executable first" {
   install_asset custom_canister
   dfx_start

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -58,8 +58,7 @@ pub async fn install_canister(
             let candid_path = canister_info
                 .get_output_idl_path()
                 .expect("Generated did file not found");
-            let deployed_path = canister_info
-                .get_build_idl_path().with_extension("old.did");
+            let deployed_path = canister_info.get_build_idl_path().with_extension("old.did");
             std::fs::write(&deployed_path, candid).with_context(|| {
                 format!(
                     "Failed to write candid to {}.",

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -58,7 +58,8 @@ pub async fn install_canister(
             let candid_path = canister_info
                 .get_output_idl_path()
                 .expect("Generated did file not found");
-            let deployed_path = candid_path.with_extension("old.did");
+            let deployed_path = canister_info
+                .get_build_idl_path().with_extension("old.did");
             std::fs::write(&deployed_path, candid).with_context(|| {
                 format!(
                     "Failed to write candid to {}.",


### PR DESCRIPTION
# Description

When dfx deploy and dfx canister install upgrade a canister, they ensure that the
new candid interface is compatible with the previous candid interface.  They write
a file with extension .old.did that contains the previous interface.  In some
circumstances these files could be written in the project directory.  dfx now
always writes them under the .dfx/ directory.

Fixes https://dfinity.atlassian.net/browse/SDK-643

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
