### PR TITLE
docs: dfx pull: hide command, and update help string

### DIFF
--- a/src/dfx/src/commands/mod.rs
+++ b/src/dfx/src/commands/mod.rs
@@ -52,6 +52,7 @@ pub enum Command {
     New(new::NewOpts),
     Nns(nns::NnsOpts),
     Ping(ping::PingOpts),
+    #[clap(hide(true))]
     Pull(pull::PullOpts),
     Quickstart,
     Remote(remote::RemoteOpts),

--- a/src/dfx/src/commands/pull.rs
+++ b/src/dfx/src/commands/pull.rs
@@ -13,7 +13,7 @@ use ic_agent::{Agent, AgentError};
 use slog::Logger;
 use tokio::runtime::Runtime;
 
-/// Pings an Internet Computer network and returns its status.
+/// Pull canisters upon which the project depends
 #[derive(Parser)]
 pub struct PullOpts {
     /// Specifies the name of the canister you want to pull.


### PR DESCRIPTION
If you run `dfx help`, this is part of the output:
```
    ping          Pings an Internet Computer network and returns its status
    pull          Pings an Internet Computer network and returns its status
```

This PR updates the help text for `dfx pull`, but also hides it from `dfx help`, since the functionality for dfx pull is still in progress.

