### PR TITLE
chore: revert conventional pr title action to 2.2.3

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: dfinity/conventional-pr-title-action@v2.4.4
+      - uses: dfinity/conventional-pr-title-action@v2.2.3
         with:
           success-state: Title follows the specification.
           failure-state: Title does not follow the specification.


### PR DESCRIPTION
# Description

It turns out that version 2.4.4 doesn't exist, so all PRs will fail, like here:
   https://github.com/dfinity/sdk/actions/runs/3272056132/jobs/5382599495

The workflow actually tests vs the base branch (pull_request_target), so the altering PR used the old version:
   https://github.com/dfinity/sdk/actions/runs/3271406085/jobs/5381159987

# How Has This Been Tested?

We actually can't test this on CI, because the workflow runs against `pull_request_target`, and the workflow on the master (base) branch will never pass.   It will have to be merged manually by administrator action.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
