### PR TITLE
fix: dfx stop and dfx start take into account processes from dfx <= 0.11.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,8 @@ dfx now stores data and control files in one of three places, rather than direct
 
 There is also a new configuration file: `$HOME/.config/dfx/networks.json`.  Its [schema](docs/networks-json-schema.json) is the same as the `networks` element in dfx.json.  Any networks you define here will be available from any project, unless a project's dfx.json defines a network with the same name.  See [The Shared Local Network](docs/cli-reference/dfx-start.md#the-shared-local-network) for the default definitions that dfx provides if this file does not exist or does not define a `local` network.
 
+### fix: `dfx start` and `dfx stop` will take into account dfx/replica processes from dfx <= 0.11.x
+
 ### feat: added command `dfx info`
 
 #### feat: `dfx info webserver-port`

--- a/e2e/tests-dfx/project_local_network.bash
+++ b/e2e/tests-dfx/project_local_network.bash
@@ -148,3 +148,20 @@ teardown() {
     assert_match "$(jq -r .hello_backend.actuallylocal <.dfx/actuallylocal/canister_ids.json)"
 }
 
+
+@test "dfx start and stop take into account dfx 0.11.x pid files" {
+    dfx_new hello
+    define_project_network
+    dfx_start
+
+    mv .dfx/network/local/pid .dfx/pid
+
+    assert_command_fail dfx start
+    assert_match 'dfx is already running'
+
+    assert_command dfx stop
+    assert_file_not_exists .dfx/pid
+    assert_not_match "Nothing to do"
+    assert_command dfx stop
+    assert_match "Nothing to do"
+}

--- a/src/dfx/src/lib/network/local_server_descriptor.rs
+++ b/src/dfx/src/lib/network/local_server_descriptor.rs
@@ -35,6 +35,8 @@ pub struct LocalServerDescriptor {
     pub replica: ConfigDefaultsReplica,
 
     pub scope: LocalNetworkScopeDescriptor,
+
+    legacy_pid_path: Option<PathBuf>,
 }
 
 impl LocalNetworkScopeDescriptor {
@@ -55,6 +57,7 @@ impl LocalServerDescriptor {
         canister_http: ConfigDefaultsCanisterHttp,
         replica: ConfigDefaultsReplica,
         scope: LocalNetworkScopeDescriptor,
+        legacy_pid_path: Option<PathBuf>,
     ) -> DfxResult<Self> {
         let bind_address =
             to_socket_addr(&bind).context("Failed to convert 'bind' field to a SocketAddress")?;
@@ -66,6 +69,7 @@ impl LocalServerDescriptor {
             canister_http,
             replica,
             scope,
+            legacy_pid_path,
         })
     }
 
@@ -78,6 +82,16 @@ impl LocalServerDescriptor {
     /// This file contains the pid of the process started with `dfx start`
     pub fn dfx_pid_path(&self) -> PathBuf {
         self.data_directory.join("pid")
+    }
+
+    /// The path of the pid file, as well as one that dfx <= 0.11.x would have created
+    pub fn dfx_pid_paths(&self) -> Vec<PathBuf> {
+        let mut pid_paths: Vec<PathBuf> = vec![];
+        if let Some(legacy_pid_path) = &self.legacy_pid_path {
+            pid_paths.push(legacy_pid_path.clone());
+        }
+        pid_paths.push(self.dfx_pid_path());
+        pid_paths
     }
 
     /// This file contains the pid of the icx-proxy process

--- a/src/dfx/src/lib/provider.rs
+++ b/src/dfx/src/lib/provider.rs
@@ -61,6 +61,7 @@ fn config_network_to_network_descriptor(
     ephemeral_wallet_config_path: &Path,
     local_bind_determination: &LocalBindDetermination,
     default_local_bind: &str,
+    legacy_pid_path: Option<PathBuf>,
 ) -> DfxResult<NetworkDescriptor> {
     match config_network {
         ConfigNetwork::ConfigNetworkProvider(network_provider) => {
@@ -128,6 +129,7 @@ fn config_network_to_network_descriptor(
                 canister_http,
                 replica,
                 local_scope,
+                legacy_pid_path,
             )?;
             Ok(NetworkDescriptor {
                 name: network_name.to_string(),
@@ -280,6 +282,7 @@ fn create_shared_network_descriptor(
             &ephemeral_wallet_config_path,
             local_bind_determination,
             DEFAULT_SHARED_LOCAL_BIND,
+            None,
         )
     })
 }
@@ -304,6 +307,7 @@ fn create_project_network_descriptor(
             );
 
             let data_directory = config.get_temp_path().join("network").join(network_name);
+            let legacy_pid_path = Some(config.get_temp_path().join("pid"));
             let ephemeral_wallet_config_path = config
                 .get_temp_path()
                 .join("local")
@@ -317,6 +321,7 @@ fn create_project_network_descriptor(
                 &ephemeral_wallet_config_path,
                 local_bind_determination,
                 DEFAULT_PROJECT_LOCAL_BIND,
+                legacy_pid_path,
             ))
         } else {
             info!(


### PR DESCRIPTION
# Description

dfx 0.12.x stores the pid file for a project-specific network in `.dfx/network/local/pid`, while dfx <= 0.11.x store it in `.dfx/pid`. 
  This change makes it so `dfx start` and `dfx stop` look in both places.

Fixes https://dfinity.atlassian.net/browse/SDK-726

# How Has This Been Tested?

Added an e2e test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
