### PR TITLE
chore: update CHANGELOG to reflect further changes do not go in 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+# 0.12.0
+
 ## DFX
 
 ### feat(frontend-canister): add warning if config is provided in `.ic-assets.json` but not used


### PR DESCRIPTION
Just update the changelog so that future changes go in a new `UNRELEASED` section, the past changes are in the `0.12.0` section.