### PR TITLE
fix: build icx-asset in the provision step

### DIFF
--- a/scripts/workflows/provision-darwin.sh
+++ b/scripts/workflows/provision-darwin.sh
@@ -32,7 +32,7 @@ fi
 if [ "$E2E_TEST" = "tests-dfx/certificate.bash" ]; then
      brew install mitmproxy
 fi
-if [ "$E2E_TEST" = "tests-icx-asset/icx-asset" ]; then
+if [ "$E2E_TEST" = "tests-icx-asset/icx-asset.bash" ]; then
     cargo build -p icx-asset
     ICX_ASSET="$(pwd)/target/debug/icx-asset"
     echo "ICX_ASSET=$ICX_ASSET" >> "$GITHUB_ENV"

--- a/scripts/workflows/provision-darwin.sh
+++ b/scripts/workflows/provision-darwin.sh
@@ -32,11 +32,6 @@ fi
 if [ "$E2E_TEST" = "tests-dfx/certificate.bash" ]; then
      brew install mitmproxy
 fi
-if [ "$E2E_TEST" = "tests-icx-asset/icx-asset.bash" ]; then
-    cargo build -p icx-asset
-    ICX_ASSET="$(pwd)/target/debug/icx-asset"
-    echo "ICX_ASSET=$ICX_ASSET" >> "$GITHUB_ENV"
-fi
 
 # Set environment variables.
 BATS_SUPPORT="/usr/local/lib/bats-support"
@@ -44,3 +39,9 @@ echo "BATSLIB=${BATS_SUPPORT}" >> "$GITHUB_ENV"
 
 # Exit temporary directory.
 popd
+
+if [ "$E2E_TEST" = "tests-icx-asset/icx-asset.bash" ]; then
+    cargo build -p icx-asset
+    ICX_ASSET="$(pwd)/target/debug/icx-asset"
+    echo "ICX_ASSET=$ICX_ASSET" >> "$GITHUB_ENV"
+fi

--- a/scripts/workflows/provision-linux.sh
+++ b/scripts/workflows/provision-linux.sh
@@ -42,11 +42,6 @@ fi
 if [ "$E2E_TEST" = "tests-dfx/identity_encryption.bash" ]; then
     sudo apt-get install --yes expect
 fi
-if [ "$E2E_TEST" = "tests-icx-asset/icx-asset.bash" ]; then
-    cargo build -p icx-asset
-    ICX_ASSET="$(pwd)/target/debug/icx-asset"
-    echo "ICX_ASSET=$ICX_ASSET" >> "$GITHUB_ENV"
-fi
 
 # Set environment variables.
 BATS_SUPPORT="/usr/local/lib/bats-support"
@@ -55,3 +50,9 @@ echo "$HOME/bin" >> "$GITHUB_PATH"
 
 # Exit temporary directory.
 popd
+
+if [ "$E2E_TEST" = "tests-icx-asset/icx-asset.bash" ]; then
+    cargo build -p icx-asset
+    ICX_ASSET="$(pwd)/target/debug/icx-asset"
+    echo "ICX_ASSET=$ICX_ASSET" >> "$GITHUB_ENV"
+fi

--- a/scripts/workflows/provision-linux.sh
+++ b/scripts/workflows/provision-linux.sh
@@ -42,7 +42,7 @@ fi
 if [ "$E2E_TEST" = "tests-dfx/identity_encryption.bash" ]; then
     sudo apt-get install --yes expect
 fi
-if [ "$E2E_TEST" = "tests-icx-asset/icx-asset" ]; then
+if [ "$E2E_TEST" = "tests-icx-asset/icx-asset.bash" ]; then
     cargo build -p icx-asset
     ICX_ASSET="$(pwd)/target/debug/icx-asset"
     echo "ICX_ASSET=$ICX_ASSET" >> "$GITHUB_ENV"


### PR DESCRIPTION
# Description

Make the provision scripts check against the actual test name.  The tests worked anyway because the tests build icx-asset if it wasn't built already, but building it in the provision step gives us more information about how long it took to build.

# How Has This Been Tested?

By inspection of test run

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
