### PR TITLE
refactor: canister id store: use config temp path

### DIFF
--- a/src/dfx/src/commands/language_service.rs
+++ b/src/dfx/src/commands/language_service.rs
@@ -56,8 +56,7 @@ pub fn exec(env: &dyn Environment, opts: LanguageServiceOpts) -> DfxResult {
             None, /* opts.network */
             LocalBindDetermination::ApplyRunningWebserverPort,
         )?;
-        let canister_id_store =
-            CanisterIdStore::new(&network_descriptor, env.get_config(), env.get_temp_dir())?;
+        let canister_id_store = CanisterIdStore::new(&network_descriptor, env.get_config())?;
         for canister_name in canister_names {
             match canister_id_store.get(&canister_name) {
                 Ok(canister_id) => package_arguments.append(&mut vec![


### PR DESCRIPTION
# Description

Use Config.get_temp_path() rather than Environment.get_temp…_dir() for canister id store path lookup.

They are the same value (`.dfx/` directory next to `dfx.json`).

If there's no Config, we can use None for the canister id store path.  Anywhere that might call CanisterIdStore.save() has already checked get_config_or_anyhow().

This removes another caller of Environment.get_temp_dir()

# How Has This Been Tested?

Handled by existing e2e tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] (n/a) I have edited the CHANGELOG accordingly.
- [x] (n/a) I have made corresponding changes to the documentation.
