### PR TITLE
chore: use actions/checkout@(v1, v2) to v3

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - id: set-matrix
         run: echo "::set-output name=matrix::$(scripts/workflows/audit-matrix.py)"
 
@@ -24,10 +24,10 @@ jobs:
       matrix: ${{fromJson(needs.build_matrix.outputs.matrix)}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: sdk
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'RustSec/advisory-db'
           path: advisory-db

--- a/.github/workflows/consistent-sources.yml
+++ b/.github/workflows/consistent-sources.yml
@@ -9,7 +9,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v13
         with:
           nix_path: nixpkgs=channel:nixos-21.05-small

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -11,7 +11,7 @@ jobs:
     name: license-check:required
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check bans licenses sources # skip advisories, which are handled by audit.yml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
         rust: ["1.60.0"]
         binary_path: ["target/release"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Cache Cargo
         uses: actions/cache@v2
         with:
@@ -52,7 +52,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - id: set-matrix
         run: echo "::set-output name=matrix::$(scripts/workflows/e2e-matrix.py)"
 
@@ -70,7 +70,7 @@ jobs:
         os: [macos-11, ubuntu-20.04]
         rust: ["1.60.0"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Download dfx binary
         uses: actions/download-artifact@v2
         with:
@@ -103,7 +103,7 @@ jobs:
     env:
       E2E_TEST: tests-${{ matrix.test }}.bash
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Download dfx binary
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ ubuntu-latest ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache Cargo
         uses: actions/cache@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/prepare-dfx-assets.yml
+++ b/.github/workflows/prepare-dfx-assets.yml
@@ -17,7 +17,7 @@ jobs:
         rust: [ '1.60.0' ]
         os: [ ubuntu-latest, macos-latest ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -9,7 +9,7 @@ jobs:
   publish-manifest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
       - name: Generate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
             name: x86_64-linux
             tar: tar
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup environment variables
         run: |

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,7 +15,7 @@ jobs:
     # ubuntu-latest has shellcheck 0.4.6, while macos-latest has 0.7.1
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install shellcheck
         run: |
           mkdir $HOME/bin

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -14,7 +14,7 @@ jobs:
         rust: [ '1.60.0' ]
         os: [ ubuntu-latest, macos-latest ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
Upgrading from `actions/checkout@v1` or `actions/checkout@v2` to `@v3`.

I had an interesting CI failure today: https://github.com/dfinity/sdk/runs/8102506163?check_suite_focus=true

When the e2e build_dfx (ubuntu) step [ran](https://github.com/dfinity/sdk/runs/8101880196?check_suite_focus=true#step:2:666), it checked out one merge commit, and built the dfx binary:
```
HEAD is now at 57088df8 Merge 00bb8ac0c5298534ef68ca49a5dd3f03f5cb4105 into 21048c4b76896316b72b05288a1231267bdc47d3
```

Then, another PR was merged to master.  The merged PR contained a new test, and a new dfx command.  The binary built above did not contain the new command that the new test required, because it was built from a commit when that command did not exist.

Next, the dfx/info tests [ran](https://github.com/dfinity/sdk/runs/8102506163?check_suite_focus=true#step:2:666), using the binary built from the earlier step, but checked out the repo at a different (newer) merge commit:

```
HEAD is now at 4a74aeb5 Merge 00bb8ac0c5298534ef68ca49a5dd3f03f5cb4105 into 3f0c9e9b6aba8067748750538cadfd8479852e30
```

The result was a test failure. 

It seems strange that the default checkout behavior would cause different jobs from the same workflow for the same pull request event to check out different merge commits.  [This issue](https://github.com/actions/checkout/issues/27) describes the problem exactly, but is closed without a resolution.  I've seen suggestions to [use the pull request HEAD commit instead of MERGE commit](https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit), but it's unclear how this would work for workflows that also run on push.

While it seems clear that the correct behavior would be to use a consistent merge commit, using the base commit from the pull request event rather than the head of the base branch at the instant of any given checkout, I have no reason to believe that `actions/checkout@v3` fixes this issue.  At the same time there is no good reason to use some v1, some v2, and some v3.
