### PR TITLE
chore: fix shellcheck in publish-manifest workflow

### DIFF
--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+      - fix-install-shellcheck
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,7 +26,7 @@ jobs:
         run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
       - name: Generate
         run: |
-          shellcheck --shell=sh public/install/*.sh --exclude SC2039,SC2154,SC2034
+          shellcheck --shell=sh public/install/*.sh --exclude SC2154,SC2034,SC3003,SC3014
           ~/go/bin/shfmt -d -p -i 4 -ci -bn -s public/install/*.sh
           sed -i "s/@revision@/${GITHUB_SHA}/" public/install/999_footer.sh
           mkdir _out
@@ -37,9 +39,14 @@ jobs:
             s/ *#.*//
           " _out/install.sh
           cp public/manifest.json _out/manifest.json
-      - name: Upload Artifacts
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        with:
-          single_commit: yes
-          branch: public-manifest
-          folder: _out/
+      - name: stop
+        if: github.branch == 'fix-install-shellcheck'
+        run: |
+          echo forced exit
+          exit 1
+#      - name: Upload Artifacts
+#        uses: JamesIves/github-pages-deploy-action@releases/v3
+##        with:
+#          single_commit: yes
+#          branch: public-manifest
+#          folder: _out/

--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -26,7 +26,7 @@ jobs:
         run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
       - name: Generate
         run: |
-          shellcheck --shell=sh public/install/*.sh --exclude SC2154,SC2034,SC3003,SC3014
+          shellcheck --shell=sh public/install/*.sh --exclude SC2154,SC2034,SC3003,SC3014,SC3043
           ~/go/bin/shfmt -d -p -i 4 -ci -bn -s public/install/*.sh
           sed -i "s/@revision@/${GITHUB_SHA}/" public/install/999_footer.sh
           mkdir _out

--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix-install-shellcheck
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -39,14 +37,9 @@ jobs:
             s/ *#.*//
           " _out/install.sh
           cp public/manifest.json _out/manifest.json
-      - name: stop
-        if: github.branch == 'fix-install-shellcheck'
-        run: |
-          echo forced exit
-          exit 1
-#      - name: Upload Artifacts
-#        uses: JamesIves/github-pages-deploy-action@releases/v3
-##        with:
-#          single_commit: yes
-#          branch: public-manifest
-#          folder: _out/
+      - name: Upload Artifacts
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          single_commit: yes
+          branch: public-manifest
+          folder: _out/

--- a/public/install/020_flags.sh
+++ b/public/install/020_flags.sh
@@ -39,7 +39,7 @@ read_flags() {
     # shellcheck disable=SC2199
     # https://github.com/koalaman/shellcheck/wiki/SC2199
     while [ -n "$*" ]; do
-        local ARG=$1
+        local ARG="$1"
         shift
 
         OLD_IFS="$IFS"


### PR DESCRIPTION
# Description

The publish-manifest workflow failed starting a few days ago, as can be seen at https://github.com/dfinity/sdk/commits/master .

There is a note at https://www.shellcheck.net/wiki/SC2039:
> Note: This warning has been retired in favor of individual SC3xxx warnings for each individual issue.

This PR replaces the exclusion for SC2039 with equivalent SC3xxx exclusions.  It also fixes another warning for `Double quote to prevent globbing and word splitting.`

# How Has This Been Tested?

Tested workflow here: https://github.com/dfinity/sdk/actions/runs/3653370698/jobs/6172766186

Also ran the install script locally
