### PR TITLE
chore: If pushing twice to the same branch, later jobs kill earlier ones

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,6 +6,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/consistent-sources.yml
+++ b/.github/workflows/consistent-sources.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -6,6 +6,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-deny:
     name: license-check:required

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_dfx:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -2,6 +2,10 @@ name: Format
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: fmt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: Lint
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: lint

--- a/.github/workflows/motoko-updater.yml
+++ b/.github/workflows/motoko-updater.yml
@@ -13,6 +13,11 @@ on:
     # * is a special character in YAML so you have to quote this string
     # Run every hour
     - cron:  '0 * * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   niv-updater:
     name: 'Check for Motoko updates'

--- a/.github/workflows/niv-updater.yml
+++ b/.github/workflows/niv-updater.yml
@@ -12,6 +12,11 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 16 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   niv-updater:
     name: 'Check for updates'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,10 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/prepare-dfx-assets.yml
+++ b/.github/workflows/prepare-dfx-assets.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prepare:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish-manifest:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-[A-Za-z]+.[0-9]+'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_dfx:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_macos:
     # ubuntu-latest has shellcheck 0.4.6, while macos-latest has 0.7.1

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -2,6 +2,10 @@ name: Update Docs
 on:
   pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update_dfx_json_schema:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -16,6 +16,11 @@ on:
         description: 'Update the NNS canisters for e2e tests'
         type: boolean
         default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IC_RELEASES_API: "https://ic-api.internetcomputer.org/api/v3/subnet-replica-versions?limit=50&offset=0"
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## DFX
 
+### chore: Kill unwanted CI jobs
+
+If pushing twice to the same branch in quick succession, the earlier CI jobs are cancelled in favour of the later ones.
+
 ### feat: add --mode=auto
 
 When using `dfx canister install`, you can now pass `auto` for the `--mode` flag, which will auto-select `install` or `upgrade` depending on need, the same way `dfx deploy` does. The default remains `install` to prevent mistakes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,8 @@
 
 ## DFX
 
+
 ### fix: `cargo run -p dfx -- --version` prints correct version
-
-### chore: Kill unwanted CI jobs
-
-If pushing twice to the same branch in quick succession, the earlier CI jobs are cancelled in favour of the later ones.
 
 ### feat: add --mode=auto
 


### PR DESCRIPTION
# Description
CI sometimes, perhaps even often, has to wait minutes to tens of minutes for runners to be available.  Reducing the total number of CPU minutes we spend is a way of freeing up compute capacity.

If a developer (e.g. myself) pushes a branch, then notices a change that needs to be made and pushes again, the earlier job still runs to completion even though it is no longer of interest.  It would be nice to kill the earlier job when it is superseded.

Github's concurrency provides setting to do just this:

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

I have opted for the configuration where each workflow has its own groups, so that a kill command from one workflow doesn't kill others.  This lets us choose for which workflows this policy is applied.  I have applied the concurrency limit to every workflow but we may decide that it is only appropriate for some.

# How Has This Been Tested?
* Feel free to push empty commits to this PR and watch CI: `git commit -m bump --allow-empty`
  * I personally have observed this working.  I pushed, waited until there were about 10 entries in https://github.com/dfinity/sdk/actions , then pushed again.  After about 20 seconds the earlier jobs that had not completed were greyed out.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
   - I think there is no corresponding documentation so this is a no-op.
