### PR TITLE
refactor: concrete error types for IdentityManager::remove

### DIFF
--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -1,7 +1,9 @@
 use crate::error::encryption::EncryptionError;
 use crate::error::foundation::FoundationError;
 use crate::error::io::IoError;
+use crate::error::keyring::KeyringError;
 use crate::error::structured_file::StructuredFileError;
+use crate::error::wallet_config::WalletConfigError;
 
 use ic_agent::identity::PemError;
 
@@ -24,6 +26,12 @@ pub enum IdentityError {
 
     #[error("Failed to derive extended secret key from path: {0}")]
     DeriveExtendedKeyFromPathFailed(bip32::Error),
+
+    #[error("Failed to display linked wallets: {0}")]
+    DisplayLinkedWalletsFailed(WalletConfigError),
+
+    #[error("If you want to remove an identity with configured wallets, please use the --drop-wallets flag.")]
+    DropWalletsFlagRequiredToRemoveIdentityWithWallets(),
 
     #[error("Cannot encrypt PEM file: {0}")]
     EncryptPemFileFailed(PathBuf, EncryptionError),
@@ -51,6 +59,15 @@ pub enum IdentityError {
 
     #[error("Cannot read identity file '{0}': {1:#}")]
     ReadIdentityFileFailed(String, PemError),
+
+    #[error("Failed to remove identity directory: {0}")]
+    RemoveIdentityDirectoryFailed(IoError),
+
+    #[error("Failed to remove identity from keyring: {0}")]
+    RemoveIdentityFromKeyringFailed(KeyringError),
+
+    #[error("Failed to remove identity file: {0}")]
+    RemoveIdentityFileFailed(IoError),
 
     #[error("Cannot rename identity directory: {0}")]
     RenameIdentityDirectoryFailed(IoError),

--- a/src/dfx-core/src/error/io.rs
+++ b/src/dfx-core/src/error/io.rs
@@ -18,6 +18,12 @@ pub enum IoError {
     #[error("Failed to read permissions of {0}: {1}")]
     ReadPermissionsFailed(PathBuf, std::io::Error),
 
+    #[error("Failed to remove directory {0}: {1}")]
+    RemoveDirectoryFailed(PathBuf, std::io::Error),
+
+    #[error("Failed to remove file {0}: {1}")]
+    RemoveFileFailed(PathBuf, std::io::Error),
+
     #[error("Failed to rename {0} to {1}: {2}")]
     RenameFailed(PathBuf, PathBuf, std::io::Error),
 

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -36,6 +36,14 @@ pub fn read_permissions(path: &Path) -> Result<Permissions, IoError> {
         .map(|x| x.permissions())
 }
 
+pub fn remove_dir(path: &Path) -> Result<(), IoError> {
+    std::fs::remove_dir(path).map_err(|err| IoError::RemoveDirectoryFailed(path.to_path_buf(), err))
+}
+
+pub fn remove_file(path: &Path) -> Result<(), IoError> {
+    std::fs::remove_file(path).map_err(|err| IoError::RemoveFileFailed(path.to_path_buf(), err))
+}
+
 pub fn set_permissions(path: &Path, permissions: Permissions) -> Result<(), IoError> {
     std::fs::set_permissions(path, permissions)
         .map_err(|err| WritePermissionsFailed(path.to_path_buf(), err))


### PR DESCRIPTION
# Description

Preparation to move code to the dfx-core crate.

# How Has This Been Tested?

Covered by CI.