### PR TITLE
fix: add new nns wasm: ic-ckbtc-minter

### DIFF
--- a/scripts/update-nns.bash
+++ b/scripts/update-nns.bash
@@ -43,6 +43,7 @@ get_binary ic-nns-init
 get_wasm registry-canister.wasm
 get_wasm governance-canister.wasm
 get_wasm governance-canister_test.wasm
+get_wasm ic-ckbtc-minter.wasm
 get_wasm ledger-canister_notify-method.wasm
 get_wasm root-canister.wasm
 get_wasm cycles-minting-canister.wasm


### PR DESCRIPTION
# Description

This is needed by the next replica release candidate.  See test failures: https://github.com/dfinity/sdk/actions/runs/3103188746/jobs/5026356601

# How Has This Been Tested?

Tested locally.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] (no need) I have edited the CHANGELOG accordingly.
- [x] (no need) I have made corresponding changes to the documentation.
