### PR TITLE
refactor: Factor out code for calling arbitrary bundled binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## DFX
 
+### refactor: Factor out code for calling arbitrary bundled binaries
+
+The function for calling sns can now call any bundled binary.
+
 ### fix: Only kill main process on `dfx stop`
 Removes misleading panics when running `dfx stop`.
 

--- a/src/dfx/src/lib/mod.rs
+++ b/src/dfx/src/lib/mod.rs
@@ -1,5 +1,6 @@
 pub mod bitcoin;
 pub mod builders;
+pub mod call_bundled;
 pub mod canister_http;
 pub mod canister_info;
 pub mod config;

--- a/src/dfx/src/lib/sns/create_config.rs
+++ b/src/dfx/src/lib/sns/create_config.rs
@@ -3,8 +3,8 @@ use fn_error_context::context;
 use std::ffi::OsString;
 use std::path::Path;
 
+use crate::lib::call_bundled::call_bundled;
 use crate::lib::error::DfxResult;
-use crate::lib::sns::sns_cli::call_sns_cli;
 use crate::Environment;
 
 /// Ceates an SNS configuration template.
@@ -16,6 +16,6 @@ pub fn create_config(env: &dyn Environment, path: &Path) -> DfxResult {
         OsString::from(path),
         OsString::from("new"),
     ];
-    call_sns_cli(env, &args)?;
+    call_bundled(env, "sns", &args)?;
     Ok(())
 }

--- a/src/dfx/src/lib/sns/deploy.rs
+++ b/src/dfx/src/lib/sns/deploy.rs
@@ -3,8 +3,8 @@ use fn_error_context::context;
 use std::ffi::OsString;
 use std::path::Path;
 
+use crate::lib::call_bundled::call_bundled;
 use crate::lib::error::DfxResult;
-use crate::lib::sns::sns_cli::call_sns_cli;
 use crate::Environment;
 
 /// Creates an SNS.  This requires funds but no proposal.
@@ -15,5 +15,6 @@ pub fn deploy_sns(env: &dyn Environment, path: &Path) -> DfxResult<String> {
         OsString::from("--init-config-file"),
         OsString::from(path),
     ];
-    call_sns_cli(env, &args).map(|stdout| format!("Deployed SNS: {}\n{}", path.display(), stdout))
+    call_bundled(env, "sns", &args)
+        .map(|stdout| format!("Deployed SNS: {}\n{}", path.display(), stdout))
 }

--- a/src/dfx/src/lib/sns/mod.rs
+++ b/src/dfx/src/lib/sns/mod.rs
@@ -2,7 +2,6 @@
 #![warn(clippy::missing_docs_in_private_items)]
 pub mod create_config;
 pub mod deploy;
-pub mod sns_cli;
 pub mod validate_config;
 
 /// The default location of an SNS configuration file.

--- a/src/dfx/src/lib/sns/validate_config.rs
+++ b/src/dfx/src/lib/sns/validate_config.rs
@@ -3,8 +3,8 @@ use fn_error_context::context;
 use std::ffi::OsString;
 use std::path::Path;
 
+use crate::lib::call_bundled::call_bundled;
 use crate::lib::error::DfxResult;
-use crate::lib::sns::sns_cli::call_sns_cli;
 use crate::Environment;
 
 /// Checks whether an SNS configuration file is valid.
@@ -16,5 +16,5 @@ pub fn validate_config(env: &dyn Environment, path: &Path) -> DfxResult<String> 
         OsString::from(path),
         OsString::from("validate"),
     ];
-    call_sns_cli(env, &args).map(|_| format!("SNS config file is valid: {}", path.display()))
+    call_bundled(env, "sns", &args).map(|_| format!("SNS config file is valid: {}", path.display()))
 }


### PR DESCRIPTION
# Description
## Motivation
There are several bundled binaries, including `ic-admin` and `sns`.  We have a wrapper for calling `sns` but it works perfectly for other bundled binaries as well.  So let's reuse it.

## Changes
Move the function for calling sns into src/dfx/lib and make the name of the bundled binary a variable.

# How Has This Been Tested?
There is no change in functionality.  Existing tests should suffice.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
  - This is a noop as there is no change to user-facing functionality