### PR TITLE
test: allow E2E_CACHE_ROOT to provide a cache root for tests

### DIFF
--- a/e2e/tests-dfx/dfx_install.bash
+++ b/e2e/tests-dfx/dfx_install.bash
@@ -15,6 +15,7 @@ teardown() {
 @test "dfx cache show does not install the dfx version into the cache" {
     [ "$USE_IC_REF" ] && skip "skipped for ic-ref"
 
+    use_test_specific_cache_root
     test -z "$(ls -A "$DFX_CACHE_ROOT")"
 
     assert_command dfx cache show
@@ -30,6 +31,7 @@ teardown() {
 @test "non-forced install populates an empty cache" {
     [ "$USE_IC_REF" ] && skip "skipped for ic-ref"
 
+    use_test_specific_cache_root
     test ! -e "$(dfx cache show)"/dfx
 
     dfx_new
@@ -39,6 +41,7 @@ teardown() {
 
 @test "forced install populates an empty cache" {
     [ "$USE_IC_REF" ] && skip "skipped for ic-ref"
+    use_test_specific_cache_root
 
     test ! -e "$(dfx cache show)"/dfx
 

--- a/e2e/tests-dfx/error_context.bash
+++ b/e2e/tests-dfx/error_context.bash
@@ -106,6 +106,8 @@ teardown() {
 }
 
 @test "moc missing" {
+    use_test_specific_cache_root   # Because this test modifies a file in the cache
+
     dfx_start
 
     assert_command dfx canister create m_o_c_missing

--- a/e2e/tests-dfx/usage_env.bash
+++ b/e2e/tests-dfx/usage_env.bash
@@ -11,6 +11,8 @@ teardown() {
 }
 
 @test "dfx config root env var stores identity & cache" {
+    use_test_specific_cache_root   # Because this test depends on a clean cache state
+
     #identity
     dfx identity new --disable-encryption alice
     assert_command head "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -15,15 +15,17 @@ standard_setup() {
     x=$(mktemp -d -t dfx-e2e-XXXXXXXX)
     export E2E_TEMP_DIR="$x"
 
+    cache_root="${E2E_CACHE_ROOT:-$x/cache-root}"
+
     mkdir "$x/working-dir"
-    mkdir "$x/cache-root"
+    mkdir -p "$cache_root"
     mkdir "$x/config-root"
     mkdir "$x/home-dir"
 
     cd "$x/working-dir" || exit
 
     export HOME="$x/home-dir"
-    export DFX_CACHE_ROOT="$x/cache-root"
+    export DFX_CACHE_ROOT="$cache_root"
     export DFX_CONFIG_ROOT="$x/config-root"
     export RUST_BACKTRACE=1
 }
@@ -296,4 +298,12 @@ get_canister_http_adapter_pid() {
 
 get_icx_proxy_pid() {
   cat ".dfx/icx-proxy-pid"
+}
+
+use_test_specific_cache_root() {
+    # Use this when a test depends on the initial state of the cache being empty,
+    # or if the test corrupts the cache in some way.
+    # The effect is to ignore the E2E_CACHE_ROOT environment variable, if set.
+    export DFX_CACHE_ROOT="$E2E_TEMP_DIR/cache-root"
+    mkdir -p "$DFX_CACHE_ROOT"
 }


### PR DESCRIPTION
You can now set `E2E_CACHE_ROOT` to some directory that is separate from your normal `$HOME/.cache`, but still isolated for tests.  If set, e2e tests will use that instead of an empty directory per-test.
  - speeds up tests (because dfx doesn't have to install the cache for each test)
  - fewer pop-up messages asking if you want to allow replica to open a network listener

A few tests needed to use a unique cache directory no matter what.

Improves the local e2e testing experience a little if you do something like
```
export E2E_CACHE_ROOT=$HOME/.e2e-cache-root
```