### PR TITLE
fix: update-settings conflicts controller -> set-controller

### DIFF
--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -35,11 +35,11 @@ pub struct UpdateSettingsOpts {
     set_controller: Option<Vec<String>>,
 
     /// Add a principal to the list of controllers of the canister.
-    #[clap(long, multiple_occurrences(true), conflicts_with("controller"))]
+    #[clap(long, multiple_occurrences(true), conflicts_with("set-controller"))]
     add_controller: Option<Vec<String>>,
 
     /// Removes a principal from the list of controllers of the canister.
-    #[clap(long, multiple_occurrences(true), conflicts_with("controller"))]
+    #[clap(long, multiple_occurrences(true), conflicts_with("set-controller"))]
     remove_controller: Option<Vec<String>>,
 
     /// Specifies the canister's compute allocation. This should be a percent in the range [0..100]


### PR DESCRIPTION
# Description

Fixes a panic in `dfx canister update-settings` that only happens when run in a debug build.

# How Has This Been Tested?

before
```
$ dfx canister update-settings
thread 'main' panicked at 'Command update-settings: Argument or group 'set_controller' specified in 'conflicts_with*' for 'add-controller' does not exist', /Users/ericswanson/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.12/src/builder/debug_asserts.rs:237:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

after
```
$ dfx canister update-settings
error: The following required arguments were not provided:
    --all

USAGE:
    dfx canister update-settings --all
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] (no need) I have edited the CHANGELOG accordingly.
- [x] (no need) I have made corresponding changes to the documentation.
