### PR TITLE
fix: creating an identity with `--force` no longer switches to the ne…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### fix: fixed error text
 - `dfx nns install` had the wrong instructions for setting up the local replica type
 
+### fix: creating an identity with `--force` no longer switches to the newly created identity
+
 ### feat(frontend-canister)!: default secure configuration for assets in frontend project template
 
 - Secure HTTP headers, preventing several typical security vulnerabilities (e.g. XSS, clickjacking, and many more). For more details, see comments in `headers` section in [default `.ic-assets.json5`](https://raw.githubusercontent.com/dfinity/sdk/master/src/dfx/assets/new_project_node_files/src/__project_name___frontend/src/.ic-assets.json5). 

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -114,6 +114,15 @@ frank'
     assert_neq "$PRINCIPAL_1" "$PRINCIPAL_2"
 }
 
+@test "identity new: --force does not switch to created identity" {
+    # Was a bug: https://dfinity.atlassian.net/browse/SDK-911
+    assert_command dfx identity new --force alice
+    PRINCIPAL_ORIGINAL="$(dfx identity get-principal)"
+    assert_command dfx identity use alice
+    PRINCIPAL_ALICE="$(dfx identity get-principal)"
+    assert_neq "$PRINCIPAL_ORIGINAL" "$PRINCIPAL_ALICE"
+}
+
 @test "identity new: create an HSM-backed identity" {
     assert_command dfx identity new --hsm-pkcs11-lib-path /something/else/somewhere.so --hsm-key-id abcd4321 bob
     assert_command jq -r .hsm.pkcs11_lib_path "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.json"

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -85,7 +85,7 @@ impl Identity {
         force: bool,
     ) -> DfxResult {
         trace!(log, "Creating identity '{name}'.");
-        let identity_in_use = name;
+        let identity_in_use = manager.get_selected_identity_name().clone();
         // cannot delete an identity in use. Use anonymous identity temporarily if we force-overwrite the identity currently in use
         let temporarily_use_anonymous_identity = identity_in_use == name && force;
 
@@ -225,7 +225,7 @@ impl Identity {
         })?;
 
         if temporarily_use_anonymous_identity {
-            manager.use_identity_named(log, identity_in_use)
+            manager.use_identity_named(log, &identity_in_use)
                 .with_context(||format!("Failed to switch back over to the identity you're replacing. Please run 'dfx identity use {}' to do it manually.", name))?;
         }
         Ok(())


### PR DESCRIPTION
…wly created identity

# Description

#2141 introduced a special case to temporarily switch to the anonymous identity if the currently selected identity gets re-created with `dfx identity new --force`. The logic to switch to `anonymous` and back to the newly created identity mistakenly triggers every time. `dfx identity new --force` isn’t supposed to automatically switch to the newly created identity.

Fixes [SDK-911](https://dfinity.atlassian.net/browse/SDK-911)

# How Has This Been Tested?

Added e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-911]: https://dfinity.atlassian.net/browse/SDK-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