### PR TITLE
refactor: make temp dir optional

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,7 +9,10 @@
 
 This is a breaking change.  The only thing this was still serving was the /_/candid endpoint.  If you need to retrieve the candid interface for a local canister, you can use `dfx canister metadata <canister> candid:service`.
 
-=== fix: dfx wallet upgrade: improved error message if there is no wallet to upgrade
+=== fix: dfx wallet upgrade: improved error messages:
+
+- if there is no wallet to upgrade
+- if trying to upgrade a local wallet from outside of a project directory
 
 === fix: dfx deploy and dfx canister install write .old.did files under .dfx/
 

--- a/e2e/tests-dfx/wallet.bash
+++ b/e2e/tests-dfx/wallet.bash
@@ -175,3 +175,8 @@ teardown() {
     assert_command_fail dfx wallet upgrade
     assert_match "There is no wallet defined for identity 'default' on network 'local'. Nothing to do."
 }
+
+@test "cannot interact with a wallet for a local network outside of a project directory" {
+    assert_command_fail dfx wallet upgrade
+    assert_match "It's only possible to interact with a wallet for a local network from a project directory."
+}

--- a/e2e/tests-dfx/wallet.bash
+++ b/e2e/tests-dfx/wallet.bash
@@ -172,6 +172,7 @@ teardown() {
 }
 
 @test "detects if there is no wallet to upgrade" {
+    dfx_new hello
     assert_command_fail dfx wallet upgrade
     assert_match "There is no wallet defined for identity 'default' on network 'local'. Nothing to do."
 }

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -176,7 +176,7 @@ pub fn exec(
     // As we know no start process is running in this project, we can
     // clean up the state if it is necessary.
     if clean {
-        clean_state(env.get_temp_dir(), &state_root)?;
+        clean_state(&local_server_descriptor.data_directory, &state_root)?;
     }
 
     let pid_file_path = empty_writable_path(pid_file_path)?;

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -290,10 +290,12 @@ impl Identity {
                     .join(name)
                     .join(WALLET_CONFIG_FILENAME)
             }
-            NetworkType::Ephemeral => env
-                .get_temp_dir()
-                .join("local")
-                .join(WALLET_CONFIG_FILENAME),
+            NetworkType::Ephemeral => {
+                env.get_project_temp_dir()
+                    .ok_or_else(||anyhow!("It's only possible to interact with a wallet for a local network from a project directory."))?
+                    .join("local")
+                    .join(WALLET_CONFIG_FILENAME)
+            }
         })
     }
 
@@ -470,16 +472,15 @@ impl Identity {
                 persistent_wallet_path,
             )?;
         }
-        let local_wallet_path = env
-            .get_temp_dir()
-            .join("local")
-            .join(WALLET_CONFIG_FILENAME);
-        if local_wallet_path.exists() {
-            Identity::rename_wallet_global_config_key(
-                original_identity,
-                renamed_identity,
-                local_wallet_path,
-            )?;
+        if let Some(temp_dir) = env.get_project_temp_dir() {
+            let local_wallet_path = temp_dir.join("local").join(WALLET_CONFIG_FILENAME);
+            if local_wallet_path.exists() {
+                Identity::rename_wallet_global_config_key(
+                    original_identity,
+                    renamed_identity,
+                    local_wallet_path,
+                )?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
# Description

This PR renames `Environment::get_temp_dir()` to `get_project_temp_dir()`.  It returns either the `.dfx/` directory in the same directory as `dfx.json`, or None if there is no project.

`Environment::get_temp_dir()` is only used in two places:
- when looking up the wallet id for a network with ephemeral canister ids, which only makes sense within a project directory
- when renaming an identity, which already allows for the wallet configuration file to not exist

This also means that dfx no longer creates a temporary directory if run outside of a project directory.  These temporary directories were never cleaned up.  It would never make sense to write or read a wallets.json file within such a temporary directory.

before
```
$ dfx wallet upgrade
dfx.json not found, using default.
Error: Failed to get wallet canister id for identity 'default' on network 'local'.
Caused by: Failed to get wallet canister id for identity 'default' on network 'local'.
  Failed to find wallet file /var/folders/7l/6w8kktld2xn8qfz_m84bx18c0000gn/T/.tmpgCtaaH/local/wallets.json.
```

after
```
$ dfx-wip wallet upgrade
dfx.json not found, using default.
Error: Failed to get wallet canister id for identity 'default' on network 'local'.
Caused by: Failed to get wallet canister id for identity 'default' on network 'local'.
  Failed to get path to wallet config file for identity 'default' on network 'local'.
    It's only possible to interact with a wallet for a local network from a project directory.
```

# How Has This Been Tested?

Added an e2e test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] (n/a) I have made corresponding changes to the documentation.
