### PR TITLE
refactor: use environment files rather than deprecated set-output

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: set-matrix
-        run: echo "::set-output name=matrix::$(scripts/workflows/audit-matrix.py)"
+        run: echo "name=matrix::$(scripts/workflows/audit-matrix.py)" >> $GITHUB_OUTPUT
 
   test:
     name: audit

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: set-matrix
-        run: echo "::set-output name=matrix::$(scripts/workflows/e2e-matrix.py)"
+        run: echo "name=matrix::$(scripts/workflows/e2e-matrix.py)" >> $GITHUB_OUTPUT
 
   smoke:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
