### PR TITLE
feat: Add --argument-file option to dfx canister sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## DFX
 
+### feat: add `--argument-file` argument to the `dfx canister sign` command
+
+Similar to how this argument works in `dfx canister call`, this argument allows providing arguments for the requst from a file.
+
 ### feat: use OS-native keyring for pem file storage
 
 If keyring integration is available, PEM files (except for the default identity) are now by default stored in the OS-provided keyring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### feat: add `--argument-file` argument to the `dfx canister sign` command
 
-Similar to how this argument works in `dfx canister call`, this argument allows providing arguments for the requst from a file.
+Similar to how this argument works in `dfx canister call`, this argument allows providing arguments for the request from a file.
 
 ### feat: use OS-native keyring for pem file storage
 

--- a/docs/cli-reference/dfx-canister.md
+++ b/docs/cli-reference/dfx-canister.md
@@ -654,7 +654,7 @@ You can specify the following options for the `dfx canister sign` command.
 
 | Option                     | Description                                                                                                                                      |
 |----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--argument-file`          | Specifies the file from which to read the argument to pass to the method.  Stdin may be referred to as `-`.                                      |
+| `--argument-file <file>`   | Specifies the file from which to read the argument to pass to the method.  Stdin may be referred to as `-`.                                      |
 | `--expire-after <seconds>` | Specifies how long the message will be valid before it expires and cannot be sent. Specify in seconds. If not defined, the default is 300s (5m). |
 | `--file <output>`          | Specifies the output file name. The default is `message.json`.                                                                                   |
 | `--random <random>`        | Specifies the configuration for generating random arguments.                                                                                     |

--- a/docs/cli-reference/dfx-canister.md
+++ b/docs/cli-reference/dfx-canister.md
@@ -652,12 +652,13 @@ You can use the following optional flags with the `dfx canister sign` command.
 
 You can specify the following options for the `dfx canister sign` command.
 
-| Option                       | Description  |
-|------------------------------|--------------|
-| `--expire-after <seconds>`   | Specifies how long the message will be valid before it expires and cannot be sent. Specify in seconds. If not defined, the default is 300s (5m).  |
-| `--file <output>`            | Specifies the output file name. The default is `message.json`.  |
-| `--random <random>`          | Specifies the configuration for generating random arguments.  |
-| `--type <type>`              | Specifies the data type for the argument when making a call using an argument. Possible values are `idl` and `raw`.  |
+| Option                     | Description                                                                                                                                      |
+|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--argument-file`          | Specifies the file from which to read the argument to pass to the method.  Stdin may be referred to as `-`.                                      |
+| `--expire-after <seconds>` | Specifies how long the message will be valid before it expires and cannot be sent. Specify in seconds. If not defined, the default is 300s (5m). |
+| `--file <output>`          | Specifies the output file name. The default is `message.json`.                                                                                   |
+| `--random <random>`        | Specifies the configuration for generating random arguments.                                                                                     |
+| `--type <type>`            | Specifies the data type for the argument when making a call using an argument. Possible values are `idl` and `raw`.                              |
 
 ### Arguments
 

--- a/e2e/tests-dfx/sign_send.bash
+++ b/e2e/tests-dfx/sign_send.bash
@@ -50,7 +50,7 @@ Signed request_status append to update message in [message-inc.json]"
     assert_match "Query message generated at \[message.json\]"
 }
 
