### PR TITLE
fix: do not build remote canisters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,12 @@ The Replica returned an error: code 1, message: "Canister requested a compute al
 
 ### fix: For `dfx start --clean --background`, the background process no longer cleans a second time.
 
+### fix: do not build or generate remote canisters
+
+Canisters that specify a remote id for the network that's getting built falsely had their build steps run, blocking some normal use patterns of `dfx deploy`.
+Canisters with a remote id specified no longer get built.
+The same applies to `dfx generate`.
+
 ### refactor: Move replica URL functions into a module for reuse
 
 The running replica port and url are generally useful information. Previously the code to get the URL was embedded in the network proxy code. This moves it out into a library for reuse.

--- a/e2e/assets/remote/envvar/dfx.json
+++ b/e2e/assets/remote/envvar/dfx.json
@@ -1,0 +1,21 @@
+{
+    "canisters": {
+        "basic": {
+            "type": "custom",
+            "candid": "main.did",
+            "wasm": "main.wasm",
+            "build": "bash -c 'echo \"CANISTER_ID_remote: $CANISTER_ID_remote\"'",
+            "dependencies": [
+                "remote"
+            ]
+        },
+        "remote": {
+            "main": "remote.mo",
+            "remote": {
+                "id": {
+                    "actuallylocal": "qoctq-giaaa-aaaaa-aaaea-cai"
+                }
+            }
+        }
+    }
+}

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -302,3 +302,13 @@ teardown() {
     assert_command jq .remote canister_ids.json
     assert_eq "null"
 }
