### PR TITLE
refactor: std::io::Error to IoError in IdentityError

### DIFF
--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -1,3 +1,5 @@
+use crate::error::io::IoError;
+
 use ic_agent::identity::PemError;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -13,8 +15,8 @@ pub enum IdentityError {
     #[error("Cannot create an anonymous identity.")]
     CannotCreateAnonymousIdentity(),
 
-    #[error("Cannot create identity directory at '{0}': {1:#}")]
-    CreateIdentityDirectoryFailed(PathBuf, std::io::Error),
+    #[error("Cannot create identity directory: {0}")]
+    CreateIdentityDirectoryFailed(IoError),
 
     #[error("Identity already exists.")]
     IdentityAlreadyExists(),
@@ -28,8 +30,8 @@ pub enum IdentityError {
     #[error("Cannot read identity file '{0}': {1:#}")]
     ReadIdentityFileFailed(String, PemError),
 
-    #[error("Cannot rename identity directory from '{0}' to '{1}': {2:#}")]
-    RenameIdentityDirectoryFailed(PathBuf, PathBuf, std::io::Error),
+    #[error("Cannot rename identity directory: {0}")]
+    RenameIdentityDirectoryFailed(IoError),
 
     #[error("An Identity named {0} cannot be created as it is reserved for internal use.")]
     ReservedIdentityName(String),

--- a/src/dfx-core/src/error/io.rs
+++ b/src/dfx-core/src/error/io.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum IoError {
+    #[error("Failed to create {0}: {1}")]
+    CreateDirectoryFailed(PathBuf, std::io::Error),
+
+    #[error("Failed to rename {0} to {1}: {2}")]
+    RenameFailed(PathBuf, PathBuf, std::io::Error),
+}

--- a/src/dfx-core/src/error/mod.rs
+++ b/src/dfx-core/src/error/mod.rs
@@ -1,1 +1,2 @@
 pub mod identity;
+pub mod io;

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -1,0 +1,12 @@
+use crate::error::io::IoError;
+use crate::error::io::IoError::{CreateDirectoryFailed, RenameFailed};
+
+use std::path::Path;
+
+pub fn create_dir_all(path: &Path) -> Result<(), IoError> {
+    std::fs::create_dir_all(path).map_err(|err| CreateDirectoryFailed(path.to_path_buf(), err))
+}
+
+pub fn rename(from: &Path, to: &Path) -> Result<(), IoError> {
+    std::fs::rename(from, to).map_err(|err| RenameFailed(from.to_path_buf(), to.to_path_buf(), err))
+}

--- a/src/dfx-core/src/lib.rs
+++ b/src/dfx-core/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod error;
+pub mod fs;

--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -10,6 +10,9 @@ use anyhow::{anyhow, bail, Context};
 use bip32::XPrv;
 use bip39::{Language, Mnemonic, MnemonicType, Seed};
 use candid::Principal;
+use dfx_core::error::identity::IdentityError::{
+    CreateIdentityDirectoryFailed, RenameIdentityDirectoryFailed,
+};
 use fn_error_context::context;
 use k256::pkcs8::LineEnding;
 use k256::SecretKey;
@@ -360,8 +363,7 @@ impl IdentityManager {
         }
 
         DfxIdentity::map_wallets_to_renamed_identity(env, from, to)?;
-        std::fs::rename(&from_dir, &to_dir)
-            .map_err(|err| IdentityError::RenameIdentityDirectoryFailed(from_dir, to_dir, err))?;
+        dfx_core::fs::rename(&from_dir, &to_dir).map_err(RenameIdentityDirectoryFailed)?;
         if let Some(keyring_identity_suffix) = &identity_config.keyring_identity_suffix {
             debug!(log, "Migrating keyring content.");
             let (pem, _) = pem_safekeeping::load_pem(log, self, from, &identity_config)?;
@@ -515,8 +517,7 @@ To create a more secure identity, create and use an identity that is protected b
     let identity_pem_path = identity_dir.join(IDENTITY_PEM);
     if !identity_pem_path.exists() {
         if !identity_dir.exists() {
-            std::fs::create_dir_all(&identity_dir)
-                .map_err(|err| IdentityError::CreateIdentityDirectoryFailed(identity_dir, err))?;
+            dfx_core::fs::create_dir_all(&identity_dir).map_err(CreateIdentityDirectoryFailed)?;
         }
 
         let maybe_creds_pem_path = get_legacy_creds_pem_path()?;


### PR DESCRIPTION
# Description

Adds the `dfx_core::io::IoError` error type, which wraps `std::io::Error` adding `PathBuf`, and makes enum variants in `IdentityError` use it.

Later PRs will refactor `anyhow` and `context` messages to use new concrete error types and add more kinds of `IoError` variants.

# How Has This Been Tested?

Covered by CI
