### PR TITLE
feat: Support installing canisters not in dfx.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## DFX
 
+### feat!: Support installing canisters not in dfx.json
+
+`install_canister_wasm` used to fail if installing a canister not listed in dfx.json.  This use case is now supported.
+
 ### feat: print the dashboard URL on startup
 
 When running `dfx start` or `dfx replica`, the path to the dashboard page is now printed.

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -568,10 +568,7 @@ impl ConfigInterface {
         network
     )]
     pub fn is_remote_canister(&self, canister: &str, network: &str) -> DfxResult<bool> {
-        Ok(self
-            .get_remote_canister_id(canister, network)
-            .unwrap_or_default()
-            .is_some())
+        Ok(self.get_remote_canister_id(canister, network)?.is_some())
     }
 
     #[context("Failed to get compute allocation for '{}'.", canister_name)]

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -568,7 +568,10 @@ impl ConfigInterface {
         network
     )]
     pub fn is_remote_canister(&self, canister: &str, network: &str) -> DfxResult<bool> {
-        Ok(self.get_remote_canister_id(canister, network)?.is_some())
+        Ok(self
+            .get_remote_canister_id(canister, network)
+            .unwrap_or_default()
+            .is_some())
     }
 
     #[context("Failed to get compute allocation for '{}'.", canister_name)]

--- a/src/dfx/src/lib/operations/canister/create_canister.rs
+++ b/src/dfx/src/lib/operations/canister/create_canister.rs
@@ -42,7 +42,8 @@ pub async fn create_canister(
 
     if let Some(remote_canister_id) = config
         .get_config()
-        .get_remote_canister_id(canister_name, &network_name)?
+        .get_remote_canister_id(canister_name, &network_name)
+        .unwrap_or_default()
     {
         bail!(
             "{} canister is remote on network {} and has canister id: {}",


### PR DESCRIPTION
# Description
Installing NNS canisters involves operating on canisters not listed in dfx.json.

In two places, the existing code checks for canister data in dfx.json.  It doesn't matter if the data is missing, but if the canister is not listed at all, the cli bails out.  E.g. it checks whether the canister has a remote canister ID; it doesn't need to have one, but if the canister is not listed, we crash.  Instead, we would like to treat this in the same way as the data being absent.

We wish to support the case where one dfx server is shared across multiple projects and explicitly do not want to add entries to the dfx.json of a particular project unless the user chooses to do so.

# How Has This Been Tested?
In the development branch `dfx nns install` this change allows NNS canisters to be installed without listing them in dfx.json.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
