### PR TITLE
fix: Correct swap wasm file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## DFX
 
+### fix: Correct wasm for the SNS swap canister
+
+Previously the incorrect wasm canister was installed.
+
 ### feat: canister HTTP support is now enabled by default.
 
 `dfx start` and `dfx replica` now ignore the `--enable-canister-http` parameter.

--- a/src/dfx/src/lib/nns/install_nns/canisters.rs
+++ b/src/dfx/src/lib/nns/install_nns/canisters.rs
@@ -151,7 +151,7 @@ pub const SNS_GOVERNANCE: SnsCanisterInstallation = SnsCanisterInstallation {
 pub const SNS_SWAP: SnsCanisterInstallation = SnsCanisterInstallation {
     canister_name: "sns-swap",
     upload_name: "swap",
-    wasm_name: "sns-governance-canister.wasm",
+    wasm_name: "sns-swap-canister.wasm",
 };
 /// Stores account balances for an SNS project.
 pub const SNS_LEDGER: SnsCanisterInstallation = SnsCanisterInstallation {


### PR DESCRIPTION
# Description
Previously the governance canister wasm was being used in place of the swap canister wasm by mistake.

# How Has This Been Tested?
With this fix, and another that deals with ic commit mismatches, I am able to create an SNS, which was previously not possible.

Testing SNS creation is to be done in another repo, as most of the complexity is outside the scope of the sdk.  The error was discovered while preparing such a test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
