### PR TITLE
fix: for dfx start --clean --background cleaning twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ The Replica returned an error: code 1, message: "Canister requested a compute al
 
 ### fix: For default node starter template: copy `ic-assets.json5` file from `src` to `dist`
 
+### fix: For `dfx start --clean --background`, the background process no longer cleans a second time.
+
 ### refactor: Move replica URL functions into a module for reuse
 
 The running replica port and url are generally useful information. Previously the code to get the URL was embedded in the network proxy code. This moves it out into a library for reuse.

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -422,7 +422,12 @@ fn send_background() -> DfxResult<()> {
     let exe = std::env::current_exe().context("Failed to get current executable.")?;
     let mut cmd = Command::new(exe);
     // Skip 1 because arg0 is this executable's path.
-    cmd.args(std::env::args().skip(1).filter(|a| !a.eq("--background")));
+    cmd.args(
+        std::env::args()
+            .skip(1)
+            .filter(|a| !a.eq("--background"))
+            .filter(|a| !a.eq("--clean")),
+    );
 
     cmd.spawn().context("Failed to spawn child process.")?;
     Ok(())


### PR DESCRIPTION


# Description

Now, only the foreground process cleans.

The cleaning by the background was causing the foreground process to fail sometimes, because the webserver port file would be deleted.  The foreground process creates that file as empty, then waits until the background process populates it with the webserver port.

Intended to fix https://dfinity.atlassian.net/browse/SDK-720, though there may be an underlying cause that this bug hides.

# How Has This Been Tested?

Manually.
1. `dfx start --clean --background`
2. `kill -9 <dfx pid> <replica pid>`
3. Notice that `icx-proxy` is still running
4. `dfx start --clean --background`

Before:
```
$ dfx-wip start --clean --background
There is no project-specific network 'local' because there is no project (no dfx.json).
Using the default definition for the 'local' shared network because /Users/ericswanson/.config/dfx/networks.json does not exist.
Error: Failed to get frontend address.
Caused by: Failed to get frontend address.
  Failed to find reusable socket address
    Failed to set socket of tcp builder to 127.0.0.1:4943.
      Address already in use (os error 48)
Error: Failed to get port.
Caused by: Failed to get port.
  Failed to open /Users/ericswanson/Library/Application Support/org.dfinity.dfx/network/local/webserver-port.
    No such file or directory (os error 2)
```

After:
```
$ dfx-wip start --clean --background
There is no project-specific network 'local' because there is no project (no dfx.json).
Using the default definition for the 'local' shared network because /Users/ericswanson/.config/dfx/networks.json does not exist.
Error: Failed to get frontend address.
Caused by: Failed to get frontend address.
  Failed to find reusable socket address
    Failed to set socket of tcp builder to 127.0.0.1:4943.
      Address already in use (os error 48)
Error: Failed to get port.
Caused by: Failed to get port.
  Timeout
```


# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] (n/a) I have made corresponding changes to the documentation.
