### PR TITLE
feat: dfx info networks-json shows path to networks.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,9 +185,13 @@ There is also a new configuration file: `$HOME/.config/dfx/networks.json`.  Its 
 
 This displays the port that the icx-proxy process listens on, meaning the port to connect to with curl or from a web browser.
 
-#### #feat: `dfx info replica-rev`
+#### feat: `dfx info replica-rev`
 
 This displays the revision of the replica bundled with dfx, which is the same revision referenced in replica election governance proposals.
+
+#### feat: `dfx info networks-json-path`
+
+This displays the path to your user's `networks.json` file where all networks are defined.
 
 ### feat: added ic-nns-init, ic-admin, and sns executables to the binary cache
 

--- a/docs/cli-reference/dfx-info.md
+++ b/docs/cli-reference/dfx-info.md
@@ -10,11 +10,11 @@ dfx info [type] [flag]
 
 These are the types of information that the `dfx info` command can display.
 
-| Option         | Description                                    |
-|----------------|------------------------------------------------|
-| networks-json  | Path to network definition file networks.json. |
-| replica-rev    | The revision of the bundled replica.           |
-| webserver-port | The local webserver (icx-proxy) port.          |
+| Option              | Description                                    |
+|---------------------|------------------------------------------------|
+| networks-json-path  | Path to network definition file networks.json. |
+| replica-rev         | The revision of the bundled replica.           |
+| webserver-port      | The local webserver (icx-proxy) port.          |
 
 ## Flags
 

--- a/docs/cli-reference/dfx-info.md
+++ b/docs/cli-reference/dfx-info.md
@@ -10,10 +10,11 @@ dfx info [type] [flag]
 
 These are the types of information that the `dfx info` command can display.
 
-| Option         | Description                          |
-|----------------|--------------------------------------|
-| replica-rev    | The revision of the bundled replica  |
-| webserver-port | The local webserver (icx-proxy) port |
+| Option         | Description                                    |
+|----------------|------------------------------------------------|
+| networks-json  | Path to network definition file networks.json. |
+| replica-rev    | The revision of the bundled replica.           |
+| webserver-port | The local webserver (icx-proxy) port.          |
 
 ## Flags
 

--- a/e2e/tests-dfx/info.bash
+++ b/e2e/tests-dfx/info.bash
@@ -26,7 +26,7 @@ teardown() {
 }
 
 @test "displays path to networks.json" {
-    assert_command dfx info networks-json
+    assert_command dfx info networks-json-path
     assert_eq "$E2E_NETWORKS_JSON"
 }
 

--- a/e2e/tests-dfx/info.bash
+++ b/e2e/tests-dfx/info.bash
@@ -25,6 +25,11 @@ teardown() {
     assert_eq "8000"
 }
 
+@test "displays path to networks.json" {
+    assert_command dfx info networks-json
+    assert_eq "$E2E_NETWORKS_JSON"
+}
+
 @test "displays the replica revision included in dfx" {
     nix_sources_path="${BATS_TEST_DIRNAME}/../../nix/sources.json"
     expected_rev="$(jq -r '."replica-x86_64-linux".rev' "$nix_sources_path")"

--- a/src/dfx/src/commands/info/mod.rs
+++ b/src/dfx/src/commands/info/mod.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 enum InfoType {
     ReplicaRev,
     WebserverPort,
-    NetworksJson,
+    NetworksJsonPath,
 }
 
 #[derive(Parser)]
@@ -26,7 +26,7 @@ pub fn exec(env: &dyn Environment, opts: InfoOpts) -> DfxResult {
     let value = match opts.info_type {
         InfoType::ReplicaRev => info::replica_rev().to_string(),
         InfoType::WebserverPort => get_webserver_port(env)?,
-        InfoType::NetworksJson => NetworksConfig::new()?
+        InfoType::NetworksJsonPath => NetworksConfig::new()?
             .get_path()
             .to_str()
             .context("Failed to convert networks.json path to a string.")?

--- a/src/dfx/src/commands/info/mod.rs
+++ b/src/dfx/src/commands/info/mod.rs
@@ -1,15 +1,18 @@
 mod webserver_port;
 
 use crate::commands::info::webserver_port::get_webserver_port;
+use crate::config::dfinity::NetworksConfig;
 use crate::lib::error::DfxResult;
 use crate::lib::info;
 use crate::Environment;
+use anyhow::Context;
 use clap::Parser;
 
 #[derive(clap::ValueEnum, Clone, Debug)]
 enum InfoType {
     ReplicaRev,
     WebserverPort,
+    NetworksJson,
 }
 
 #[derive(Parser)]
@@ -23,6 +26,11 @@ pub fn exec(env: &dyn Environment, opts: InfoOpts) -> DfxResult {
     let value = match opts.info_type {
         InfoType::ReplicaRev => info::replica_rev().to_string(),
         InfoType::WebserverPort => get_webserver_port(env)?,
+        InfoType::NetworksJson => NetworksConfig::new()?
+            .get_path()
+            .to_str()
+            .context("Failed to convert networks.json path to a string.")?
+            .to_string(),
     };
     println!("{}", value);
     Ok(())


### PR DESCRIPTION
# Description

Having a universal way to figure out where networks are defined will make writing tutorials much easier.

# How Has This Been Tested?

Added e2e.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
