### PR TITLE
chore: remove dfx version pin from default project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,6 +364,10 @@ Previously, dfx only accepted canister aliases and produced an error message tha
 
 Motivated by [this forum post](https://forum.dfinity.org/t/dfx-0-10-0-dfx-canister-deposit-cycles-returns-error/13251/6).
 
+### chore: projects created with `dfx new` are not pinned to a specific dfx version anymore
+
+It is still possible to pin the dfx version by adding `"dfx":"<dfx version to pin to>"` to a project's `dfx.json`.
+
 ### fix: print links to cdk-rs docs in dfx new
 
 ### fix: Small grammar change to identity password decryption prompt

--- a/src/dfx/assets/new_project_motoko_files/dfx.json
+++ b/src/dfx/assets/new_project_motoko_files/dfx.json
@@ -1,6 +1,5 @@
 {
   "version": 1,
-  "dfx": "{dfx_version}",
   "canisters": {
     "{project_name}_backend": {
       "type": "motoko",

--- a/src/dfx/assets/new_project_rust_files/dfx.json
+++ b/src/dfx/assets/new_project_rust_files/dfx.json
@@ -1,6 +1,5 @@
 {
   "version": 1,
-  "dfx": "{dfx_version}",
   "canisters": {
     "{project_name}_backend": {
       "type": "rust",


### PR DESCRIPTION
# Description

As discussed in yesterday's meeting we discussed removing the version pin from the default project.

# How Has This Been Tested?

tested manually

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
