### PR TITLE
chore: run shellcheck on the rest of the scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -23,7 +23,7 @@ jobs:
           curl -L https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.darwin.x86_64.tar.xz \
             | xz -d | tar x
       - name: Check e2e scripts
-        run: $HOME/bin/shellcheck-v0.7.1/shellcheck e2e/tests-dfx/*.bash e2e/tests-replica/*.bash
+        run: $HOME/bin/shellcheck-v0.7.1/shellcheck e2e/**/*.*sh
       - name: Check release script
         run: $HOME/bin/shellcheck-v0.7.1/shellcheck scripts/release.sh
       - name: Check asset prep script

--- a/e2e/assets/canister_args/patch.bash
+++ b/e2e/assets/canister_args/patch.bash
@@ -1,3 +1,1 @@
-#!/dev/null
-
 jq '.canisters.e2e_project_backend.args="--compacting-gcY" | .defaults.build.args="--compacting-gcX"' dfx.json | sponge dfx.json

--- a/e2e/assets/default_args/patch.bash
+++ b/e2e/assets/default_args/patch.bash
@@ -1,3 +1,1 @@
-#!/dev/null
-
 jq '.defaults.build.args="--compacting-gcX"' dfx.json | sponge dfx.json

--- a/e2e/assets/empty_canister_args/patch.bash
+++ b/e2e/assets/empty_canister_args/patch.bash
@@ -1,3 +1,1 @@
-#!/dev/null
-
 jq '.defaults.build.args="--error-detail 5 --compacting-gcX" | .canisters.e2e_project_backend.args=""' dfx.json | sponge dfx.json

--- a/e2e/assets/invalid/patch.bash
+++ b/e2e/assets/invalid/patch.bash
@@ -1,3 +1,1 @@
-#!/dev/null
-
 jq '.canisters.e2e_project_backend.main="invalid.mo"' dfx.json | sponge dfx.json

--- a/e2e/tests-dfx/basic-project.bash
+++ b/e2e/tests-dfx/basic-project.bash
@@ -100,8 +100,7 @@ teardown() {
     # Call using the wallet's call forwarding
     assert_command dfx canister call hello_backend read --async --wallet="$(dfx identity get-wallet)"
     assert_command dfx canister request-status "$stdout" "$(dfx identity get-wallet)"
-    assert_eq \
-    '(variant { 17_724 = record { 153_986_224 = blob "DIDL\00\01}\b9\0a" } })'
+    assert_eq '(variant { 17_724 = record { 153_986_224 = blob "DIDL\00\01}\b9\0a" } })'
 
 }
 

--- a/e2e/tests-dfx/basic-project.bash
+++ b/e2e/tests-dfx/basic-project.bash
@@ -45,7 +45,12 @@ teardown() {
     # At this point $output is the request ID.
     # shellcheck disable=SC2154
     assert_command dfx canister request-status "$stdout" "$(dfx identity get-wallet)"
-    assert_eq '( variant { 17_724 = record { 153_986_224 = blob "DIDL\00\01q\11Hello, Blueberry!" } }, )'
+    assert_eq \
+'(
+    variant {
+        17_724 = record { 153_986_224 = blob "DIDL\00\01q\11Hello, Blueberry!" }
+    },
+)'
 }
 
 @test "build + install + call + request-status -- counter_mo" {
@@ -95,7 +100,8 @@ teardown() {
     # Call using the wallet's call forwarding
     assert_command dfx canister call hello_backend read --async --wallet="$(dfx identity get-wallet)"
     assert_command dfx canister request-status "$stdout" "$(dfx identity get-wallet)"
-    assert_eq '(variant { 17_724 = record { 153_986_224 = blob "DIDL\00\01}\b9\0a" } })'
+    assert_eq \
+    '(variant { 17_724 = record { 153_986_224 = blob "DIDL\00\01}\b9\0a" } })'
 
 }
 
@@ -118,5 +124,12 @@ teardown() {
     dfx canister install --all
 
     assert_command dfx canister call hello_backend multiply '(vec{vec{1;2};vec{3;4};vec{5;6}},vec{vec{1;2;3};vec{4;5;6}})'
-    assert_eq "( vec { vec { 9 : int; 12 : int; 15 : int }; vec { 19 : int; 26 : int; 33 : int }; vec { 29 : int; 40 : int; 51 : int }; }, )"
+    assert_eq \
+"(
+    vec {
+        vec { 9 : int; 12 : int; 15 : int };
+        vec { 19 : int; 26 : int; 33 : int };
+        vec { 29 : int; 40 : int; 51 : int };
+    },
+)"
 }

