### PR TITLE
fix: resolves jsdoc service typing and trailing comment

### DIFF
--- a/src/dfx/assets/language_bindings/index.js.hbs
+++ b/src/dfx/assets/language_bindings/index.js.hbs
@@ -11,9 +11,8 @@ export const canisterId = {{canister_name_process_env}};
  * 
  * @param {string | import("@dfinity/principal").Principal} canisterId Canister ID of Agent
  * @param {{agentOptions?: import(\"@dfinity/agent\").HttpAgentOptions; actorOptions?: import(\"@dfinity/agent\").ActorConfig}} [options]
- * @return {import("@dfinity/agent").ActorSubclass<import("./{{canister_name}}.did.js")._SERVICE>}
+ * @return {import("@dfinity/agent").ActorSubclass<import("{{{{/raw}}}}./{{canister_name}}.did.js")._SERVICE>}
  */
-{{{{/raw}}}}
 export const createActor = (canisterId, options) => {
   const agent = new HttpAgent(options ? { ...options.agentOptions } : {});
   
@@ -31,10 +30,4 @@ export const createActor = (canisterId, options) => {
     canisterId,
     ...(options ? options.actorOptions : {}),
   });
-};
-  
-/**
- * A ready-to-use agent for the {{canister_name}} canister
- * @type {import("@dfinity/agent").ActorSubclass<import("./{{canister_name}}.did.js")._SERVICE>}
- */
-{{{actor_export}}}
+};{{{actor_export}}}

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -196,7 +196,7 @@ pub trait CanisterBuilder {
                     // create the handlebars registry
                     let handlebars = Handlebars::new();
 
-                    let mut data = BTreeMap::new();
+                    let mut data: BTreeMap<String, &String> = BTreeMap::new();
 
                     let canister_name = &info.get_name().to_string();
 
@@ -207,10 +207,11 @@ pub trait CanisterBuilder {
                         // leave empty for nodejs
                         "".to_string()
                     } else {
-                        format!(
-                            r#"/**
-* A ready-to-use agent for the {0} canister
-* @type {{import("@dfinity/agent").ActorSubclass<import("./{0}.did.js")._SERVICE>}}
+                        format!(r#"
+
+/**
+ * A ready-to-use agent for the {0} canister
+ * @type {{import("@dfinity/agent").ActorSubclass<import("./{0}.did.js")._SERVICE>}}
 */
 export const {0} = createActor(canisterId);"#,
                             canister_name

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -207,7 +207,8 @@ pub trait CanisterBuilder {
                         // leave empty for nodejs
                         "".to_string()
                     } else {
-                        format!(r#"
+                        format!(
+                            r#"
 
 /**
  * A ready-to-use agent for the {0} canister


### PR DESCRIPTION
# Description

The JSDOC export for create actor was not injecting the path to canister_name.did.js. Also the comment for the export was included unneccesarily for type:node declarations

# How Has This Been Tested?

manual testing for node_compatibility true and false

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
