### PR TITLE
fix: clarify doc string for canisters.<canister>.args

### DIFF
--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -128,8 +128,8 @@ pub struct ConfigCanistersCanister {
     #[serde(default)]
     pub remote: Option<ConfigCanistersCanisterRemote>,
 
-    /// # Canister Argument
-    /// This field defines a static argument to use when deploying the canister.
+    /// # Canister-Specific Build Argument
+    /// This field defines an additional argument to pass to the Motoko compiler when building the canister.
     pub args: Option<String>,
 
     /// # Resource Allocation Settings


### PR DESCRIPTION
# Description

Fixes the erroneous doc string reported in [this post](https://forum.dfinity.org/t/dfx-json-actor-with-mandatory-arguments/14454/7) .
