### PR TITLE
feat: Change `--controller` to `--set-controller`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,10 @@
 
 == DFX
 
+=== feat!: changed update-settings syntax
+
+When using `+dfx canister update-settings+`, it is easy to mistake `+--controller+` for `+--add-controller+`. For this reason `+--controller+` has been renamed to `+--set-controller+`.
+
 === feat!: removed the internal webserver
 
 This is a breaking change.  The only thing this was still serving was the /_/candid endpoint.  If you need to retrieve the candid interface for a local canister, you can use `dfx canister metadata <canister> candid:service`.

--- a/docs/cli-reference/dfx-canister.md
+++ b/docs/cli-reference/dfx-canister.md
@@ -908,7 +908,7 @@ You can specify the following options for the `dfx canister update-settings` com
 |--------------------------------------------|--------------|
 | `--add-controller <principal>`             | Add a principal to the list of controllers of the canister.  |
 | `-c`, `--compute-allocation <allocation>`  | Specifies the canister's compute allocation. This should be a percent in the range [0..100].  |
-| `--controller <principal>`                 | Specifies the identity name or the principal of the new controller.  |
+| `--set-controller <principal>`             | Specifies the identity name or the principal of the new controller.  |
 | `--memory-allocation <allocation>`         | Specifies how much memory the canister is allowed to use in total. This should be a value in the range [0..12 GiB]. A setting of 0 means the canister will have access to memory on a “best-effort” basis: It will only be charged for the memory it uses, but at any point in time may stop running if it tries to allocate more memory when there isn’t space available on the subnet. |
 | `--remove-controller <principal>`          | Removes a principal from the list of controllers of the canister. |
 | `--freezing-threshold <seconds>`           | Set the [freezing threshold](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-create_canister) in seconds for a canister. This should be a value in the range [0..2^64^-1]. Very long thresholds require the `--confirm-very-long-freezing-threshold` flag.  |