-@test "call subcommand accepts argument from a file" {
+@test "sign subcommand accepts argument from a file" {
     install_asset greet
     dfx_start
     dfx_deploy
@@ -60,10 +60,14 @@ Signed request_status append to update message in [message-inc.json]"
     assert_command dfx canister sign --argument-file "$TMP_NAME_FILE" --query hello_backend
     assert_eq "Query message generated at [message.json]"
 
+    echo y | assert_command dfx canister send message.json
+    # cbor-encoded response that says "Hello, Names can be very long!"
+    assert_match "d9d9f7a266737461747573677265706c696564657265706c79a16361726758264449444c0001711e48656c6c6f2c204e616d65732063616e2062652076657279206c6f6e6721"
+
     rm "$TMP_NAME_FILE"
 }
 
-@test "call subcommand accepts argument from stdin" {
+@test "sign subcommand accepts argument from stdin" {
     install_asset greet
     dfx_start
     dfx_deploy
@@ -72,6 +76,10 @@ Signed request_status append to update message in [message-inc.json]"
 
     assert_command dfx canister sign --argument-file - --query hello_backend greet < "$TMP_NAME_FILE"
     assert_eq "Query message generated at [message.json]"
+
+    echo y | assert_command dfx canister send message.json
+    # cbor-encoded response that says "Hello, stdin!"
+    assert_match "d9d9f7a266737461747573677265706c696564657265706c79a163617267554449444c0001710d48656c6c6f2c20737464696e21"
 
     rm "$TMP_NAME_FILE"
 }

--- a/e2e/tests-dfx/sign_send.bash
+++ b/e2e/tests-dfx/sign_send.bash
@@ -60,10 +60,8 @@ Signed request_status append to update message in [message-inc.json]"
     assert_command dfx canister sign --argument-file "$TMP_NAME_FILE" --query hello_backend greet
     assert_eq "Query message generated at [message.json]"
 
-    echo y | dfx canister send message.json > out.txt
-    assert_command cat out.txt
-    # cbor-encoded response that says "Hello, Names can be very long!"
-    assert_match "d9d9f7a266737461747573677265706c696564657265706c79a16361726758264449444c0001711e48656c6c6f2c204e616d65732063616e2062652076657279206c6f6e6721"
+    assert_command jq -rc .arg message.json
+    assert_match "[68,73,68,76,0,1,113,21,78,97,109,101,115,32,99,97,110,32,98,101,32,118,114,121,32,108,111,110,103]"
 
     rm "$TMP_NAME_FILE"
 }
@@ -78,10 +76,8 @@ Signed request_status append to update message in [message-inc.json]"
     assert_command dfx canister sign --argument-file - --query hello_backend greet < "$TMP_NAME_FILE"
     assert_eq "Query message generated at [message.json]"
 
-    echo y | dfx canister send message.json > out.txt
-    assert_command cat out.txt
-    # cbor-encoded response that says "Hello, stdin!"
-    assert_match "d9d9f7a2657265706c79a163617267554449444c0001710d48656c6c6f2c20737464696e2166737461747573677265706c696564"
+    assert_command jq -rc .arg message.json
+    assert_match "[68,73,68,76,0,1,113,5,115,116,100,105,110]"
 
     rm "$TMP_NAME_FILE"
 }

--- a/e2e/tests-dfx/sign_send.bash
+++ b/e2e/tests-dfx/sign_send.bash
@@ -57,10 +57,11 @@ Signed request_status append to update message in [message-inc.json]"
     TMP_NAME_FILE="$(mktemp)"
     printf '("Names can be very long")' > "$TMP_NAME_FILE"
 
-    assert_command dfx canister sign --argument-file "$TMP_NAME_FILE" --query hello_backend
+    assert_command dfx canister sign --argument-file "$TMP_NAME_FILE" --query hello_backend greet
     assert_eq "Query message generated at [message.json]"
 
-    echo y | assert_command dfx canister send message.json
+    echo y | dfx canister send message.json > out.txt
+    assert_command cat out.txt
     # cbor-encoded response that says "Hello, Names can be very long!"
     assert_match "d9d9f7a266737461747573677265706c696564657265706c79a16361726758264449444c0001711e48656c6c6f2c204e616d65732063616e2062652076657279206c6f6e6721"
 

--- a/e2e/tests-dfx/sign_send.bash
+++ b/e2e/tests-dfx/sign_send.bash
@@ -78,7 +78,8 @@ Signed request_status append to update message in [message-inc.json]"
     assert_command dfx canister sign --argument-file - --query hello_backend greet < "$TMP_NAME_FILE"
     assert_eq "Query message generated at [message.json]"
 
-    echo y | assert_command dfx canister send message.json
+    echo y | dfx canister send message.json > out.txt
+    assert_command cat out.txt
     # cbor-encoded response that says "Hello, stdin!"
     assert_match "d9d9f7a266737461747573677265706c696564657265706c79a163617267554449444c0001710d48656c6c6f2c20737464696e21"
 

--- a/e2e/tests-dfx/sign_send.bash
+++ b/e2e/tests-dfx/sign_send.bash
@@ -53,7 +53,7 @@ Signed request_status append to update message in [message-inc.json]"
 @test "sign subcommand accepts argument from a file" {
     install_asset greet
     dfx_start
-    dfx_deploy
+    dfx deploy
     TMP_NAME_FILE="$(mktemp)"
     printf '("Names can be very long")' > "$TMP_NAME_FILE"
 
@@ -70,7 +70,7 @@ Signed request_status append to update message in [message-inc.json]"
 @test "sign subcommand accepts argument from stdin" {
     install_asset greet
     dfx_start
-    dfx_deploy
+    dfx deploy
     TMP_NAME_FILE="$(mktemp)"
     printf '("stdin")' > "$TMP_NAME_FILE"
 

--- a/e2e/tests-dfx/sign_send.bash
+++ b/e2e/tests-dfx/sign_send.bash
@@ -49,3 +49,29 @@ Signed request_status append to update message in [message-inc.json]"
     assert_command dfx canister sign --query rwlgt-iiaaa-aaaaa-aaaaa-cai read --network ic
     assert_match "Query message generated at \[message.json\]"
 }
+
+@test "call subcommand accepts argument from a file" {
+    install_asset greet
+    dfx_start
+    dfx_deploy
+    TMP_NAME_FILE="$(mktemp)"
+    printf '("Names can be very long")' > "$TMP_NAME_FILE"
+
+    assert_command dfx canister sign --argument-file "$TMP_NAME_FILE" --query hello_backend
+    assert_eq "Query message generated at [message.json]"
+
+    rm "$TMP_NAME_FILE"
+}
+
+@test "call subcommand accepts argument from stdin" {
+    install_asset greet
+    dfx_start
+    dfx_deploy
+    TMP_NAME_FILE="$(mktemp)"
+    printf '("stdin")' > "$TMP_NAME_FILE"
+
+    assert_command dfx canister sign --argument-file - --query hello_backend greet < "$TMP_NAME_FILE"
+    assert_eq "Query message generated at [message.json]"
+
+    rm "$TMP_NAME_FILE"
+}

--- a/e2e/tests-dfx/sign_send.bash
+++ b/e2e/tests-dfx/sign_send.bash
@@ -81,7 +81,7 @@ Signed request_status append to update message in [message-inc.json]"
     echo y | dfx canister send message.json > out.txt
     assert_command cat out.txt
     # cbor-encoded response that says "Hello, stdin!"
-    assert_match "d9d9f7a266737461747573677265706c696564657265706c79a163617267554449444c0001710d48656c6c6f2c20737464696e21"
+    assert_match "d9d9f7a2657265706c79a163617267554449444c0001710d48656c6c6f2c20737464696e2166737461747573677265706c696564"
 
     rm "$TMP_NAME_FILE"
 }

