### PR TITLE
feat: enable canister sandboxing

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,10 @@ a file with extension .old.did that contains the previous interface.  In some
 circumstances these files could be written in the project directory.  dfx now
 always writes them under the .dfx/ directory.
 
+=== feat: enable canister sandboxing
+
+Canister sandboxing is enabled to be consistent with the mainnet.
+
 = 0.11.1
 
 == DFX

--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -310,6 +310,10 @@ fn replica_start_thread(
         if let Some(port) = port {
             cmd.args(&["--http-port", &port.to_string()]);
         }
+        // Enable canister sandboxing to be consistent with the mainnet.
+        // The flag will be removed on the `ic-starter` side once this
+        // change is rolled out without any issues.
+        cmd.args(&["--subnet-features", "canister_sandboxing"]);
         if config.btc_adapter.enabled {
             cmd.args(&["--subnet-features", "bitcoin_regtest"]);
             if let Some(socket_path) = config.btc_adapter.socket_path {


### PR DESCRIPTION
The mainnet runs with canister sandboxing, so dfx also should
run with canister sandboxing to be consistent otherwise some
upcoming features like deterministic time slicing would not
work in dfx.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
