### PR TITLE
feat: run build command in /bin/sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## DFX
 
+### feat: build commands are run via /bin/sh
+
+`dfx canister build` (and all commands running builds) now run custom canister `build:` commands through `/bin/sh`.
+
 ### fix: Save SNS canister IDs
 
 SNS canister IDs were not being parsed reliably.  Now the candid file is being specified explicitly, which resolves the issue in at least some cases.

--- a/e2e/assets/custom_canister/dfx.json
+++ b/e2e/assets/custom_canister/dfx.json
@@ -17,6 +17,12 @@
       "type": "custom",
       "candid": "main.did",
       "wasm": "main.wasm"
+    },
+    "custom4": {
+      "type": "custom",
+      "candid": "main.did",
+      "wasm": "main.wasm",
+      "build": "echo -n CUSTOM_CANISTER4 && echo _BUILD_DONE"
     }
   },
   "defaults": {

--- a/e2e/tests-dfx/build.bash
+++ b/e2e/tests-dfx/build.bash
@@ -147,6 +147,8 @@ teardown() {
   assert_command dfx build custom2
   assert_match "CUSTOM_CANISTER2_BUILD_DONE"
   assert_command dfx build custom3
+  assert_command dfx build custom4
+  assert_match "CUSTOM_CANISTER4_BUILD_DONE"
 
   dfx canister install --all
   assert_command dfx canister call custom fromQuery


### PR DESCRIPTION
This stops running commands directly and instead runs commands in `/bin/sh`.

Before this, build commands were parsed using the third-party crate `shell_words` (which tries to replicate shell argument parsing) and the command executable would be called directly.

With these changes, commands are run via `sh`, which is more consistent with other tools like `npm` and allows shell constructs (`foo && bar | baz`). This also simplifies the code a bit.

This won't work on pure Windows but will work on WSL since `sh` is POSIX. If we do want to run anything on pure Windows then we'll probably need some local config like npm: https://docs.npmjs.com/cli/v8/using-npm/config#script-shell

**Note**: I haven't updated the documentation since I assume most people will expect commands to be shell commands by default; happy to update it though.

# How Has This Been Tested?

I've added an e2e test that uses shell constructs.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
