### PR TITLE
feat: change port for default shared local network from 8000 to 4943

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,7 +91,7 @@ jobs:
           fi
           time dfx deploy
           time dfx canister call smoke_backend greet '("fire")'
-          time curl --fail http://localhost:8000/sample-asset.txt?canisterId=$(dfx canister id smoke_frontend)
+          time curl --fail http://localhost:"$(dfx info webserver-port)"/sample-asset.txt?canisterId=$(dfx canister id smoke_frontend)
           time dfx stop
 
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ## DFX
 
-### feat: changed the default port of the shared local network from 8000 to 4943.
+### feat!: changed the default port of the shared local network from 8000 to 4943.
 
 This is so dfx doesn't connect to a project-specific network instead of the local shared network.
 
-### feat: added ic-nns-init executable to the binary cache
+In combination with the "system-wide dfx start" feature, there is a potential difference to be aware of with respect to existing projects.
 
-### fix: improved responsiveness of `greet` method call in default Motoko project template
+Since previous versions of dfx populate dfx.json with a `networks.local` definition that specifies port 8000, the behavior for existing projects won't change.
 
-`greet` method was marked as an `update` call, but it performs no state updates. Changing it to `query` call will result in faster execution.
+However, if you've edited dfx.json and removed the `networks.local` definition, the behavior within the project will change: dfx will connect to the shared local network on port 4943 rather than to the project-specific network on port 8000.  You woiuld need to edit webpack.config.js to match.  If you have scripts, you can run the new command `dfx info webserver-port` from the project directory to retrieve the port value.
 
 ### feat!: "system-wide dfx start"
 
@@ -26,7 +26,7 @@ The intended benefits:
 
 We're calling this the "shared local network."  `dfx start` and `dfx stop` will manage this network when run outside any project directory, or when a project's dfx.json does not define the `local` network.  The dfx.json template for new projects no longer defines any networks.
 
