### PR TITLE
refactor: remove unnecessary explicit calls to DfxError::new

### DIFF
--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -361,11 +361,11 @@ impl IdentityManager {
 
         DfxIdentity::map_wallets_to_renamed_identity(env, from, to)?;
         std::fs::rename(&from_dir, &to_dir).map_err(|err| {
-            DfxError::new(IdentityError::RenameIdentityDirectoryFailed(
+            IdentityError::RenameIdentityDirectoryFailed(
                 from_dir,
                 to_dir,
                 Box::new(DfxError::new(err)),
-            ))
+            )
         })?;
         if let Some(keyring_identity_suffix) = &identity_config.keyring_identity_suffix {
             debug!(log, "Migrating keyring content.");
@@ -521,10 +521,10 @@ To create a more secure identity, create and use an identity that is protected b
     if !identity_pem_path.exists() {
         if !identity_dir.exists() {
             std::fs::create_dir_all(&identity_dir).map_err(|err| {
-                DfxError::new(IdentityError::CreateIdentityDirectoryFailed(
+                IdentityError::CreateIdentityDirectoryFailed(
                     identity_dir,
                     Box::new(DfxError::new(err)),
-                ))
+                )
             })?;
         }
 
@@ -583,8 +583,7 @@ fn get_legacy_creds_pem_path() -> DfxResult<Option<PathBuf>> {
         Ok(None)
     } else {
         let config_root = std::env::var("DFX_CONFIG_ROOT").ok();
-        let home = std::env::var("HOME")
-            .map_err(|_| DfxError::new(IdentityError::NoHomeInEnvironment()))?;
+        let home = std::env::var("HOME").map_err(|_| IdentityError::NoHomeInEnvironment())?;
         let root = config_root.unwrap_or(home);
 
         Ok(Some(

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -247,10 +247,7 @@ impl Identity {
         was_encrypted: bool,
     ) -> DfxResult<Self> {
         let inner = Box::new(BasicIdentity::from_pem(pem_content).map_err(|e| {
-            DfxError::new(IdentityError::ReadIdentityFileFailed(
-                name.into(),
-                Box::new(DfxError::new(e)),
-            ))
+            IdentityError::ReadIdentityFileFailed(name.into(), Box::new(DfxError::new(e)))
         })?);
 
         Ok(Self {
@@ -268,10 +265,7 @@ impl Identity {
         was_encrypted: bool,
     ) -> DfxResult<Self> {
         let inner = Box::new(Secp256k1Identity::from_pem(pem_content).map_err(|e| {
-            DfxError::new(IdentityError::ReadIdentityFileFailed(
-                name.into(),
-                Box::new(DfxError::new(e)),
-            ))
+            IdentityError::ReadIdentityFileFailed(name.into(), Box::new(DfxError::new(e)))
         })?);
 
         Ok(Self {
@@ -287,15 +281,12 @@ impl Identity {
         name: &str,
         hsm: HardwareIdentityConfiguration,
     ) -> DfxResult<Self> {
-        let inner = Box::new(
-            HardwareIdentity::new(
-                hsm.pkcs11_lib_path,
-                HSM_SLOT_INDEX,
-                &hsm.key_id,
-                identity_manager::get_dfx_hsm_pin,
-            )
-            .map_err(DfxError::new)?,
-        );
+        let inner = Box::new(HardwareIdentity::new(
+            hsm.pkcs11_lib_path,
+            HSM_SLOT_INDEX,
+            &hsm.key_id,
+            identity_manager::get_dfx_hsm_pin,
+        )?);
         Ok(Self {
             name: name.to_string(),
             inner,


### PR DESCRIPTION
# Description

Remove some explicit calls to `DfxError::new()` which turn out to not be needed.  This is in preparation for upcoming work and will make the diffs a little smaller.

The upcoming work is to remove the identity manager's dependence on `anyhow`, as part of moving it into a crate.

