### PR TITLE
chore(e2e): update bats-support `ztombol/bats-support@v0.3.0 -> bats-core/bats-support@v0.3.0`

### DIFF
--- a/e2e/tests-dfx/error_context.bash
+++ b/e2e/tests-dfx/error_context.bash
@@ -118,7 +118,7 @@ teardown() {
     assert_match "moc"
 
     # expect to see the full path of the binary
-    assert_match "$(dfx cache show)/moc"
+    assert_contains "$(dfx cache show)/moc"
 
     # expect to see the underlying cause
     assert_match "No such file or directory"

--- a/scripts/workflows/provision-darwin.sh
+++ b/scripts/workflows/provision-darwin.sh
@@ -16,8 +16,8 @@ fi
 brew install bats-core
 
 # Install Bats support.
-version=2.0.0
-curl --location --output bats-support.tar.gz https://github.com/bats-core/bats-support/archive/refs/tags/v$version.tar.gz
+version=0.3.0
+curl --location --output bats-support.tar.gz https://github.com/bats-core/bats-support/archive/v$version.tar.gz
 mkdir /usr/local/lib/bats-support
 tar --directory /usr/local/lib/bats-support --extract --file bats-support.tar.gz --strip-components 1
 rm bats-support.tar.gz

--- a/scripts/workflows/provision-darwin.sh
+++ b/scripts/workflows/provision-darwin.sh
@@ -16,8 +16,8 @@ fi
 brew install bats-core
 
 # Install Bats support.
-version=0.3.0
-curl --location --output bats-support.tar.gz https://github.com/ztombol/bats-support/archive/v$version.tar.gz
+version=2.0.0
+curl --location --output bats-support.tar.gz https://github.com/bats-core/bats-support/archive/refs/tags/v$version.tar.gz
 mkdir /usr/local/lib/bats-support
 tar --directory /usr/local/lib/bats-support --extract --file bats-support.tar.gz --strip-components 1
 rm bats-support.tar.gz

--- a/scripts/workflows/provision-linux.sh
+++ b/scripts/workflows/provision-linux.sh
@@ -11,8 +11,8 @@ pushd /tmp
 sudo apt-get install --yes bats moreutils
 
 # Install Bats support.
-version=0.3.0
-wget https://github.com/ztombol/bats-support/archive/v$version.tar.gz
+version=2.0.0
+wget https://github.com/bats-core/bats-support/archive/refs/tags/v$version.tar.gz
 sudo mkdir /usr/local/lib/bats-support
 sudo tar --directory /usr/local/lib/bats-support --extract --file v$version.tar.gz --strip-components 1
 rm v$version.tar.gz

--- a/scripts/workflows/provision-linux.sh
+++ b/scripts/workflows/provision-linux.sh
@@ -11,8 +11,8 @@ pushd /tmp
 sudo apt-get install --yes bats moreutils
 
 # Install Bats support.
-version=2.0.0
-wget https://github.com/bats-core/bats-support/archive/refs/tags/v$version.tar.gz
+version=0.3.0
+wget https://github.com/bats-core/bats-support/archive/v$version.tar.gz
 sudo mkdir /usr/local/lib/bats-support
 sudo tar --directory /usr/local/lib/bats-support --extract --file v$version.tar.gz --strip-components 1
 rm v$version.tar.gz


### PR DESCRIPTION
# Description

I want to see if updating `bats-support` will be as easy as updating the source's repo and version
TODO:
- [ ] replace most of the /e2e/bash/utils with `bats-assert` 
# How Has This Been Tested?

CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