--- a/src/dfx/src/commands/canister/sign.rs
+++ b/src/dfx/src/commands/canister/sign.rs
@@ -7,7 +7,8 @@ use crate::lib::operations::canister::get_local_cid_and_candid_path;
 use crate::lib::sign::sign_transport::SignReplicaV2Transport;
 use crate::lib::sign::signed_message::SignedMessageV1;
 
-use crate::util::{blob_from_arguments, get_candid_type};
+use crate::util::clap::validators::file_or_stdin_validator;
+use crate::util::{arguments_from_file, blob_from_arguments, get_candid_type};
 
 use candid::Principal;
 use ic_agent::AgentError;
@@ -44,6 +45,15 @@ pub struct CanisterSignOpts {
 
     /// Specifies the argument to pass to the method.
     argument: Option<String>,
+
+    /// Specifies the file from which to read the argument to pass to the method.
+    #[clap(
+        long,
+        validator(file_or_stdin_validator),
+        conflicts_with("random"),
+        conflicts_with("argument")
+    )]
+    argument_file: Option<String>,
 
     /// Specifies the config for generating random argument.
     #[clap(long, conflicts_with("argument"))]
@@ -94,7 +104,13 @@ pub async fn exec(
     let method_type = maybe_candid_path.and_then(|path| get_candid_type(&path, method_name));
     let is_query_method = method_type.as_ref().map(|(_, f)| f.is_query());
 
+    let arguments_from_file = opts
+        .argument_file
+        .map(|v| arguments_from_file(&v))
+        .transpose()?;
     let arguments = opts.argument.as_deref();
+    let arguments = arguments_from_file.as_deref().or(arguments);
+
     let arg_type = opts.r#type.as_deref();
     let is_query = match is_query_method {
         Some(true) => !opts.update,

--- a/src/dfx/src/util/mod.rs
+++ b/src/dfx/src/util/mod.rs
@@ -17,6 +17,7 @@ use schemars::JsonSchema;
 use serde::Serialize;
 use std::convert::TryFrom;
 use std::fmt::Display;
+use std::io::{stdin, Read};
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::time::Duration;
@@ -155,6 +156,19 @@ pub fn check_candid_file(idl_path: &std::path::Path) -> DfxResult<(TypeEnv, Opti
             idl_path.to_string_lossy()
         )
     })
+}
+
+pub fn arguments_from_file(file_name: &str) -> DfxResult<String> {
+    if file_name == "-" {
+        let mut content = String::new();
+        stdin().read_to_string(&mut content).map_err(|e| {
+            error_invalid_argument!("Could not read arguments from stdin to string: {}", e)
+        })?;
+        Ok(content)
+    } else {
+        std::fs::read_to_string(file_name)
+            .map_err(|e| error_invalid_argument!("Could not read arguments file to string: {}", e))
+    }
 }
 
 #[context("Failed to create argument blob.")]


### PR DESCRIPTION
# Description

`dfx canister call` command has an argument `--argument-file` to allow sending the request when argument string is too long for shell. `dfx canister sign` command didn't have this argument so some of the requests possible by `dfx canister call` were not possible to be executed through sign/send workflow. This PR fixes this unfortunate inconvenience:

* add `--argument-file` option to `sign` command
* move the logic related to reading argument string from a file from `call` command to utils so that it can be reused by both `call` and `sign`
* refactor the logic a little to use correct error handling instead of `expect`s

# How Has This Been Tested?

Added e2e test cases. Also did signing manually with compiled `dfx`, including some very long argument strings that didn't fit into CLI arguments.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
