### PR TITLE
test: retry canister call, after a delay, when restarting replica

### DIFF
--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -64,7 +64,13 @@ set_local_network_bitcoin_enabled() {
     #     IC0304: Attempt to execute a message on canister <>> which contains no Wasm module
     # but the condition clears.
     timeout 30s sh -c \
-      "until dfx canister call hello_backend greet '(\"wait\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
+      "until dfx canister call hello_backend greet '(\"wait 1\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
+      || (echo "canister call did not succeed") # but continue, for better error reporting
+    # even after the above, still sometimes fails with
+    #     IC0515: Certified state is not available yet. Please try again...
+    sleep 10
+    timeout 30s sh -c \
+      "until dfx canister call hello_backend greet '(\"wait 2\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
       || (echo "canister call did not succeed") # but continue, for better error reporting
 
     assert_command dfx canister call hello_backend greet '("Omega")'
@@ -79,7 +85,7 @@ set_local_network_bitcoin_enabled() {
     assert_command curl --fail http://localhost:"$(get_webserver_port)"/sample-asset.txt?canisterId="$ID"
 }
 
-@test "dfx restarts replica when ic-btc-adapter restarts (replica and bootstrap)" {
+@test "dfx restarts replica when ic-btc-adapter restarts - replica and bootstrap" {
     dfx_new hello
     set_default_bitcoin_enabled
     dfx_replica
@@ -113,7 +119,13 @@ set_local_network_bitcoin_enabled() {
     #     IC0304: Attempt to execute a message on canister <>> which contains no Wasm module
     # but the condition clears.
     timeout 30s sh -c \
-      "until dfx canister call hello_backend greet '(\"wait\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
+      "until dfx canister call hello_backend greet '(\"wait 1\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
+      || (echo "canister call did not succeed") # but continue, for better error reporting
+    # even after the above, still sometimes fails with
+    #     IC0515: Certified state is not available yet. Please try again...
+    sleep 10
+    timeout 30s sh -c \
+      "until dfx canister call hello_backend greet '(\"wait 2\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
       || (echo "canister call did not succeed") # but continue, for better error reporting
 
     assert_command dfx canister call hello_backend greet '("Omega")'
@@ -153,7 +165,7 @@ set_local_network_bitcoin_enabled() {
     assert_file_not_empty .dfx/ic-btc-adapter-pid
 }
 
-@test "can enable bitcoin through default configuration (dfx start)" {
+@test "can enable bitcoin through default configuration - dfx start" {
     dfx_new hello
     set_default_bitcoin_enabled
 
@@ -162,7 +174,7 @@ set_local_network_bitcoin_enabled() {
     assert_file_not_empty .dfx/ic-btc-adapter-pid
 }
 
-@test "can enable bitcoin through local network configuration (dfx start)" {
+@test "can enable bitcoin through local network configuration - dfx start" {
     dfx_new hello
     set_local_network_bitcoin_enabled
 
@@ -171,7 +183,7 @@ set_local_network_bitcoin_enabled() {
     assert_file_not_empty .dfx/ic-btc-adapter-pid
 }
 
-@test "can enable bitcoin through default configuration (dfx replica)" {
+@test "can enable bitcoin through default configuration - dfx replica" {
     dfx_new hello
     set_default_bitcoin_enabled
 

--- a/e2e/tests-dfx/canister_http.bash
+++ b/e2e/tests-dfx/canister_http.bash
@@ -54,11 +54,15 @@ set_local_network_canister_http_enabled() {
     #     IC0304: Attempt to execute a message on canister <>> which contains no Wasm module
     # but the condition clears.
     timeout 30s sh -c \
-      "until dfx canister call hello_backend greet '(\"wait\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
+      "until dfx canister call hello_backend greet '(\"wait 1\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
       || (echo "canister call did not succeed") # but continue, for better error reporting
 
     # Even so, after that passes, sometimes this happens:
     #     IC0515: Certified state is not available yet. Please try again...
+    sleep 10
+    timeout 30s sh -c \
+      "until dfx canister call hello_backend greet '(\"wait 2\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
+      || (echo "canister call did not succeed") # but continue, for better error reporting
 
     assert_command dfx canister call hello_backend greet '("Omega")'
     assert_eq '("Hello, Omega!")'
@@ -106,7 +110,14 @@ set_local_network_canister_http_enabled() {
     #     IC0304: Attempt to execute a message on canister <>> which contains no Wasm module
     # but the condition clears.
     timeout 30s sh -c \
-      "until dfx canister call hello_backend greet '(\"wait\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
+      "until dfx canister call hello_backend greet '(\"wait 1\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
+      || (echo "canister call did not succeed") # but continue, for better error reporting
+
+    # Even so, after that passes, sometimes this happens:
+    #     IC0515: Certified state is not available yet. Please try again...
+    sleep 10
+    timeout 30s sh -c \
+      "until dfx canister call hello_backend greet '(\"wait 2\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
       || (echo "canister call did not succeed") # but continue, for better error reporting
 
     assert_command dfx canister call hello_backend greet '("Omega")'
@@ -129,7 +140,7 @@ set_local_network_canister_http_enabled() {
     assert_file_not_empty .dfx/ic-canister-http-adapter-pid
 }
 
-@test "can enable http through default configuration (dfx start)" {
+@test "can enable http through default configuration - dfx start" {
     dfx_new hello
     set_default_canister_http_enabled
 
@@ -138,7 +149,7 @@ set_local_network_canister_http_enabled() {
     assert_file_not_empty .dfx/ic-canister-http-adapter-pid
 }
 
-@test "can enable http through local network configuration (dfx start)" {
+@test "can enable http through local network configuration - dfx start" {
     dfx_new hello
     set_local_network_canister_http_enabled
 
@@ -147,7 +158,7 @@ set_local_network_canister_http_enabled() {
     assert_file_not_empty .dfx/ic-canister-http-adapter-pid
 }
 
-@test "can enable http through default configuration (dfx replica)" {
+@test "can enable http through default configuration - dfx replica" {
     dfx_new hello
     set_default_canister_http_enabled
 

--- a/e2e/tests-dfx/start.bash
+++ b/e2e/tests-dfx/start.bash
@@ -41,6 +41,12 @@ teardown() {
     timeout 30s sh -c \
       "until dfx canister call hello_backend greet '(\"wait\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
       || (echo "canister call did not succeed") # but continue, for better error reporting
+    # even after the above, still sometimes fails with
+    #     IC0515: Certified state is not available yet. Please try again...
+    sleep 10
+    timeout 30s sh -c \
+      "until dfx canister call hello_backend greet '(\"wait\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
+      || (echo "canister call did not succeed") # but continue, for better error reporting
 
     assert_command dfx canister call hello_backend greet '("Omega")'
     assert_eq '("Hello, Omega!")'
@@ -102,6 +108,12 @@ teardown() {
     # Sometimes initially get an error like:
     #     IC0304: Attempt to execute a message on canister <>> which contains no Wasm module
     # but the condition clears.
+    timeout 30s sh -c \
+      "until dfx canister call hello_backend greet '(\"wait\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
+      || (echo "canister call did not succeed") # but continue, for better error reporting
+    # even after the above, still sometimes fails with
+    #     IC0515: Certified state is not available yet. Please try again...
+    sleep 10
     timeout 30s sh -c \
       "until dfx canister call hello_backend greet '(\"wait\")'; do echo waiting for any canister call to succeed; sleep 1; done" \
       || (echo "canister call did not succeed") # but continue, for better error reporting


### PR DESCRIPTION
The intent of this PR is to reduce test flakiness in CI in a few tests.

After a test restarts the replica, and waits until a `dfx canister call` succeeds, sometimes the next`dfx canister call` fails with this replica error:

```
IC0515: Certified state is not available yet. Please try again...
```

This PR adds a small delay after `dfx canister call` succeeds the first time, then waits again until `dfx canister call` succeeds, before proceeding.

Also renamed some tests to not have parenthesis in the name, to make it easier to use `bats -f "<name of test>"` to run a single test.