### PR TITLE
feat: dfx info replica-port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,10 @@ There is also a new configuration file: `$HOME/.config/dfx/networks.json`.  Its 
 
 This displays the port that the icx-proxy process listens on, meaning the port to connect to with curl or from a web browser.
 
+#### feat: `dfx info replica-port`
+
+This displays the listening port of the replica.
+
 #### feat: `dfx info replica-rev`
 
 This displays the revision of the replica bundled with dfx, which is the same revision referenced in replica election governance proposals.

--- a/docs/cli-reference/dfx-info.md
+++ b/docs/cli-reference/dfx-info.md
@@ -13,6 +13,7 @@ These are the types of information that the `dfx info` command can display.
 | Option              | Description                                    |
 |---------------------|------------------------------------------------|
 | networks-json-path  | Path to network definition file networks.json. |
+| replica-port        | The listening port of the replica.             |
 | replica-rev         | The revision of the bundled replica.           |
 | webserver-port      | The local webserver (icx-proxy) port.          |
 

--- a/e2e/tests-dfx/info.bash
+++ b/e2e/tests-dfx/info.bash
@@ -20,7 +20,12 @@ teardown() {
 
     dfx_start
     assert_command dfx info replica-port
-    assert_eq "$(get_replica_port)"
+    if [ "$USE_IC_REF" ]
+    then
+        assert_eq "$(get_ic_ref_port)"
+    else
+        assert_eq "$(get_replica_port)"
+    fi
 }
 
 @test "displays the default webserver port for the local shared network" {

--- a/e2e/tests-dfx/info.bash
+++ b/e2e/tests-dfx/info.bash
@@ -14,6 +14,15 @@ teardown() {
     standard_teardown
 }
 
+@test "displays the replica port" {
+    assert_command_fail dfx info replica-port
+    assert_contains "No replica port found"
+
+    dfx_start
+    assert_command dfx info replica-port
+    assert_eq "$(get_replica_port)"
+}
+
 @test "displays the default webserver port for the local shared network" {
     assert_command dfx info webserver-port
     assert_eq "4943"

--- a/src/dfx/src/commands/info/mod.rs
+++ b/src/dfx/src/commands/info/mod.rs
@@ -1,15 +1,19 @@
+mod replica_port;
 mod webserver_port;
 
+use crate::commands::info::replica_port::get_replica_port;
 use crate::commands::info::webserver_port::get_webserver_port;
 use crate::config::dfinity::NetworksConfig;
 use crate::lib::error::DfxResult;
 use crate::lib::info;
 use crate::Environment;
+
 use anyhow::Context;
 use clap::Parser;
 
 #[derive(clap::ValueEnum, Clone, Debug)]
 enum InfoType {
+    ReplicaPort,
     ReplicaRev,
     WebserverPort,
     NetworksJsonPath,
@@ -24,6 +28,7 @@ pub struct InfoOpts {
 
 pub fn exec(env: &dyn Environment, opts: InfoOpts) -> DfxResult {
     let value = match opts.info_type {
+        InfoType::ReplicaPort => get_replica_port(env)?,
         InfoType::ReplicaRev => info::replica_rev().to_string(),
         InfoType::WebserverPort => get_webserver_port(env)?,
         InfoType::NetworksJsonPath => NetworksConfig::new()?

--- a/src/dfx/src/commands/info/replica_port.rs
+++ b/src/dfx/src/commands/info/replica_port.rs
@@ -1,0 +1,24 @@
+use crate::lib::error::DfxResult;
+use crate::lib::provider::{create_network_descriptor, LocalBindDetermination};
+use crate::util::network::get_running_replica_port;
+use crate::Environment;
+
+use anyhow::bail;
+
+pub(crate) fn get_replica_port(env: &dyn Environment) -> DfxResult<String> {
+    let network_descriptor = create_network_descriptor(
+        env.get_config(),
+        env.get_networks_config(),
+        None,
+        None,
+        LocalBindDetermination::AsConfigured,
+    )?;
+
+    if let Some(port) =
+        get_running_replica_port(None, network_descriptor.local_server_descriptor()?)?
+    {
+        Ok(format!("{}", port))
+    } else {
+        bail!("No replica port found");
+    }
+}


### PR DESCRIPTION
# Description

Adds a command to display the replica listening port.

Fixes https://dfinity.atlassian.net/browse/SDK-777

# How Has This Been Tested?

Added an e2e test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
