### PR TITLE
fix(ci): docker build frontend canister on linux/amd64 platform

### DIFF
--- a/scripts/update-frontend-canister.sh
+++ b/scripts/update-frontend-canister.sh
@@ -16,5 +16,5 @@ if [ -d "${CARGO_HOME:-"$HOME/.cargo"}/registry/index" ]; then
     registry_flag="--build-context=registry=${CARGO_HOME:-"$HOME/.cargo"}/registry/index"
 fi
 
-docker buildx build . -f "$SCRIPT_DIR/update-frontend-canister.Dockerfile" -o src/distributed \
+docker buildx build --platform linux/amd64 --progress plain . -f "$SCRIPT_DIR/update-frontend-canister.Dockerfile" -o src/distributed \
     --build-arg=RUST_VERSION="$rust_version" ${registry_flag:+"$registry_flag"}


### PR DESCRIPTION
# Description

`docker build` on macOS M1 without `--platform linux/amd64` flag frontend canister build artifact will differ from the made by CI workflow (`name: Check frontend canister build`). 

This change won't have any effect on the current CI workflow, however, it will make building the frontend canister locally a bit longer on macOS M1. 