### PR TITLE
feat: Add `--mode=auto` to `dfx canister install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## DFX
 
+### feat: add --mode=auto
+
+When using `dfx canister install`, you can now pass `auto` for the `--mode` flag, which will auto-select `install` or `upgrade` depending on need, the same way `dfx deploy` does. The default remains `install` to prevent mistakes.
+
 ### feat: sns config validate
 
 There is a new command that verifies that an SNS initialization config is valid.

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -153,3 +153,13 @@ teardown() {
     assert_command dfx canister call gzipped fromQuery '()'
     assert_match "$(dfx identity get-principal)"
 }
+
+@test "--mode=auto selects install or upgrade automatically" {
+    dfx_start
+    assert_command dfx canister create e2e_project_backend
+    assert_command dfx build e2e_project_backend
+    assert_command dfx canister install e2e_project_backend --mode auto
+    assert_command dfx canister call e2e_project_backend greet dfx
+    assert_command dfx canister install e2e_project_backend --mode auto --upgrade-unchanged
+    assert_command dfx canister call e2e_project_backend greet dfx
+}

--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -31,6 +31,7 @@ pub struct CanisterInstallOpts {
     async_call: bool,
 
     /// Specifies the type of deployment. You can set the canister deployment modes to install, reinstall, or upgrade.
+    /// If auto is selected, either install or upgrade will be used depending on if the canister has already been installed.
     #[clap(long, short('m'), default_value("install"),
         possible_values(&["install", "reinstall", "upgrade", "auto"]))]
     mode: String,

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -265,7 +265,7 @@ async fn install_canisters(
             &mut canister_id_store,
             &canister_info,
             &install_args,
-            install_mode,
+            Some(install_mode),
             timeout,
             call_sender,
             installed_module_hash,

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -37,7 +37,7 @@ pub async fn install_canister(
     canister_id_store: &mut CanisterIdStore,
     canister_info: &CanisterInfo,
     args: impl FnOnce() -> DfxResult<Vec<u8>>,
-    mode: InstallMode,
+    mode: Option<InstallMode>,
     timeout: Duration,
     call_sender: &CallSender,
     installed_module_hash: Option<Vec<u8>>,
@@ -49,7 +49,13 @@ pub async fn install_canister(
     if !network.is_ic && named_canister::get_ui_canister_id(canister_id_store).is_none() {
         named_canister::install_ui_canister(env, canister_id_store, None).await?;
     }
-
+    let mode = mode.unwrap_or_else(|| {
+        if installed_module_hash.is_some() {
+            InstallMode::Upgrade
+        } else {
+            InstallMode::Install
+        }
+    });
     let canister_id = canister_info.get_canister_id()?;
     if matches!(mode, InstallMode::Reinstall | InstallMode::Upgrade) {
         let candid = read_module_metadata(agent, canister_id, "candid:service").await;


### PR DESCRIPTION
`dfx deploy` automatically determines whether to use the `install` or `upgrade` modes depending on the canister state. This provides that same functionality to `dfx canister install`, by passing `auto` for the `--mode`. The default remains `install`. 

Fixes #2013 and SDK-590. This was chosen over the suggested feature, `dfx deploy --no-build`, for better consistency with semantics.