### PR TITLE
feat: allow http adapter log level to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ dfx start --clean --background
 dfx nns install
 ```
 
+### feat: configure logging level of http adapter
+
+It is now possible to set the http adapter's log level in dfx.json or in networks.json:
+
+    "http": {
+      "enabled": true,
+      "log_level": "info"
+    }
+
+By default, a log level of "error" is used, in order to keep the output of a first-time `dfx start` minimal. Change it to "debug" for more verbose logging.
+
 ### feat: generate secp256k1 keys by default
 
 When creating a new identity with `dfx identity new`, whereas previously it would have generated an Ed25519 key, it now generates a secp256k1 key. This is to enable users to write down a BIP39-style seed phrase, to recover their key in case of emergency, which will be printed when the key is generated and can be used with a new `--seed-phrase` flag in `dfx identity import`. `dfx identity import` is however still capable of importing an Ed25519 key.

--- a/e2e/tests-dfx/canister_http.bash
+++ b/e2e/tests-dfx/canister_http.bash
@@ -278,3 +278,45 @@ set_shared_local_network_canister_http_empty() {
 
     assert_file_empty "$E2E_SHARED_LOCAL_NETWORK_DATA_DIRECTORY/ic-canister-http-adapter-pid"
 }
+
+@test "dfx starts http adapter with correct log level - project defaults" {
+    dfx_new
+    jq '.defaults.canister_http.log_level="warning"' dfx.json | sponge dfx.json
+    define_project_network
+
+    assert_command dfx start --background
+    assert_match "log level: Warning"
+    assert_command dfx stop
+
+    jq '.defaults.canister_http.log_level="critical"' dfx.json | sponge dfx.json
+    assert_command dfx start --background
+    assert_match "log level: Critical"
+}
+
+@test "dfx starts http adapter with correct log level - local network" {
+    dfx_new
+    jq '.networks.local.canister_http.log_level="warning"' dfx.json | sponge dfx.json
+    define_project_network
+
+    assert_command dfx start --background
+    assert_match "log level: Warning"
+    assert_command dfx stop
+
+    jq '.networks.local.canister_http.log_level="critical"' dfx.json | sponge dfx.json
+    assert_command dfx start --background
+    assert_match "log level: Critical"
+}
+
+@test "dfx starts http adapter with correct log level - shared network" {
+    dfx_new
+    create_networks_json
+    jq '.local.canister_http.log_level="warning"' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
+
+    assert_command dfx start --background
+    assert_match "log level: Warning"
+    assert_command dfx stop
+
+    jq '.local.canister_http.log_level="critical"' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
+    assert_command dfx start --background
+    assert_match "log level: Critical"
+}

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -578,7 +578,8 @@ pub fn configure_canister_http_adapter_if_enabled(
     let socket_path =
         get_persistent_socket_path(uds_holder_path, "ic-canister-http-adapter-socket")?;
 
-    let adapter_config = canister_http::adapter::Config::new(socket_path);
+    let log_level = local_server_descriptor.canister_http.log_level;
+    let adapter_config = canister_http::adapter::Config::new(socket_path, log_level);
 
     let contents = serde_json::to_string_pretty(&adapter_config)
         .context("Unable to serialize canister http adapter configuration to json")?;

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 use crate::lib::bitcoin::adapter::config::BitcoinAdapterLogLevel;
+use crate::lib::canister_http::adapter::config::HttpAdapterLogLevel;
 use crate::lib::config::get_config_dfx_dir_path;
 use crate::lib::error::{BuildError, DfxError, DfxResult};
 use crate::util::{PossiblyStr, SerdeVec};
@@ -242,11 +243,19 @@ pub struct ConfigDefaultsCanisterHttp {
     /// # Enable HTTP Adapter
     #[serde(default = "default_as_true")]
     pub enabled: bool,
+
+    /// # Logging Level
+    /// The logging level of the adapter.
+    #[serde(default)]
+    pub log_level: HttpAdapterLogLevel,
 }
 
 impl Default for ConfigDefaultsCanisterHttp {
     fn default() -> Self {
-        ConfigDefaultsCanisterHttp { enabled: true }
+        ConfigDefaultsCanisterHttp {
+            enabled: true,
+            log_level: HttpAdapterLogLevel::default(),
+        }
     }
 }
 

--- a/src/dfx/src/lib/canister_http/adapter/config.rs
+++ b/src/dfx/src/lib/canister_http/adapter/config.rs
@@ -1,5 +1,6 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
 
 // These definitions come from https://gitlab.com/dfinity-lab/public/ic/-/blob/master/rs/canister_http/adapter/src/config.rs
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -18,18 +19,60 @@ impl Default for IncomingSource {
     }
 }
 
+/// Represents the log level of the HTTP adapter.
+#[derive(Clone, Debug, Serialize, Deserialize, Copy, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum HttpAdapterLogLevel {
+    Critical,
+    Error,
+    Warning,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl FromStr for HttpAdapterLogLevel {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<HttpAdapterLogLevel, Self::Err> {
+        match input {
+            "critical" => Ok(HttpAdapterLogLevel::Critical),
+            "error" => Ok(HttpAdapterLogLevel::Error),
+            "warning" => Ok(HttpAdapterLogLevel::Warning),
+            "info" => Ok(HttpAdapterLogLevel::Info),
+            "debug" => Ok(HttpAdapterLogLevel::Debug),
+            "trace" => Ok(HttpAdapterLogLevel::Trace),
+            other => Err(format!("Unknown log level: {}", other)),
+        }
+    }
+}
+
+impl Default for HttpAdapterLogLevel {
+    fn default() -> Self {
+        HttpAdapterLogLevel::Error
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LoggerConfig {
+    pub level: HttpAdapterLogLevel,
+}
+
 /// This struct contains configuration options for the Canister HTTP Adapter.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Config {
     /// Specifies which unix domain socket should be used for serving incoming requests.
     #[serde(default)]
     pub incoming_source: IncomingSource,
+
+    pub logger: LoggerConfig,
 }
 
 impl Config {
-    pub fn new(uds_path: PathBuf) -> Config {
+    pub fn new(uds_path: PathBuf, log_level: HttpAdapterLogLevel) -> Config {
         Config {
             incoming_source: IncomingSource::Path(uds_path),
+            logger: LoggerConfig { level: log_level },
         }
     }
 

--- a/src/dfx/src/lib/network/local_server_descriptor.rs
+++ b/src/dfx/src/lib/network/local_server_descriptor.rs
@@ -6,6 +6,7 @@ use crate::config::dfinity::{
     ConfigDefaultsBitcoin, ConfigDefaultsBootstrap, ConfigDefaultsCanisterHttp,
     ConfigDefaultsReplica,
 };
+use crate::lib::canister_http::adapter::config::HttpAdapterLogLevel;
 use crate::lib::error::DfxResult;
 
 use anyhow::Context;
@@ -262,6 +263,12 @@ impl LocalServerDescriptor {
 
         if self.canister_http.enabled {
             println!("  canister http: enabled");
+            let diffs: String = if self.canister_http.log_level != HttpAdapterLogLevel::default() {
+                format!(" (default: {:?})", HttpAdapterLogLevel::default())
+            } else {
+                "".to_string()
+            };
+            println!("    log level: {:?}{}", self.canister_http.log_level, diffs);
         } else {
             println!("  canister http: disabled (default: enabled)");
         }

--- a/src/dfx/src/lib/provider.rs
+++ b/src/dfx/src/lib/provider.rs
@@ -976,7 +976,8 @@ mod tests {
                 "local": {
                   "bind": "127.0.0.1:8000",
                   "canister_http": {
-                    "enabled": true
+                    "enabled": true,
+                    "log_level": "debug"
                   }
                 }
               }
@@ -999,7 +1000,10 @@ mod tests {
 
         assert_eq!(
             canister_http_config,
-            &ConfigDefaultsCanisterHttp { enabled: true }
+            &ConfigDefaultsCanisterHttp {
+                enabled: true,
+                log_level: crate::lib::canister_http::adapter::config::HttpAdapterLogLevel::Debug
+            }
         );
     }
 


### PR DESCRIPTION
# Description

`dfx start` log output is noisy. This PR sets the HTTP adapter's default log level to `error`, but also adds the possibility to set it back to some more talkative level.

Fixes [SDK-728](https://dfinity.atlassian.net/browse/SDK-728)

# How Has This Been Tested?

Added e2e for:
- dfx.json - project defaults
- dfx.json - local network
- networks.json

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
