### PR TITLE
fix(frontend-canister): copy `.ic-assets.json` file from `src` to `dist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ## DFX
 
+### fix: For default node starter template: copy `ic-assets.json5` file from `src` to `dist`
+
 ### refactor: Move replica URL functions into a module for reuse
 
 The running replica port and url are generally useful information. Previously the code to get the URL was embedded in the network proxy code. This moves it out into a library for reuse.
-
-### feat: use JSON5 file format for .ic-assets.json5 config
 
 ### chore: Frontend canister build process no longer depends on `dfx` or `ic-cdk-optimizer`
 
@@ -24,8 +24,6 @@ Additionally, after build step, the `.wasm` file is archived with `gzip`.
 | `dfinity/certified-assets` `/`              | `/src/canisters/frontend/ic-asset`           | wrapper around the core, helps build the canister wasm                                      |
 | `dfinity/agent-rs` `/ic-asset`              | `/src/canisters/frontend/ic-asset`           | library facilitating interactions with frontend canister (e.g. uploading or listing assets) |
 | `dfinity/agent-rs` `/icx-asset`             | `/src/canisters/frontend/icx-asset`          | CLI executable tool - wraps `ic-asset`                                                      |
-
-
 
 ### feat: use JSON5 file format for frontend canister asset configuration
 

--- a/e2e/tests-dfx/frontend.bash
+++ b/e2e/tests-dfx/frontend.bash
@@ -65,3 +65,19 @@ teardown() {
     assert_command_fail curl http://localhost:8000
     assert_match "Connection refused"
 }
+
+@test "dfx uses .ic-assets.json file provided in src/__project_name__frontend/src" {
+    echo '[{"match": "*", "headers": {"x-key": "x-value"}}]' > src/e2e_project_frontend/src/.ic-assets.json
+
+    dfx_start
+    dfx canister create --all
+    dfx build
+    dfx canister install --all
+
+    ID=$(dfx canister id e2e_project_frontend)
+    PORT=$(get_webserver_port)
+    assert_command curl -vv http://localhost:"$PORT"/?canisterId="$ID"
+    assert_match "< x-key: x-value"
+    assert_command curl -vv http://localhost:"$PORT"/index.js?canisterId="$ID"
+    assert_match "< x-key: x-value"
+}

--- a/src/dfx/assets/new_project_node_files/package.json
+++ b/src/dfx/assets/new_project_node_files/package.json
@@ -16,6 +16,7 @@
     "@dfinity/principal": "{js_agent_version}",
     "assert": "2.0.0",
     "buffer": "6.0.3",
+    "copy-webpack-plugin": "^11.0.0",
     "events": "3.3.0",
     "html-webpack-plugin": "5.5.0",
     "process": "0.11.10",

--- a/src/dfx/assets/new_project_node_files/webpack.config.js
+++ b/src/dfx/assets/new_project_node_files/webpack.config.js
@@ -2,6 +2,7 @@ const path = require("path");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
+const CopyPlugin = require("copy-webpack-plugin");
 
 function initCanisterEnv() {
   let localCanisters, prodCanisters;
@@ -92,6 +93,15 @@ module.exports = {
     new webpack.ProvidePlugin({
       Buffer: [require.resolve("buffer/"), "Buffer"],
       process: require.resolve("process/browser"),
+    }),
+    new CopyPlugin({
+      patterns: [
+        {
+          from: `src/${frontendDirectory}/src/.ic-assets.json*`,
+          to: ".ic-assets.json5",
+          noErrorOnMissing: true
+        },
+      ],
     }),
   ],
   // proxy /api to port 4943 during development.


### PR DESCRIPTION
# Description

for default node starter template: adds webpack copy plugin to copy `.ic-assets.json*` file from `src` to `dist` 

# How Has This Been Tested?


# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
