### PR TITLE
chore: Change jq commands to use sponge

### DIFF
--- a/e2e/assets/base/patch.bash
+++ b/e2e/assets/base/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.e2e_project_backend.main="main.mo"' dfx.json)" >dfx.json
+jq '.canisters.e2e_project_backend.main="main.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/call/patch.bash
+++ b/e2e/assets/call/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.hello_backend.main="call.mo"' dfx.json)" >dfx.json
+jq '.canisters.hello_backend.main="call.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/canister_args/patch.bash
+++ b/e2e/assets/canister_args/patch.bash
@@ -1,4 +1,3 @@
 #!/dev/null
 
-cat <<<"$(jq '.canisters.e2e_project_backend.args="--compacting-gcY"' dfx.json)" >dfx.json
-cat <<<"$(jq '.defaults.build.args="--compacting-gcX"' dfx.json)" >dfx.json
+jq '.canisters.e2e_project_backend.args="--compacting-gcY" | .defaults.build.args="--compacting-gcX"' dfx.json | sponge dfx.json

--- a/e2e/assets/certificate/patch.bash
+++ b/e2e/assets/certificate/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.certificate_backend.main="certificate.mo"' dfx.json)" >dfx.json
+jq '.canisters.certificate_backend.main="certificate.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/counter/patch.bash
+++ b/e2e/assets/counter/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.hello_backend.main="counter.mo"' dfx.json)" >dfx.json
+jq '.canisters.hello_backend.main="counter.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/counter_idl/patch.bash
+++ b/e2e/assets/counter_idl/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.hello_backend.main="counter_idl.mo"' dfx.json)" >dfx.json
+jq '.canisters.hello_backend.main="counter_idl.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/default_args/patch.bash
+++ b/e2e/assets/default_args/patch.bash
@@ -1,3 +1,3 @@
 #!/dev/null
 
-cat <<<"$(jq '.defaults.build.args="--compacting-gcX"' dfx.json)" >dfx.json
+jq '.defaults.build.args="--compacting-gcX"' dfx.json | sponge dfx.json

--- a/e2e/assets/empty_canister_args/patch.bash
+++ b/e2e/assets/empty_canister_args/patch.bash
@@ -1,16 +1,3 @@
 #!/dev/null
 
