### PR TITLE
refactor: rename error enum names

### DIFF
--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -77,7 +77,7 @@ pub fn get_cache_root() -> DfxResult<PathBuf> {
     #[cfg(not(windows))]
     let p = {
         let home = std::env::var_os("HOME")
-            .ok_or_else(|| DfxError::new(CacheError::CannotFindHomeDirectory()))?;
+            .ok_or_else(|| DfxError::new(CacheError::NoHomeInEnvironment()))?;
         let root = cache_root.unwrap_or(home);
         PathBuf::from(root).join(".cache").join("dfinity")
     };
@@ -88,10 +88,10 @@ pub fn get_cache_root() -> DfxResult<PathBuf> {
     };
     if !p.exists() {
         if let Err(_e) = std::fs::create_dir_all(&p) {
-            return Err(DfxError::new(CacheError::CannotCreateCacheDirectory(p)));
+            return Err(DfxError::new(CacheError::CreateCacheDirectoryFailed(p)));
         }
     } else if !p.is_dir() {
-        return Err(DfxError::new(CacheError::CannotFindCacheDirectory(p)));
+        return Err(DfxError::new(CacheError::FindCacheDirectoryFailed(p)));
     }
     Ok(p)
 }
@@ -104,10 +104,10 @@ pub fn get_bin_cache_root() -> DfxResult<PathBuf> {
 
     if !p.exists() {
         if let Err(_e) = std::fs::create_dir_all(&p) {
-            return Err(DfxError::new(CacheError::CannotCreateCacheDirectory(p)));
+            return Err(DfxError::new(CacheError::CreateCacheDirectoryFailed(p)));
         }
     } else if !p.is_dir() {
-        return Err(DfxError::new(CacheError::CannotFindCacheDirectory(p)));
+        return Err(DfxError::new(CacheError::FindCacheDirectoryFailed(p)));
     }
 
     Ok(p)

--- a/src/dfx/src/lib/error/cache.rs
+++ b/src/dfx/src/lib/error/cache.rs
@@ -4,15 +4,15 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum CacheError {
     #[error("Cannot create cache directory at '{0}'.")]
-    CannotCreateCacheDirectory(PathBuf),
+    CreateCacheDirectoryFailed(PathBuf),
 
     #[error("Cannot find cache directory at '{0}'.")]
-    CannotFindCacheDirectory(PathBuf),
+    FindCacheDirectoryFailed(PathBuf),
 
     // Windows paths do not require environment variables (and are found by dirs-next, which has its own errors)
     #[cfg(not(windows))]
     #[error("Cannot find home directory.")]
-    CannotFindHomeDirectory(),
+    NoHomeInEnvironment(),
 
     #[error("Unknown version '{0}'.")]
     UnknownVersion(String),

--- a/src/dfx/src/lib/error/identity.rs
+++ b/src/dfx/src/lib/error/identity.rs
@@ -15,10 +15,10 @@ pub enum IdentityError {
     IdentityDoesNotExist(String, PathBuf),
 
     #[error("Cannot create identity directory at '{0}': {1:#}")]
-    CannotCreateIdentityDirectory(PathBuf, Box<DfxError>),
+    CreateIdentityDirectoryFailed(PathBuf, Box<DfxError>),
 
     #[error("Cannot rename identity directory from '{0}' to '{1}': {2:#}")]
-    CannotRenameIdentityDirectory(PathBuf, PathBuf, Box<DfxError>),
+    RenameIdentityDirectoryFailed(PathBuf, PathBuf, Box<DfxError>),
 
     #[error("Cannot delete the default identity.")]
     CannotDeleteDefaultIdentity(),
@@ -29,9 +29,9 @@ pub enum IdentityError {
     #[error("Cannot create an anonymous identity.")]
     CannotCreateAnonymousIdentity(),
 
-    #[error("Cannot find home directory.")]
-    CannotFindHomeDirectory(),
+    #[error("Cannot find home directory (no HOME environment variable).")]
+    NoHomeInEnvironment(),
 
     #[error("Cannot read identity file '{0}': {1:#}")]
-    CannotReadIdentityFile(String, Box<DfxError>),
+    ReadIdentityFileFailed(String, Box<DfxError>),
 }

--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -361,7 +361,7 @@ impl IdentityManager {
 
         DfxIdentity::map_wallets_to_renamed_identity(env, from, to)?;
         std::fs::rename(&from_dir, &to_dir).map_err(|err| {
-            DfxError::new(IdentityError::CannotRenameIdentityDirectory(
+            DfxError::new(IdentityError::RenameIdentityDirectoryFailed(
                 from_dir,
                 to_dir,
                 Box::new(DfxError::new(err)),
@@ -521,7 +521,7 @@ To create a more secure identity, create and use an identity that is protected b
     if !identity_pem_path.exists() {
         if !identity_dir.exists() {
             std::fs::create_dir_all(&identity_dir).map_err(|err| {
-                DfxError::new(IdentityError::CannotCreateIdentityDirectory(
+                DfxError::new(IdentityError::CreateIdentityDirectoryFailed(
                     identity_dir,
                     Box::new(DfxError::new(err)),
                 ))
@@ -584,7 +584,7 @@ fn get_legacy_creds_pem_path() -> DfxResult<Option<PathBuf>> {
     } else {
         let config_root = std::env::var("DFX_CONFIG_ROOT").ok();
         let home = std::env::var("HOME")
-            .map_err(|_| DfxError::new(IdentityError::CannotFindHomeDirectory()))?;
+            .map_err(|_| DfxError::new(IdentityError::NoHomeInEnvironment()))?;
         let root = config_root.unwrap_or(home);
 
         Ok(Some(

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -247,7 +247,7 @@ impl Identity {
         was_encrypted: bool,
     ) -> DfxResult<Self> {
         let inner = Box::new(BasicIdentity::from_pem(pem_content).map_err(|e| {
-            DfxError::new(IdentityError::CannotReadIdentityFile(
+            DfxError::new(IdentityError::ReadIdentityFileFailed(
                 name.into(),
                 Box::new(DfxError::new(e)),
             ))
@@ -268,7 +268,7 @@ impl Identity {
         was_encrypted: bool,
     ) -> DfxResult<Self> {
         let inner = Box::new(Secp256k1Identity::from_pem(pem_content).map_err(|e| {
-            DfxError::new(IdentityError::CannotReadIdentityFile(
+            DfxError::new(IdentityError::ReadIdentityFileFailed(
                 name.into(),
                 Box::new(DfxError::new(e)),
             ))


### PR DESCRIPTION
Renamed error enum names like `Cannot*`, for situations where an operation failed, to the form `*Failed`.

A few names remain of the form `Cannot*`, because they indicate things that one cannot ever do:
- `CannotDeleteDefaultIdentity`
- `CannotDeleteAnonymousIdentity`
- `CannotCreateAnonymousIdentity`

This is in preparation for adding more concrete error types.
