### PR TITLE
fix: Small grammar change to identity password decryption prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,14 @@ Previously, dfx only accepted canister aliases and produced an error message tha
 
 ### fix: print links to cdk-rs docs in dfx new
 
+### fix: Small grammar change to identity password decryption prompt
+
+The prompt for entering your passphrase in order to decrypt an identity password read:
+    "Please enter a passphrase for your identity"
+However, at that point, it isn't "a" passphrase.  It's either your passphrase, or incorrect.
+Changed the text in this case to read:
+    "Please enter the passphrase for your identity"
+
 ### ic-ref
 
 Updated ic-ref to 0.0.1-1fba03ee

--- a/e2e/assets/expect_scripts/create_identity_with_password.exp
+++ b/e2e/assets/expect_scripts/create_identity_with_password.exp
@@ -13,7 +13,7 @@ expect eof
 
 spawn dfx identity get-principal
 expect {
-	"Please enter a passphrase for your identity: " {
+	"Please enter the passphrase for your identity: " {
 		send -- "testpassword\r"
 	}
 	timeout {

--- a/e2e/assets/expect_scripts/import_export_identity_with_password.exp
+++ b/e2e/assets/expect_scripts/import_export_identity_with_password.exp
@@ -38,7 +38,7 @@ while {1} {
 	# use 'bash -c' to use output redirection
 	spawn bash -c "dfx identity export alice > export.pem"
 	expect {
-		"Please enter a passphrase for your identity: " {
+		"Please enter the passphrase for your identity: " {
 			send -- "testpassword\r"
 		}
 		timeout {

--- a/e2e/assets/expect_scripts/rename_identity_with_password.exp
+++ b/e2e/assets/expect_scripts/rename_identity_with_password.exp
@@ -22,7 +22,7 @@ spawn dfx identity use bob
 expect eof
 
 spawn dfx identity get-principal
-expect -exact "\rPlease enter a passphrase for your identity: "
+expect -exact "\rPlease enter the passphrase for your identity: "
 send -- "testpassword\r"
 expect {
 	"Decryption complete." {

--- a/e2e/assets/expect_scripts/wrong_password_rejected.exp
+++ b/e2e/assets/expect_scripts/wrong_password_rejected.exp
@@ -12,7 +12,7 @@ spawn dfx identity use alice
 expect eof
 
 spawn dfx identity get-principal
-expect "Please enter a passphrase for your identity: "
+expect "Please enter the passphrase for your identity: "
 send -- "wrong_password\r"
 expect {
 	"Failed during decryption." {}


### PR DESCRIPTION
# Description

When testing something else, I noticed that when prompting for the decryption password for an identity, the prompt is `Please enter a passphrase for your identity`.  However, at that point dfx is not asking for **a** passphrase, it's asking for **the** passphrase. 

# How Has This Been Tested?

Updated e2e tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
