### PR TITLE
chore: Delete OpenSSL

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,6 @@ jobs:
           fetch-depth: 0
       - name: Setup environment variables
         run: |
-          echo "OPENSSL_STATIC=yes" >> $GITHUB_ENV
           echo "RUSTFLAGS=--remap-path-prefix=${GITHUB_WORKSPACE}=/builds/dfinity" >> $GITHUB_ENV
       - name: Cache Cargo
         uses: actions/cache@v2
@@ -58,17 +57,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
         if: contains(matrix.os, 'macos')
-      - name: Build static-linked openssl
-        run: |
-          # https://github.com/rust-lang/cargo/issues/713#issuecomment-59597433
-          git clone git://git.openssl.org/openssl.git
-          cd openssl
-          ./config -fPIC --prefix=/usr/local --openssldir=/usr/local/ssl
-          make
-          sudo make install
-          echo "OPENSSL_LIB_DIR=/usr/local/lib64" >> $GITHUB_ENV
-          echo "OPENSSL_INCLUDE_DIR=/usr/local/include" >> $GITHUB_ENV
-        if: contains(matrix.target, 'linux-gnu')
       - name: Build
         run: |
           cargo clean --target ${{ matrix.target }} --release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Setup environment variables
         run: |
-          echo "OPENSSL_STATIC=yes" >> $GITHUB_ENV
           echo "RUSTFLAGS=--remap-path-prefix=${GITHUB_WORKSPACE}=/builds/dfinity" >> $GITHUB_ENV
 
       # GITHUB_REF_NAME will be something link 2353/merge for branch builds, which isn't great as a dfx version
@@ -74,18 +73,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
         if: contains(matrix.os, 'macos')
-
-      - name: Build static-linked openssl
-        run: |
-          # https://github.com/rust-lang/cargo/issues/713#issuecomment-59597433
-          git clone git://git.openssl.org/openssl.git
-          cd openssl
-          ./config -fPIC --prefix=/usr/local --openssldir=/usr/local/ssl
-          make
-          sudo make install
-          echo "OPENSSL_LIB_DIR=/usr/local/lib64" >> $GITHUB_ENV
-          echo "OPENSSL_INCLUDE_DIR=/usr/local/include" >> $GITHUB_ENV
-        if: contains(matrix.target, 'linux-gnu')
 
       - name: Build
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
  "pbkdf2",
  "rand_core",
  "ripemd",
- "sha2 0.10.2",
+ "sha2 0.10.6",
  "subtle",
  "zeroize",
 ]
@@ -323,7 +323,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -770,7 +770,6 @@ dependencies = [
  "mockito",
  "net2",
  "num-traits",
- "openssl",
  "pem",
  "petgraph",
  "proptest",
@@ -786,6 +785,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
+ "sha2 0.10.6",
  "shell-words",
  "slog",
  "slog-async",
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
@@ -946,7 +946,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.3",
+ "digest 0.10.5",
  "ff",
  "generic-array",
  "group",
@@ -1350,7 +1350,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -1485,7 +1485,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "sha2 0.10.2",
+ "sha2 0.10.6",
  "simple_asn1",
  "thiserror",
  "url",
@@ -1514,7 +1514,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "sha2 0.10.2",
+ "sha2 0.10.6",
  "tempfile",
  "walkdir",
 ]
@@ -1591,7 +1591,7 @@ dependencies = [
  "ic-agent",
  "num-bigint 0.4.3",
  "pkcs11",
- "sha2 0.10.2",
+ "sha2 0.10.6",
  "simple_asn1",
  "thiserror",
 ]
@@ -1607,7 +1607,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_bytes",
- "sha2 0.10.2",
+ "sha2 0.10.6",
  "thiserror",
 ]
 
@@ -1778,7 +1778,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.2",
+ "sha2 0.10.6",
  "sha3",
 ]
 
@@ -2191,15 +2191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "111.22.0+1.1.1q"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2208,7 +2199,6 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2290,7 +2280,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -2761,7 +2751,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1facec54cb5e0dc08553501fa740091086d0259ad0067e0d4103448e4cb22ed3"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -3051,7 +3041,7 @@ checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -3069,13 +3059,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -3084,7 +3074,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
  "keccak",
 ]
 
@@ -3109,7 +3099,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.5",
  "rand_core",
 ]
 
@@ -3424,7 +3414,7 @@ dependencies = [
  "pbkdf2",
  "rand",
  "rustc-hash",
- "sha2 0.10.2",
+ "sha2 0.10.6",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 [build-dependencies]
 flate2 = "1.0.11"
 hex = "0.4.2"
-openssl = "0.10.32"
+sha2 = "0.10.6"
 tar = "0.4.26"
 walkdir = "2.3.2"
 
@@ -54,7 +54,6 @@ mime = "0.3.16"
 mime_guess = "2.0.4"
 net2 = "0.2.34"
 num-traits = "0.2"
-openssl = "0.10.32"
 pem = "1.0.2"
 petgraph = "0.6.0"
 rand = "0.8.5"
@@ -69,6 +68,7 @@ serde = "1.0"
 serde_bytes = "0.11.2"
 serde_cbor = "0.11.1"
 serde_json = "1.0.79"
+sha2 = "0.10.6"
 shell-words = "1.1.0"
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 slog-async = "2.4.0"
@@ -107,6 +107,3 @@ env_logger = "0.9"
 proptest = "1.0"
 mockito = "0.31.0"
 tempfile = "3.1.0"
-
-[features]
-vendored-openssl = ["openssl/vendored"]

--- a/src/dfx/assets/build.rs
+++ b/src/dfx/assets/build.rs
@@ -1,6 +1,6 @@
 use flate2::write::GzEncoder;
 use flate2::Compression;
-use openssl::sha::Sha256;
+use sha2::{Digest, Sha256};
 use std::fs::{read_to_string, File};
 use std::io::{BufRead, Read, Write};
 use std::path::{Path, PathBuf};
@@ -32,7 +32,7 @@ fn calculate_hash_of_inputs(project_root_path: &Path) -> String {
         sha256.update(&buffer);
     }
 
-    hex::encode(sha256.finish())
+    hex::encode(sha256.finalize())
 }
 
 fn get_project_root_path() -> PathBuf {

--- a/src/dfx/src/lib/nns_types/account_identifier.rs
+++ b/src/dfx/src/lib/nns_types/account_identifier.rs
@@ -7,8 +7,8 @@
 use anyhow::Context;
 use candid::CandidType;
 use candid::Principal;
-use openssl::sha::Sha224;
 use serde::{de, de::Error, Deserialize, Serialize};
+use sha2::{Digest, Sha224};
 use std::convert::{TryFrom, TryInto};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
@@ -38,7 +38,7 @@ impl AccountIdentifier {
         hash.update(&sub_account.0[..]);
 
         AccountIdentifier {
-            hash: hash.finish(),
+            hash: hash.finalize().into(),
         }
     }
 


### PR DESCRIPTION
I don't know if we used to use OpenSSL for more, but right now we only use it for sha2, which is capably provided by the `sha2` crate instead. In the meantime every last problem I have had with the build system has been due to OpenSSL's inclusion. This PR removes the last vestiges of OpenSSL along with the build system hacks necessary to build it.