### PR TITLE
ci: Use a regex to check for conventional commits

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,9 +1,6 @@
 name: Check PR title
 on:
-  # SAFETY: dfinity/conventional-pr-title-action does not run any of the committed code.
-  # Therefore it is ok to give it R/W permission.
-  # More details see here: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -24,11 +21,20 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: dfinity/conventional-pr-title-action@v2.2.3
-        with:
-          success-state: Title follows the specification.
-          failure-state: Title does not follow the specification.
-          context-name: conventional-pr-title
-          preset: conventional-changelog-angular@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.PR_VALIDATION_TOKEN }}
+      - name: conventional-pr-title:required
+        - # Conventional commit patterns:
+          #   verb: description
+          #   verb!: description of breaking change
+          #   verb (scope): Description of change to $scope
+          #   verb (scope)!: Description of breaking change to $scope
+          # verb: feat, fix, ...
+          # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
+          # !: Indicates that the PR contains a breaking change.
+        run: |
+          if [[ "${{ github.event.pull_request.title }}" =~ /^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?!?:.*/ ]]; then
+              echo pass
+          else
+              echo "PR title does not match conventions"
+              echo "PR title: ${{ github.event.pull_request.title }}"
+              exit 1
+          fi


### PR DESCRIPTION
# Description

Thanks to @bitdivine for doing all the work here: https://github.com/dfinity/sdk/pull/2709

This PR uses a bash script.  Note that the workflow runs on `ubuntu-latest`, so ancient bash versions on OSX are not an issue.

Also note that it now triggers on `pull_request`, not `pull_request_target`, meaning this PR can be used to test itself

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
