### PR TITLE
feat: Move the wasm cache into the main cache

### DIFF
--- a/e2e/tests-dfx/nns.bash
+++ b/e2e/tests-dfx/nns.bash
@@ -124,7 +124,7 @@ assert_nns_canister_id_matches() {
         dfx canister info "$(nns_canister_id "$1")" | awk '/Module hash/{print $3; exit 0}END{exit 1}'
     }
     downloaded_wasm_hash() {
-        sha256sum ".dfx/wasms/nns/$(dfx --version | awk '{printf "%s-%s", $1, $2}')/$1" | awk '{print "0x" $1}'
+        sha256sum "$(dfx cache show)/wasms/$1" | awk '{print "0x" $1}'
     }
     wasm_matches() {
         echo "Comparing $* ..."

--- a/src/dfx/src/lib/nns/install_nns.rs
+++ b/src/dfx/src/lib/nns/install_nns.rs
@@ -73,7 +73,7 @@ pub async fn install_nns(
     eprintln!("Installing the core backend wasm canisters...");
     download_nns_wasms(env).await?;
     let ic_nns_init_opts = IcNnsInitOpts {
-        wasm_dir: nns_wasm_dir(env),
+        wasm_dir: nns_wasm_dir(env)?,
         nns_url: nns_url.to_string(),
         test_accounts: Some(canisters::TEST_ACCOUNT.to_string()),
         sns_subnets: Some(subnet_id.to_string()),
@@ -91,7 +91,7 @@ pub async fn install_nns(
         canister_id,
     } in NNS_FRONTEND
     {
-        let local_wasm_path = nns_wasm_dir(env).join(wasm_name);
+        let local_wasm_path = nns_wasm_dir(env)?.join(wasm_name);
         let parsed_wasm_url = Url::parse(wasm_url)
             .with_context(|| format!("Could not parse url for {canister_name} wasm: {wasm_url}"))?;
         download(&parsed_wasm_url, &local_wasm_path).await?;
@@ -419,7 +419,7 @@ pub async fn download_ic_repo_wasm(
 #[context("Failed to download NNS wasm files.")]
 pub async fn download_nns_wasms(env: &dyn Environment) -> anyhow::Result<()> {
     let ic_commit = std::env::var("DFX_IC_COMMIT").unwrap_or_else(|_| replica_rev().to_string());
-    let wasm_dir = &nns_wasm_dir(env);
+    let wasm_dir = &nns_wasm_dir(env)?;
     for IcNnsInitCanister {
         wasm_name,
         test_wasm_name,
@@ -560,7 +560,7 @@ pub fn upload_nns_sns_wasms_canister_wasms(env: &dyn Environment) -> anyhow::Res
     } in SNS_CANISTERS
     {
         let sns_cli = bundled_binary(env, "sns")?;
-        let wasm_path = nns_wasm_dir(env).join(wasm_name);
+        let wasm_path = nns_wasm_dir(env)?.join(wasm_name);
         let mut command = Command::new(sns_cli);
         command
             .arg("add-sns-wasm-for-tests")
@@ -646,8 +646,9 @@ pub async fn install_canister(
 }
 
 /// The local directory where NNS wasm files are cached.  The directory is typically created on demand.
-fn nns_wasm_dir(env: &dyn Environment) -> PathBuf {
-    Path::new(&format!(".dfx/wasms/nns/dfx-{}/", env.get_version())).to_path_buf()
+fn nns_wasm_dir(env: &dyn Environment) -> anyhow::Result<PathBuf> {
+    // A subdirectory "wasms" of the binaries cache dir:
+    bundled_binary(env, "wasms")
 }
 
 /// Get the path to a bundled command line binary


### PR DESCRIPTION
# Description
At the moment, NNS wasms were cached under `$PWD/.dfx/`.  This is inappropriate because `dfx nns install` is not tied to a particular project; it may be run from anywhere.  Furthermore, even though the wasms are fixed for a given version of dfx, this prevents the wasm cache from being reused if `dfx nns install` is run from a different directory.

## Changes
Store NNS wasms in the main cache dir for the current version of dfx.

# How Has This Been Tested?
```
dfx start --clean --background
dfx nns install
```
Observe that downloads go to the expected dir:
```
Downloading /home/max/.cache/dfinity/versions/0.12.0-beta.2+rev47.dirty-5d1476ff/wasms/sns-wasm-canister.wasm
  from https://download.dfinity.systems/ic/9173c5f1b28e140931060b90e9de65b923ee57e6/canisters/sns-wasm-canister.wasm.gz
Downloading /home/max/.cache/dfinity/versions/0.12.0-beta.2+rev47.dirty-5d1476ff/wasms/ic-ckbtc-minter.wasm
  from https://download.dfinity.systems/ic/9173c5f1b28e140931060b90e9de65b923ee57e6/canisters/ic-ckbtc-minter.wasm.gz
etc
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