--- a/e2e/tests-dfx/update_settings.bash
+++ b/e2e/tests-dfx/update_settings.bash
@@ -48,7 +48,7 @@ teardown() {
     ID=$(dfx canister id hello_backend)
 
     # Set controller using canister name and identity name
-    assert_command dfx canister update-settings hello_backend --controller bob
+    assert_command dfx canister update-settings hello_backend --set-controller bob
     assert_match "Set controller of \"hello_backend\" to: bob"
 
     # Bob is controller, Alice cannot reinstall
@@ -59,23 +59,23 @@ teardown() {
 
     assert_command dfx identity use bob
     # Set controller using canister id and principal
-    assert_command dfx canister update-settings "$ID" --controller "${ALICE_PRINCIPAL}"
+    assert_command dfx canister update-settings "$ID" --set-controller "${ALICE_PRINCIPAL}"
     assert_match "Set controller of \"${ID}\" to: ${ALICE_PRINCIPAL}"
     echo "yes" | assert_command_fail dfx canister install hello_backend -m reinstall
 
     # Set controller using combination of name/id and identity/principal
-    assert_command dfx --identity alice canister update-settings hello_backend --controller "${BOB_PRINCIPAL}"
+    assert_command dfx --identity alice canister update-settings hello_backend --set-controller "${BOB_PRINCIPAL}"
     assert_match "Set controller of \"hello_backend\" to: ${BOB_PRINCIPAL}"
 
-    assert_command dfx --identity bob canister update-settings "${ID}" --controller alice
+    assert_command dfx --identity bob canister update-settings "${ID}" --set-controller alice
     assert_match "Set controller of \"${ID}\" to: alice"
 
     # Set controller using invalid principal/identity fails
-    assert_command_fail dfx --identity alice canister update-settings hello_backend --controller charlie
+    assert_command_fail dfx --identity alice canister update-settings hello_backend --set-controller charlie
     assert_match "Identity charlie does not exist"
 
     # Set controller using invalid canister name/id fails
-    assert_command_fail dfx --identity alice canister update-settings hello_assets --controller bob
+    assert_command_fail dfx --identity alice canister update-settings hello_assets --set-controller bob
     assert_match "Cannot find canister id. Please issue 'dfx canister create hello_assets'."
 }
 
@@ -96,7 +96,7 @@ teardown() {
     ID=$(dfx canister id hello_backend)
 
     # Set controller using canister name and identity name
-    assert_command dfx canister --wallet "${ALICE_WALLET}" update-settings hello_backend --controller "${BOB_WALLET}"
+    assert_command dfx canister --wallet "${ALICE_WALLET}" update-settings hello_backend --set-controller "${BOB_WALLET}"
     assert_match "Set controller of \"hello_backend\" to: ${BOB_WALLET}"
 
     # Bob is controller, Alice cannot reinstall
@@ -107,23 +107,23 @@ teardown() {
 
     assert_command dfx identity use bob
     # Set controller using canister id and principal
-    assert_command dfx canister --wallet "${BOB_WALLET}" update-settings "${ID}" --controller "${ALICE_WALLET}"
+    assert_command dfx canister --wallet "${BOB_WALLET}" update-settings "${ID}" --set-controller "${ALICE_WALLET}"
     assert_match "Set controller of \"${ID}\" to: ${ALICE_WALLET}"
     echo "yes" | assert_command_fail dfx canister --wallet "${BOB_WALLET}" install hello_backend -m reinstall
 
     # Set controller using combination of name/id and identity/principal
-    assert_command dfx --identity alice canister --wallet "${ALICE_WALLET}" update-settings hello_backend --controller "${BOB_WALLET}"
+    assert_command dfx --identity alice canister --wallet "${ALICE_WALLET}" update-settings hello_backend --set-controller "${BOB_WALLET}"
     assert_match "Set controller of \"hello_backend\" to: ${BOB_WALLET}"
 
-    assert_command dfx --identity bob canister --wallet "${BOB_WALLET}" update-settings "${ID}" --controller alice
+    assert_command dfx --identity bob canister --wallet "${BOB_WALLET}" update-settings "${ID}" --set-controller alice
     assert_match "Set controller of \"${ID}\" to: alice"
 
     # Set controller using invalid principal/identity fails
-    assert_command_fail dfx --identity alice canister --wallet "${ALICE_WALLET}" update-settings hello_backend --controller charlie
+    assert_command_fail dfx --identity alice canister --wallet "${ALICE_WALLET}" update-settings hello_backend --set-controller charlie
     assert_match "Identity charlie does not exist"
 
     # Set controller using invalid canister name/id fails
-    assert_command_fail dfx --identity alice canister --wallet "${ALICE_WALLET}" update-settings hello_assets --controller bob
+    assert_command_fail dfx --identity alice canister --wallet "${ALICE_WALLET}" update-settings hello_assets --set-controller bob
     assert_match "Cannot find canister id. Please issue 'dfx canister create hello_assets'."
 }
 
@@ -146,7 +146,7 @@ teardown() {
     ID=$(dfx canister id hello_backend)
 
     # Set controller using canister name and identity name
-    assert_command dfx canister --wallet "${ALICE_WALLET}" update-settings hello_backend --controller "${BOB_WALLET}"
+    assert_command dfx canister --wallet "${ALICE_WALLET}" update-settings hello_backend --set-controller "${BOB_WALLET}"
     assert_match "Set controller of \"hello_backend\" to: ${BOB_WALLET}"
 
     # Bob is controller, Alice cannot reinstall
@@ -157,23 +157,23 @@ teardown() {
 
     assert_command dfx identity use bob
     # Set controller using canister id and principal
-    assert_command dfx canister --wallet "${BOB_WALLET}" update-settings "${ID}" --controller "${ALICE_WALLET}"
+    assert_command dfx canister --wallet "${BOB_WALLET}" update-settings "${ID}" --set-controller "${ALICE_WALLET}"
     assert_match "Set controller of \"${ID}\" to: ${ALICE_WALLET}"
     echo "yes" | assert_command_fail dfx canister --wallet "${BOB_WALLET}" install hello_backend -m reinstall
 
     # Set controller using combination of name/id and identity/principal
-    assert_command dfx --identity alice canister --wallet "${ALICE_WALLET}" update-settings hello_backend --controller "${BOB_WALLET}"
+    assert_command dfx --identity alice canister --wallet "${ALICE_WALLET}" update-settings hello_backend --set-controller "${BOB_WALLET}"
     assert_match "Set controller of \"hello_backend\" to: ${BOB_WALLET}"
 
-    assert_command dfx --identity bob canister --wallet "${BOB_WALLET}" update-settings "${ID}" --controller alice
+    assert_command dfx --identity bob canister --wallet "${BOB_WALLET}" update-settings "${ID}" --set-controller alice
     assert_match "Set controller of \"${ID}\" to: alice"
 
     # Set controller using invalid principal/identity fails
-    assert_command_fail dfx --identity alice canister update-settings hello_backend --controller charlie
+    assert_command_fail dfx --identity alice canister update-settings hello_backend --set-controller charlie
     assert_match "Identity charlie does not exist"
 
     # Set controller using invalid canister name/id fails
-    assert_command_fail dfx --identity alice canister update-settings hello_assets --controller bob
+    assert_command_fail dfx --identity alice canister update-settings hello_assets --set-controller bob
     assert_match "Cannot find canister id. Please issue 'dfx canister create hello_assets'."
 }
 
@@ -196,7 +196,7 @@ teardown() {
     ID=$(dfx canister id hello_backend)
 
     # Set controller using canister name and identity name
-    assert_command dfx canister update-settings hello_backend --controller bob
+    assert_command dfx canister update-settings hello_backend --set-controller bob
     assert_match "Set controller of \"hello_backend\" to: bob"
 
     # Bob is controller, Alice cannot reinstall
@@ -207,23 +207,23 @@ teardown() {
 
     assert_command dfx identity use bob
     # Set controller using canister id and principal
-    assert_command dfx canister update-settings "$ID" --controller "${ALICE_PRINCIPAL}"
+    assert_command dfx canister update-settings "$ID" --set-controller "${ALICE_PRINCIPAL}"
     assert_match "Set controller of \"${ID}\" to: ${ALICE_PRINCIPAL}"
     echo "yes" | assert_command_fail dfx canister install hello_backend -m reinstall
 
     # Set controller using combination of name/id and identity/principal
-    assert_command dfx --identity alice canister update-settings hello_backend --controller "${BOB_PRINCIPAL}"
+    assert_command dfx --identity alice canister update-settings hello_backend --set-controller "${BOB_PRINCIPAL}"
     assert_match "Set controller of \"hello_backend\" to: ${BOB_PRINCIPAL}"
 
-    assert_command dfx --identity bob canister update-settings "${ID}" --controller alice
+    assert_command dfx --identity bob canister update-settings "${ID}" --set-controller alice
     assert_match "Set controller of \"${ID}\" to: alice"
 
     # Set controller using invalid principal/identity fails
-    assert_command_fail dfx --identity alice canister update-settings hello_backend --controller charlie
+    assert_command_fail dfx --identity alice canister update-settings hello_backend --set-controller charlie
     assert_match "Identity charlie does not exist"
 
     # Set controller using invalid canister name/id fails
-    assert_command_fail dfx --identity alice canister update-settings hello_assets --controller bob
+    assert_command_fail dfx --identity alice canister update-settings hello_assets --set-controller bob
     assert_match "Cannot find canister id. Please issue 'dfx canister create hello_assets'."
 }
 
@@ -247,7 +247,7 @@ teardown() {
     ID=$(dfx canister id hello_backend)
 
     # Set controller using canister name and identity name
-    assert_command dfx canister update-settings hello_backend --controller "${ALICE_PRINCIPAL}" --controller "${BOB_PRINCIPAL}"
+    assert_command dfx canister update-settings hello_backend --set-controller "${ALICE_PRINCIPAL}" --set-controller "${BOB_PRINCIPAL}"
     assert_match "Set controllers of \"hello_backend\" to: $PRINCIPALS_SORTED"
 
     # Both can reinstall
@@ -276,7 +276,7 @@ teardown() {
     ID=$(dfx canister id hello_backend)
 
     # Set controller using canister name and identity name
-    assert_command dfx canister --wallet "${ALICE_WALLET}" update-settings hello_backend --controller "${ALICE_WALLET}" --controller "${BOB_WALLET}"
+    assert_command dfx canister --wallet "${ALICE_WALLET}" update-settings hello_backend --set-controller "${ALICE_WALLET}" --set-controller "${BOB_WALLET}"
     assert_match "Set controllers of \"hello_backend\" to: ${WALLETS_SORTED}"
 
     # Both can reinstall
@@ -307,7 +307,7 @@ teardown() {
     ID=$(dfx canister id hello_backend)
 
     # Set controller using canister name and identity name
-    assert_command dfx canister --wallet "${ALICE_WALLET}" update-settings hello_backend --controller "${ALICE_WALLET}" --controller "${BOB_WALLET}"
+    assert_command dfx canister --wallet "${ALICE_WALLET}" update-settings hello_backend --set-controller "${ALICE_WALLET}" --set-controller "${BOB_WALLET}"
     assert_match "Set controllers of \"hello_backend\" to: $WALLETS_SORTED"
 
     # Both can reinstall
@@ -339,7 +339,7 @@ teardown() {
     ID=$(dfx canister id hello_backend)
 
     # Set controller using canister name and identity name
-    assert_command dfx canister update-settings hello_backend --controller "${ALICE_PRINCIPAL}" --controller "${BOB_PRINCIPAL}"
+    assert_command dfx canister update-settings hello_backend --set-controller "${ALICE_PRINCIPAL}" --set-controller "${BOB_PRINCIPAL}"
     assert_match "Set controllers of \"hello_backend\" to: $PRINCIPALS_SORTED"
 
     # Both can reinstall

--- a/e2e/tests-dfx/wallet.bash
+++ b/e2e/tests-dfx/wallet.bash
@@ -68,8 +68,8 @@ teardown() {
     ID_TWO=$(dfx canister --network actuallylocal id hello_frontend)
 
     # set controller to user
-    dfx canister --network actuallylocal update-settings hello_backend --controller "$(dfx identity get-principal)"
-    dfx canister --network actuallylocal update-settings hello_frontend --controller "$(dfx identity get-principal)"
+    dfx canister --network actuallylocal update-settings hello_backend --set-controller "$(dfx identity get-principal)"
+    dfx canister --network actuallylocal update-settings hello_frontend --set-controller "$(dfx identity get-principal)"
 
     assert_command_fail dfx identity --network actuallylocal set-wallet "${ID}"
     assert_not_match "Setting wallet for identity"
@@ -91,8 +91,8 @@ teardown() {
     ID_TWO=$(dfx canister --network actuallylocal id hello_backend)
 
     # set controller to user
-    dfx canister --network actuallylocal update-settings hello_backend --controller "$(dfx identity get-principal)"
-    dfx canister --network actuallylocal update-settings hello_frontend --controller "$(dfx identity get-principal)"
+    dfx canister --network actuallylocal update-settings hello_backend --set-controller "$(dfx identity get-principal)"
+    dfx canister --network actuallylocal update-settings hello_frontend --set-controller "$(dfx identity get-principal)"
 
     # We're testing on a local network so the create command actually creates a wallet
     # Delete this file to force associate wallet created by deploy-wallet to identity

--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -32,7 +32,7 @@ pub struct UpdateSettingsOpts {
 
     /// Specifies the identity name or the principal of the new controller.
     #[clap(long, multiple_occurrences(true))]
-    controller: Option<Vec<String>>,
+    set_controller: Option<Vec<String>>,
 
     /// Add a principal to the list of controllers of the canister.
     #[clap(long, multiple_occurrences(true), conflicts_with("controller"))]
@@ -90,7 +90,7 @@ pub async fn exec(
     let config_interface = config.get_config();
     fetch_root_key_if_needed(env).await?;
 
-    let controllers: Option<DfxResult<Vec<_>>> = opts.controller.as_ref().map(|controllers| {
+    let controllers: Option<DfxResult<Vec<_>>> = opts.set_controller.as_ref().map(|controllers| {
         let y: DfxResult<Vec<_>> = controllers
             .iter()
             .map(|controller| controller_to_principal(env, controller))
@@ -99,7 +99,7 @@ pub async fn exec(
     });
     let controllers = controllers
         .transpose()
-        .context("Failed to determine all new controllers given in --controllers.")?;
+        .context("Failed to determine all new controllers given in --set-controller.")?;
 
     let canister_id_store = CanisterIdStore::for_env(env)?;
 
@@ -253,7 +253,7 @@ fn controller_to_principal(env: &dyn Environment, controller: &str) -> DfxResult
 }
 
 fn display_controller_update(opts: &UpdateSettingsOpts, canister_name_or_id: &str) {
-    if let Some(new_controllers) = opts.controller.as_ref() {
+    if let Some(new_controllers) = opts.set_controller.as_ref() {
         let mut controllers = new_controllers.clone();
         controllers.sort();
 


### PR DESCRIPTION
Resolves SDK-583.

A user mistakenly entered `--controller`, in `dfx canister update-settings`, instead of `--add-controller`, removing the DFX principal as a controller. This solves such a confusion by renaming it to `--set-controller`.