### PR TITLE
refactor: move IdentityError type to dfx-core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,10 @@ dependencies = [
 [[package]]
 name = "dfx-core"
 version = "0.0.1"
+dependencies = [
+ "ic-agent",
+ "thiserror",
+]
 
 [[package]]
 name = "dhall"

--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -3,3 +3,7 @@ name = "dfx-core"
 version = "0.0.1"
 authors = ["DFINITY Team"]
 edition = "2021"
+
+[dependencies]
+ic-agent = { version = "0.23.0", features = ["reqwest"] }
+thiserror = "1.0.20"

--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -1,5 +1,4 @@
-use crate::lib::error::DfxError;
-use std::boxed::Box;
+use ic_agent::identity::PemError;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -15,7 +14,7 @@ pub enum IdentityError {
     CannotCreateAnonymousIdentity(),
 
     #[error("Cannot create identity directory at '{0}': {1:#}")]
-    CreateIdentityDirectoryFailed(PathBuf, Box<DfxError>),
+    CreateIdentityDirectoryFailed(PathBuf, std::io::Error),
 
     #[error("Identity already exists.")]
     IdentityAlreadyExists(),
@@ -27,10 +26,10 @@ pub enum IdentityError {
     NoHomeInEnvironment(),
 
     #[error("Cannot read identity file '{0}': {1:#}")]
-    ReadIdentityFileFailed(String, Box<DfxError>),
+    ReadIdentityFileFailed(String, PemError),
 
     #[error("Cannot rename identity directory from '{0}' to '{1}': {2:#}")]
-    RenameIdentityDirectoryFailed(PathBuf, PathBuf, Box<DfxError>),
+    RenameIdentityDirectoryFailed(PathBuf, PathBuf, std::io::Error),
 
     #[error("An Identity named {0} cannot be created as it is reserved for internal use.")]
     ReservedIdentityName(String),

--- a/src/dfx-core/src/error/mod.rs
+++ b/src/dfx-core/src/error/mod.rs
@@ -1,0 +1,1 @@
+pub mod identity;

--- a/src/dfx-core/src/lib.rs
+++ b/src/dfx-core/src/lib.rs
@@ -1,1 +1,1 @@
-
+pub mod error;

--- a/src/dfx/src/lib/error/mod.rs
+++ b/src/dfx/src/lib/error/mod.rs
@@ -1,10 +1,9 @@
 pub mod build;
 pub mod cache;
-pub mod identity;
 
 pub use build::BuildError;
 pub use cache::CacheError;
-pub use identity::IdentityError;
+pub use dfx_core::error::identity::IdentityError;
 
 /// The type to represent DFX results.
 pub type DfxResult<T = ()> = anyhow::Result<T>;

--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -360,13 +360,8 @@ impl IdentityManager {
         }
 
         DfxIdentity::map_wallets_to_renamed_identity(env, from, to)?;
-        std::fs::rename(&from_dir, &to_dir).map_err(|err| {
-            IdentityError::RenameIdentityDirectoryFailed(
-                from_dir,
-                to_dir,
-                Box::new(DfxError::new(err)),
-            )
-        })?;
+        std::fs::rename(&from_dir, &to_dir)
+            .map_err(|err| IdentityError::RenameIdentityDirectoryFailed(from_dir, to_dir, err))?;
         if let Some(keyring_identity_suffix) = &identity_config.keyring_identity_suffix {
             debug!(log, "Migrating keyring content.");
             let (pem, _) = pem_safekeeping::load_pem(log, self, from, &identity_config)?;
@@ -520,12 +515,8 @@ To create a more secure identity, create and use an identity that is protected b
     let identity_pem_path = identity_dir.join(IDENTITY_PEM);
     if !identity_pem_path.exists() {
         if !identity_dir.exists() {
-            std::fs::create_dir_all(&identity_dir).map_err(|err| {
-                IdentityError::CreateIdentityDirectoryFailed(
-                    identity_dir,
-                    Box::new(DfxError::new(err)),
-                )
-            })?;
+            std::fs::create_dir_all(&identity_dir)
+                .map_err(|err| IdentityError::CreateIdentityDirectoryFailed(identity_dir, err))?;
         }
 
         let maybe_creds_pem_path = get_legacy_creds_pem_path()?;

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -5,7 +5,7 @@
 use crate::config::dfinity::NetworksConfig;
 use crate::lib::config::get_config_dfx_dir_path;
 use crate::lib::environment::Environment;
-use crate::lib::error::{DfxError, DfxResult, IdentityError};
+use crate::lib::error::{DfxResult, IdentityError};
 use crate::lib::identity::identity_manager::IdentityStorageMode;
 use crate::lib::network::network_descriptor::{NetworkDescriptor, NetworkTypeDescriptor};
 use crate::lib::root_key::fetch_root_key_if_needed;
@@ -246,9 +246,10 @@ impl Identity {
         pem_content: &[u8],
         was_encrypted: bool,
     ) -> DfxResult<Self> {
-        let inner = Box::new(BasicIdentity::from_pem(pem_content).map_err(|e| {
-            IdentityError::ReadIdentityFileFailed(name.into(), Box::new(DfxError::new(e)))
-        })?);
+        let inner = Box::new(
+            BasicIdentity::from_pem(pem_content)
+                .map_err(|e| IdentityError::ReadIdentityFileFailed(name.into(), e))?,
+        );
 
         Ok(Self {
             name: name.to_string(),
@@ -264,9 +265,10 @@ impl Identity {
         pem_content: &[u8],
         was_encrypted: bool,
     ) -> DfxResult<Self> {
-        let inner = Box::new(Secp256k1Identity::from_pem(pem_content).map_err(|e| {
-            IdentityError::ReadIdentityFileFailed(name.into(), Box::new(DfxError::new(e)))
-        })?);
+        let inner = Box::new(
+            Secp256k1Identity::from_pem(pem_content)
+                .map_err(|e| IdentityError::ReadIdentityFileFailed(name.into(), e))?,
+        );
 
         Ok(Self {
             name: name.to_string(),


### PR DESCRIPTION
Also remove the boxing and dependence on DfxError.

Fixes https://dfinity.atlassian.net/jira/software/c/projects/SDK/issues/SDK-891

[SDK-891]: https://dfinity.atlassian.net/browse/SDK-891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