### PR TITLE
refactor: remove CanisterInfo build_root, canister_root

### DIFF
--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -37,9 +37,7 @@ pub struct CanisterInfo {
     remote_candid: Option<PathBuf>, // always exists if the field is configured
 
     workspace_root: PathBuf,
-    build_root: PathBuf,
-    output_root: PathBuf,
-    canister_root: PathBuf,
+    output_root: PathBuf, // <project dir>/.dfx/<network>/canisters/<canister>
 
     canister_id: Option<CanisterId>,
 
@@ -64,8 +62,8 @@ impl CanisterInfo {
         let network_name = get_network_context()?;
         let build_root = config
             .get_temp_path()
-            .join(util::network_to_pathcompat(&network_name));
-        let build_root = build_root.join("canisters");
+            .join(util::network_to_pathcompat(&network_name))
+            .join("canisters");
         std::fs::create_dir_all(&build_root)
             .with_context(|| format!("Failed to create {}.", build_root.to_string_lossy()))?;
 
@@ -77,7 +75,6 @@ impl CanisterInfo {
             .get(name)
             .ok_or_else(|| anyhow!("Cannot find canister '{}',", name.to_string()))?;
 
-        let canister_root = workspace_root.to_path_buf();
         let declarations_config_pre = canister_config.declarations.clone();
 
         let remote_id = canister_config
@@ -120,9 +117,7 @@ impl CanisterInfo {
             remote_id,
             remote_candid,
             workspace_root: workspace_root.to_path_buf(),
-            build_root,
             output_root,
-            canister_root,
             canister_id,
             packtool: build_defaults.get_packtool(),
             args,
@@ -159,9 +154,6 @@ impl CanisterInfo {
     }
     pub fn get_workspace_root(&self) -> &Path {
         &self.workspace_root
-    }
-    pub fn get_build_root(&self) -> &Path {
-        &self.build_root
     }
     pub fn get_output_root(&self) -> &Path {
         &self.output_root
@@ -202,24 +194,15 @@ impl CanisterInfo {
     }
 
     pub fn get_build_wasm_path(&self) -> PathBuf {
-        self.build_root
-            .join(PathBuf::from(&self.name))
-            .join(&self.name)
-            .with_extension("wasm")
+        self.output_root.join(&self.name).with_extension("wasm")
     }
 
     pub fn get_build_idl_path(&self) -> PathBuf {
-        self.build_root
-            .join(PathBuf::from(&self.name))
-            .join(&self.name)
-            .with_extension("did")
+        self.output_root.join(&self.name).with_extension("did")
     }
 
     pub fn get_index_js_path(&self) -> PathBuf {
-        self.build_root
-            .join(PathBuf::from(&self.name))
-            .join("index")
-            .with_extension("js")
+        self.output_root.join("index").with_extension("js")
     }
 
     pub fn get_output_idl_path(&self) -> Option<PathBuf> {

--- a/src/dfx/src/lib/canister_info/assets.rs
+++ b/src/dfx/src/lib/canister_info/assets.rs
@@ -50,9 +50,6 @@ impl AssetsCanisterInfo {
 
 impl CanisterInfoFactory for AssetsCanisterInfo {
     fn create(info: &CanisterInfo) -> DfxResult<AssetsCanisterInfo> {
-        let build_root = info.get_build_root();
-        let name = info.get_name();
-
         let input_root = info.get_workspace_root().to_path_buf();
         // If there are no "source" field, we just ignore this.
         let source_paths = if let CanisterTypeProperties::Assets { source } = &info.type_specific {
@@ -64,7 +61,7 @@ impl CanisterInfoFactory for AssetsCanisterInfo {
             )
         };
 
-        let output_root = build_root.join(name);
+        let output_root = info.get_output_root();
 
         let output_wasm_path = output_root.join(Path::new("assetstorage.wasm.gz"));
         let output_idl_path = output_wasm_path.with_extension("").with_extension("did");

--- a/src/dfx/src/lib/canister_info/motoko.rs
+++ b/src/dfx/src/lib/canister_info/motoko.rs
@@ -56,7 +56,6 @@ impl MotokoCanisterInfo {
 impl CanisterInfoFactory for MotokoCanisterInfo {
     fn create(info: &CanisterInfo) -> DfxResult<MotokoCanisterInfo> {
         let workspace_root = info.get_workspace_root();
-        let build_root = info.get_build_root();
         let name = info.get_name();
         ensure!(
             matches!(info.type_specific, CanisterTypeProperties::Motoko { .. }),
@@ -67,7 +66,7 @@ impl CanisterInfoFactory for MotokoCanisterInfo {
             .get_main_file()
             .context("`main` attribute is required on Motoko canisters in dfx.json")?;
         let input_path = workspace_root.join(&main_path);
-        let output_root = build_root.join(name);
+        let output_root = info.get_output_root().to_path_buf();
         let output_wasm_path = output_root.join(name).with_extension("wasm");
         let output_idl_path = if let Some(remote_candid) = info.get_remote_candid_if_remote() {
             workspace_root.join(remote_candid)


### PR DESCRIPTION
# Description

Removes the `build_root` and `canister_root` fields from CanisterInfo.

- `build_root` was only used by joining the canister name to it.   However, `build_root.join(canister_name)` is already known as `output_root`, so used that instead.
    - The method names (unchanged in this PR) `get_build_wasm_path()` and `get_build_idl_path()` aren't great, because they refer to files within the `output_root` (also unchanged in this PR, though more obvious now).  However, there is another method named `get_output_idl_path()`.  I hope to untangle this in a PR to follow.

- `canister_root` wasn't used by anything.




# How Has This Been Tested?

Covered by existing e2e tests

