### PR TITLE
feat: Switch to zlib-ng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -1910,6 +1920,16 @@ checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
  "winapi",
+]
+
+[[package]]
+name = "libz-ng-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4399ae96a9966bf581e726de86969f803a81b7ce795fcd5480e640589457e0f2"
+dependencies = [
+ "cmake",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,6 @@ lto = true
 [profile.dev.package.argon2]
 opt-level = 3
 
-[profile.dev.package.miniz_oxide]
-opt-level = 3
-
 [profile.release.package.ic-frontend-canister]
 opt-level = 'z'
 

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [build-dependencies]
 bytes = "1"
-flate2 = "1.0.11"
+flate2 = { version = "1.0.11", default-features = false, features = ["zlib-ng"] }
 hex = "0.4.3"
 reqwest = "0.11.9"
 serde = { version = "1.0", features = ["derive"] }
@@ -39,7 +39,7 @@ crossbeam = "0.8.1"
 ctrlc = { version = "3.2.1", features = [ "termination" ] }
 dialoguer = "0.10.0"
 directories-next = "2.0.0"
-flate2 = "1.0.11"
+flate2 = { version = "1.0.11", default-features = false, features = ["zlib-ng"] }
 fn-error-context = "0.2.0"
 futures = "0.3.21"
 futures-util = "0.3.21"


### PR DESCRIPTION
We're currently using miniz_oxide for our compression, and while miniz is great for minor workloads, it's not the most performant. By using zlib-ng, both building and installing will be much faster.