### PR TITLE
docs: dfx canister request-status requires canister to be specified

### DIFF
--- a/docs/cli-reference/dfx-canister.md
+++ b/docs/cli-reference/dfx-canister.md
@@ -555,7 +555,7 @@ Use the `dfx canister request-status` command to request the status of a specifi
 ### Basic usage
 
 ``` bash
-dfx canister request-status request_id [option]
+dfx canister request-status [OPTIONS] <REQUEST_ID> <CANISTER>
 ```
 
 ### Flags
@@ -587,7 +587,7 @@ You can specify the following argument for the `dfx canister request-status` com
 You can use the `dfx canister request-status` command to check on the status of a canister state change or to verify that a call was not rejected by running a command similar to the following:
 
 ``` bash
-dfx canister request-status 0x58d08e785445dcab4ff090463b9e8b12565a67bf436251d13e308b32b5058608
+dfx canister request-status 0x58d08e785445dcab4ff090463b9e8b12565a67bf436251d13e308b32b5058608 backend
 ```
 
 This command displays an error message if the request identifier is invalid or refused by the canister.

--- a/docs/cli-reference/dfx-canister.md
+++ b/docs/cli-reference/dfx-canister.md
@@ -555,7 +555,7 @@ Use the `dfx canister request-status` command to request the status of a specifi
 ### Basic usage
 
 ``` bash
-dfx canister request-status request_id canister <option>
+dfx canister request-status request_id canister [option]
 ```
 
 ### Flags

--- a/docs/cli-reference/dfx-canister.md
+++ b/docs/cli-reference/dfx-canister.md
@@ -555,7 +555,7 @@ Use the `dfx canister request-status` command to request the status of a specifi
 ### Basic usage
 
 ``` bash
-dfx canister request-status [OPTIONS] <REQUEST_ID> <CANISTER>
+dfx canister request-status request_id canister <option>
 ```
 
 ### Flags


### PR DESCRIPTION
It's correctly documented in the dfx cli help

Here's what that looks like:
![image](https://user-images.githubusercontent.com/7412443/195884794-41aa149f-00ac-4beb-9dbb-4e73057ea888.png)

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
