### PR TITLE
chore: Bump github actions that use node v12

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -43,7 +43,7 @@ jobs:
           path: advisory-db
           ref: ${{ matrix.advisory-db-rev }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/build-frontend-canister.yml
+++ b/.github/workflows/build-frontend-canister.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           ./scripts/update-frontend-canister.sh
       - name: Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: assetstorage
           path: ${{ github.workspace }}/src/distributed/assetstorage.wasm.gz

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           echo "RUSTFLAGS=--remap-path-prefix=${GITHUB_WORKSPACE}=/builds/dfinity" >> $GITHUB_ENV
       - name: Cache Cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,7 @@ jobs:
           strip dfx
         if: contains(matrix.os, 'ubuntu')
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dfx-${{ matrix.os }}-rs-${{ matrix.rust }}
           path: ${{ matrix.binary_path }}/dfx

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Cache Cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/prepare-dfx-assets.yml
+++ b/.github/workflows/prepare-dfx-assets.yml
@@ -28,7 +28,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload Artifacts
         if: github.ref_type == 'tag'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dfx-artifacts-${{ matrix.rust }}-${{ matrix.name }}
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
           echo "SHA256_FILENAME=dfx-$GITHUB_REF_NAME-${{ matrix.name }}.tar.gz.sha256" >> $GITHUB_ENV
 
       - name: Cache Cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
# Description
There are currently a lot of warnings that make it hard to see real problems.

Some easy-to-fix problems stem from:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/cache, actions/upload-artifact, actions/cache

# Changes
- Bump github actions to use later versions of node

# How Has This Been Tested?
See CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
  - noop as there are no user facing changes
- [x] I have made corresponding changes to the documentation.
  - noop as there are no user facing changes