+
+@test "build step sets remote cid env var correctly" {
+    install_asset remote/envvar
+    install_asset wasm/identity # need to have some .did and .wasm files to point our custom canister to
+    dfx_start
+    setup_actuallylocal_shared_network
+
+    assert_command dfx deploy --network actuallylocal -vv
+    assert_match "CANISTER_ID_remote: qoctq-giaaa-aaaaa-aaaea-cai"
+}

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -37,8 +37,7 @@ teardown() {
 
     # set up: remote method is update, local is query
     # call remote method as update to make a change
-    assert_command dfx deploy --network actuallylocal -vv
-    # todo!("add test case")
+    assert_command dfx deploy --network actuallylocal
     assert_command dfx canister call remote which_am_i --network actuallylocal
     assert_eq '("actual")'
 
@@ -138,7 +137,7 @@ teardown() {
     assert_match "Canister 'remote' is a remote canister on network 'actuallylocal', and cannot be installed from here."
 }
 
-@test "canister create --all and canister install --all skip remote canisters" {
+@test "canister create --all, canister install --all, dfx generate skip remote canisters" {
     install_asset remote/actual
     dfx_start
     setup_actuallylocal_shared_network
@@ -175,8 +174,12 @@ teardown() {
     assert_eq '("mock")'
 
     assert_command dfx canister create --all --network actuallylocal
-    assert_command dfx build --network actuallylocal
+    assert_command dfx build --network actuallylocal -vv
+    assert_match "Not building canister 'remote'"
     assert_command dfx canister install --all --network actuallylocal
+    assert_command dfx generate --network actuallylocal
+    assert_match "Generating type declarations for canister basic"
+    assert_not_match "Generating type declarations for canister remote"
 
     assert_command dfx canister call basic read_remote --network actuallylocal
     assert_eq '("this is data in the remote canister")'
@@ -267,6 +270,7 @@ teardown() {
     setup_actuallylocal_shared_network
     setup_local_shared_network
     jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
+    cat dfx.json
 
     assert_command dfx deploy
     assert_command dfx canister call basic read_remote
@@ -274,7 +278,9 @@ teardown() {
     assert_command dfx canister call remote which_am_i
     assert_eq '("mock")'
 
-    assert_command dfx deploy --network actuallylocal
+    echo "DEPLOY STARTS HERE"
+    assert_command dfx deploy --network actuallylocal -vv
+    assert_match "Not building canister 'remote'"
     assert_command dfx canister call basic read_remote --network actuallylocal
     assert_eq '("this is data in the remote canister")'
 

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -303,7 +303,7 @@ teardown() {
     assert_eq "null"
 }
 
-@test "build step sets remote cid env var correctly" {
+@test "build step sets remote cid environment variable correctly" {
     install_asset remote/envvar
     install_asset wasm/identity # need to have some .did and .wasm files to point our custom canister to
     dfx_start

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -37,7 +37,7 @@ teardown() {
 
     # set up: remote method is update, local is query
     # call remote method as update to make a change
-    assert_command dfx deploy --network actuallylocal
+    assert_command dfx deploy --network actuallylocal -vv
     assert_command dfx canister call remote which_am_i --network actuallylocal
     assert_eq '("actual")'
 

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -38,6 +38,7 @@ teardown() {
     # set up: remote method is update, local is query
     # call remote method as update to make a change
     assert_command dfx deploy --network actuallylocal -vv
+    # todo!("add test case")
     assert_command dfx canister call remote which_am_i --network actuallylocal
     assert_eq '("actual")'
 

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -270,7 +270,6 @@ teardown() {
     setup_actuallylocal_shared_network
     setup_local_shared_network
     jq ".canisters.remote.remote.id.actuallylocal=\"$REMOTE_CANISTER_ID\"" dfx.json | sponge dfx.json
-    cat dfx.json
 
     assert_command dfx deploy
     assert_command dfx canister call basic read_remote
@@ -278,7 +277,6 @@ teardown() {
     assert_command dfx canister call remote which_am_i
     assert_eq '("mock")'
 
-    echo "DEPLOY STARTS HERE"
     assert_command dfx deploy --network actuallylocal -vv
     assert_match "Not building canister 'remote'"
     assert_command dfx canister call basic read_remote --network actuallylocal

--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -44,12 +44,24 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
     let _all = opts.all;
 
     // Option can be None in which case --all was specified
-    let canister_names = config
+    let canisters_to_load = config
         .get_config()
         .get_canister_names_with_dependencies(opts.canister_name.as_deref())?;
+    let canisters_to_build = canisters_to_load
+        .clone()
+        .into_iter()
+        .filter(|canister_name| {
+            !matches!(
+                config
+                    .get_config()
+                    .get_remote_canister_id(canister_name, &env.get_network_descriptor().name),
+                Ok(Some(_))
+            )
+        })
+        .collect();
 
     // Get pool of canisters to build
-    let canister_pool = CanisterPool::load(&env, build_mode_check, &canister_names)?;
+    let canister_pool = CanisterPool::load(&env, build_mode_check, &canisters_to_load)?;
 
     // Create canisters on the replica and associate canister ids locally.
     if build_mode_check {
@@ -70,12 +82,10 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
     slog::info!(logger, "Building canisters...");
 
     let runtime = Runtime::new().expect("Unable to create a runtime");
-    let build_config = BuildConfig::from_config(&config)?.with_build_mode_check(build_mode_check);
-    runtime.block_on(canister_pool.build_or_fail(
-        logger,
-        &build_config,
-        &canister_names.as_slice(),
-    ))?;
+    let build_config = BuildConfig::from_config(&config)?
+        .with_build_mode_check(build_mode_check)
+        .with_canisters_to_build(canisters_to_build);
+    runtime.block_on(canister_pool.build_or_fail(logger, &build_config))?;
 
     Ok(())
 }

--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -50,12 +50,10 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
         .clone()
         .into_iter()
         .filter(|canister_name| {
-            !matches!(
-                config
-                    .get_config()
-                    .get_remote_canister_id(canister_name, &env.get_network_descriptor().name),
-                Ok(Some(_))
-            )
+            !config
+                .get_config()
+                .is_remote_canister(canister_name, &env.get_network_descriptor().name)
+                .unwrap_or(false)
         })
         .collect();
 

--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -54,7 +54,7 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
     // Create canisters on the replica and associate canister ids locally.
     if build_mode_check {
         slog::warn!(
-            env.get_logger(),
+            logger,
             "Building canisters to check they build ok. Canister IDs might be hard coded."
         );
     } else {

--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -71,7 +71,11 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
 
     let runtime = Runtime::new().expect("Unable to create a runtime");
     let build_config = BuildConfig::from_config(&config)?.with_build_mode_check(build_mode_check);
-    runtime.block_on(canister_pool.build_or_fail(&build_config))?;
+    runtime.block_on(canister_pool.build_or_fail(
+        logger,
+        &build_config,
+        &canister_names.as_slice(),
+    ))?;
 
     Ok(())
 }

--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -60,7 +60,6 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
         })
         .collect();
 
-    // Get pool of canisters to build
     let canister_pool = CanisterPool::load(&env, build_mode_check, &canisters_to_load)?;
 
     // Create canisters on the replica and associate canister ids locally.

--- a/src/dfx/src/commands/generate.rs
+++ b/src/dfx/src/commands/generate.rs
@@ -76,11 +76,11 @@ pub fn exec(env: &dyn Environment, opts: GenerateOpts) -> DfxResult {
     let generate_config =
         BuildConfig::from_config(&config)?.with_canisters_to_build(canisters_to_generate);
 
-    if !build_config
+    if build_config
         .canisters_to_build
         .as_ref()
-        .map(|v| v.is_empty())
-        .unwrap_or(true)
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
     {
         slog::info!(log, "Building canisters before generate for Motoko");
         let runtime = Runtime::new().expect("Unable to create a runtime");

--- a/src/dfx/src/commands/generate.rs
+++ b/src/dfx/src/commands/generate.rs
@@ -40,12 +40,10 @@ pub fn exec(env: &dyn Environment, opts: GenerateOpts) -> DfxResult {
         .clone()
         .into_iter()
         .filter(|canister_name| {
-            !matches!(
-                config
-                    .get_config()
-                    .get_remote_canister_id(canister_name, &env.get_network_descriptor().name),
-                Ok(Some(_))
-            )
+            !config
+                .get_config()
+                .is_remote_canister(canister_name, &env.get_network_descriptor().name)
+                .unwrap_or(false)
         })
         .collect();
 

--- a/src/dfx/src/commands/generate.rs
+++ b/src/dfx/src/commands/generate.rs
@@ -32,12 +32,24 @@ pub fn exec(env: &dyn Environment, opts: GenerateOpts) -> DfxResult {
     env.get_cache().install()?;
 
     // Option can be None which means generate types for all canisters
-    let canister_names = config
+    let canisters_to_load = config
         .get_config()
         .get_canister_names_with_dependencies(opts.canister_name.as_deref())?;
+    let canisters_to_generate = canisters_to_load
+        .clone()
+        .into_iter()
+        .filter(|canister_name| {
+            !matches!(
+                config
+                    .get_config()
+                    .get_remote_canister_id(canister_name, &env.get_network_descriptor().name),
+                Ok(Some(_))
+            )
+        })
+        .collect();
 
     // Get pool of canisters to build
-    let canister_pool = CanisterPool::load(&env, false, &canister_names)?;
+    let canister_pool = CanisterPool::load(&env, false, &canisters_to_load)?;
 
     // This is just to display an error if trying to generate before creating the canister.
     let store = CanisterIdStore::for_env(&env)?;
@@ -58,23 +70,27 @@ pub fn exec(env: &dyn Environment, opts: GenerateOpts) -> DfxResult {
         }
     }
 
-    let build_config = BuildConfig::from_config(&config)?;
+    let build_config =
+        BuildConfig::from_config(&config)?.with_canisters_to_build(build_before_generate);
+    let generate_config =
+        BuildConfig::from_config(&config)?.with_canisters_to_build(canisters_to_generate);
 
-    if !build_before_generate.is_empty() {
+    if !build_config
+        .canisters_to_build
+        .as_ref()
+        .map(|v| v.is_empty())
+        .unwrap_or(true)
+    {
         slog::info!(
             env.get_logger(),
             "Building canisters before generate for Motoko"
         );
         let runtime = Runtime::new().expect("Unable to create a runtime");
-        runtime.block_on(canister_pool.build_or_fail(
-            env.get_logger(),
-            &build_config,
-            &build_before_generate,
-        ))?;
+        runtime.block_on(canister_pool.build_or_fail(env.get_logger(), &build_config))?;
     }
 
-    for canister in canister_pool.get_canister_list() {
-        canister.generate(&canister_pool, &build_config)?;
+    for canister in canister_pool.with_canisters_to_build(&generate_config) {
+        canister.generate(&canister_pool, &generate_config)?;
     }
 
     Ok(())

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -365,6 +365,8 @@ pub struct BuildConfig {
     pub lsp_root: PathBuf,
     /// The root for all build files.
     pub build_root: PathBuf,
+    /// If only a subset of canisters should be built, then canisters_to_build contains these canisters's names.
+    pub canisters_to_build: Option<Vec<String>>,
 }
 
 impl BuildConfig {
@@ -382,12 +384,20 @@ impl BuildConfig {
             build_root: canister_root.clone(),
             idl_root: canister_root.join("idl/"), // TODO: possibly move to `network_root.join("idl/")`
             lsp_root: network_root.join("lsp/"),
+            canisters_to_build: None,
         })
     }
 
     pub fn with_build_mode_check(self, build_mode_check: bool) -> Self {
         Self {
             build_mode_check,
+            ..self
+        }
+    }
+
+    pub fn with_canisters_to_build(self, canisters: Vec<String>) -> Self {
+        Self {
+            canisters_to_build: Some(canisters),
             ..self
         }
     }

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -366,6 +366,7 @@ pub struct BuildConfig {
     /// The root for all build files.
     pub build_root: PathBuf,
     /// If only a subset of canisters should be built, then canisters_to_build contains these canisters' names.
+    /// If all canisters should be built, then this is None.
     pub canisters_to_build: Option<Vec<String>>,
 }
 

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -365,7 +365,7 @@ pub struct BuildConfig {
     pub lsp_root: PathBuf,
     /// The root for all build files.
     pub build_root: PathBuf,
-    /// If only a subset of canisters should be built, then canisters_to_build contains these canisters's names.
+    /// If only a subset of canisters should be built, then canisters_to_build contains these canisters' names.
     pub canisters_to_build: Option<Vec<String>>,
 }
 

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -146,7 +146,6 @@ impl CanisterBuilder for MotokoBuilder {
         };
 
         // Generate wasm
-        // todo!("add dependencies properly");
         let params = MotokoParams {
             build_target: match profile {
                 Profile::Release => BuildTarget::Release,

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -146,6 +146,7 @@ impl CanisterBuilder for MotokoBuilder {
         };
 
         // Generate wasm
+        // todo!("add dependencies properly");
         let params = MotokoParams {
             build_target: match profile {
                 Profile::Release => BuildTarget::Release,

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -13,6 +13,7 @@ use crate::lib::wasm::metadata::add_candid_service_metadata;
 use anyhow::{anyhow, bail, Context};
 use candid::Principal as CanisterId;
 use fn_error_context::context;
+use itertools::Itertools;
 use petgraph::graph::{DiGraph, NodeIndex};
 use rand::{thread_rng, RngCore};
 use slog::{error, info, trace, warn, Logger};
@@ -440,15 +441,15 @@ impl CanisterPool {
             .map(|idx| *graph.node_weight(*idx).unwrap())
             .collect();
 
-        let canister_names_to_build = self
-            .canisters_to_build(build_config)
-            .iter()
-            .map(|c| c.get_name())
-            .collect::<Vec<_>>();
+        let canisters_to_build = self.canisters_to_build(build_config);
         let mut result = Vec::new();
         for canister_id in &order {
             if let Some(canister) = self.get_canister(canister_id) {
-                if canister_names_to_build.contains(&canister.get_name()) {
+                if canisters_to_build
+                    .iter()
+                    .map(|c| c.get_name())
+                    .contains(&canister.get_name())
+                {
                     trace!(log, "Building canister '{}'.", canister.info.get_name());
                 } else {
                     trace!(log, "Not building canister '{}'.", canister.info.get_name());

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -257,7 +257,7 @@ impl CanisterPool {
                     if std::fs::copy(&from, &to).is_err() {
                         warn!(
                                     log,
-                                    "Failed to copy remote canister candid from {} to {}. This may produce errors during the build.",
+                                    "Failed to copy canister candid from {} to {}. This may produce errors during the build.",
                                     from.to_string_lossy(),
                                     to.to_string_lossy()
                                 );

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -248,22 +248,25 @@ impl CanisterPool {
             } else {
                 canister.info.get_output_idl_path()
             };
-            if maybe_from.is_some() && maybe_from.as_ref().unwrap().exists() {
-                let from = maybe_from.unwrap();
-                let to = build_config.idl_root.join(format!(
-                    "{}.did",
-                    canister.info.get_canister_id()?.to_text()
-                ));
-                if std::fs::copy(&from, &to).is_err() {
-                    warn!(
-                                log,
-                                "Failed to copy remote canister candid from {} to {}. This may produce errors during the build.",
-                                from.to_string_lossy(),
-                                to.to_string_lossy()
-                            );
+            if let Some(from) = maybe_from.as_ref() {
+                if from.exists() {
+                    let to = build_config.idl_root.join(format!(
+                        "{}.did",
+                        canister.info.get_canister_id()?.to_text()
+                    ));
+                    if std::fs::copy(&from, &to).is_err() {
+                        warn!(
+                                    log,
+                                    "Failed to copy remote canister candid from {} to {}. This may produce errors during the build.",
+                                    from.to_string_lossy(),
+                                    to.to_string_lossy()
+                                );
+                    }
+                } else {
+                    warn!(log, ".did file for canister '{}' does not exist at {}. This may result in errors during the build.", canister.get_name(), from.to_string_lossy());
                 }
             } else {
-                warn!(log, "Failed to find a .did file for canister '{}'. Not providing that file may produce errors during the build.", canister.info.get_name());
+                warn!(log, "Failed to find a configured .did file for canister '{}'. Not specifying that field may result in errors during the build.", canister.get_name());
             }
         }
 
@@ -450,9 +453,9 @@ impl CanisterPool {
                     .map(|c| c.get_name())
                     .contains(&canister.get_name())
                 {
-                    trace!(log, "Building canister '{}'.", canister.info.get_name());
+                    trace!(log, "Building canister '{}'.", canister.get_name());
                 } else {
-                    trace!(log, "Not building canister '{}'.", canister.info.get_name());
+                    trace!(log, "Not building canister '{}'.", canister.get_name());
                     continue;
                 }
                 result.push(

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -16,7 +16,7 @@ use ic_utils::interfaces::management_canister::attributes::{
     ComputeAllocation, FreezingThreshold, MemoryAllocation,
 };
 use ic_utils::interfaces::management_canister::builders::InstallMode;
-use slog::{info, trace};
+use slog::info;
 use std::convert::TryFrom;
 use std::time::Duration;
 
@@ -44,12 +44,6 @@ pub async fn deploy_canisters(
     let network = env.get_network_descriptor();
 
     let canisters_to_load = canister_with_dependencies(&config, some_canister)?;
-    trace!(
-        log,
-        "Found {} canisters to load: {:?}",
-        canisters_to_load.len(),
-        &canisters_to_load
-    );
 
     let canisters_to_deploy = if force_reinstall {
         // don't force-reinstall the dependencies too.
@@ -77,11 +71,6 @@ pub async fn deploy_canisters(
             })
             .collect()
     };
-    trace!(
-        log,
-        "Found {} canisters to deploy.",
-        canisters_to_deploy.len()
-    );
 
     if some_canister.is_some() {
         info!(log, "Deploying: {}", canisters_to_deploy.join(" "));

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -62,12 +62,10 @@ pub async fn deploy_canisters(
             .clone()
             .into_iter()
             .filter(|canister_name| {
-                !matches!(
-                    config
-                        .get_config()
-                        .get_remote_canister_id(canister_name, &network.name),
-                    Ok(Some(_))
-                )
+                !config
+                    .get_config()
+                    .is_remote_canister(canister_name, &env.get_network_descriptor().name)
+                    .unwrap_or(false)
             })
             .collect()
     };

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -194,18 +194,18 @@ async fn register_canisters(
 #[context("Failed to build call canisters.")]
 async fn build_canisters(
     env: &dyn Environment,
-    required_canisters: &[String],
+    referenced_canisters: &[String],
     canisters_to_build: &[String],
     config: &Config,
 ) -> DfxResult<CanisterPool> {
     let log = env.get_logger();
     info!(log, "Building canisters...");
     let build_mode_check = false;
-    let canister_pool = CanisterPool::load(env, build_mode_check, required_canisters)?;
+    let canister_pool = CanisterPool::load(env, build_mode_check, referenced_canisters)?;
 
-    canister_pool
-        .build_or_fail(log, &BuildConfig::from_config(config)?, canisters_to_build)
-        .await?;
+    let build_config =
+        BuildConfig::from_config(config)?.with_canisters_to_build(canisters_to_build.into());
+    canister_pool.build_or_fail(log, &build_config).await?;
     Ok(canister_pool)
 }
 

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -16,7 +16,7 @@ use ic_utils::interfaces::management_canister::attributes::{
     ComputeAllocation, FreezingThreshold, MemoryAllocation,
 };
 use ic_utils::interfaces::management_canister::builders::InstallMode;
-use slog::info;
+use slog::{info, trace};
 use std::convert::TryFrom;
 use std::time::Duration;
 
@@ -43,7 +43,13 @@ pub async fn deploy_canisters(
 
     let network = env.get_network_descriptor();
 
-    let canisters_to_build = canister_with_dependencies(&config, some_canister)?;
+    let canisters_to_load = canister_with_dependencies(&config, some_canister)?;
+    trace!(
+        log,
+        "Found {} canisters to load: {:?}",
+        canisters_to_load.len(),
+        &canisters_to_load
+    );
 
     let canisters_to_deploy = if force_reinstall {
         // don't force-reinstall the dependencies too.
@@ -58,19 +64,24 @@ pub async fn deploy_canisters(
             None => bail!("The --mode=reinstall is only valid when deploying a single canister, because reinstallation destroys all data in the canister."),
         }
     } else {
-        canisters_to_build.clone()
+        canisters_to_load
+            .clone()
+            .into_iter()
+            .filter(|canister_name| {
+                !matches!(
+                    config
+                        .get_config()
+                        .get_remote_canister_id(canister_name, &network.name),
+                    Ok(Some(_))
+                )
+            })
+            .collect()
     };
-    let canisters_to_deploy: Vec<String> = canisters_to_deploy
-        .into_iter()
-        .filter(|canister_name| {
-            !matches!(
-                config
-                    .get_config()
-                    .get_remote_canister_id(canister_name, &network.name),
-                Ok(Some(_))
-            )
-        })
-        .collect();
+    trace!(
+        log,
+        "Found {} canisters to deploy.",
+        canisters_to_deploy.len()
+    );
 
     if some_canister.is_some() {
         info!(log, "Deploying: {}", canisters_to_deploy.join(" "));
@@ -80,7 +91,7 @@ pub async fn deploy_canisters(
 
     register_canisters(
         env,
-        &canisters_to_build,
+        &canisters_to_deploy,
         &initial_canister_id_store,
         timeout,
         with_cycles,
@@ -89,7 +100,7 @@ pub async fn deploy_canisters(
     )
     .await?;
 
-    let pool = build_canisters(env, &canisters_to_build, &config).await?;
+    let pool = build_canisters(env, &canisters_to_load, &canisters_to_deploy, &config).await?;
 
     install_canisters(
         env,
@@ -124,6 +135,7 @@ fn canister_with_dependencies(
     Ok(canister_names)
 }
 
+/// Creates canisters that have not been created yet.
 #[context("Failed while trying to register all canisters.")]
 async fn register_canisters(
     env: &dyn Environment,
@@ -193,15 +205,17 @@ async fn register_canisters(
 #[context("Failed to build call canisters.")]
 async fn build_canisters(
     env: &dyn Environment,
-    canister_names: &[String],
+    required_canisters: &[String],
+    canisters_to_build: &[String],
     config: &Config,
 ) -> DfxResult<CanisterPool> {
-    info!(env.get_logger(), "Building canisters...");
+    let log = env.get_logger();
+    info!(log, "Building canisters...");
     let build_mode_check = false;
-    let canister_pool = CanisterPool::load(env, build_mode_check, canister_names)?;
+    let canister_pool = CanisterPool::load(env, build_mode_check, required_canisters)?;
 
     canister_pool
-        .build_or_fail(&BuildConfig::from_config(config)?)
+        .build_or_fail(log, &BuildConfig::from_config(config)?, canisters_to_build)
         .await?;
     Ok(canister_pool)
 }


### PR DESCRIPTION
# Description

If a canister config specifies a “remote” canister ID, like the NNS subnet canisters do, or if the canister is deployed from another directory locally, it should skip the build step.

Fixes [SDK-766](https://dfinity.atlassian.net/browse/SDK-766)

# How Has This Been Tested?

Added checks to CI that remote canisters are not processed in:
- `dfx deploy`
- `dfx build`
- `dfx generate`

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
