### PR TITLE
refactor: e2e functions to start and stop a webserver

### DIFF
--- a/e2e/tests-dfx/upgrade.bash
+++ b/e2e/tests-dfx/upgrade.bash
@@ -2,10 +2,13 @@
 
 load ../utils/_
 
-RANDOM_EMPHEMERAL_PORT=$(shuf -i 49152-65535 -n 1)
-
 setup() {
     standard_setup
+}
+
+teardown() {
+    stop_webserver
+    standard_teardown
 }
 
 @test "upgrade succeeds" {
@@ -26,26 +29,21 @@ setup() {
         "0.4.7"
       ]
     }' > manifest.json
-    python3 -m http.server "$RANDOM_EMPHEMERAL_PORT" &
-    WEB_SERVER_PID=$!
 
-    while ! nc -z localhost "$RANDOM_EMPHEMERAL_PORT"; do
-        sleep 1
-    done
+    start_webserver
 
     # Override current version to force upgrade
     assert_command ./dfx upgrade \
         --current-version 0.4.6 \
-        --release-root "http://localhost:$RANDOM_EMPHEMERAL_PORT"
+        --release-root "http://localhost:$E2E_WEB_SERVER_PORT"
     assert_match "Current version: .*"
     assert_match "Fetching manifest .*"
     assert_match "New version available: .*"
 
     assert_command ./dfx upgrade \
-        --release-root "http://localhost:$RANDOM_EMPHEMERAL_PORT"
+        --release-root "http://localhost:$E2E_WEB_SERVER_PORT"
     assert_match "Already up to date"
 
-    kill "$WEB_SERVER_PID"
     assert_command ./dfx --version
     assert_match "$version"
 }

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -1,6 +1,7 @@
 set -e
 load "${BATSLIB}/load.bash"
 load ../utils/assertions
+load ../utils/webserver
 
 # Takes a name of the asset folder, and copy those files to the current project.
 install_asset() {

--- a/e2e/utils/webserver.bash
+++ b/e2e/utils/webserver.bash
@@ -1,0 +1,19 @@
+start_webserver() {
+    local port script_dir
+    script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+    port=$(python3 "$script_dir/get_ephemeral_port.py")
+    export E2E_WEB_SERVER_PORT="$port"
+
+    python3 -m http.server "$E2E_WEB_SERVER_PORT" "$@" &
+    export E2E_WEB_SERVER_PID=$!
+
+    while ! nc -z localhost "$E2E_WEB_SERVER_PORT"; do
+      sleep 1
+    done
+}
+
+stop_webserver() {
+    if [ "$E2E_WEB_SERVER_PID" ]; then
+        kill "$E2E_WEB_SERVER_PID"
+    fi
+}


### PR DESCRIPTION
Refactor the start/stop webserver logic from the `upgrade` test, so that other tests can use it.

Also:
- Use an actual unused port rather than a random one
- Stop the webserver process in teardown, so that if there is a test failure, bats doesn't hang due to a still-running child process
