### PR TITLE
fix: compatibility check error should not block canister install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## DFX
 
+### fix: allow users to skip compatibility check if parsing fails
+
 ### feat: canister HTTP support is now enabled by default.
 
 `dfx start` and `dfx replica` now ignore the `--enable-canister-http` parameter.

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -217,9 +217,11 @@ fn check_candid_compatibility(
     })?;
     let (mut env, opt_new) =
         check_candid_file(&candid_path).context("Checking generated did file.")?;
-    let new_type = opt_new.expect("Generated did file should contain some service interface");
+    let new_type = opt_new
+        .ok_or_else(|| anyhow!("Generated did file should contain some service interface"))?;
     let (env2, opt_old) = check_candid_file(&deployed_path).context("Checking old candid file.")?;
-    let old_type = opt_old.expect("Deployed did file should contain some service interface");
+    let old_type = opt_old
+        .ok_or_else(|| anyhow!("Deployed did file should contain some service interface"))?;
     let mut gamma = HashSet::new();
     let old_type = env.merge_type(env2, old_type);
     let result = candid::types::subtype::subtype(&mut gamma, &env, &new_type, &old_type);

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -53,57 +53,33 @@ pub async fn install_canister(
     let canister_id = canister_info.get_canister_id()?;
     if matches!(mode, InstallMode::Reinstall | InstallMode::Upgrade) {
         let candid = read_module_metadata(agent, canister_id, "candid:service").await;
-        if let Some(candid) = candid {
-            use crate::util::check_candid_file;
-            let candid_path = canister_info.get_build_idl_path();
-            let deployed_path = canister_info.get_build_idl_path().with_extension("old.did");
-            std::fs::write(&deployed_path, candid).with_context(|| {
-                format!(
-                    "Failed to write candid to {}.",
-                    deployed_path.to_string_lossy()
-                )
-            })?;
-            let (mut env, opt_new) =
-                check_candid_file(&candid_path).context("Checking generated did file.")?;
-            let new_type =
-                opt_new.expect("Generated did file should contain some service interface");
-            let (env2, opt_old) =
-                check_candid_file(&deployed_path).context("Checking old candid file.")?;
-            let old_type =
-                opt_old.expect("Deployed did file should contain some service interface");
-            let mut gamma = HashSet::new();
-            let old_type = env.merge_type(env2, old_type);
-            let result = candid::types::subtype::subtype(&mut gamma, &env, &new_type, &old_type);
-            if let Err(err) = result {
-                let msg = format!("Candid interface compatibility check failed for canister '{}'.\nYou are making a BREAKING change. Other canisters or frontend clients relying on your canister may stop working.\n\n", canister_info.get_name()) + &err.to_string();
-                ask_for_consent(&msg)?;
+        if let Some(candid) = &candid {
+            match check_candid_compatibility(canister_info, candid) {
+                Ok(None) => (),
+                Ok(Some(err)) => {
+                    let msg = format!("Candid interface compatibility check failed for canister '{}'.\nYou are making a BREAKING change. Other canisters or frontend clients relying on your canister may stop working.\n\n", canister_info.get_name()) + &err;
+                    ask_for_consent(&msg)?;
+                }
+                Err(e) => {
+                    let msg = format!("An error occurred during Candid interface compatibility check for canister '{}'.\n\n", canister_info.get_name()) + &e.to_string();
+                    ask_for_consent(&msg)?;
+                }
             }
         }
     }
     if canister_info.is_motoko() && matches!(mode, InstallMode::Upgrade) {
-        use crate::lib::canister_info::motoko::MotokoCanisterInfo;
-        let info = canister_info.as_info::<MotokoCanisterInfo>()?;
-        let stable_path = info.get_output_stable_path();
-        let deployed_stable_path = stable_path.with_extension("old.most");
         let stable_types = read_module_metadata(agent, canister_id, "motoko:stable-types").await;
-        if let Some(stable_types) = stable_types {
-            std::fs::write(&deployed_stable_path, stable_types).with_context(|| {
-                format!(
-                    "Failed to write stable types to {}.",
-                    deployed_stable_path.to_string_lossy()
-                )
-            })?;
-            let cache = env.get_cache();
-            let output = cache
-                .get_binary_command("moc")?
-                .arg("--stable-compatible")
-                .arg(&deployed_stable_path)
-                .arg(&stable_path)
-                .output()
-                .context("Failed to run 'moc'.")?;
-            if !output.status.success() {
-                let msg = format!("Stable interface compatibility check failed for canister '{}'.\nUpgrade will either FAIL or LOSE some stable variable data.\n\n", canister_info.get_name()) + &String::from_utf8_lossy(&output.stderr);
-                ask_for_consent(&msg)?;
+        if let Some(stable_types) = &stable_types {
+            match check_stable_compatibility(canister_info, env, stable_types) {
+                Ok(None) => (),
+                Ok(Some(err)) => {
+                    let msg = format!("Stable interface compatibility check failed for canister '{}'.\nUpgrade will either FAIL or LOSE some stable variable data.\n\n", canister_info.get_name()) + &err;
+                    ask_for_consent(&msg)?;
+                }
+                Err(e) => {
+                    let msg = format!("An error occurred during stable interface compatibility check for canister '{}'.\n\n", canister_info.get_name()) + &e.to_string();
+                    ask_for_consent(&msg)?;
+                }
             }
         }
     }
@@ -224,6 +200,63 @@ pub async fn install_canister(
     }
 
     Ok(())
+}
+
+fn check_candid_compatibility(
+    canister_info: &CanisterInfo,
+    candid: &str,
+) -> anyhow::Result<Option<String>> {
+    use crate::util::check_candid_file;
+    let candid_path = canister_info.get_build_idl_path();
+    let deployed_path = canister_info.get_build_idl_path().with_extension("old.did");
+    std::fs::write(&deployed_path, candid).with_context(|| {
+        format!(
+            "Failed to write candid to {}.",
+            deployed_path.to_string_lossy()
+        )
+    })?;
+    let (mut env, opt_new) =
+        check_candid_file(&candid_path).context("Checking generated did file.")?;
+    let new_type = opt_new.expect("Generated did file should contain some service interface");
+    let (env2, opt_old) = check_candid_file(&deployed_path).context("Checking old candid file.")?;
+    let old_type = opt_old.expect("Deployed did file should contain some service interface");
+    let mut gamma = HashSet::new();
+    let old_type = env.merge_type(env2, old_type);
+    let result = candid::types::subtype::subtype(&mut gamma, &env, &new_type, &old_type);
+    Ok(match result {
+        Ok(_) => None,
+        Err(e) => Some(e.to_string()),
+    })
+}
+
+fn check_stable_compatibility(
+    canister_info: &CanisterInfo,
+    env: &dyn Environment,
+    stable_types: &str,
+) -> anyhow::Result<Option<String>> {
+    use crate::lib::canister_info::motoko::MotokoCanisterInfo;
+    let info = canister_info.as_info::<MotokoCanisterInfo>()?;
+    let stable_path = info.get_output_stable_path();
+    let deployed_stable_path = stable_path.with_extension("old.most");
+    std::fs::write(&deployed_stable_path, stable_types).with_context(|| {
+        format!(
+            "Failed to write stable types to {}.",
+            deployed_stable_path.to_string_lossy()
+        )
+    })?;
+    let cache = env.get_cache();
+    let output = cache
+        .get_binary_command("moc")?
+        .arg("--stable-compatible")
+        .arg(&deployed_stable_path)
+        .arg(&stable_path)
+        .output()
+        .context("Failed to run 'moc'.")?;
+    Ok(if !output.status.success() {
+        Some(String::from_utf8_lossy(&output.stderr).to_string())
+    } else {
+        None
+    })
 }
 
 #[context("Failed to run post-install tasks")]


### PR DESCRIPTION
# Description

If an error occurs during parsing Candid or stable signature, dfx will error out. This blocks canister upgrade if the generated .did or .most file has bugs that fails the parser.

The fix is to move the checking code into a separate function, dfx checks if the error comes from the 
the actual checking or the preparation steps, and allow users to skip the checking if parsing fails.

# How Has This Been Tested?

Tested manually, but it's hard to test in CI, as it requires pulling in ic-wasm binary as a dependency.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
