### PR TITLE
fix: Encode curve name in key imported from seed phrase

### DIFF
--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -536,6 +536,9 @@ XXX
     assert_command dfx identity import alice2 --seed-file seed.txt --disable-encryption
     assert_command dfx identity get-principal --identity alice2
     assert_eq "$principal"
+    dfx identity export alice2 > export.pem
+    assert_command openssl asn1parse -in export.pem
+    assert_match ':secp256k1'
 }
 
 @test "identity: consistently imports a known seed phrase" {

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -20,6 +20,7 @@ use ic_identity_hsm::HardwareIdentity;
 use ic_utils::call::AsyncCall;
 use ic_utils::interfaces::management_canister::builders::InstallMode;
 use ic_utils::interfaces::{ManagementCanister, WalletCanister};
+use sec1::EncodeEcPrivateKey;
 use serde::{Deserialize, Serialize};
 use slog::{debug, info, trace, Logger};
 use std::collections::BTreeMap;
@@ -195,7 +196,7 @@ impl Identity {
                 identity_config = create_identity_config(log, mode, name, None)?;
                 let mnemonic = Mnemonic::from_phrase(&mnemonic, Language::English)?;
                 let key = identity_manager::mnemonic_to_key(&mnemonic)?;
-                let pem = key.to_pem(k256::pkcs8::LineEnding::CRLF)?;
+                let pem = key.to_sec1_pem(k256::pkcs8::LineEnding::CRLF)?;
                 let pem_content = pem.as_bytes();
                 pem_safekeeping::save_pem(
                     log,


### PR DESCRIPTION
Repeat of #2741, but for `dfx identity import --seed-file`.