### PR TITLE
chore: add retry logic to download script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,8 @@ However, at that point, it isn't "a" passphrase.  It's either your passphrase, o
 Changed the text in this case to read:
     "Please enter the passphrase for your identity"
 
+### chore: add retry logic to dfx download script
+
 ## Dependencies
 
 ### Replica

--- a/public/install/200_downloader.sh
+++ b/public/install/200_downloader.sh
@@ -69,19 +69,19 @@ downloader() {
         need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if check_help_for curl --proto --tlsv1.2; then
-            curl --proto '=https' --tlsv1.2 --show-error --fail --location "$1" --output "$2"
+            curl --proto '=https' --tlsv1.2 --show-error --fail --connect-timeout 10 --retry 5 --location "$1" --output "$2"
         elif ! [ "$flag_INSECURE" ]; then
             warn "Not forcing TLS v1.2, this is potentially less secure"
-            curl --show-error --fail --location "$1" --output "$2"
+            curl --show-error --fail --connect-timeout 10 --retry 5 --location "$1" --output "$2"
         else
             err "TLS 1.2 is not supported on this platform. To force using it, use the --insecure flag."
         fi
     elif [ "$_dld" = wget ]; then
         if check_help_for wget --https-only --secure-protocol; then
-            wget --https-only --secure-protocol=TLSv1_2 "$1" -O "$2"
+            wget --https-only --secure-protocol=TLSv1_2 --timeout 10 --tries 5 --waitretry 5 "$1" -O "$2"
         elif ! [ "$flag_INSECURE" ]; then
             warn "Not forcing TLS v1.2, this is potentially less secure"
-            wget "$1" -O "$2"
+            wget --timeout 10 --tries 5 --waitretry 5 "$1" -O "$2"
         else
             err "TLS 1.2 is not supported on this platform. To force using it, use the --insecure flag."
         fi


### PR DESCRIPTION
# Description

Adds retry logic to the install script so that downloading dfx is less flaky. Added flag:
```
- curl
  - connect-timeout: max time allowed to set up the connection
  - retry: number of retries performed if something goes wrong
- wget
  - tries: number of retries performed if something goes wrong
  - timeout: number of seconds to wait for anything (dns, connection set up, any data received during download) before retrying
  - waitretry: number of seconds to wait before retrying
```
Fixes [SDK-671](https://dfinity.atlassian.net/browse/SDK-671)

# How Has This Been Tested?

Some manual tests with @smallstepman show that the added flags do the right thing.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
