### PR TITLE
refactor: rename DFX_E2E_TEMP_DIR -> E2E_TEMP_DIR

### DIFF
--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -123,7 +123,7 @@ teardown() {
     ID="$(dfx canister id hello_backend)"
     NETWORK="http://localhost:$(cat .dfx/webserver-port)"
     (
-        cd "$DFX_E2E_TEMP_DIR"
+        cd "$E2E_TEMP_DIR"
         mkdir "not-a-project-dir"
         cd "not-a-project-dir"
         assert_command dfx canister call "$ID" greet '("you")' --network "$NETWORK"

--- a/e2e/tests-dfx/ping.bash
+++ b/e2e/tests-dfx/ping.bash
@@ -38,9 +38,9 @@ teardown() {
     dfx_start
     webserver_port=$(get_webserver_port)
 
-    mkdir "$DFX_E2E_TEMP_DIR/not-a-project"
+    mkdir "$E2E_TEMP_DIR/not-a-project"
     (
-        cd "$DFX_E2E_TEMP_DIR/not-a-project"
+        cd "$E2E_TEMP_DIR/not-a-project"
 
         assert_command dfx ping http://127.0.0.1:"$webserver_port"
         assert_match "\"ic_api_version\""

--- a/e2e/tests-dfx/sign_send.bash
+++ b/e2e/tests-dfx/sign_send.bash
@@ -41,7 +41,7 @@ teardown() {
 }
 
 @test "sign outside of a dfx project" {
-    cd "$DFX_E2E_TEMP_DIR"
+    cd "$E2E_TEMP_DIR"
     mkdir not-a-project-dir
     cd not-a-project-dir
 

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -13,7 +13,7 @@ install_asset() {
 standard_setup() {
     # We want to work from a temporary directory, different for every test.
     x=$(mktemp -d -t dfx-e2e-XXXXXXXX)
-    export DFX_E2E_TEMP_DIR="$x"
+    export E2E_TEMP_DIR="$x"
 
     mkdir "$x/working-dir"
     mkdir "$x/cache-root"
@@ -29,7 +29,7 @@ standard_setup() {
 }
 
 standard_teardown() {
-    rm -rf "$DFX_E2E_TEMP_DIR" || rm -rf "$DFX_E2E_TEMP_DIR"
+    rm -rf "$E2E_TEMP_DIR" || rm -rf "$E2E_TEMP_DIR"
 }
 
 dfx_new_frontend() {


### PR DESCRIPTION
Just a small change for brevity.

Upcoming changes add a few more environment variables, and they will also use prefix `E2E_`