### PR TITLE
fix: do not add candid:service metadata to custom canisters

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,10 @@
 
 == DFX
 
+=== fix: dfx no longer adds candid:service metadata to custom canisters
+
+Instead, you can use https://github.com/dfinity/ic-wasm in your custom canister's build step if necessary.
+
 === feat!: removed the internal webserver
 
 This is a breaking change.  The only thing this was still serving was the /_/candid endpoint.  If you need to retrieve the candid interface for a local canister, you can use `dfx canister metadata <canister> candid:service`.

--- a/e2e/tests-dfx/build.bash
+++ b/e2e/tests-dfx/build.bash
@@ -143,10 +143,6 @@ teardown() {
   dfx canister install --all
   assert_command dfx canister call custom fromQuery
   assert_command dfx canister call custom2 fromQuery
-
-  # dfx sets the candid:service metadata
-  dfx canister metadata custom candid:service >installed.did
-  assert_command diff main.did installed.did
 }
 
 @test "upgrade check writes .old.did under .dfx" {
@@ -226,25 +222,23 @@ teardown() {
   assert_command ls .dfx/actuallylocal/canisters/e2e_project_backend/e2e_project_backend.wasm
 }
 
-@test "does not add candid:service metadata for a custom canister if there are no build steps" {
+@test "does not add candid:service metadata for a custom canister" {
   install_asset prebuilt_custom_canister
 
   dfx_start
   dfx deploy
 
-  # this canister has a build step, so dfx sets the candid metadata
-  dfx canister metadata custom_with_build_step candid:service >from_canister.txt
-  diff custom_with_build_step.did from_canister.txt
+  # in all cases, dfx leaves the candid:service metadata alone
 
-  # this canister doesn't have a build step, so dfx leaves the candid metadata as-is
+  dfx canister metadata custom_with_build_step candid:service >from_canister.txt
+  diff main.did from_canister.txt
+
   dfx canister metadata prebuilt_custom_no_build candid:service >from_canister.txt
   diff main.did from_canister.txt
 
-  # this canister has a build step, but it is an empty string, so dfx leaves the candid:service metadata as-is
   dfx canister metadata prebuilt_custom_blank_build candid:service >from_canister.txt
   diff main.did from_canister.txt
 
-  # this canister has a build step, but it is an empty array, so dfx leaves the candid:service metadata as-is
   dfx canister metadata prebuilt_custom_empty_build candid:service >from_canister.txt
   diff main.did from_canister.txt
 }

--- a/src/dfx/src/lib/builders/custom.rs
+++ b/src/dfx/src/lib/builders/custom.rs
@@ -103,7 +103,6 @@ impl CanisterBuilder for CustomBuilder {
         let canister_id = info.get_canister_id().unwrap();
         let vars = super::environment_variables(info, &config.network_name, pool, &dependencies);
 
-        let mut add_candid_service_metadata = false;
         for command in build {
             info!(
                 self.logger,
@@ -117,7 +116,6 @@ impl CanisterBuilder for CustomBuilder {
                 .with_context(|| format!("Cannot parse command '{}'.", command))?;
             // No commands, noop.
             if !args.is_empty() {
-                add_candid_service_metadata = true;
                 run_command(args, &vars, info.get_workspace_root())
                     .with_context(|| format!("Failed to run {}.", command))?;
             }
@@ -127,7 +125,7 @@ impl CanisterBuilder for CustomBuilder {
             canister_id,
             wasm: WasmBuildOutput::File(wasm),
             idl: IdlBuildOutput::File(candid),
-            add_candid_service_metadata,
+            add_candid_service_metadata: false,
         })
     }
 


### PR DESCRIPTION
# Description

It turns out it's surprising that dfx adds custom metadata to custom canisters.  For the sake of build reproducibility, let's have dfx leave custom canisters alone.  The build step can use ic-wasm if appropriate, instead.

Fixes https://dfinity.atlassian.net/browse/SDK-644

# How Has This Been Tested?

Updated existing e2e tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
