### PR TITLE
chore: remove unused dependency pathdiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,6 @@ dependencies = [
  "mime",
  "mime_guess",
  "mockito",
- "pathdiff",
  "proptest",
  "serde",
  "serde_bytes",
@@ -2287,12 +2286,6 @@ name = "paste"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pem"

--- a/src/canisters/frontend/ic-asset/Cargo.toml
+++ b/src/canisters/frontend/ic-asset/Cargo.toml
@@ -27,7 +27,6 @@ ic-agent = { version = "0.20", features = [ "pem" ] }
 ic-utils = "0.20"
 mime = "0.3.16"
 mime_guess = "2.0.4"
-pathdiff = "0.2.1"
 serde = "1.0"
 serde_bytes = "0.11.2"
 serde_json = "1.0.81"


### PR DESCRIPTION
The pathdiff dependency from ic-asset is unused. This removes it.