### PR TITLE
refactor: pem_safekeeping.write_pem_to_file to return concrete error type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,8 @@ dependencies = [
 name = "dfx-core"
 version = "0.0.1"
 dependencies = [
+ "aes-gcm",
+ "argon2",
  "ic-agent",
  "thiserror",
 ]

--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -5,5 +5,7 @@ authors = ["DFINITY Team"]
 edition = "2021"
 
 [dependencies]
+aes-gcm = "0.9.4"
+argon2 = "0.4.0"
 ic-agent = { version = "0.23.0", features = ["reqwest"] }
 thiserror = "1.0.20"

--- a/src/dfx-core/src/error/encryption.rs
+++ b/src/dfx-core/src/error/encryption.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum EncryptionError {
+    #[error("Failed to encrypt content: {0}")]
+    EncryptContentFailed(aes_gcm::Error),
+
+    #[error("Failed to hash password: {0}")]
+    HashPasswordFailed(argon2::password_hash::Error),
+
+    #[error("Failed to read user input: {0}")]
+    ReadUserPasswordFailed(std::io::Error),
+}

--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -1,6 +1,8 @@
 use crate::error::io::IoError;
 
+use crate::error::encryption::EncryptionError;
 use ic_agent::identity::PemError;
+
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -17,6 +19,9 @@ pub enum IdentityError {
 
     #[error("Cannot create identity directory: {0}")]
     CreateIdentityDirectoryFailed(IoError),
+
+    #[error("Cannot encrypt PEM file: {0}")]
+    EncryptPemFileFailed(PathBuf, EncryptionError),
 
     #[error("Identity already exists.")]
     IdentityAlreadyExists(),
@@ -35,4 +40,7 @@ pub enum IdentityError {
 
     #[error("An Identity named {0} cannot be created as it is reserved for internal use.")]
     ReservedIdentityName(String),
+
+    #[error("Cannot write PEM file: {0}")]
+    WritePemFileFailed(IoError),
 }

--- a/src/dfx-core/src/error/io.rs
+++ b/src/dfx-core/src/error/io.rs
@@ -6,6 +6,18 @@ pub enum IoError {
     #[error("Failed to create {0}: {1}")]
     CreateDirectoryFailed(PathBuf, std::io::Error),
 
+    #[error("Cannot determine parent folder for {0}")]
+    NoParent(PathBuf),
+
+    #[error("Failed to read permissions of {0}: {1}")]
+    ReadPermissionsFailed(PathBuf, std::io::Error),
+
     #[error("Failed to rename {0} to {1}: {2}")]
     RenameFailed(PathBuf, PathBuf, std::io::Error),
+
+    #[error("Failed to write to {0}: {1}")]
+    WriteFileFailed(PathBuf, std::io::Error),
+
+    #[error("Failed to set permissions of {0}: {1}")]
+    WritePermissionsFailed(PathBuf, std::io::Error),
 }

--- a/src/dfx-core/src/error/mod.rs
+++ b/src/dfx-core/src/error/mod.rs
@@ -1,2 +1,3 @@
+pub mod encryption;
 pub mod identity;
 pub mod io;

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -1,12 +1,39 @@
 use crate::error::io::IoError;
-use crate::error::io::IoError::{CreateDirectoryFailed, RenameFailed};
+use crate::error::io::IoError::{
+    CreateDirectoryFailed, ReadPermissionsFailed, RenameFailed, WriteFileFailed,
+    WritePermissionsFailed,
+};
 
-use std::path::Path;
+use std::fs::Permissions;
+use std::path::{Path, PathBuf};
 
 pub fn create_dir_all(path: &Path) -> Result<(), IoError> {
     std::fs::create_dir_all(path).map_err(|err| CreateDirectoryFailed(path.to_path_buf(), err))
 }
 
+pub fn parent(path: &Path) -> Result<PathBuf, IoError> {
+    match path.parent() {
+        None => Err(IoError::NoParent(path.to_path_buf())),
+        Some(parent) => Ok(parent.to_path_buf()),
+    }
+}
+
 pub fn rename(from: &Path, to: &Path) -> Result<(), IoError> {
     std::fs::rename(from, to).map_err(|err| RenameFailed(from.to_path_buf(), to.to_path_buf(), err))
+}
+
+pub fn read_permissions(path: &Path) -> Result<Permissions, IoError> {
+    std::fs::metadata(path)
+        .map_err(|err| ReadPermissionsFailed(path.to_path_buf(), err))
+        .map(|x| x.permissions())
+}
+
+pub fn set_permissions(path: &Path, permissions: Permissions) -> Result<(), IoError> {
+    std::fs::set_permissions(path, permissions)
+        .map_err(|err| WritePermissionsFailed(path.to_path_buf(), err))
+}
+
+pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<(), IoError> {
+    std::fs::write(path.as_ref(), contents)
+        .map_err(|err| WriteFileFailed(path.as_ref().to_path_buf(), err))
 }

--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -5,14 +5,14 @@ use crate::lib::identity::{
     pem_safekeeping, Identity as DfxIdentity, ANONYMOUS_IDENTITY_NAME, IDENTITY_JSON, IDENTITY_PEM,
     IDENTITY_PEM_ENCRYPTED, TEMP_IDENTITY_PREFIX,
 };
+use dfx_core::error::identity::IdentityError::{
+    CreateIdentityDirectoryFailed, RenameIdentityDirectoryFailed,
+};
 
 use anyhow::{anyhow, bail, Context};
 use bip32::XPrv;
 use bip39::{Language, Mnemonic, MnemonicType, Seed};
 use candid::Principal;
-use dfx_core::error::identity::IdentityError::{
-    CreateIdentityDirectoryFailed, RenameIdentityDirectoryFailed,
-};
 use fn_error_context::context;
 use k256::pkcs8::LineEnding;
 use k256::SecretKey;


### PR DESCRIPTION
# Description

Continuing remove dependencies on the DfxError, DfxResult, and `anyhow` types in preparation for moving the identity manager to a separate crate.

# How Has This Been Tested?

Covered by CI