### PR TITLE
chore: deposit-cycles uses default wallet if none is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,10 @@ Canister sandboxing is enabled to be consistent with the mainnet.
 It is now possible to do e.g. `dfx ledger account-id --of-canister fg7gi-vyaaa-aaaal-qadca-cai` as well as `dfx ledger account-id --of-canister my_canister_name` when checking the ledger account id of a canister.
 Previously, dfx only accepted canister aliases and produced an error message that was hard to understand.
 
+### chore: dfx canister deposit-cycles uses default wallet if none is specified
+
+Motivated by [this forum post](https://forum.dfinity.org/t/dfx-0-10-0-dfx-canister-deposit-cycles-returns-error/13251/6).
+
 ### fix: print links to cdk-rs docs in dfx new
 
 ### fix: Small grammar change to identity password decryption prompt

--- a/e2e/tests-dfx/wallet.bash
+++ b/e2e/tests-dfx/wallet.bash
@@ -171,6 +171,13 @@ teardown() {
     assert_command dfx canister deposit-cycles 1 hello_backend --wallet "$(dfx identity get-wallet)"
 }
 
+@test "dfx canister deposit-cycles uses default wallet if no wallet is specified" {
+    dfx_new hello
+    dfx_start
+    dfx deploy
+    assert_command dfx canister deposit-cycles 1 hello_backend
+}
+
 @test "detects if there is no wallet to upgrade" {
     dfx_new hello
     assert_command_fail dfx wallet upgrade


### PR DESCRIPTION
# Description

> I think the default behavior if a wallet-id or name is not provided would be to use this default wallet for the developer’s identity.

Fixes [feature request on the forum](https://forum.dfinity.org/t/dfx-0-10-0-dfx-canister-deposit-cycles-returns-error/13251/6).

# How Has This Been Tested?

Added an e2e test, also tested manually

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation. Not needed since the requirement to add `--wallet` was not documented.
