### PR TITLE
docs: update references to smartcontracts.org to internetcomputer.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1374,7 +1374,7 @@ Newly deployed Motoko canisters now embed the Candid interface and Motoko stable
 	1) the backward compatible of Candid interface in both upgrade and reinstall mode;
 	2) the type safety of Motoko stable variable type in upgrade mode to avoid accidentally lossing data;
 
-See [Upgrade compatibility](https://smartcontracts.org/docs/language-guide/compatibility.html) for more details.
+See [Upgrade compatibility](https://internetcomputer.org/docs/language-guide/compatibility) for more details.
 
 ### feat: Unified environment variables across build commands
 

--- a/docs/cli-reference/dfx-envars.md
+++ b/docs/cli-reference/dfx-envars.md
@@ -38,4 +38,4 @@ The `.cache/dfinity/uninstall.sh` script uses this environment variable to ident
 
 Use the `DFX_VERSION` environment variable to identify a specific version of the SDK that you want to install.
 
-    DFX_VERSION=0.10.0 sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
+    DFX_VERSION=0.10.0 sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"

--- a/docs/cli-reference/dfx-upgrade.md
+++ b/docs/cli-reference/dfx-upgrade.md
@@ -37,6 +37,6 @@ This command checks the version of `dfx` you have currently installed and the la
 
 ``` bash
 Current version: 0.6.8
-Fetching manifest \https://smartcontracts.org/manifest.json
+Fetching manifest \https://sdk.dfinity.org/manifest.json
 Already up to date
 ```

--- a/src/dfx/assets/new_project_rust_files/README.md
+++ b/src/dfx/assets/new_project_rust_files/README.md
@@ -6,12 +6,12 @@ To get started, you might want to explore the project directory structure and th
 
 To learn more before you start working with {project_name}, see the following documentation available online:
 
-- [Quick Start](https://smartcontracts.org/docs/quickstart/quickstart-intro.html)
-- [SDK Developer Tools](https://smartcontracts.org/docs/developers-guide/sdk-guide.html)
-- [Rust Canister Devlopment Guide](https://smartcontracts.org/docs/rust-guide/rust-intro.html)
+- [Quick Start](https://internetcomputer.org/docs/quickstart/quickstart-intro)
+- [SDK Developer Tools](https://internetcomputer.org/docs/developers-guide/sdk-guide)
+- [Rust Canister Devlopment Guide](https://internetcomputer.org/docs/rust-guide/rust-intro)
 - [ic-cdk](https://docs.rs/ic-cdk)
 - [ic-cdk-macros](https://docs.rs/ic-cdk-macros)
-- [Candid Introduction](https://smartcontracts.org/docs/candid-guide/candid-intro.html)
+- [Candid Introduction](https://internetcomputer.org/docs/candid-guide/candid-intro)
 - [JavaScript API Reference](https://erxue-5aaaa-aaaab-qaagq-cai.raw.ic0.app)
 
 If you want to start working on your project right away, you might want to try the following commands:


### PR DESCRIPTION
# Description

Changed all documentation links from smartcontracts.org to internetcomputer.org, or in the case of the `dfx upgrade` doc, to what the command actually displays.

Note that all of the links of the form `https://smartcontracts.org/<something>.html` were broken.

# How Has This Been Tested?

Tested new links manually
