### PR TITLE
chore: remove unused variable

### DIFF
--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -41,7 +41,6 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
     env.get_cache().install()?;
 
     let build_mode_check = opts.check;
-    let _all = opts.all;
 
     // Option can be None in which case --all was specified
     let canister_names = config


### PR DESCRIPTION
This removes a variable that wasn't being used (warnings were silenced because name was `_all`).