### PR TITLE
fix: give more cycles margin when deleting canisters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ The flag `--disable-encryption` is deprecated in favour of `--storage-mode plain
 The Motoko compiler expects all imported canisters' .did files to be in one folder when it compiles a canister.
 `dfx` failed to organize the .did files correctly when running `dfx deploy <single Motoko canister>` in combintaion with the `--mode reinstall` flag.
 
+### fix: give more cycles margin when deleting canisters
+
+There have been a few reports of people not being able to delete canisters.
+The error happens if the temporary wallet tries to transfer out too many cycles.
+The number of cycles left in the canister is bumped a little bit so that people can again reliably delete their canisters.
+
 ## Dependencies
 
 Updated candid to 0.8.4

--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -36,7 +36,7 @@ const DANK_PRINCIPAL: Principal =
     Principal::from_slice(&[0, 0, 0, 0, 0, 0xe0, 1, 0x11, 0x01, 0x01]); // Principal: aanaa-xaaaa-aaaah-aaeiq-cai
 
 // "Couldn't send message" when deleting a canister: increase WITHDRAWAL_COST
-const WITHDRAWAL_COST: u128 = 10_303_000_000; // 2% higher than a value observed ok locally
+const WITHDRAWAL_COST: u128 = 10_606_030_000; // 5% higher than a value observed ok locally
 const MAX_MEMORY_ALLOCATION: u64 = 8589934592;
 
 /// Deletes a currently stopped canister.


### PR DESCRIPTION
# Description

[Two reports on the forum](https://forum.dfinity.org/t/cannot-delete-canisters-anymore/11594/15) and code comments indicate that the wallet does not have enough cycles left in the wallet when deleting a canister recently. I'm bumping the margin from 2% to 5% in hopes of avoiding this problem.

# How Has This Been Tested?

Tested manually by Christian on a canister that couldn't be deleted with the previous version

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
