### PR TITLE
feat: nns usability improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## DFX
 
+### feat: NNS usability improvements
+
+The command line interface for nns commands has been updated to:
+
+- Give better help when the subnet type is incorrect
+- Not offer --network as a flag given that it is unused
+- List nns subcommands
+
 ### fix: Compute Motoko dependencies in linear (not exponential) time by detecting visited imports.
 
 ### fix(generate): add missing typescript types and fix issues with bindings array in dfx.json

--- a/src/dfx/src/commands/nns/mod.rs
+++ b/src/dfx/src/commands/nns/mod.rs
@@ -27,11 +27,9 @@ pub struct NnsOpts {
 /// Command line options for subcommands of `dfx nns`.
 #[derive(Parser)]
 enum SubCommand {
-    /// Options for importing NNS API definitions and canister IDs.
-    #[clap(hide(true))]
+    /// Import NNS API definitions and canister IDs.
     Import(import::ImportOpts),
-    /// Options for installing an NNS.
-    #[clap(hide(true))]
+    /// Install an NNS on the local dfx server.
     Install(install::InstallOpts),
 }
 

--- a/src/dfx/src/commands/nns/mod.rs
+++ b/src/dfx/src/commands/nns/mod.rs
@@ -3,7 +3,6 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::provider::create_agent_environment;
-use crate::NetworkOpt;
 
 use clap::Parser;
 use tokio::runtime::Runtime;
@@ -18,10 +17,6 @@ pub struct NnsOpts {
     /// `dfx nns` subcommand arguments.
     #[clap(subcommand)]
     subcmd: SubCommand,
-
-    /// An argument to choose the network from those specified in dfx.json.
-    #[clap(flatten)]
-    network: NetworkOpt,
 }
 
 /// Command line options for subcommands of `dfx nns`.
@@ -35,7 +30,7 @@ enum SubCommand {
 
 /// Executes `dfx nns` and its subcommands.
 pub fn exec(env: &dyn Environment, opts: NnsOpts) -> DfxResult {
-    let env = create_agent_environment(env, opts.network.network)?;
+    let env = create_agent_environment(env, None)?;
     let runtime = Runtime::new().expect("Unable to create a runtime");
     runtime.block_on(async {
         match opts.subcmd {

--- a/src/dfx/src/lib/nns/install_nns.rs
+++ b/src/dfx/src/lib/nns/install_nns.rs
@@ -320,7 +320,28 @@ fn local_replica_type(env: &dyn Environment) -> anyhow::Result<ReplicaSubnetType
 pub fn verify_local_replica_type_is_system(env: &dyn Environment) -> anyhow::Result<()> {
     match local_replica_type(env) {
         Ok(ReplicaSubnetType::System) => Ok(()),
-        other => Err(anyhow!("The replica subnet_type needs to be \"system\" to run NNS canisters. Current value: {other:?}. You can configure it by setting defaults.replica.subnet_type in your project's dfx.json or by setting local.replica.subnet_type in your global networks.json to \"system\".")),
+        other => Err(anyhow!(
+            r#"The replica subnet_type needs to be \"system\" to run NNS canisters. Current value: {other:?}.
+             
+             You can configure it by setting local.replica.subnet_type to "system" in your global networks.json:
+             
+             1) Create or edit: {}
+             2) Set the local config to:
+                 {{
+                   "local": {{
+                     "bind": "127.0.0.1:8080",
+                     "type": "ephemeral",
+                     "replica": {{
+                       "subnet_type": "application"
+                     }}
+                   }}
+                 }}
+             3) Verify that you have no network configurations in dfx.json.
+             4) Restart dfx:
+                 dfx stop
+                 dfx start --clean
+             
+             "#, env.get_networks_config().get_path().to_string_lossy())),
     }
 }
 

--- a/src/dfx/src/lib/nns/install_nns.rs
+++ b/src/dfx/src/lib/nns/install_nns.rs
@@ -321,7 +321,7 @@ pub fn verify_local_replica_type_is_system(env: &dyn Environment) -> anyhow::Res
     match local_replica_type(env) {
         Ok(ReplicaSubnetType::System) => Ok(()),
         other => Err(anyhow!(
-            r#"The replica subnet_type needs to be "system" to run NNS canisters. Current value: {other:?}.
+            r#"The replica subnet_type needs to be 'system' to run NNS canisters. Current value: {other:?}.
              
              You can configure it by setting local.replica.subnet_type to "system" in your global networks.json:
              

--- a/src/dfx/src/lib/nns/install_nns.rs
+++ b/src/dfx/src/lib/nns/install_nns.rs
@@ -341,7 +341,9 @@ pub fn verify_local_replica_type_is_system(env: &dyn Environment) -> anyhow::Res
                  dfx stop
                  dfx start --clean
              
-             "#, env.get_networks_config().get_path().to_string_lossy())),
+             "#,
+            env.get_networks_config().get_path().to_string_lossy()
+        )),
     }
 }
 

--- a/src/dfx/src/lib/nns/install_nns.rs
+++ b/src/dfx/src/lib/nns/install_nns.rs
@@ -321,7 +321,7 @@ pub fn verify_local_replica_type_is_system(env: &dyn Environment) -> anyhow::Res
     match local_replica_type(env) {
         Ok(ReplicaSubnetType::System) => Ok(()),
         other => Err(anyhow!(
-            r#"The replica subnet_type needs to be \"system\" to run NNS canisters. Current value: {other:?}.
+            r#"The replica subnet_type needs to be "system" to run NNS canisters. Current value: {other:?}.
              
              You can configure it by setting local.replica.subnet_type to "system" in your global networks.json:
              


### PR DESCRIPTION
# Description
The `dfx nns`commands are technically ready to use but can be confusing or hard to use, even though they should be very simple.  The following issues are addressed.

## Local network type
`dfx nns install` needs to be run with particular network settings.  There is an existing check that the network type is "system" and an error message but the error message doesn't seem to be helping; it is not clear or explicit enough, it doesn't give people the information they need to configure the network.

**Change:** Expand the error message with explicit steps the user needs to take.

![Screenshot from 2022-10-08 04-42-03](https://user-images.githubusercontent.com/5982633/194685534-23b23a4e-59c5-422d-b36e-5e62d894be63.png)

## Help is not shown
`dfx nns --help` was not showing subcommands.  This was intentional as the nns subcommands were stubbed in, however now the subcommands have been implemented.

**Change:** Make the subcommands public and tweak their descriptions.

## `--network` option is advertised but unused
No current `nns` commands use the `--network` flag, yet the flag is advertised.

**Change:** Remove the `--network` flag from the `nns` subcommand.

# How Has This Been Tested?




# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
  This is a noop