### PR TITLE
feat: createactor options accept pre-initialized agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ The `dfx schema` command can now display the schema for either dfx.json or for n
 dfx schema --for networks
 ```
 
+### feat: createActor options accept pre-initialized agent
+
+If you have a pre-initialized agent in your JS code, you can now pass it to createActor's options. Conflicts with the agentOptions config - if you pass both the agent option will be used and you will receive a warning.
+
+```js
+const plugActor = createActor(canisterId, {
+  agent: plugAgent
+})
+```
+
 ### feat!: option for nodejs compatibility in dfx generate
 
 Users can now specify `node_compatibility: true` in `declarations`. The flag introduces `node.js` enhancements, which include importing `isomorphic-fetch` and configuring the default actor with `isomorphic-fetch` and `host`.

--- a/src/dfx/assets/language_bindings/index.js.hbs
+++ b/src/dfx/assets/language_bindings/index.js.hbs
@@ -1,10 +1,10 @@
 import { Actor, HttpAgent } from "@dfinity/agent";
 
 // Imports and re-exports candid interface
-import { idlFactory } from './{{canister_name}}.did.js';
-export { idlFactory } from './{{canister_name}}.did.js';
+import { idlFactory } from "./{{canister_name}}.did.js";
+export { idlFactory } from "./{{canister_name}}.did.js";
 // CANISTER_ID is replaced by webpack based on node environment
-export const canisterId = {{canister_name_process_env}};
+export const canisterId = {{{canister_name_process_env}}};
 
 {{{{raw}}}}
 /**
@@ -18,9 +18,9 @@ export const canisterId = {{canister_name_process_env}};
  *
  * @param {string | import("@dfinity/principal").Principal} canisterId Canister ID of Agent
  * @param {CreateActorOptions} options {@link CreateActorOptions}
- * @param {CreateActorOptions['agent']} [options.agent] An initialized agent
- * @param {CreateActorOptions['agentOptions']} [options.agentOptions] Options to initialize an {@link HttpAgent}. Overridden if an `agent` is passed.
- * @param {CreateActorOptions['actorOptions']} [options.actorOptions] Options of to pass during the actor initialization.
+ * @param {CreateActorOptions["agent"]} [options.agent] An initialized agent
+ * @param {CreateActorOptions["agentOptions"]} [options.agentOptions] Options to initialize an {@link HttpAgent}. Overridden if an `agent` is passed.
+ * @param {CreateActorOptions["actorOptions"]} [options.actorOptions] Options of to pass during the actor initialization.
  * @return {import("@dfinity/agent").ActorSubclass<import("{{{{/raw}}}}./{{canister_name}}.did.js")._SERVICE>} ActorSubclass configured for the canister
  */
 export const createActor = (canisterId, options = {}) => {
@@ -31,10 +31,10 @@ export const createActor = (canisterId, options = {}) => {
       "Detected both agent and agentOptions passed to createActor. Ignoring agentOptions and proceeding with the provided agent."
     );
   }
-  
+
   // Fetch root key for certificate validation during development
   if (process.env.DFX_NETWORK !== "ic") {
-    agent.fetchRootKey().catch(err => {
+    agent.fetchRootKey().catch((err) => {
       console.warn(
         "Unable to fetch root key. Check to ensure that your local replica is running"
       );

--- a/src/dfx/assets/language_bindings/index.js.hbs
+++ b/src/dfx/assets/language_bindings/index.js.hbs
@@ -26,7 +26,7 @@ export const canisterId = {{{canister_name_process_env}}};
 export const createActor = (canisterId, options = {}) => {
   const agent = options.agent || new HttpAgent({ ...options.agentOptions });
 
-  if (options.agent && options.agentConfig) {
+  if (options.agent && options.agentOptions) {
     console.warn(
       "Detected both agent and agentOptions passed to createActor. Ignoring agentOptions and proceeding with the provided agent."
     );

--- a/src/dfx/assets/language_bindings/index.js.hbs
+++ b/src/dfx/assets/language_bindings/index.js.hbs
@@ -8,18 +8,36 @@ export const canisterId = {{canister_name_process_env}};
 
 {{{{raw}}}}
 /**
- * 
- * @param {string | import("@dfinity/principal").Principal} canisterId Canister ID of Agent
- * @param {{agentOptions?: import(\"@dfinity/agent\").HttpAgentOptions; actorOptions?: import(\"@dfinity/agent\").ActorConfig}} [options]
- * @return {import("@dfinity/agent").ActorSubclass<import("{{{{/raw}}}}./{{canister_name}}.did.js")._SERVICE>}
+ * @typedef CreateActorOptions
+ * @property {(import("@dfinity/agent").Agent)} [agent]
+ * @property {(import("@dfinity/agent").HttpAgentOptions)} [agentOptions]
+ * @property {(import("@dfinity/agent").ActorConfig)} [actorOptions]
  */
-export const createActor = (canisterId, options) => {
-  const agent = new HttpAgent(options ? { ...options.agentOptions } : {});
+
+/**
+ *
+ * @param {string | import("@dfinity/principal").Principal} canisterId Canister ID of Agent
+ * @param {CreateActorOptions} options {@link CreateActorOptions}
+ * @param {CreateActorOptions['agent']} [options.agent] An initialized agent
+ * @param {CreateActorOptions['agentOptions']} [options.agentOptions] Options to initialize an {@link HttpAgent}. Overridden if an `agent` is passed.
+ * @param {CreateActorOptions['actorOptions']} [options.actorOptions] Options of to pass during the actor initialization.
+ * @return {import("@dfinity/agent").ActorSubclass<import("{{{{/raw}}}}./{{canister_name}}.did.js")._SERVICE>} ActorSubclass configured for the canister
+ */
+export const createActor = (canisterId, options = {}) => {
+  const agent = options.agent || new HttpAgent({ ...options.agentOptions });
+
+  if (options.agent && options.agentConfig) {
+    console.warn(
+      "Detected both agent and agentOptions passed to createActor. Ignoring agentOptions and proceeding with the provided agent."
+    );
+  }
   
   // Fetch root key for certificate validation during development
   if (process.env.DFX_NETWORK !== "ic") {
     agent.fetchRootKey().catch(err => {
-      console.warn("Unable to fetch root key. Check to ensure that your local replica is running");
+      console.warn(
+        "Unable to fetch root key. Check to ensure that your local replica is running"
+      );
       console.error(err);
     });
   }
@@ -28,6 +46,6 @@ export const createActor = (canisterId, options) => {
   return Actor.createActor(idlFactory, {
     agent,
     canisterId,
-    ...(options ? options.actorOptions : {}),
+    ...options.actorOptions,
   });
 };{{{actor_export}}}

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -225,7 +225,7 @@ export const {0} = createActor(canisterId);"#,
 
                     let process_string: String = match &info.get_declarations_config().env_override
                     {
-                        Some(s) => s.clone(),
+                        Some(s) => format!(r#""{}""#, s.clone()),
                         None => {
                             format!(
                                 "process.env.{}{}",


### PR DESCRIPTION
# Description

If you have a pre-initialized agent in your JS code, you can now pass it to createActor's options. Conflicts with the agentOptions config - if you pass both the agent option will be used and you will receive a warning.

```js
const plugActor = createActor(canisterId, {
  agent: plugAgent
})
```

# How Has This Been Tested?

Manual testing of output

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
