### PR TITLE
test: add basic canister http test

### DIFF
--- a/e2e/assets/canister_http/main.mo
+++ b/e2e/assets/canister_http/main.mo
@@ -1,0 +1,45 @@
+import Types "types";
+import Cycles "mo:base/ExperimentalCycles";
+import Nat64 "mo:base/Nat64";
+import Text "mo:base/Text";
+import Blob "mo:base/Blob";
+import Nat "mo:base/Nat";
+
+shared actor class HttpQuery() = this {
+    let MAX_RESPONSE_BYTES : Nat64 = 12000;
+    let CYCLES_TO_PAY : Nat = 2_000_000_000;
+
+    public func get_url(host : Text, url : Text) : async Text {
+        let request_headers = [
+            { name = "Host"; value = host },
+            { name = "User-Agent"; value = "sdk-e2e-test" },
+        ];
+
+        let request : Types.CanisterHttpRequestArgs = {
+            url = url;
+            max_response_bytes = ?MAX_RESPONSE_BYTES;
+            headers = request_headers;
+            body = null;
+            method = #get;
+            transform = ?(#function(transform));
+        };
+
+        Cycles.add(CYCLES_TO_PAY);
+        let ic : Types.IC = actor ("aaaaa-aa");
+        let response : Types.CanisterHttpResponsePayload = await ic.http_request(request);
+        let result : Text = switch (Text.decodeUtf8(Blob.fromArray(response.body))) {
+            case null "";
+            case (?decoded) decoded;
+        };
+        result
+    };
+
+    public query func transform(raw : Types.CanisterHttpResponsePayload) : async Types.CanisterHttpResponsePayload {
+        let transformed : Types.CanisterHttpResponsePayload = {
+            status = raw.status;
+            body = raw.body;
+            headers = [];
+        };
+        transformed;
+    };
+};

--- a/e2e/assets/canister_http/patch.bash
+++ b/e2e/assets/canister_http/patch.bash
@@ -1,0 +1,1 @@
+jq '.canisters.e2e_project_backend.main="main.mo"' dfx.json | sponge dfx.json

--- a/e2e/assets/canister_http/types.mo
+++ b/e2e/assets/canister_http/types.mo
@@ -1,0 +1,53 @@
+import HashMap "mo:base/HashMap";
+import Principal "mo:base/Principal";
+
+module Types {
+    public type Timestamp = Nat64;
+    public type Rate = Text;
+
+    public type TimeRange = {
+        start : Timestamp;
+        end : Timestamp;
+    };
+
+    public type RatesWithInterval = {
+        interval : Nat64;
+        rates : [(Timestamp, Rate)];
+    };
+
+    public type HttpHeader = {
+        name : Text;
+        value : Text;
+    };
+
+    public type HttpMethod = {
+        #get;
+        #post;
+        #head;
+    };
+
+    public type TransformType = {
+        #function : shared CanisterHttpResponsePayload -> async CanisterHttpResponsePayload;
+    };
+
+    public type CanisterHttpRequestArgs = {
+        url : Text;
+        max_response_bytes : ?Nat64;
+        headers : [HttpHeader];
+        body : ?[Nat8];
+        method : HttpMethod;
+        transform : ?{
+            #function : shared query CanisterHttpResponsePayload -> async CanisterHttpResponsePayload;
+        };
+    };
+
+    public type CanisterHttpResponsePayload = {
+        status : Nat;
+        headers : [HttpHeader];
+        body : [Nat8];
+    };
+
+    public type IC = actor {
+        http_request : Types.CanisterHttpRequestArgs -> async Types.CanisterHttpResponsePayload;
+    };
+};

--- a/e2e/tests-dfx/canister_http.bash
+++ b/e2e/tests-dfx/canister_http.bash
@@ -320,3 +320,17 @@ set_shared_local_network_canister_http_empty() {
     assert_command dfx start --background --verbose
     assert_match "log level: Critical"
 }
+
+@test "can query a website" {
+    dfx_start
+
+    dfx_new
+    install_asset canister_http
+
+    dfx deploy
+
+    assert_command dfx canister call e2e_project_backend get_url '("smartcontracts.org:443","https://smartcontracts.org:443")'
+    assert_contains "Internet Computer"
+    assert_contains "smart contracts"
+    assert_contains "dapps"
+}


### PR DESCRIPTION
# Description

Adds a basic test of canister http request functionality.  It's meant to test that things are hooked up for canister http requests, not to verify any of the details of the canister http feature.

The original intent was to run a webserver during CI for this test, but that turned out not to be possible:
- the canister http service requires the `https` scheme
- the canister http service rejects requests to a local https server using a key/cert generated by openssl, with: `Failed to connect: error trying to connect: The certificate was not trusted.`

The commit comment mentions the above issues, for later retrieval with `git blame`.

Instead, this test reads https://smartcontracts.org and looks for some terms that should always show up there.

Fixes https://dfinity.atlassian.net/browse/SDK-453

# How Has This Been Tested?

This is an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] (n/a) I have edited the CHANGELOG accordingly.
- [x] (n/a) I have made corresponding changes to the documentation.