-We recommend that you remove the `local` network definition from dfx.json and instead use the shared local network.
+We recommend that you remove the `local` network definition from dfx.json and instead use the shared local network.  As mentioned above, doing so will make dfx use port 4943 rather than port 8000.
 
 See [Local Server Configuration](docs/cli-reference/dfx-start.md#local-server-configuration) for details.
 
@@ -36,6 +36,16 @@ dfx now stores data and control files in one of three places, rather than direct
 - `$HOME/Library/Application Support/org.dfinity.dfx/network/local` (for the shared local network on MacOS)
 
 There is also a new configuration file: `$HOME/.config/dfx/networks.json`.  Its [schema](docs/networks-json-schema.json) is the same as the `networks` element in dfx.json.  Any networks you define here will be available from any project, unless a project's dfx.json defines a network with the same name.  See [The Shared Local Network](docs/cli-reference/dfx-start.md#the-shared-local-network) for the default definitions that dfx provides if this file does not exist or does not define a `local` network.
+
+### feat: added `dfx info webserver-port` command
+
+This displays the port that the icx-proxy process listens on, meaning the port to connect to with curl or from a web browser.
+
+### feat: added ic-nns-init executable to the binary cache
+
+### fix: improved responsiveness of `greet` method call in default Motoko project template
+
+`greet` method was marked as an `update` call, but it performs no state updates. Changing it to `query` call will result in faster execution.
 
 ### feat: dfx schema --for networks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## DFX
 
+### feat: changed the default port of the shared local network from 8000 to 4943.
+
+This is so dfx doesn't connect to a project-specific network instead of the local shared network.
+
 ### feat: added ic-nns-init executable to the binary cache
 
 ### fix: improved responsiveness of `greet` method call in default Motoko project template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ In combination with the "system-wide dfx start" feature, there is a potential di
 
 Since previous versions of dfx populate dfx.json with a `networks.local` definition that specifies port 8000, the behavior for existing projects won't change.
 
-However, if you've edited dfx.json and removed the `networks.local` definition, the behavior within the project will change: dfx will connect to the shared local network on port 4943 rather than to the project-specific network on port 8000.  You woiuld need to edit webpack.config.js to match.  If you have scripts, you can run the new command `dfx info webserver-port` from the project directory to retrieve the port value.
+However, if you've edited dfx.json and removed the `networks.local` definition, the behavior within the project will change: dfx will connect to the shared local network on port 4943 rather than to the project-specific network on port 8000.  You would need to edit webpack.config.js to match.  If you have scripts, you can run the new command `dfx info webserver-port` from the project directory to retrieve the port value.
 
 ### feat!: "system-wide dfx start"
 

--- a/docs/cli-reference/dfx-info.md
+++ b/docs/cli-reference/dfx-info.md
@@ -1,0 +1,34 @@
+# dfx info
+
+The `dfx info` command prints the schema for `dfx.json`.
+
+## Basic usage
+
+``` bash
+dfx info [type] [flag]
+```
+
+## Flags
+
+You can use the following optional flags with the `dfx schema` command.
+
+| Flag              | Description |
+|-------------------|-------------|
+| `-h`, `--help`    | Displays usage information. |
+
+## Information Types
+
+You can use the following option with the `dfx schema` command.
+
+| Option               | Description                                                                                                       |
+|----------------------|-------------------------------------------------------------------------------------------------------------------|
+| webserver-port       | Display schema for either dfx.json or networks.json. (default: dfx) |
+
+## Examples
+
+You can print the schema for `dfx.json` by running the following command:
+
+``` bash
+$ dfx info webserver-port
+4943
+```

--- a/docs/cli-reference/dfx-info.md
+++ b/docs/cli-reference/dfx-info.md
@@ -1,32 +1,30 @@
 # dfx info
 
-The `dfx info` command prints the schema for `dfx.json`.
-
 ## Basic usage
 
 ``` bash
 dfx info [type] [flag]
 ```
 
+## Information Types
+
+These are the types of information that the `dfx info` command can display.
+
+| Option               | Description                          |
+|----------------------|--------------------------------------|
+| webserver-port       | The local webserver (icx-proxy) port |
+
 ## Flags
 
-You can use the following optional flags with the `dfx schema` command.
+You can use the following optional flags with the `dfx info` command.
 
 | Flag              | Description |
 |-------------------|-------------|
 | `-h`, `--help`    | Displays usage information. |
 
-## Information Types
-
-You can use the following option with the `dfx schema` command.
-
-| Option               | Description                                                                                                       |
-|----------------------|-------------------------------------------------------------------------------------------------------------------|
-| webserver-port       | Display schema for either dfx.json or networks.json. (default: dfx) |
-
 ## Examples
 
-You can print the schema for `dfx.json` by running the following command:
+You can display the webserver port by running the following command:
 
 ``` bash
 $ dfx info webserver-port

--- a/docs/cli-reference/dfx-start.md
+++ b/docs/cli-reference/dfx-start.md
@@ -27,10 +27,10 @@ You can use the following optional flags with the `dfx start` command.
 
 You can use the following option with the `dfx start` command.
 
-| Option        | Description                                                                                                       |
-|---------------|-------------------------------------------------------------------------------------------------------------------|
-| `--host host` | Specifies the host interface IP address and port number to bind the frontend to. The default is `127.0.0.1:8000`. |
-| `--bitcoin-node host:port` | Specifies the address of a bitcoind node. Implies `--enable-bitcoin`. |
+| Option        | Description                                                                                                                                                                                                         |
+|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--host host` | Specifies the host interface IP address and port number to bind the frontend to. The default for the local shared network is `127.0.0.1:4943`, while the default for a project-specific network is '127.0.0.1:8000'. |
+| `--bitcoin-node host:port` | Specifies the address of a bitcoind node. Implies `--enable-bitcoin`.                                                                                                                                               |
 
 ## Examples
 

--- a/docs/cli-reference/dfx-start.md
+++ b/docs/cli-reference/dfx-start.md
@@ -69,7 +69,7 @@ If run from outside any dfx project, or if dfx.json does not define the `local` 
 ```
 {
   "local": {
-    "bind": "127.0.0.1:8000",
+    "bind": "127.0.0.1:4943",
     "type": "ephemeral"
   }
 }

--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -30,6 +30,8 @@ When you have the SDK installed, you can use the following commands to specify t
 
 -   [dfx identity](./dfx-identity.md)
 
+-   [dfx info](./dfx-info.md)
+
 -   [dfx ledger](./dfx-ledger.md)
 
 -   [dfx new](./dfx-new.md)

--- a/docs/dfx-json-schema.json
+++ b/docs/dfx-json-schema.json
@@ -519,7 +519,7 @@
       "type": "object",
       "properties": {
         "bind": {
-          "description": "Bind address for the webserver. For the shared local network, the default is 127.0.0.1:4943 For project-specific local networks, the default is 127.0.0.1:8000",
+          "description": "Bind address for the webserver. For the shared local network, the default is 127.0.0.1:4943. For project-specific local networks, the default is 127.0.0.1:8000.",
           "type": [
             "string",
             "null"
@@ -652,7 +652,7 @@
     },
     "NetworkType": {
       "title": "Network Type",
-      "description": "Type 'ephemeral' is used for networks that are regularly reset. Type 'perstistent' is used for networks that last for a long time and where it is preferred that canister IDs get stored in source control.",
+      "description": "Type 'ephemeral' is used for networks that are regularly reset. Type 'persistent' is used for networks that last for a long time and where it is preferred that canister IDs get stored in source control.",
       "type": "string",
       "enum": [
         "ephemeral",

--- a/docs/dfx-json-schema.json
+++ b/docs/dfx-json-schema.json
@@ -519,9 +519,11 @@
       "type": "object",
       "properties": {
         "bind": {
-          "description": "Bind address for the webserver.",
-          "default": "127.0.0.1:8000",
-          "type": "string"
+          "description": "Bind address for the webserver. For the shared local network, the default is 127.0.0.1:4943 For project-specific local networks, the default is 127.0.0.1:8000",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "bitcoin": {
           "anyOf": [

--- a/docs/networks-json-schema.json
+++ b/docs/networks-json-schema.json
@@ -120,9 +120,11 @@
       "type": "object",
       "properties": {
         "bind": {
-          "description": "Bind address for the webserver.",
-          "default": "127.0.0.1:8000",
-          "type": "string"
+          "description": "Bind address for the webserver. For the shared local network, the default is 127.0.0.1:4943 For project-specific local networks, the default is 127.0.0.1:8000",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "bitcoin": {
           "anyOf": [

--- a/docs/networks-json-schema.json
+++ b/docs/networks-json-schema.json
@@ -120,7 +120,7 @@
       "type": "object",
       "properties": {
         "bind": {
-          "description": "Bind address for the webserver. For the shared local network, the default is 127.0.0.1:4943 For project-specific local networks, the default is 127.0.0.1:8000",
+          "description": "Bind address for the webserver. For the shared local network, the default is 127.0.0.1:4943. For project-specific local networks, the default is 127.0.0.1:8000.",
           "type": [
             "string",
             "null"
@@ -214,7 +214,7 @@
     },
     "NetworkType": {
       "title": "Network Type",
-      "description": "Type 'ephemeral' is used for networks that are regularly reset. Type 'perstistent' is used for networks that last for a long time and where it is preferred that canister IDs get stored in source control.",
+      "description": "Type 'ephemeral' is used for networks that are regularly reset. Type 'persistent' is used for networks that last for a long time and where it is preferred that canister IDs get stored in source control.",
       "type": "string",
       "enum": [
         "ephemeral",

--- a/docs/process/release.adoc
+++ b/docs/process/release.adoc
@@ -204,8 +204,8 @@ $dfx_rc canister call hello_world greet everyone
 +
 [source, bash]
 ----
-export hello_world_backend_candid_url="http://localhost:8000/candid?canisterId=$($dfx_rc canister id hello_world_backend)"
-export hello_world_frontend_url="http://localhost:8000/?canisterId=$($dfx_rc canister id hello_world_frontend)"
+export hello_world_backend_candid_url="http://localhost:4943/candid?canisterId=$($dfx_rc canister id hello_world_backend)"
+export hello_world_frontend_url="http://localhost:4943/?canisterId=$($dfx_rc canister id hello_world_frontend)"
 ----
 . Open a web browser and clear your cache or switch to Private Browsing/Incognito mode.
 . Open the following URL in your web browser:

--- a/e2e/tests-dfx/bootstrap.bash
+++ b/e2e/tests-dfx/bootstrap.bash
@@ -18,7 +18,7 @@ teardown() {
 @test "forbid starting webserver with a forwarded port" {
     [ "$USE_IC_REF" ] && skip "skipped for ic-ref"
 
-    assert_command_fail dfx bootstrap --port 8000
+    assert_command_fail dfx bootstrap --port 4943
     assert_match "Cannot forward API calls to the same bootstrap server"
 }
 

--- a/e2e/tests-dfx/describe_local_network.bash
+++ b/e2e/tests-dfx/describe_local_network.bash
@@ -46,10 +46,11 @@ teardown() {
     assert_match "Using the default definition for the 'local' shared network because $DFX_CONFIG_ROOT/.config/dfx/networks.json does not exist."
 
     assert_match "Local server configuration:"
-    assert_match "bind address: 127.0.0.1:0 \(default: 127.0.0.1:8000\)"
+    assert_match "bind address: 127.0.0.1:0 \(default: 127.0.0.1:4943\)"
     assert_match "bitcoin: disabled"
     assert_match "canister http: disabled"
     assert_match "subnet type: Application"
+    assert_match "scope: shared"
 }
 
 @test "dfx start outside of a project with default configuration" {
@@ -102,7 +103,7 @@ teardown() {
     assert_command dfx start --background
 
     assert_match "Local server configuration:"
-    assert_match "bind address: 127.0.0.1:0 \(default: 127.0.0.1:8000\)"
+    assert_match "bind address: 127.0.0.1:0 \(default: 127.0.0.1:4943\)"
     assert_match "bitcoin: disabled"
     assert_match "canister http: disabled"
     assert_match "subnet type: Application"

--- a/e2e/tests-dfx/info.bash
+++ b/e2e/tests-dfx/info.bash
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+load ../utils/_
+
+setup() {
+    standard_setup
+
+    dfx_new
+}
+
+teardown() {
+    dfx_stop
+
+    standard_teardown
+}
+
+@test "displays the default webserver port for the local shared network" {
+    assert_command dfx info webserver-port
+    assert_eq "4943"
+}
+
+@test "displays the webserver port for a project-specific network" {
+    define_project_network
+    assert_command dfx info webserver-port
+    assert_eq "8000"
+}

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -31,9 +31,9 @@ teardown() {
     rm canister_ids.json
 
     install_asset remote/call/mock
+    jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
     setup_actuallylocal_shared_network
     setup_local_shared_network
-    jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
 
     # set up: remote method is update, local is query
     # call remote method as update to make a change
@@ -223,9 +223,9 @@ teardown() {
     rm canister_ids.json
 
     install_asset remote/extra
+    jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
     setup_actuallylocal_shared_network
     setup_local_shared_network
-    jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
 
     # We expect the local network deploy to succeed, because it is built using the candid file from
     # the local canister.

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -323,7 +323,6 @@ use_default_wallet_wasm() {
 
 get_webserver_port() {
   dfx info webserver-port
-  # cat "$E2E_NETWORK_DATA_DIRECTORY/webserver-port"
 }
 overwrite_webserver_port() {
   echo "$1" >"$E2E_NETWORK_DATA_DIRECTORY/webserver-port"

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -322,7 +322,8 @@ use_default_wallet_wasm() {
 }
 
 get_webserver_port() {
-  cat "$E2E_NETWORK_DATA_DIRECTORY/webserver-port"
+  dfx info webserver-port
+  # cat "$E2E_NETWORK_DATA_DIRECTORY/webserver-port"
 }
 overwrite_webserver_port() {
   echo "$1" >"$E2E_NETWORK_DATA_DIRECTORY/webserver-port"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -111,8 +111,9 @@ validate_default_project() {
         hello_world_frontend_canister_id=$(dfx canister id hello_world_frontend)
         application_canister_id=$(dfx canister id hello_world_backend)
         candid_ui_id=$(dfx canister id __Candid_UI)
-        export hello_world_frontend_url="http://localhost:8000/?canisterId=$hello_world_frontend_canister_id"
-        export candid_ui_url="http://localhost:8000/?canisterId=$candid_ui_id&id=$application_canister_id"
+        webserver_port="$(dfx info webserver-port)"
+        export hello_world_frontend_url="http://localhost:$webserver_port/?canisterId=$hello_world_frontend_canister_id"
+        export candid_ui_url="http://localhost:$webserver_port/?canisterId=$candid_ui_id&id=$application_canister_id"
 
         echo
         echo "=================================================="

--- a/src/dfx/assets/new_project_motoko_files/README.md
+++ b/src/dfx/assets/new_project_motoko_files/README.md
@@ -32,7 +32,7 @@ dfx start --background
 dfx deploy
 ```
 
-Once the job completes, your application will be available at `http://localhost:8000?canisterId={asset_canister_id}`.
+Once the job completes, your application will be available at `http://localhost:4943?canisterId={asset_canister_id}`.
 
 Additionally, if you are making frontend changes, you can start a development server with
 
@@ -40,7 +40,7 @@ Additionally, if you are making frontend changes, you can start a development se
 npm start
 ```
 
-Which will start a server at `http://localhost:8080`, proxying API requests to the replica at port 8000.
+Which will start a server at `http://localhost:8080`, proxying API requests to the replica at port 4943.
 
 ### Note on frontend environment variables
 

--- a/src/dfx/assets/new_project_node_files/webpack.config.js
+++ b/src/dfx/assets/new_project_node_files/webpack.config.js
@@ -98,7 +98,7 @@ module.exports = {
   devServer: {
     proxy: {
       "/api": {
-        target: "http://127.0.0.1:8000",
+        target: "http://127.0.0.1:4943",
         changeOrigin: true,
         pathRewrite: {
           "^/api": "/api",

--- a/src/dfx/assets/new_project_node_files/webpack.config.js
+++ b/src/dfx/assets/new_project_node_files/webpack.config.js
@@ -94,7 +94,8 @@ module.exports = {
       process: require.resolve("process/browser"),
     }),
   ],
-  // proxy /api to port 8000 during development
+  // proxy /api to port 4943 during development.
+  // if you edit dfx.json to define a project-specific local network, change the port to match.
   devServer: {
     proxy: {
       "/api": {

--- a/src/dfx/assets/new_project_rust_files/README.md
+++ b/src/dfx/assets/new_project_rust_files/README.md
@@ -34,4 +34,4 @@ dfx start --background
 dfx deploy
 ```
 
-Once the job completes, your application will be available at `http://localhost:8000?canisterId={asset_canister_id}`.
+Once the job completes, your application will be available at `http://localhost:4943?canisterId={asset_canister_id}`.

--- a/src/dfx/src/commands/info/mod.rs
+++ b/src/dfx/src/commands/info/mod.rs
@@ -1,0 +1,37 @@
+use crate::lib::provider::{create_network_descriptor, LocalBindDetermination};
+use crate::{DfxResult, Environment};
+use clap::Parser;
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+enum InfoType {
+    WebserverPort,
+}
+
+#[derive(Parser)]
+#[clap(name("info"))]
+pub struct InfoOpts {
+    #[clap(value_enum)]
+    info_type: InfoType,
+}
+
+pub fn exec(env: &dyn Environment, opts: InfoOpts) -> DfxResult {
+    let value = match opts.info_type {
+        InfoType::WebserverPort => get_webserver_port(env)?,
+    };
+    print!("{}", value);
+    Ok(())
+}
+
+fn get_webserver_port(env: &dyn Environment) -> DfxResult<String> {
+    let port = create_network_descriptor(
+        env.get_config(),
+        env.get_networks_config(),
+        None, /* opts.network */
+        None,
+        LocalBindDetermination::ApplyRunningWebserverPort,
+    )?
+    .local_server_descriptor()?
+    .bind_address
+    .port();
+    Ok(format!("{}", port))
+}

--- a/src/dfx/src/commands/info/mod.rs
+++ b/src/dfx/src/commands/info/mod.rs
@@ -1,4 +1,6 @@
-use crate::lib::provider::{create_network_descriptor, LocalBindDetermination};
+mod webserver_port;
+
+use crate::commands::info::webserver_port::get_webserver_port;
 use crate::{DfxResult, Environment};
 use clap::Parser;
 
@@ -18,20 +20,6 @@ pub fn exec(env: &dyn Environment, opts: InfoOpts) -> DfxResult {
     let value = match opts.info_type {
         InfoType::WebserverPort => get_webserver_port(env)?,
     };
-    print!("{}", value);
+    println!("{}", value);
     Ok(())
-}
-
-fn get_webserver_port(env: &dyn Environment) -> DfxResult<String> {
-    let port = create_network_descriptor(
-        env.get_config(),
-        env.get_networks_config(),
-        None, /* opts.network */
-        None,
-        LocalBindDetermination::ApplyRunningWebserverPort,
-    )?
-    .local_server_descriptor()?
-    .bind_address
-    .port();
-    Ok(format!("{}", port))
 }

--- a/src/dfx/src/commands/info/webserver_port.rs
+++ b/src/dfx/src/commands/info/webserver_port.rs
@@ -1,0 +1,16 @@
+use crate::lib::provider::{create_network_descriptor, LocalBindDetermination};
+use crate::{DfxResult, Environment};
+
+pub(crate) fn get_webserver_port(env: &dyn Environment) -> DfxResult<String> {
+    let port = create_network_descriptor(
+        env.get_config(),
+        env.get_networks_config(),
+        None,
+        None,
+        LocalBindDetermination::ApplyRunningWebserverPort,
+    )?
+    .local_server_descriptor()?
+    .bind_address
+    .port();
+    Ok(format!("{}", port))
+}

--- a/src/dfx/src/commands/mod.rs
+++ b/src/dfx/src/commands/mod.rs
@@ -12,6 +12,7 @@ mod diagnose;
 mod fix;
 mod generate;
 mod identity;
+mod info;
 mod language_service;
 mod ledger;
 mod new;
@@ -36,6 +37,7 @@ pub enum Command {
     Fix(BaseOpts<fix::FixOpts>),
     Generate(BaseOpts<generate::GenerateOpts>),
     Identity(identity::IdentityCommand),
+    Info(BaseOpts<info::InfoOpts>),
     #[clap(name("_language-service"))]
     LanguageServices(BaseOpts<language_service::LanguageServiceOpts>),
     Ledger(ledger::LedgerCommand),
@@ -80,6 +82,7 @@ pub fn dispatch(cmd: Command) -> DfxResult {
         Command::Diagnose(v) => diagnose::exec(&init_env(v.env_opts)?, v.command_opts),
         Command::Fix(v) => fix::exec(&init_env(v.env_opts)?, v.command_opts),
         Command::Generate(v) => generate::exec(&init_env(v.env_opts)?, v.command_opts),
+        Command::Info(v) => info::exec(&init_env(v.env_opts)?, v.command_opts),
         Command::LanguageServices(v) => {
             language_service::exec(&init_env(v.env_opts)?, v.command_opts)
         }

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -53,7 +53,8 @@ pub struct ConfigCanistersCanisterRemote {
     pub id: BTreeMap<String, Principal>,
 }
 
-pub const DEFAULT_LOCAL_BIND: &str = "127.0.0.1:8000";
+pub const DEFAULT_SHARED_LOCAL_BIND: &str = "127.0.0.1:4943"; // hex for "IC"
+pub const DEFAULT_PROJECT_LOCAL_BIND: &str = "127.0.0.1:8000";
 pub const DEFAULT_IC_GATEWAY: &str = "https://ic0.app";
 pub const DEFAULT_IC_GATEWAY_TRAILING_SLASH: &str = "https://ic0.app/";
 pub const DEFAULT_REPLICA_PORT: u16 = 8080;
@@ -379,8 +380,10 @@ pub struct ConfigNetworkProvider {
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ConfigLocalProvider {
     /// Bind address for the webserver.
-    #[serde(default = "default_local_bind")]
-    pub bind: String,
+    /// For the shared local network, the default is 127.0.0.1:4943
+    /// For project-specific local networks, the default is 127.0.0.1:8000
+    // #[serde(default = "default_local_bind")]
+    pub bind: Option<String>,
 
     /// Persistence type of this network.
     #[serde(default = "NetworkType::ephemeral")]
@@ -392,9 +395,9 @@ pub struct ConfigLocalProvider {
     pub replica: Option<ConfigDefaultsReplica>,
 }
 
-fn default_local_bind() -> String {
-    String::from(DEFAULT_LOCAL_BIND)
-}
+// fn default_local_bind() -> String {
+//     String::from(DEFAULT_LOCAL_BIND)
+// }
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
 pub enum ConfigNetwork {

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -380,8 +380,8 @@ pub struct ConfigNetworkProvider {
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ConfigLocalProvider {
     /// Bind address for the webserver.
-    /// For the shared local network, the default is 127.0.0.1:4943
-    /// For project-specific local networks, the default is 127.0.0.1:8000
+    /// For the shared local network, the default is 127.0.0.1:4943.
+    /// For project-specific local networks, the default is 127.0.0.1:8000.
     pub bind: Option<String>,
 
     /// Persistence type of this network.

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -382,7 +382,6 @@ pub struct ConfigLocalProvider {
     /// Bind address for the webserver.
     /// For the shared local network, the default is 127.0.0.1:4943
     /// For project-specific local networks, the default is 127.0.0.1:8000
-    // #[serde(default = "default_local_bind")]
     pub bind: Option<String>,
 
     /// Persistence type of this network.
@@ -395,9 +394,6 @@ pub struct ConfigLocalProvider {
     pub replica: Option<ConfigDefaultsReplica>,
 }
 
-// fn default_local_bind() -> String {
-//     String::from(DEFAULT_LOCAL_BIND)
-// }
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
 pub enum ConfigNetwork {

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -312,7 +312,7 @@ pub struct ConfigDefaultsReplica {
 // Schemars doesn't add the enum value's docstrings. Therefore the explanations have to be up here.
 /// # Network Type
 /// Type 'ephemeral' is used for networks that are regularly reset.
-/// Type 'perstistent' is used for networks that last for a long time and where it is preferred that canister IDs get stored in source control.
+/// Type 'persistent' is used for networks that last for a long time and where it is preferred that canister IDs get stored in source control.
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum NetworkType {

--- a/src/dfx/src/lib/network/local_server_descriptor.rs
+++ b/src/dfx/src/lib/network/local_server_descriptor.rs
@@ -1,4 +1,6 @@
-use crate::config::dfinity::{to_socket_addr, ReplicaSubnetType, DEFAULT_LOCAL_BIND};
+use crate::config::dfinity::{
+    to_socket_addr, ReplicaSubnetType, DEFAULT_PROJECT_LOCAL_BIND, DEFAULT_SHARED_LOCAL_BIND,
+};
 use crate::config::dfinity::{
     ConfigDefaultsBitcoin, ConfigDefaultsBootstrap, ConfigDefaultsCanisterHttp,
     ConfigDefaultsReplica,
@@ -220,7 +222,12 @@ impl LocalServerDescriptor {
 impl LocalServerDescriptor {
     pub fn describe(&self, include_replica: bool, include_replica_port: bool) {
         println!("Local server configuration:");
-        let default_bind: SocketAddr = DEFAULT_LOCAL_BIND.parse().unwrap();
+        let default_local_bind = match self.scope {
+            LocalNetworkScopeDescriptor::Project => DEFAULT_PROJECT_LOCAL_BIND,
+            LocalNetworkScopeDescriptor::Shared { .. } => DEFAULT_SHARED_LOCAL_BIND,
+        };
+
+        let default_bind: SocketAddr = default_local_bind.parse().unwrap();
         let diffs = if self.bind_address != default_bind {
             format!(" (default: {:?})", default_bind)
         } else {

--- a/src/dfx/src/lib/network/local_server_descriptor.rs
+++ b/src/dfx/src/lib/network/local_server_descriptor.rs
@@ -222,12 +222,13 @@ impl LocalServerDescriptor {
 impl LocalServerDescriptor {
     pub fn describe(&self, include_replica: bool, include_replica_port: bool) {
         println!("Local server configuration:");
-        let default_local_bind = match self.scope {
+        let default_bind: SocketAddr = match self.scope {
             LocalNetworkScopeDescriptor::Project => DEFAULT_PROJECT_LOCAL_BIND,
             LocalNetworkScopeDescriptor::Shared { .. } => DEFAULT_SHARED_LOCAL_BIND,
-        };
+        }
+        .parse()
+        .unwrap();
 
-        let default_bind: SocketAddr = default_local_bind.parse().unwrap();
         let diffs = if self.bind_address != default_bind {
             format!(" (default: {:?})", default_bind)
         } else {

--- a/src/dfx/src/lib/provider.rs
+++ b/src/dfx/src/lib/provider.rs
@@ -644,7 +644,7 @@ mod tests {
                 .local_server_descriptor()
                 .unwrap()
                 .bind_address,
-            to_socket_addr("127.0.0.1:8000").unwrap()
+            to_socket_addr("127.0.0.1:4943").unwrap()
         );
     }
 
@@ -669,7 +669,7 @@ mod tests {
                 .local_server_descriptor()
                 .unwrap()
                 .bind_address,
-            to_socket_addr("127.0.0.1:8000").unwrap()
+            to_socket_addr("127.0.0.1:4943").unwrap()
         );
     }
 

--- a/src/dfx/src/lib/provider.rs
+++ b/src/dfx/src/lib/provider.rs
@@ -47,6 +47,7 @@ pub enum LocalBindDetermination {
     ApplyRunningWebserverPort,
 }
 
+#[allow(clippy::too_many_arguments)]
 #[context("Failed to get network descriptor for network '{}.", network_name)]
 fn config_network_to_network_descriptor(
     network_name: &str,


### PR DESCRIPTION
# Description

Make the default shared local network use port 4943 ("hex for `IC`"), so that if a project-specific network happens to be running, dfx won't connect to it when trying to connect to the local shared network.

Also added command `dfx info webserver-port` to display the port, since it may come from one of several places.

Fixes https://dfinity.atlassian.net/browse/SDK-216

# How Has This Been Tested?

Tested locally and added e2e tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
