### PR TITLE
chore: Update II wasm url to fetch latest release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+## DFX
+
+### chore: Update II wasm url to always fetch the latest release.
+
 ## Dependencies
 
 ### Replica

--- a/README.md
+++ b/README.md
@@ -115,10 +115,5 @@ dfx stop && dfx start --clean --background
 ```
 
 ### Using Internet Identity Locally
-You can deploy the Internet Identity canister into your replica alongside your project by cloning https://github.com/dfinity/internet-identity. From the `internet-identity` directory, run the following command:
-
-``` bash
-II_ENV=development dfx deploy --no-wallet --argument '(null)'
-```
-
-There are more notes at https://github.com/dfinity/internet-identity#running-locally that may be helpful.
+You can deploy the Internet Identity canister into your replica alongside your project.
+To do so, either run `dfx nns install` or follow the instructions in the example project here: https://github.com/dfinity/internet-identity/tree/main/demos/using-dev-build

--- a/src/dfx/src/lib/nns/install_nns/canisters.rs
+++ b/src/dfx/src/lib/nns/install_nns/canisters.rs
@@ -106,7 +106,7 @@ pub const INTERNET_IDENTITY: StandardCanister = StandardCanister {
     canister_name: "internet_identity",
     canister_id: "qhbym-qaaaa-aaaaa-aaafq-cai",
     wasm_name: "internet_identity_dev.wasm",
-    wasm_url: "https://github.com/dfinity/internet-identity/releases/download/release-2022-07-11/internet_identity_dev.wasm"
+    wasm_url: "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm"
 };
 /// Frontend dapp for voting and managing neurons.
 pub const NNS_DAPP: StandardCanister = StandardCanister {


### PR DESCRIPTION
# Description

This PR updates the II wasm url to always fetch the latest dev build.

# How Has This Been Tested?

Tested by running `dfx nns install` using a dev build including this change.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
