### PR TITLE
fix: creating a canister costs 0.1T

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,10 @@ This is a breaking change.  The only thing this was still serving was the /_/can
 - if there is no wallet to upgrade
 - if trying to upgrade a local wallet from outside of a project directory
 
+### fix: canister creation cost is 0.1T cycles
+
+Canister creation fee was calculated with 1T cycles instead of 0.1T.
+
 ### fix: dfx deploy and dfx canister install write .old.did files under .dfx/
 
 When dfx deploy and dfx canister install upgrade a canister, they ensure that the

--- a/src/dfx/src/lib/operations/canister/create_canister.rs
+++ b/src/dfx/src/lib/operations/canister/create_canister.rs
@@ -16,8 +16,8 @@ use slog::info;
 use std::format;
 use std::time::Duration;
 
-// The cycle fee for create request is 1T cycles.
-const CANISTER_CREATE_FEE: u128 = 1_000_000_000_000_u128;
+// The cycle fee for create request is 0.1T cycles.
+const CANISTER_CREATE_FEE: u128 = 100_000_000_000_u128;
 // We do not know the minimum cycle balance a canister should have.
 // For now create the canister with 3T cycle balance.
 const CANISTER_INITIAL_CYCLE_BALANCE: u128 = 3_000_000_000_000_u128;


### PR DESCRIPTION
# Description

dfx contains the wrong fee. 0.1T is correct

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
