### PR TITLE
fix: use Description section for commit message, if it exists

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -32,7 +32,7 @@ pull_request_rules:
         commit_message_template: |
           {{ title }} (#{{ number }})
 
-          {{ body }}
+          {{ body | get_section('# Description', default=body) }}
       delete_head_branch: {}
   - name: Clean up automerge tags
     conditions:


### PR DESCRIPTION
# Description

In order to help avoid commit messages like [this one](https://github.com/dfinity/sdk/commit/d3d2b71c4e60323d48a2ee68ee140bd9f32280a1), alter the mergify configuration to use the "Description" section from the PR description if it's present, otherwise the whole PR description.  Also we don't really need the "How Has This Been Tested" and checklist boilerplate in commit messages.  In any case, we will still have to make sure not to approve PRs with a PR body that is unchanged from the pull request template.

See alsoo https://docs.mergify.com/actions/merge/#commit-message-template


# How Has This Been Tested?

I tried setting up a branch and a [PR against it](https://github.com/dfinity/sdk/pull/2844), but it seems the mergify rules always run against .mergify.yml on the master branch, so that didn't work.  In other words, I don't see a way to test this without merging to master and then testing.
