### PR TITLE
fix: drop an additional step only run by ic-ref in asset canister tests

### DIFF
--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -26,7 +26,6 @@ teardown() {
   install_asset assetscanister
   dfx_start
   assert_command dfx deploy
-  [ "$USE_IC_REF" ] && dfx canister update-settings --add-controller "$(dfx canister id e2e_project_frontend)" --all # Dec. 2022: ic-ref has not received the change yet that a canister is always allowed to check it's status
 
   # deployer is automatically authorized
   assert_command dfx canister call e2e_project_frontend list_authorized '()'


### PR DESCRIPTION
`ic-hs` can now handle `canister_status` management canister call from a canister querying its own status if the canister does not control itself.