### PR TITLE
feat: custom canisters: allow candid field to specify a URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ You can still disable the canister http feature through configuration:
 
 ### feat: custom canister `wasm` field can now specify a URL from which to download
 
-Support for a URL in the `candid` field is coming soon.
+### feat: custom canister `candid` field can now specify a URL from which to download
 
 ### feat: deploy NNS canisters
 

--- a/e2e/tests-dfx/build.bash
+++ b/e2e/tests-dfx/build.bash
@@ -15,7 +15,7 @@ teardown() {
     standard_teardown
 }
 
-@test "can build a custom canister with wasm from a url" {
+@test "can build a custom canister with wasm and/or candid from a url" {
     install_asset wasm/identity
     mkdir -p www/wasm
     mv main.wasm www/wasm/
@@ -27,12 +27,7 @@ teardown() {
 
     jq '.canisters={}' dfx.json | sponge dfx.json
 
-    # URL for candid field is not supported
-    # shellcheck disable=SC2154
-    cp "${assets}/wasm/identity/main.did" main.did
-    # jq '.canisters.e2e_project.candid="http://localhost:'"$E2E_WEB_SERVER_PORT"'/wasm/main.did"' dfx.json | sponge dfx.json
-    jq '.canisters.e2e_project.candid="main.did"' dfx.json | sponge dfx.json
-
+    jq '.canisters.e2e_project.candid="http://localhost:'"$E2E_WEB_SERVER_PORT"'/wasm/main.did"' dfx.json | sponge dfx.json
     jq '.canisters.e2e_project.wasm="http://localhost:'"$E2E_WEB_SERVER_PORT"'/wasm/main.wasm"' dfx.json | sponge dfx.json
     jq '.canisters.e2e_project.type="custom"' dfx.json | sponge dfx.json
 

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -136,8 +136,8 @@ pub enum CanisterTypeProperties {
         wasm: String,
 
         /// # Candid File
-        /// Path to this canister's candid interface declaration.
-        candid: PathBuf,
+        /// Path to this canister's candid interface declaration.  A URL to a candid file is also acceptable.
+        candid: String,
 
         /// # Build Commands
         /// Commands that are executed in order to produce this canister's WASM module.
@@ -822,8 +822,8 @@ impl<'de> Visitor<'de> for PropertiesVisitor {
     {
         let missing_field = A::Error::missing_field;
         let mut wasm: Option<String> = None;
-        let (mut package, mut source, mut candid, mut build, mut r#type) =
-            (None, None, None, None, None);
+        let mut candid: Option<String> = None;
+        let (mut package, mut source, mut build, mut r#type) = (None, None, None, None);
         while let Some(key) = map.next_key::<String>()? {
             match &*key {
                 "package" => package = Some(map.next_value()?),
@@ -838,7 +838,7 @@ impl<'de> Visitor<'de> for PropertiesVisitor {
         let props = match r#type.as_deref() {
             Some("motoko") | None => CanisterTypeProperties::Motoko,
             Some("rust") => CanisterTypeProperties::Rust {
-                candid: candid.ok_or_else(|| missing_field("candid"))?,
+                candid: PathBuf::from(candid.ok_or_else(|| missing_field("candid"))?),
                 package: package.ok_or_else(|| missing_field("package"))?,
             },
             Some("assets") => CanisterTypeProperties::Assets {

--- a/src/dfx/src/lib/canister_info/custom.rs
+++ b/src/dfx/src/lib/canister_info/custom.rs
@@ -14,6 +14,7 @@ enum CustomFileLocation {
 pub struct CustomCanisterInfo {
     input_wasm_url: Option<Url>,
     output_wasm_path: PathBuf,
+    input_candid_url: Option<Url>,
     output_idl_path: PathBuf,
     build: Vec<String>,
 }
@@ -24,6 +25,9 @@ impl CustomCanisterInfo {
     }
     pub fn get_output_wasm_path(&self) -> &Path {
         self.output_wasm_path.as_path()
+    }
+    pub fn get_input_candid_url(&self) -> &Option<Url> {
+        &self.input_candid_url
     }
     pub fn get_output_idl_path(&self) -> &Path {
         self.output_idl_path.as_path()
@@ -67,16 +71,23 @@ impl CanisterInfoFactory for CustomCanisterInfo {
             let output_wasm_path = workspace_root.join(wasm);
             (None, output_wasm_path)
         };
-        let candid = if let Some(remote_candid) = info.get_remote_candid_if_remote() {
-            remote_candid
-        } else {
-            candid
-        };
-        let output_idl_path = workspace_root.join(candid);
+        let (input_candid_url, output_idl_path) =
+            if let Some(remote_candid) = info.get_remote_candid_if_remote() {
+                (None, workspace_root.join(remote_candid))
+            } else if let Ok(input_candid_url) = Url::parse(&candid) {
+                let output_candid_path = info
+                    .get_output_root()
+                    .join(info.get_name())
+                    .with_extension("did");
+                (Some(input_candid_url), output_candid_path)
+            } else {
+                (None, workspace_root.join(candid))
+            };
 
         Ok(Self {
             input_wasm_url,
             output_wasm_path,
+            input_candid_url,
             output_idl_path,
             build,
         })


### PR DESCRIPTION
# Description

We recently added the ability to specify a URL for a custom canister's wasm field.  This adds the same support for a custom canister's candid field.

Fixes https://dfinity.atlassian.net/browse/SDK-732

# How Has This Been Tested?

Updated an e2e test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
