### PR TITLE
refactor: IdentityManager::use_identity_named to use concrete types

### DIFF
--- a/src/dfx/src/commands/identity/use.rs
+++ b/src/dfx/src/commands/identity/use.rs
@@ -1,5 +1,5 @@
 use crate::lib::environment::Environment;
-use crate::lib::error::DfxResult;
+use crate::lib::error::{DfxError, DfxResult};
 use crate::lib::identity::identity_manager::IdentityManager;
 
 use clap::Parser;
@@ -18,5 +18,7 @@ pub fn exec(env: &dyn Environment, opts: UseOpts) -> DfxResult {
     let log = env.get_logger();
     info!(log, r#"Using identity: "{}"."#, identity);
 
-    IdentityManager::new(env)?.use_identity_named(log, identity)
+    IdentityManager::new(env)?
+        .use_identity_named(log, identity)
+        .map_err(DfxError::new)
 }


### PR DESCRIPTION
# Description

Changed IdentityManager::use_identity_named and a few methods that it calls to return std::Result rather than anyhow

# How Has This Been Tested?

Covered by CI