### PR TITLE
feat: add dfx autocomplete command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +844,7 @@ dependencies = [
  "bytes",
  "candid",
  "clap",
+ "clap_complete",
  "console",
  "crc32fast",
  "crossbeam",

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -33,6 +33,7 @@ byte-unit = { version = "4.0.14", features = ["serde"] }
 bytes = "1.2.1"
 candid = { version = "0.8.2", features = [ "random" ] }
 clap = { version = "3.1.6", features = [ "derive" ] }
+clap_complete = "3.2.5"
 console = "0.15.0"
 crc32fast = "1.3.2"
 crossbeam = "0.8.1"

--- a/src/dfx/src/commands/beta/generate_autocompletion_script.rs
+++ b/src/dfx/src/commands/beta/generate_autocompletion_script.rs
@@ -1,0 +1,44 @@
+use crate::lib::error::DfxResult;
+use crate::CliOpts;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use clap::CommandFactory;
+use clap::Parser;
+use clap_complete::generate;
+use clap_complete::Shell;
+
+/// Generate a shell autocompletion script.
+#[derive(Parser)]
+pub struct AutocompleteOpts {
+    /// The shell for which to generate autocomplete scripts
+    #[clap(long, default_value("bash"))]
+    shell: Shell,
+
+    /// The name of the binary
+    #[clap(long, default_value("dfx"))]
+    bin_name: String,
+
+    #[clap(name = "OUTPUT_FILE", parse(from_os_str), default_value("-"))]
+    output_file: PathBuf,
+}
+
+pub fn exec(opts: AutocompleteOpts) -> DfxResult {
+    let mut output: Box<dyn Write> =
+        if opts.output_file == PathBuf::from("-") {
+            Box::new(std::io::stdout())
+        } else {
+            Box::new(File::create(&opts.output_file).with_context(|| {
+                format!("Unable to open {} for output", opts.output_file.display())
+            })?)
+        };
+    generate(
+        opts.shell,
+        &mut CliOpts::command(),
+        opts.bin_name,
+        &mut *output,
+    );
+    Ok(())
+}

--- a/src/dfx/src/commands/beta/mod.rs
+++ b/src/dfx/src/commands/beta/mod.rs
@@ -3,6 +3,7 @@ use crate::Environment;
 
 use clap::Parser;
 
+mod generate_autocompletion_script;
 mod project;
 
 /// Beta commands.
@@ -15,11 +16,13 @@ pub struct BetaOpts {
 
 #[derive(Parser)]
 enum SubCommand {
+    GenerateAutocompletionScript(generate_autocompletion_script::AutocompleteOpts),
     Project(project::ProjectOpts),
 }
 
 pub fn exec(env: &dyn Environment, cmd: BetaOpts) -> DfxResult {
     match cmd.subcmd {
+        SubCommand::GenerateAutocompletionScript(v) => generate_autocompletion_script::exec(v),
         SubCommand::Project(v) => project::exec(env, v),
     }
 }


### PR DESCRIPTION
# Description

Adds `dfx beta generate-autocompletion-script`. By default generates a bash script, but can generate scripts for zsh, fish, elvish, and powershell with the `--shell` parameter.

Of the features listed in SDK-599, it does the following, replacing "most similar to" with "that starts with":
> As a user begins typing a command a dfx command and then presses the tab key, the command most similar to the phrase that is being typed should auto-complete. This should work for flags as well if possible.

It does not do this, and I do not foresee a path that would provide for it:
>  If there is no phrase that is currently being typed, dfx should autocomplete with the most recently used command.

See https://dfinity.atlassian.net/browse/SDK-599

# How Has This Been Tested?

I've tested this with zsh on OSX, using the bash script output, and it seems to work:

```
    $ dfx beta generate-autocompletion-script >x.sh
    $ source x.sh
    $ dfx can<tab>
```
I tried the `--shell zsh` output and went through some steps to configure zsh to use that, without success.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
