### PR TITLE
test: Import more NNS canister IDs

### DIFF
--- a/e2e/tests-dfx/nns.bash
+++ b/e2e/tests-dfx/nns.bash
@@ -84,6 +84,31 @@ nns_canister_id() {
     esac
 }
 
+assert_nns_canister_id_matches() {
+    [[ "$(nns_canister_id "$1")" == "$(dfx canister id "$1")" ]] || {
+       echo "ERROR: NNS canister ID mismatch for $1: $(nns_canister_id "$1") != $(dfx canister id "$1")"
+       exit 1
+    } >&2
+}
+
+@test "dfx nns import ids are as expected" {
+    # TODO: The IC commit currently used by the sdk doesn't have all the canister IDs yet.
+    #       When it does, remove this DFX_IC_SRC override.
+    export DFX_IC_SRC="https://raw.githubusercontent.com/dfinity/ic/master"
+    dfx nns import --network-mapping local
+    assert_nns_canister_id_matches nns-registry
+    assert_nns_canister_id_matches nns-governance
+    assert_nns_canister_id_matches nns-ledger
+    assert_nns_canister_id_matches nns-root
+    assert_nns_canister_id_matches nns-cycles-minting
+    assert_nns_canister_id_matches nns-lifeline
+    assert_nns_canister_id_matches nns-genesis-token
+    assert_nns_canister_id_matches nns-sns-wasm
+    # TODO: No source provides these canister IDs - yet.
+    #assert_nns_canister_id_matches internet_identity
+    #assert_nns_canister_id_matches nns-dapp
+}
+
 @test "dfx nns install runs" {
     echo Setting up...
     install_shared_asset subnet_type/shared_network_settings/system

--- a/src/dfx/src/commands/nns/import.rs
+++ b/src/dfx/src/commands/nns/import.rs
@@ -25,9 +25,11 @@ pub async fn exec(env: &dyn Environment, opts: ImportOpts) -> DfxResult {
 
     let network_mappings = get_network_mappings(&opts.network_mapping)?;
     let ic_commit = replica_rev();
-    let dfx_url_str =
-        format!("https://raw.githubusercontent.com/dfinity/ic/{ic_commit}/rs/nns/dfx.json");
 
+    let dfx_url_str = {
+        let ic_project = std::env::var("DFX_IC_SRC").unwrap_or_else(|_| format!("https://raw.githubusercontent.com/dfinity/ic/{ic_commit}"));
+        format!("{ic_project}/rs/nns/dfx.json")
+    };
     import_canister_definitions(
         env.get_logger(),
         &mut config,

--- a/src/dfx/src/commands/nns/import.rs
+++ b/src/dfx/src/commands/nns/import.rs
@@ -27,7 +27,9 @@ pub async fn exec(env: &dyn Environment, opts: ImportOpts) -> DfxResult {
     let ic_commit = replica_rev();
 
     let dfx_url_str = {
-        let ic_project = std::env::var("DFX_IC_SRC").unwrap_or_else(|_| format!("https://raw.githubusercontent.com/dfinity/ic/{ic_commit}"));
+        let ic_project = std::env::var("DFX_IC_SRC").unwrap_or_else(|_| {
+            format!("https://raw.githubusercontent.com/dfinity/ic/{ic_commit}")
+        });
         format!("{ic_project}/rs/nns/dfx.json")
     };
     import_canister_definitions(


### PR DESCRIPTION
# Description
`dfx nns import` sets only some NNS canister IDs, as not all back end NNS canister IDs are included in the upstream dfx file we use.

Upstream now includes those canisters.  It will be 1-2 weeks before the code in master is blessed, but we can verify now that we will have those canister IDs.

Note: This PR dos not address the fact that dfx nns install does not set front end canister IDs.  The front end canister IDs are more complicated.  The canister IDs created by `ic-nns-init` don't match prod, but ic-nns-init also manages to use some of the front end canister IDs for other purposes.  The only reliable source for those canister IDs is the code for `dfx nns install`.

# Changes
- `ic nns import` now respects an environment variable `DFX_IC_SRC` that tells `dfx nns import` to pull the canister details from another location.  This has actually been very useful and I wish it were available for other commands as well.
- Added a test that `ic nns import` sets all the local back-end NNS canister IDs with a sufficiently recent commit of the ic repo.

# How Has This Been Tested?
- There is a test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
  I assume that this is a noop.  Should the env var be made public?  It is probably only of use to internal developers.
- [x] I have made corresponding changes to the documentation.
  Ditto.