### PR TITLE
ci: Use a regex to check for conventional commita

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,11 +24,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: dfinity/conventional-pr-title-action@v2.2.3
-        with:
-          success-state: Title follows the specification.
-          failure-state: Title does not follow the specification.
-          context-name: conventional-pr-title
-          preset: conventional-changelog-angular@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.PR_VALIDATION_TOKEN }}
+      - name: Conventional PR title
+        # Conventional commit patterns:
+        #   verb: description
+        #   verb!: description of breaking change
+        #   verb (scope): Description of change to $scope
+        #   verb (scope)!: Description of breaking change to $scope
+        # verb: feat, fix, ...
+        # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
+        # !: Indicates that the PR contains a breaking change.
+        run: commit="${{ github.event.pull_request.title }}" perl -E 'exit !($ENV{commit} =~ /^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)( \([a-zA-Z0-9,]+\))?!?:.*/)' ; echo $?
+        if: github.event_name == 'pull_request'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,5 +33,5 @@ jobs:
         # verb: feat, fix, ...
         # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
         # !: Indicates that the PR contains a breaking change.
-        run: commit="${{ github.event.pull_request.title }}" perl -E 'exit !($ENV{commit} =~ /^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)( \([a-zA-Z0-9,]+\))?!?:.*/)' ; echo $?
+        run: commit="${{ github.event.pull_request.title }}" perl -E 'exit !($ENV{commit} =~ /^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?!?:.*/)' ; echo $?
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
# Description
We currently use a GitHub action to check conventional commit titles.  This is heavyweight and slow and has out-of-date dependencies.

Note: We run tests on Mac; Mac uses ancient versions of bash and sed so it is perhaps unwise to rely on bash or sed.  Perl on mac is however not too broken for this use case.  So we will use perl aka "There is more than one way of doing things" to enforce one way of writing PR titles.

# How Has This Been Tested?
Here are the most recent commits on master that do NOT match the pattern.  Do we want to whitelist any of these?
```
git log --pretty=format:'%s' | perl -ne 'print if !(/^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?!?:.*/g)' | head -n20
Use perl to check for conventional commit
Update LICENSE (#2680)
Add a -y flag to deploy/install (#2667)
Update generate.rs (#2614)
update CHANGELOG (#2525)
rebuild frontend canister after cargo fmt (#2523)
facilitate frontend asset verification (#2518)
add helper message if cargo build fails (#2517)
Removed reference to dfx config (#2362)
adding cli-ref markdown files (#2210)
Remove spurious configuration error (#2169)
Actually run the optimizer (#2075)
Change type:rust template to use standard package structure (#2058)
Use locked version of cargo-audit (#2035)
add Monterey as a supported macos version (#2006)
Document #1950 (#1953)
bump candid ui wasm (#1843)
make it easier to read (#1729)
updates to webpack config for hot reloading (#1754)
Fix: New Terms and Conditions (#1711)
```

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
