### PR TITLE
chore: dfx generate prints mix between absolute and relative paths

### DIFF
--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -199,7 +199,10 @@ pub trait CanisterBuilder {
                 format!("Failed to remove {}.", generated_idl_path.to_string_lossy())
             })?;
         } else {
-            eprintln!("  {}", &generated_idl_path.display());
+            let relative_idl_path = generated_idl_path
+                .strip_prefix(info.get_workspace_root())
+                .unwrap_or(&generated_idl_path);
+            eprintln!("  {}", &relative_idl_path.display());
         }
 
         Ok(())


### PR DESCRIPTION
# Description
`dfx generate` prints relative paths for all generated files, except for the .did one. This PR makes the .did path relative as well.

Fixes #2768, [SDK-859](https://dfinity.atlassian.net/browse/SDK-859)

# How Has This Been Tested?

Tested manually

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
