### PR TITLE
chore: disable Update Docs workflow on external PRs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -14,6 +14,8 @@ env:
 
 jobs:
   update_dfx_json_schema:
+    # Workflow breaks if it gets executed on an external PR
+    if: github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -21,13 +23,6 @@ jobs:
         rust: ["1.60.0"]
         os: [ ubuntu-20.04 ]
     steps:
-      - name: Check Branch Source Repo
-        run: |
-          echo "Repo full name: ${{github.event.pull_request.head.repo.full_name}}"
-          echo "Repo: ${{github.repository}}"
-          if [[ ${{ github.event.pull_request.head.repo.full_name != github.repository }} ]]; then
-            exit 0
-          fi
       - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
@@ -52,16 +47,9 @@ jobs:
           echo "networks.json schema:"
           cat docs/networks-json-schema.json
           if [[ $(git status | wc -l) -eq 2 ]]; then
-            if [[ ${{ github.event.pull_request.head.repo.full_name == github.repository }} ]]; then
-              git config user.name "GitHub Actions Bot"
-              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-              git add docs/dfx-json-schema.json docs/networks-json-schema.json
-              git commit -m "update dfx-json-schema and networks-json-schema" || true
-              git push
-            else
-              echo "Schemas are not up to date. Please run the following:"
-              echo "  dfx schema --outfile docs/dfx-json-schema.json"
-              echo "  dfx schema --for networks --outfile docs/networks-json-schema.json"
-              exit 1
-            fi
+            git config user.name "GitHub Actions Bot"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add docs/dfx-json-schema.json docs/networks-json-schema.json
+            git commit -m "update dfx-json-schema and networks-json-schema" || true
+            git push
           fi

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   update_dfx_json_schema:
     # Workflow breaks if it gets executed on an external PR
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -21,6 +21,13 @@ jobs:
         rust: ["1.60.0"]
         os: [ ubuntu-20.04 ]
     steps:
+      - name: Check Branch Source Repo
+        run: |
+          echo "Repo full name: ${{github.event.pull_request.head.repo.full_name}}"
+          echo "Repo: ${{github.repository}}"
+          if [[ ${{ github.event.pull_request.head.repo.full_name != github.repository }} ]]; then
+            exit 0
+          fi
       - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
The Update Docs workflow breaks on all external PRs, e.g. #2787. I recommend we disable it for now for all PRs from external repos