-patch dfx.json <<EOF
-@@ -4,7 +4,8 @@
-   "canisters": {
-     "e2e_project": {
-       "type": "motoko",
--      "main": "src/e2e_project_backend/main.mo"
-+      "main": "src/e2e_project_backend/main.mo",
-+      "args" : ""
-     },
-     "e2e_project_frontend": {
-       "type": "assets",
-EOF
-
-cat <<<"$(jq '.defaults.build.args="--error-detail 5 --compacting-gcX"' dfx.json)" >dfx.json
+jq '.defaults.build.args="--error-detail 5 --compacting-gcX" | .canisters.e2e_project_backend.args=""' dfx.json | sponge dfx.json

--- a/e2e/assets/greet/patch.bash
+++ b/e2e/assets/greet/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.hello_backend.main="greet.mo"' dfx.json)" >dfx.json
+jq '.canisters.hello_backend.main="greet.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/greet_arg/patch.bash
+++ b/e2e/assets/greet_arg/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.hello_backend.main="greet.mo"' dfx.json)" >dfx.json
+jq '.canisters.hello_backend.main="greet.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/identity/patch.bash
+++ b/e2e/assets/identity/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.e2e_project_backend.main="identity.mo"' dfx.json)" >dfx.json
+jq '.canisters.e2e_project_backend.main="identity.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/import/patch.bash
+++ b/e2e/assets/import/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.e2e_project_backend.main="main.mo"' dfx.json)" >dfx.json
+jq '.canisters.e2e_project_backend.main="main.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/import_error/patch.bash
+++ b/e2e/assets/import_error/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.e2e_project_backend.main="main.mo"' dfx.json)" >dfx.json
+jq '.canisters.e2e_project_backend.main="main.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/invalid/patch.bash
+++ b/e2e/assets/invalid/patch.bash
@@ -1,3 +1,3 @@
 #!/dev/null
 
-cat <<<"$(jq '.canisters.e2e_project_backend.main="invalid.mo"' dfx.json)" >dfx.json
+jq '.canisters.e2e_project_backend.main="invalid.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/packtool/configure_packtool.bash
+++ b/e2e/assets/packtool/configure_packtool.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.defaults.build.packtool="echo --package describe ./vessel/describe/v1.0.1/src --package rate ./vessel/rate/v1.0.0/src"' dfx.json)" >dfx.json
+jq '.defaults.build.packtool="echo --package describe ./vessel/describe/v1.0.1/src --package rate ./vessel/rate/v1.0.0/src"' dfx.json | sponge dfx.json

--- a/e2e/assets/packtool/patch.bash
+++ b/e2e/assets/packtool/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.e2e_project_backend.main="packtool.mo"' dfx.json)" >dfx.json
+jq '.canisters.e2e_project_backend.main="packtool.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/recurse/patch.bash
+++ b/e2e/assets/recurse/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.hello_backend.main="recurse.mo"' dfx.json)" >dfx.json
+jq '.canisters.hello_backend.main="recurse.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/upgrade/patch.bash
+++ b/e2e/assets/upgrade/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.hello_backend.main="v1.mo"' dfx.json)" >dfx.json
+jq '.canisters.hello_backend.main="v1.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/warning/patch.bash
+++ b/e2e/assets/warning/patch.bash
@@ -1,1 +1,1 @@
-cat <<<"$(jq '.canisters.e2e_project_backend.main="main.mo"' dfx.json)" >dfx.json
+jq '.canisters.e2e_project_backend.main="main.mo"' dfx.json | sponge dfx.json

--- a/e2e/tests-dfx/base.bash
+++ b/e2e/tests-dfx/base.bash
@@ -31,8 +31,7 @@ teardown() {
 
 @test "does not provide base library if there is a packtool" {
     install_asset base
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.defaults.build.packtool="echo"' dfx.json)" >dfx.json
+    jq '.defaults.build.packtool="echo"' dfx.json | sponge dfx.json
 
     dfx_start
     dfx canister create --all

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -20,19 +20,16 @@ teardown() {
 }
 
 set_project_default_bitcoin_enabled() {
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.defaults.bitcoin.enabled=true' dfx.json)" >dfx.json
+    jq '.defaults.bitcoin.enabled=true' dfx.json | sponge dfx.json
 }
 
 set_shared_local_network_bitcoin_enabled() {
     create_networks_json
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.local.bitcoin.enabled=true' "$E2E_NETWORKS_JSON")" >"$E2E_NETWORKS_JSON"
+    jq '.local.bitcoin.enabled=true' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
 }
 
 set_local_network_bitcoin_enabled() {
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.networks.local.bitcoin.enabled=true' dfx.json)" >dfx.json
+    jq '.networks.local.bitcoin.enabled=true' dfx.json | sponge dfx.json
 }
 
 @test "noop" {

--- a/e2e/tests-dfx/build.bash
+++ b/e2e/tests-dfx/build.bash
@@ -97,15 +97,13 @@ teardown() {
 @test "build fails if canister type is not supported" {
   dfx_start
   dfx canister create --all
-  # shellcheck disable=SC2094
-  cat <<<"$(jq '.canisters.e2e_project_backend.type="unknown_canister_type"' dfx.json)" >dfx.json
+  jq '.canisters.e2e_project_backend.type="unknown_canister_type"' dfx.json | sponge dfx.json
   assert_command_fail dfx build
   # shellcheck disable=SC2016
   assert_match 'unknown variant `unknown_canister_type`'
 
   # If canister type is invalid, `dfx stop` fails
-  # shellcheck disable=SC2094
-  cat <<<"$(jq '.canisters.e2e_project_backend.type="motoko"' dfx.json)" >dfx.json
+  jq '.canisters.e2e_project_backend.type="motoko"' dfx.json | sponge dfx.json
 }
 
 @test "can build a custom canister type" {
@@ -146,8 +144,7 @@ teardown() {
   install_asset custom_canister
   dfx_start
   dfx canister create custom2
-  #shellcheck disable=SC2094
-  cat <<<"$(jq '.canisters.custom2.build="ln"' dfx.json)" >dfx.json
+  jq '.canisters.custom2.build="ln"' dfx.json | sponge dfx.json
   mv ./build.sh ./ln
 
   assert_command dfx build custom2

--- a/e2e/tests-dfx/canister_http.bash
+++ b/e2e/tests-dfx/canister_http.bash
@@ -16,20 +16,17 @@ teardown() {
 }
 
 set_project_default_canister_http_enabled() {
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.defaults.canister_http.enabled=true' dfx.json)" >dfx.json
+    jq '.defaults.canister_http.enabled=true' dfx.json | sponge dfx.json
 }
 
 set_project_local_network_canister_http_enabled() {
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.networks.local.canister_http.enabled=true' dfx.json)" >dfx.json
+    jq '.networks.local.canister_http.enabled=true' dfx.json | sponge dfx.json
 }
 
 set_shared_local_network_canister_http_enabled() {
     create_networks_json
 
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.local.canister_http.enabled=true' "$E2E_NETWORKS_JSON")" >"$E2E_NETWORKS_JSON"
+    jq '.local.canister_http.enabled=true' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
 }
 
 @test "dfx restarts replica when ic-canister-http-adapter restarts" {

--- a/e2e/tests-dfx/create.bash
+++ b/e2e/tests-dfx/create.bash
@@ -88,16 +88,14 @@ teardown() {
 @test "create fails if selected network exists but has no providers" {
     dfx_start
 
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.networks.actuallylocal.providers=[]' dfx.json)" >dfx.json
+    jq '.networks.actuallylocal.providers=[]' dfx.json | sponge dfx.json
     assert_command_fail dfx canister create --all --network actuallylocal
     assert_match "Cannot find providers for network"
 }
 
 @test "create fails with network parameter when network does not exist" {
     dfx_start
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.networks.actuallylocal.providers=["http://not-real.nowhere.test."]' dfx.json)" >dfx.json
+    jq '.networks.actuallylocal.providers=["http://not-real.nowhere.test."]' dfx.json | sponge dfx.json
     assert_command_fail dfx canister create --all --network actuallylocal
     assert_match "dns error: failed to lookup address information"
 }

--- a/e2e/tests-dfx/error_context.bash
+++ b/e2e/tests-dfx/error_context.bash
@@ -93,8 +93,7 @@ teardown() {
 
     assert_command dfx canister create packtool_missing
 
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.defaults.build.packtool="not-a-valid-packtool and some parameters"' dfx.json)" >dfx.json
+    jq '.defaults.build.packtool="not-a-valid-packtool and some parameters"' dfx.json | sponge dfx.json
 
 
     assert_command_fail dfx build packtool_missing

--- a/e2e/tests-dfx/frontend.bash
+++ b/e2e/tests-dfx/frontend.bash
@@ -26,8 +26,7 @@ teardown() {
     assert_match "e2e_project_frontend: http://127.0.0.1:$PORT/\?canisterId=$ASSETS_ID"
 
     # the urls are a little nicer if the bind address is localhost:8000 rather than 127.0.0.1:8000
-    # shellcheck disable=SC2094
-    echo "{}" | jq '.local.bind="localhost:'"$PORT"'"' >"$E2E_NETWORKS_JSON"
+    jq -n '.local.bind="localhost:'"$PORT"'"' >"$E2E_NETWORKS_JSON"
 
     assert_command dfx deploy
     assert_match "e2e_project_backend: http://$CANDID_UI_ID.localhost:$PORT/\?id=$APP_ID"
@@ -53,8 +52,7 @@ teardown() {
 
     dfx_start --host 127.0.0.1:12345
 
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.networks.local.bind="127.0.0.1:12345"' dfx.json)" >dfx.json
+    jq '.networks.local.bind="127.0.0.1:12345"' dfx.json | sponge dfx.json
 
     dfx canister create --all
     dfx build

--- a/e2e/tests-dfx/id.bash
+++ b/e2e/tests-dfx/id.bash
@@ -41,8 +41,7 @@ teardown() {
 @test "id subcommand works from a subdirectory of the project - persistent id" {
     install_asset id
 
-    # shellcheck disable=SC2094
-    cat <<<"$(jq .networks.local.type=\"persistent\" dfx.json)" >dfx.json
+    jq '.networks.local.type="persistent"' dfx.json | sponge dfx.json
     dfx_start
     dfx canister create --all
     ID=$(dfx canister id e2e_project_backend)

--- a/e2e/tests-dfx/network.bash
+++ b/e2e/tests-dfx/network.bash
@@ -33,8 +33,7 @@ teardown() {
     dfx_start
 
     setup_actuallylocal_shared_network
-    # shellcheck disable=SC2094
-    cat <<<"$(jq .actuallylocal.type=\"ephemeral\" "$E2E_NETWORKS_JSON")" >"$E2E_NETWORKS_JSON"
+    jq '.actuallylocal.type="ephemeral"' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
     dfx_set_wallet
 
     dfx canister create --all --network actuallylocal
@@ -61,10 +60,8 @@ teardown() {
 
     create_networks_json
 
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.local.bind="127.0.0.1:'"$webserver_port"'"' "$E2E_NETWORKS_JSON")" >"$E2E_NETWORKS_JSON"
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.local.type="persistent"' "$E2E_NETWORKS_JSON")" >"$E2E_NETWORKS_JSON"
+    jq '.local.bind="127.0.0.1:'"$webserver_port"'"' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
+    jq '.local.type="persistent"' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
 
     assert_command dfx canister create --all --network local
 

--- a/e2e/tests-dfx/packtool.bash
+++ b/e2e/tests-dfx/packtool.bash
@@ -52,8 +52,7 @@ teardown() {
 
 @test "failure to invoke the package tool reports the command line and reason" {
     install_asset packtool
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.defaults.build.packtool="./no-such-command that command cannot be invoked"' dfx.json)" >dfx.json
+    jq '.defaults.build.packtool="./no-such-command that command cannot be invoked"' dfx.json | sponge dfx.json
 
     dfx_start
     dfx canister create --all
@@ -65,8 +64,7 @@ teardown() {
 
 @test "failure in execution reports the command line and exit code" {
     install_asset packtool
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.defaults.build.packtool="sh ./command-that-fails.bash"' dfx.json)" >dfx.json
+    jq '.defaults.build.packtool="sh ./command-that-fails.bash"' dfx.json | sponge dfx.json
 
     dfx_start
     dfx canister create --all

--- a/e2e/tests-dfx/ping.bash
+++ b/e2e/tests-dfx/ping.bash
@@ -57,8 +57,7 @@ teardown() {
 @test "dfx ping succeeds by network name if network bind address is host:port format" {
     dfx_start
     webserver_port=$(get_webserver_port)
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.networks.nnn.bind="127.0.0.1:'"$webserver_port"'"' dfx.json)" >dfx.json
+    jq '.networks.nnn.bind="127.0.0.1:'"$webserver_port"'"' dfx.json | sponge dfx.json
     assert_command dfx ping nnn
 
     assert_match "\"ic_api_version\""
@@ -72,16 +71,14 @@ teardown() {
     # Make dfx use the port from configuration:
     rm "$E2E_SHARED_LOCAL_NETWORK_DATA_DIRECTORY/webserver-port"
 
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.networks.arbitrary.providers=["http://127.0.0.1:12345"]' dfx.json)" >dfx.json
+    jq '.networks.arbitrary.providers=["http://127.0.0.1:12345"]' dfx.json | sponge dfx.json
 
     assert_command dfx ping arbitrary
     assert_match "\"ic_api_version\""
 
     assert_command_fail dfx ping
     # this port won't match the ephemeral port that the replica picked
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.networks.arbitrary.providers=["127.0.0.1:22113"]' dfx.json)" >dfx.json
+    jq '.networks.arbitrary.providers=["127.0.0.1:22113"]' dfx.json | sponge dfx.json
     assert_command_fail dfx ping arbitrary
 }
 

--- a/e2e/tests-dfx/project_local_network.bash
+++ b/e2e/tests-dfx/project_local_network.bash
@@ -138,8 +138,7 @@ teardown() {
     dfx_start
 
     setup_actuallylocal_project_network
-    # shellcheck disable=SC2094
-    cat <<<"$(jq .networks.actuallylocal.type=\"ephemeral\" dfx.json)" >dfx.json
+    jq '.networks.actuallylocal.type="ephemeral"' dfx.json | sponge dfx.json
     dfx_set_wallet
 
     dfx canister create --all --network actuallylocal

--- a/e2e/tests-dfx/provider.bash
+++ b/e2e/tests-dfx/provider.bash
@@ -39,15 +39,13 @@ teardown() {
 
 @test "uses local bind address if there is no local network" {
   [ "$USE_IC_REF" ] && skip "skipped for ic-ref"
-  # shellcheck disable=SC2094
-  cat <<<"$(jq 'del(.networks.local)' dfx.json)" >dfx.json
+  jq 'del(.networks.local)' dfx.json | sponge dfx.json
   dfx_start
 }
 
 @test "uses local bind address if there are no networks" {
   [ "$USE_IC_REF" ] && skip "skipped for ic-ref"
-  # shellcheck disable=SC2094
-  cat <<<"$(jq 'del(.networks)' dfx.json)" >dfx.json
+  jq 'del(.networks)' dfx.json | sponge dfx.json
   dfx_start
 }
 

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -33,8 +33,7 @@ teardown() {
     install_asset remote/call/mock
     setup_actuallylocal_shared_network
     setup_local_shared_network
-    # shellcheck disable=SC2094
-    cat <<<"$(jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json)" >dfx.json
+    jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
 
     # set up: remote method is update, local is query
     # call remote method as update to make a change
@@ -66,8 +65,7 @@ teardown() {
     assert_eq '(record { a = "A update by name"; b = "B update by name" })'
 
     # This also should work when no canister type can be determined / if no info but the bare minimum of remote id and remote candid is given:
-    # shellcheck disable=SC2094
-    cat <<<"$(jq 'del(.canisters.remote.main)' dfx.json)" >dfx.json
+    jq 'del(.canisters.remote.main)' dfx.json | sponge dfx.json
     assert_command dfx canister call --query  remote make_struct '("A query by name", "B query by name")' --network actuallylocal
     assert_eq '(record { a = "A query by name"; b = "B query by name" })'
 
@@ -111,8 +109,7 @@ teardown() {
     install_asset remote/basic
     setup_actuallylocal_shared_network
     setup_local_shared_network
-    # shellcheck disable=SC2094
-    cat <<<"$(jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json)" >dfx.json
+    jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
 
     assert_command_fail dfx canister create remote --network actuallylocal
     assert_match "remote" canister is remote on network actuallylocal and has canister id: "$REMOTE_CANISTER_ID"
@@ -134,8 +131,7 @@ teardown() {
     install_asset remote/basic
     setup_actuallylocal_shared_network
     setup_local_shared_network
-    # shellcheck disable=SC2094
-    cat <<<"$(jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json)" >dfx.json
+    jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
 
     assert_command_fail dfx canister install remote --network actuallylocal
     assert_match "Canister 'remote' is a remote canister on network 'actuallylocal', and cannot be installed from here."
@@ -165,8 +161,7 @@ teardown() {
     install_asset remote/basic
     setup_actuallylocal_shared_network
     setup_local_shared_network
-    # shellcheck disable=SC2094
-    cat <<<"$(jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json)" >dfx.json
+    jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
 
     # Here we want to make sure that create+build+install works with the common flow
     assert_command dfx canister create --all
@@ -230,8 +225,7 @@ teardown() {
     install_asset remote/extra
     setup_actuallylocal_shared_network
     setup_local_shared_network
-    # shellcheck disable=SC2094
-    cat <<<"$(jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json)" >dfx.json
+    jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
 
     # We expect the local network deploy to succeed, because it is built using the candid file from
     # the local canister.
@@ -271,8 +265,7 @@ teardown() {
     install_asset remote/basic
     setup_actuallylocal_shared_network
     setup_local_shared_network
-    # shellcheck disable=SC2094
-    cat <<<"$(jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json)" >dfx.json
+    jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
 
     assert_command dfx deploy
     assert_command dfx canister call basic read_remote

--- a/e2e/tests-dfx/update_settings.bash
+++ b/e2e/tests-dfx/update_settings.bash
@@ -409,8 +409,7 @@ teardown() {
     CANISTER_ID=$(dfx canister id hello_backend)
 
     rm .dfx/local/canister_ids.json
-    # shellcheck disable=SC2094
-    cat <<<"$(jq .canisters={} dfx.json)" >dfx.json
+    jq '.canisters={}' dfx.json | sponge dfx.json
 
     assert_command dfx canister status "$CANISTER_ID"
     assert_match 'Memory allocation: 0'

--- a/e2e/tests-dfx/upgrade_check.bash
+++ b/e2e/tests-dfx/upgrade_check.bash
@@ -19,8 +19,7 @@ teardown() {
   dfx_start
   dfx deploy
   dfx canister call hello_backend inc '()'
-    # shellcheck disable=SC2094
-  cat <<<"$(jq '.canisters.hello_backend.main="v2.mo"' dfx.json)" >dfx.json
+  jq '.canisters.hello_backend.main="v2.mo"' dfx.json | sponge dfx.json
   dfx deploy
   assert_command dfx canister call hello_backend read '()'
   assert_match "(1 : nat)"
@@ -31,8 +30,7 @@ teardown() {
     dfx_start
     dfx deploy
     dfx canister call hello_backend inc '()'
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.canisters.hello_backend.main="v2_bad.mo"' dfx.json)" >dfx.json
+    jq '.canisters.hello_backend.main="v2_bad.mo"' dfx.json | sponge dfx.json
     echo yes | (
       assert_command dfx deploy
       assert_match "Stable interface compatibility check failed"
@@ -46,8 +44,7 @@ teardown() {
     dfx_start
     dfx deploy
     dfx canister call hello_backend inc '()'
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.canisters.hello_backend.main="v2_bad.mo"' dfx.json)" >dfx.json
+    jq '.canisters.hello_backend.main="v2_bad.mo"' dfx.json | sponge dfx.json
     dfx build
     echo yes | dfx canister install hello_backend --mode=reinstall
     assert_command dfx canister call hello_backend read '()'
@@ -59,8 +56,7 @@ teardown() {
     dfx_start
     dfx deploy
     dfx canister call hello_backend inc '()'
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.canisters.hello_backend.main="v3_bad.mo"' dfx.json)" >dfx.json
+    jq '.canisters.hello_backend.main="v3_bad.mo"' dfx.json | sponge dfx.json
     echo yes | (
       assert_command dfx deploy
       assert_match "Candid interface compatibility check failed"

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -277,15 +277,13 @@ dfx_set_wallet() {
 setup_actuallylocal_project_network() {
     webserver_port=$(get_webserver_port)
     # [ ! -f "$E2E_ROUTE_NETWORKS_JSON" ] && echo "{}" >"$E2E_ROUTE_NETWORKS_JSON"
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.networks.actuallylocal.providers=["http://127.0.0.1:'"$webserver_port"'"]' dfx.json)" >dfx.json
+    jq '.networks.actuallylocal.providers=["http://127.0.0.1:'"$webserver_port"'"]' dfx.json | sponge dfx.json
 }
 
 setup_actuallylocal_shared_network() {
     webserver_port=$(get_webserver_port)
     [ ! -f "$E2E_NETWORKS_JSON" ] && echo "{}" >"$E2E_NETWORKS_JSON"
-    # shellcheck disable=SC2094
-    cat <<<"$(jq '.actuallylocal.providers=["http://127.0.0.1:'"$webserver_port"'"]' "$E2E_NETWORKS_JSON")" >"$E2E_NETWORKS_JSON"
+    jq '.actuallylocal.providers=["http://127.0.0.1:'"$webserver_port"'"]' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
 }
 
 setup_local_shared_network() {
@@ -298,8 +296,7 @@ setup_local_shared_network() {
 
     [ ! -f "$E2E_NETWORKS_JSON" ] && echo "{}" >"$E2E_NETWORKS_JSON"
 
-    # shellcheck disable=SC2094
-    cat <<<"$(jq ".local.bind=\"127.0.0.1:${replica_port}\"" "$E2E_NETWORKS_JSON")" >"$E2E_NETWORKS_JSON"
+    jq ".local.bind=\"127.0.0.1:${replica_port}\"" "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
 }
 
 use_wallet_wasm() {
@@ -352,8 +349,7 @@ create_networks_json() {
 }
 
 define_project_network() {
-    # shellcheck disable=SC2094
-    cat <<<"$(jq .networks.local.bind=\"127.0.0.1:8000\" dfx.json)" >dfx.json
+    jq .networks.local.bind=\"127.0.0.1:8000\" dfx.json | sponge dfx.json
 }
 
 use_test_specific_cache_root() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -163,8 +163,7 @@ build_release_branch() {
 
     echo "Updating version in src/dfx/Cargo.toml"
     # update first version in src/dfx/Cargo.toml to be NEW_DFX_VERSION
-    # shellcheck disable=SC2094
-    cat <<<"$(awk 'NR==1,/^version = ".*"/{sub(/^version = ".*"/, "version = \"'"$NEW_DFX_VERSION"'\"")} 1' <src/dfx/Cargo.toml)" >src/dfx/Cargo.toml
+    awk 'NR==1,/^version = ".*"/{sub(/^version = ".*"/, "version = \"'"$NEW_DFX_VERSION"'\"")} 1' <src/dfx/Cargo.toml | sponge src/dfx/Cargo.toml
 
     echo "Building dfx with cargo."
     # not --locked, because Cargo.lock needs to be updated with the new version
@@ -173,8 +172,7 @@ build_release_branch() {
 
     echo "Appending version to public/manifest.json"
     # Append the new version to `public/manifest.json` by appending it to the `versions` list.
-    # shellcheck disable=SC2094
-    cat <<<"$(jq --indent 4 '.versions += ["'"$NEW_DFX_VERSION"'"]' public/manifest.json)" >public/manifest.json
+    jq --indent 4 '.versions += ["'"$NEW_DFX_VERSION"'"]' public/manifest.json | sponge public/manifest.json
 
     echo "Creating release branch: $BRANCH"
     $DRY_RUN_ECHO git add -u

--- a/scripts/workflows/provision-darwin.sh
+++ b/scripts/workflows/provision-darwin.sh
@@ -7,7 +7,7 @@ export
 # Enter temporary directory.
 pushd /tmp
 
-brew install coreutils
+brew install coreutils moreutils
 
 # Install Bats.
 if [ "$(uname -r)" = "19.6.0" ]; then

--- a/scripts/workflows/provision-linux.sh
+++ b/scripts/workflows/provision-linux.sh
@@ -7,8 +7,8 @@ export
 # Enter temporary directory.
 pushd /tmp
 
-# Install Bats.
-sudo apt-get install --yes bats
+# Install Bats + moreutils.
+sudo apt-get install --yes bats moreutils
 
 # Install Bats support.
 version=0.3.0


### PR DESCRIPTION
Currently, we have a large number of commands that go `cat <<<"$(jq ... foo.json)" >foo.json`. This is hard to read, hard to write, and breaks vscode's syntax highlighter depending on the quoting. This PR changes it to `jq ... foo.json | sponge foo.json`, utilizing moreutils' sponge, which also lets us get rid of every single SC2094 suppression.