--- a/e2e/tests-dfx/basic-project.bash
+++ b/e2e/tests-dfx/basic-project.bash
@@ -47,9 +47,9 @@ teardown() {
     assert_command dfx canister request-status "$stdout" "$(dfx identity get-wallet)"
     assert_eq \
 '(
-    variant {
-        17_724 = record { 153_986_224 = blob "DIDL\00\01q\11Hello, Blueberry!" }
-    },
+  variant {
+    17_724 = record { 153_986_224 = blob "DIDL\00\01q\11Hello, Blueberry!" }
+  },
 )'
 }
 
@@ -125,10 +125,10 @@ teardown() {
     assert_command dfx canister call hello_backend multiply '(vec{vec{1;2};vec{3;4};vec{5;6}},vec{vec{1;2;3};vec{4;5;6}})'
     assert_eq \
 "(
-    vec {
-        vec { 9 : int; 12 : int; 15 : int };
-        vec { 19 : int; 26 : int; 33 : int };
-        vec { 29 : int; 40 : int; 51 : int };
-    },
+  vec {
+    vec { 9 : int; 12 : int; 15 : int };
+    vec { 19 : int; 26 : int; 33 : int };
+    vec { 29 : int; 40 : int; 51 : int };
+  },
 )"
 }

--- a/e2e/tests-dfx/certified_info.bash
+++ b/e2e/tests-dfx/certified_info.bash
@@ -20,7 +20,9 @@ teardown() {
     assert_command dfx canister info "$(dfx canister id hello_backend)"
     WALLET_ID=$(dfx identity get-wallet)
     SELF_ID=$(dfx identity get-principal)
-    assert_match "Controllers: ($WALLET_ID $SELF_ID|$SELF_ID $WALLET_ID) Module hash: None"
+    assert_match \
+"Controllers: ($WALLET_ID $SELF_ID|$SELF_ID $WALLET_ID)
+    Module hash: None"
 
     dfx build hello_backend
     RESULT="$(openssl dgst -sha256 .dfx/local/canisters/hello_backend/hello_backend.wasm)"

--- a/e2e/tests-dfx/certified_info.bash
+++ b/e2e/tests-dfx/certified_info.bash
@@ -22,7 +22,7 @@ teardown() {
     SELF_ID=$(dfx identity get-principal)
     assert_match \
 "Controllers: ($WALLET_ID $SELF_ID|$SELF_ID $WALLET_ID)
-    Module hash: None"
+Module hash: None"
 
     dfx build hello_backend
     RESULT="$(openssl dgst -sha256 .dfx/local/canisters/hello_backend/hello_backend.wasm)"

--- a/e2e/tests-dfx/certified_info.bash
+++ b/e2e/tests-dfx/certified_info.bash
@@ -31,5 +31,7 @@ teardown() {
 
     dfx canister install hello_backend  
     assert_command dfx canister info "$(dfx canister id hello_backend)"
-    assert_match "Controllers: ($WALLET_ID $SELF_ID|$SELF_ID $WALLET_ID) Module hash: $(HASH)"
+    assert_match \
+"Controllers: ($WALLET_ID $SELF_ID|$SELF_ID $WALLET_ID)
+Module hash: $(HASH)"
 }

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -36,10 +36,23 @@ teardown() {
     assert_command dfx identity new --disable-encryption alice
     assert_command dfx identity new --disable-encryption bob
     assert_command dfx identity list
-    assert_match 'alice anonymous bob dan default frank'
+    assert_match \
+'alice
+anonymous
+bob
+dan
+default
+frank'
     assert_command dfx identity new --disable-encryption charlie
     assert_command dfx identity list
-    assert_match 'alice anonymous bob charlie dan default frank'
+    assert_match \
+'alice
+anonymous
+bob
+charlie
+dan
+default
+frank'
 }
 
 @test "identity list: shows the anonymous identity" {
@@ -118,7 +131,10 @@ teardown() {
     assert_command head "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
     assert_match "BEGIN PRIVATE KEY"
     assert_command dfx identity list
-    assert_match 'alice anonymous default'
+    assert_match \
+'alice
+anonymous
+default'
 
     assert_command dfx identity remove alice
     assert_match 'Removed identity "alice".' "$stderr"
@@ -154,7 +170,10 @@ teardown() {
     assert_command head "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
     assert_match "BEGIN PRIVATE KEY"
     assert_command dfx identity list
-    assert_match 'alice anonymous default'
+    assert_match \
+'alice
+anonymous
+default'
 }
 
 @test "identity remove: cannot remove the default identity" {
@@ -187,7 +206,10 @@ teardown() {
 @test "identity rename: can rename an identity" {
     assert_command dfx identity new --disable-encryption alice
     assert_command dfx identity list
-    assert_match 'alice anonymous default'
+    assert_match \
+'alice
+anonymous
+default'
     assert_command head "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
     assert_match "BEGIN PRIVATE KEY"
     x=$(cat "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem")
@@ -197,7 +219,10 @@ teardown() {
     assert_match 'Renamed identity "alice" to "bob".' "$stderr"
 
     assert_command dfx identity list
-    assert_match 'anonymous bob default'
+    assert_match \
+'anonymous
+bob
+default'
     assert_command cat "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.pem"
     assert_eq "$key" "$(cat "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.pem")"
     assert_match "BEGIN PRIVATE KEY"
@@ -221,11 +246,17 @@ teardown() {
     assert_command dfx identity new --disable-encryption alice
     assert_command dfx identity use alice
     assert_command dfx identity list
-    assert_match 'alice anonymous default'
+    assert_match \
+'alice
+anonymous
+default'
     assert_command dfx identity rename alice charlie
 
     assert_command dfx identity list
-    assert_match 'anonymous charlie default'
+    assert_match \
+'anonymous
+charlie
+default'
 
     assert_command dfx identity whoami
     assert_eq 'charlie'

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -112,7 +112,7 @@ teardown() {
     jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
 
     assert_command_fail dfx canister create remote --network actuallylocal
-    assert_match "remote canister is remote on network actuallylocal and has canister id: $REMOTE_CANISTER_ID"
+    assert_match "Canister 'remote' is a remote canister on network 'actuallylocal', and cannot be created from here."
 }
 
 @test "canister install <canister> fails for a remote canister" {

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -112,7 +112,7 @@ teardown() {
     jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
 
     assert_command_fail dfx canister create remote --network actuallylocal
-    assert_match "remote" canister is remote on network actuallylocal and has canister id: "$REMOTE_CANISTER_ID"
+    assert_match "remote canister is remote on network actuallylocal and has canister id: $REMOTE_CANISTER_ID"
 }
 
 @test "canister install <canister> fails for a remote canister" {

--- a/e2e/tests-dfx/sign_send.bash
+++ b/e2e/tests-dfx/sign_send.bash
@@ -32,7 +32,8 @@ teardown() {
     assert_eq "Error: [message.json] already exists, please specify a different output file name."
 
     assert_command dfx canister sign --update hello_backend inc --file message-inc.json
-    assert_eq "Update message generated at [message-inc.json] Signed request_status append to update message in [message-inc.json]"
+    assert_eq "Update message generated at [message-inc.json]
+Signed request_status append to update message in [message-inc.json]"
 
     sleep 10
     echo y | assert_command dfx canister send message-inc.json

--- a/e2e/tests-dfx/usage.bash
+++ b/e2e/tests-dfx/usage.bash
@@ -20,7 +20,7 @@ teardown() {
 
 @test "using an invalid command fails" {
     run dfx blurp
-    if [[ $status == 0 ]]; then
+    if [[ $status -eq 0 ]]; then
         echo "$@" >&2
         exit 1
     fi

--- a/e2e/tests-dfx/wallet.bash
+++ b/e2e/tests-dfx/wallet.bash
@@ -174,5 +174,5 @@ teardown() {
 @test "detects if there is no wallet to upgrade" {
     dfx_new hello
     assert_command_fail dfx wallet upgrade
-    assert_match "There is no wallet defined for identity 'default' on network 'local'. Nothing to do."
+    assert_match "There is no wallet defined for identity 'default' on network 'local'.  Nothing to do."
 }

--- a/e2e/utils/assertions.bash
+++ b/e2e/utils/assertions.bash
@@ -86,9 +86,9 @@ assert_not_match() {
         text="$2"
     fi
     if [[ "$text" =~ $regex ]]; then
-        (batslib_print_kv_single_or_multi 10 "regex" "$regex" "actual" "$text" \
-         | batslib_decorate "output matches but is expected not to" \
-         | fail)
+        batslib_print_kv_single_or_multi 10 "regex" "$regex" "actual" "$text" \
+            | batslib_decorate "output matches but is expected not to" \
+            | fail
     fi
 }
 

--- a/e2e/utils/assertions.bash
+++ b/e2e/utils/assertions.bash
@@ -129,10 +129,11 @@ assert_neq() {
         actual="$2"
     fi
 
-    [[ "$actual" != "$expected" ]] || \
+    if [[ "$actual" = "$expected" ]]; then
         batslib_print_kv_single_or_multi 10 "expected" "$expected" "actual" "$actual" \
             | batslib_decorate "output does not match" \
             | fail
+    fi
 }
 
 

--- a/e2e/utils/assertions.bash
+++ b/e2e/utils/assertions.bash
@@ -7,23 +7,24 @@
 # Returns:
 #   none
 assert_command() {
-    local stderrf="$(mktemp)"
-    local stdoutf="$(mktemp)"
-    local statusf="$(mktemp)"
+    local stdoutf stderrf statusf
+    stderrf="$(mktemp)"
+    stdoutf="$(mktemp)"
+    statusf="$(mktemp)"
     ( set +e; "$@" 2>"$stderrf" >"$stdoutf"; echo -n "$?" > "$statusf" )
-    status="$(<$statusf)"; rm "$statusf"
-
-    stderr="$(cat $stderrf)"; rm "$stderrf"
-    stdout="$(cat $stdoutf)"; rm "$stdoutf"
-    output="$( \
-        [ "$stderr" ] && echo $stderr || true; \
-        [ "$stdout" ] && echo $stdout || true; \
+    status=$(< "$statusf"); rm "$statusf"
+    stderr=$(< "$stderrf"); rm "$stderrf"
+    stdout=$(< "$stdoutf"); rm "$stdoutf"
+    output="$(
+        if [ "$stderr" ]; then echo "$stderr"; fi 
+        if [ "$stdout" ]; then echo "$stdout"; fi
     )"
 
-    [[ $status == 0 ]] || \
-        (  (echo "$*"; echo "status: $status"; echo "$output" | batslib_decorate "Output") \
+    if [[ ! $status -eq 0 ]]; then 
+        (echo "$*"; echo "status: $status"; echo "$output" | batslib_decorate "Output") \
          | batslib_decorate "Command failed" \
-         | fail)
+         | fail
+    fi
 }
 
 # Asserts that a command line fails. Still sets $output to the stdout and stderr
@@ -33,23 +34,24 @@ assert_command() {
 # Returns:
 #   none
 assert_command_fail() {
-    local stderrf="$(mktemp)"
-    local stdoutf="$(mktemp)"
-    local statusf="$(mktemp)"
+    local stdoutf stderrf statusf
+    stderrf="$(mktemp)"
+    stdoutf="$(mktemp)"
+    statusf="$(mktemp)"
     ( set +e; "$@" 2>"$stderrf" >"$stdoutf"; echo -n "$?" >"$statusf" )
-    status="$(<$statusf)"; rm "$statusf"
-
-    stderr="$(cat $stderrf)"; rm "$stderrf"
-    stdout="$(cat $stdoutf)"; rm "$stdoutf"
+    status=$(< "$statusf"); rm "$statusf"
+    stderr=$(< "$stderrf"); rm "$stderrf"
+    stdout=$(< "$stdoutf"); rm "$stdoutf"
     output="$(
-        [ "$stderr" ] && echo $stderr || true;
-        [ "$stdout" ] && echo $stdout || true;
+        if [ "$stderr" ]; then echo "$stderr"; fi;
+        if [ "$stdout" ]; then echo "$stdout"; fi;
     )"
 
-    [[ $status != 0 ]] || \
-        (  (echo "$*"; echo "$output" | batslib_decorate "Output") \
-         | batslib_decorate "Command succeeded (should have failed)" \
-         | fail)
+    if [[ $status -eq 0 ]]; then
+        ( echo "$*"; echo "$output" | batslib_decorate "Output") \
+            | batslib_decorate "Command succeeded (should have failed)" \
+            | fail
+    fi
 }
 
 # Asserts that a string contains another string, using regexp.
@@ -59,15 +61,16 @@ assert_command_fail() {
 #         $output.
 assert_match() {
     regex="$1"
-    if [[ $# < 2 ]]; then
+    if [[ $# -lt 2 ]]; then
         text="$output"
     else
         text="$2"
     fi
-    [[ "$text" =~ $regex ]] || \
-        (batslib_print_kv_single_or_multi 10 "regex" "$regex" "actual" "$text" \
-         | batslib_decorate "output does not match" \
-         | fail)
+    if [[ ! "$text" =~ $regex ]]; then
+        batslib_print_kv_single_or_multi 10 "regex" "$regex" "actual" "$text" \
+            | batslib_decorate "output does not match" \
+            | fail
+    fi
 }
 
 # Asserts that a string does not contain another string, using regexp.
@@ -77,7 +80,7 @@ assert_match() {
 #         $output.
 assert_not_match() {
     regex="$1"
-    if [[ $# < 2 ]]; then
+    if [[ $# -lt 2 ]]; then
         text="$output"
     else
         text="$2"
@@ -101,16 +104,17 @@ assert_not_match() {
 #    $2 - The actual value.
 assert_eq() {
     expected="$1"
-    if [[ $# < 2 ]]; then
+    if [[ $# -lt 2 ]]; then
         actual="$output"
     else
         actual="$2"
     fi
 
-    [[ "$actual" == "$expected" ]] || \
-        (batslib_print_kv_single_or_multi 10 "expected" "$expected" "actual" "$actual" \
-         | batslib_decorate "output does not match" \
-         | fail)
+    if [[ ! "$actual" == "$expected" ]]; then
+        batslib_print_kv_single_or_multi 10 "expected" "$expected" "actual" "$actual" \
+            | batslib_decorate "output does not match" \
+            | fail
+    fi
 }
 
 # Asserts that two values are not equal.
@@ -119,16 +123,16 @@ assert_eq() {
 #    $2 - The actual value.
 assert_neq() {
     expected="$1"
-    if [[ $# < 2 ]]; then
+    if [[ $# -lt 2 ]]; then
         actual="$output"
     else
         actual="$2"
     fi
 
     [[ "$actual" != "$expected" ]] || \
-        (batslib_print_kv_single_or_multi 10 "expected" "$expected" "actual" "$actual" \
-         | batslib_decorate "output does not match" \
-         | fail)
+        batslib_print_kv_single_or_multi 10 "expected" "$expected" "actual" "$actual" \
+            | batslib_decorate "output does not match" \
+            | fail
 }
 
 
@@ -142,7 +146,7 @@ assert_process_exits() {
 
     echo "waiting up to $timeout seconds for process $pid to exit"
 
-    timeout $timeout sh -c \
+    timeout "$timeout" sh -c \
       "while kill -0 $pid; do echo waiting for process $pid to exit; sleep 1; done" \
       || (echo "process $pid did not exit" && ps aux && exit 1)
 
@@ -151,10 +155,10 @@ assert_process_exits() {
 
 # Asserts that `dfx start` and `replica` are no longer running
 assert_no_dfx_start_or_replica_processes() {
-    ! ( ps | grep "[/[:space:]]dfx start" )
+    ! ( pgrep "dfx start" )
     if [ -e .dfx/replica-configuration/replica-pid ];
     then
-      ! ( kill -0 $(cat .dfx/replica-configuration/replica-pid) 2>/dev/null )
+      ! ( kill -0 "$(< .dfx/replica-configuration/replica-pid)" 2>/dev/null )
     fi
 }
 
@@ -184,7 +188,7 @@ assert_file_not_exists() {
     filename="$1"
 
     if [[ -f $filename ]]; then
-        cat "$filename" | head -n 10 \
+        head -n 10 "$filename" \
         | batslib_decorate "Expected file to not exist. $filename exists and starts with:" \
         | fail
     fi
@@ -194,7 +198,7 @@ assert_file_eventually_exists() {
     filename="$1"
     timeout="$2"
 
-    timeout $timeout sh -c \
+    timeout "$timeout" sh -c \
       "until [ -f \"$filename\" ]; do echo waiting for \"$filename\"; sleep 1; done" \
       || (echo "file \"$filename\" was never created" && ls && exit 1)
 }


### PR DESCRIPTION
Currently we only shellcheck the explicit e2e tests. This extends shellcheck to the entire e2e directory, including asset patch scripts and the utils scripts.