### PR TITLE
refactor: identity manager load/save configuration concrete error types

### DIFF
--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -33,6 +33,9 @@ pub enum IdentityError {
     #[error("Failed to load configuration for identity '{0}': {1}")]
     LoadIdentityConfigurationFailed(String, StructuredFileError),
 
+    #[error("Failed to load identity manager configuration: {0}")]
+    LoadIdentityManagerConfigurationFailed(StructuredFileError),
+
     #[error("Cannot find home directory (no HOME environment variable).")]
     NoHomeInEnvironment(),
 
@@ -44,6 +47,9 @@ pub enum IdentityError {
 
     #[error("An Identity named {0} cannot be created as it is reserved for internal use.")]
     ReservedIdentityName(String),
+
+    #[error("Failed to save identity manager configuration: {0}")]
+    SaveIdentityManagerConfigurationFailed(StructuredFileError),
 
     #[error("Cannot write PEM file: {0}")]
     WritePemFileFailed(IoError),

--- a/src/dfx-core/src/error/structured_file.rs
+++ b/src/dfx-core/src/error/structured_file.rs
@@ -9,4 +9,10 @@ pub enum StructuredFileError {
 
     #[error("Failed to read JSON file: {0}")]
     ReadJsonFileFailed(IoError),
+
+    #[error("Failed to serialize JSON to {0}: {1}")]
+    SerializeJsonFileFailed(PathBuf, serde_json::Error),
+
+    #[error("Failed to write JSON file: {0}")]
+    WriteJsonFileFailed(IoError),
 }

--- a/src/dfx-core/src/json/mod.rs
+++ b/src/dfx-core/src/json/mod.rs
@@ -1,7 +1,10 @@
 use crate::error::structured_file::StructuredFileError;
-use crate::error::structured_file::StructuredFileError::DeserializeJsonFileFailed;
 use crate::error::structured_file::StructuredFileError::ReadJsonFileFailed;
+use crate::error::structured_file::StructuredFileError::{
+    DeserializeJsonFileFailed, SerializeJsonFileFailed, WriteJsonFileFailed,
+};
 
+use serde::Serialize;
 use std::path::Path;
 
 pub fn load_json_file<T: for<'a> serde::de::Deserialize<'a>>(
@@ -11,4 +14,10 @@ pub fn load_json_file<T: for<'a> serde::de::Deserialize<'a>>(
 
     serde_json::from_slice(content.as_ref())
         .map_err(|err| DeserializeJsonFileFailed(path.to_path_buf(), err))
+}
+
+pub fn save_json_file<T: Serialize>(path: &Path, value: &T) -> Result<(), StructuredFileError> {
+    let content = serde_json::to_string_pretty(&value)
+        .map_err(|err| SerializeJsonFileFailed(path.to_path_buf(), err))?;
+    crate::fs::write(path, content).map_err(WriteJsonFileFailed)
 }


### PR DESCRIPTION
# Description

Replacing more `anyhow` usage with concrete error types.

Part of https://dfinity.atlassian.net/browse/SDK-892

# How Has This Been Tested?

Covered by CI.
