### PR TITLE
refactor: e2e workflow: do not check dynamic-linked libraries

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,39 +61,6 @@ jobs:
         run: |
           cargo clean --target ${{ matrix.target }} --release
           cargo build --target ${{ matrix.target }} --locked --release
-      - name: Check dynamically-linked libraries (macos)
-        run: |
-          ACTUAL="$(otool -L ${{ matrix.binary_path }}/dfx | awk 'NR > 1{ print $1 }' | grep -v /System/Library/Frameworks | sort | awk -v d=" " '{s=(NR==1?s:s d)$0}END{printf "%s",s}')"
-          EXPECTED="/usr/lib/libSystem.B.dylib /usr/lib/libiconv.2.dylib /usr/lib/libresolv.9.dylib"
-          echo "Dynamically-linked libraries:"
-          echo "  Actual:   $ACTUAL"
-          echo "  Expected: $EXPECTED"
-          if [ "$ACTUAL" != "$EXPECTED" ]; then
-              exit 1
-          fi
-        if: contains(matrix.os, 'macos')
-      - name: Check dynamically-linked libraries (ubuntu 20.04)
-        run: |
-          ACTUAL="$(ldd ${{ matrix.binary_path }}/dfx | awk '{ print $1 }' | sort | awk -v d=" " '{s=(NR==1?s:s d)$0}END{printf "%s",s}')"
-          EXPECTED="/lib64/ld-linux-x86-64.so.2 libc.so.6 libdl.so.2 libgcc_s.so.1 libm.so.6 libpthread.so.0 linux-vdso.so.1"
-          echo "Dynamically-linked libraries:"
-          echo "  Actual:   $ACTUAL"
-          echo "  Expected: $EXPECTED"
-          if [ "$ACTUAL" != "$EXPECTED" ]; then
-              exit 1
-          fi
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
-      - name: Check dynamically-linked libraries (ubuntu 22.04)
-        run: |
-          ACTUAL="$(ldd ${{ matrix.binary_path }}/dfx | awk '{ print $1 }' | sort | awk -v d=" " '{s=(NR==1?s:s d)$0}END{printf "%s",s}')"
-          EXPECTED="/lib64/ld-linux-x86-64.so.2 libc.so.6 libgcc_s.so.1 libm.so.6 linux-vdso.so.1"
-          echo "Dynamically-linked libraries:"
-          echo "  Actual:   $ACTUAL"
-          echo "  Expected: $EXPECTED"
-          if [ "$ACTUAL" != "$EXPECTED" ]; then
-              exit 1
-          fi
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
       - name: Strip binaries
         run: |
           cd ${{ matrix.binary_path }}


### PR DESCRIPTION
The publish workflow already performs this, so we don't need to duplicate the logic.
