### PR TITLE
refactor: IoError is box wrapper for IoErrorKind

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,10 +59,6 @@ jobs:
         if: contains(matrix.os, 'macos')
       - name: Build
         run: |
-          set -x
-          git status
-          git log -4
-          cat src/dfx-core/src/fs/mod.rs
           cargo build --target ${{ matrix.target }} --locked --release
       - name: Strip binaries
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,6 +59,10 @@ jobs:
         if: contains(matrix.os, 'macos')
       - name: Build
         run: |
+          set -x
+          git status
+          git log -4
+          cat src/dfx-core/src/fs/mod.rs
           cargo build --target ${{ matrix.target }} --locked --release
       - name: Strip binaries
         run: |

--- a/src/dfx-core/src/error/io.rs
+++ b/src/dfx-core/src/error/io.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum IoError {
+pub enum IoErrorKind {
     #[error("Failed to copy {0} to {1}: {2}")]
-    CopyFileFailed(PathBuf, PathBuf, std::io::Error),
+    CopyFileFailed(Box<PathBuf>, Box<PathBuf>, std::io::Error),
 
     #[error("Failed to create {0}: {1}")]
     CreateDirectoryFailed(PathBuf, std::io::Error),
@@ -19,11 +19,30 @@ pub enum IoError {
     ReadPermissionsFailed(PathBuf, std::io::Error),
 
     #[error("Failed to rename {0} to {1}: {2}")]
-    RenameFailed(PathBuf, PathBuf, std::io::Error),
+    RenameFailed(Box<PathBuf>, Box<PathBuf>, std::io::Error),
 
     #[error("Failed to write to {0}: {1}")]
     WriteFileFailed(PathBuf, std::io::Error),
 
     #[error("Failed to set permissions of {0}: {1}")]
     WritePermissionsFailed(PathBuf, std::io::Error),
+}
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub struct IoError(pub Box<IoErrorKind>);
+
+impl IoError {
+    pub fn new(kind: IoErrorKind) -> Self {
+        IoError(Box::new(kind))
+    }
+}
+
+impl<E> From<E> for IoError
+where
+    IoErrorKind: From<E>,
+{
+    fn from(err: E) -> Self {
+        IoError(Box::new(IoErrorKind::from(err)))
+    }
 }

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -2,7 +2,7 @@ use crate::error::io::IoError;
 
 use crate::error::io::IoErrorKind::{
     CopyFileFailed, CreateDirectoryFailed, NoParent, ReadFileFailed, ReadPermissionsFailed,
-    RenameFailed, WriteFileFailed, WritePermissionsFailed,
+    RemoveDirectoryFailed, RemoveFileFailed, RenameFailed, WriteFileFailed, WritePermissionsFailed,
 };
 use std::fs::Permissions;
 use std::path::{Path, PathBuf};
@@ -50,11 +50,13 @@ pub fn read_permissions(path: &Path) -> Result<Permissions, IoError> {
 }
 
 pub fn remove_dir(path: &Path) -> Result<(), IoError> {
-    std::fs::remove_dir(path).map_err(|err| IoError::RemoveDirectoryFailed(path.to_path_buf(), err))
+    std::fs::remove_dir(path)
+        .map_err(|err| IoError::new(RemoveDirectoryFailed(path.to_path_buf(), err)))
 }
 
 pub fn remove_file(path: &Path) -> Result<(), IoError> {
-    std::fs::remove_file(path).map_err(|err| IoError::RemoveFileFailed(path.to_path_buf(), err))
+    std::fs::remove_file(path)
+        .map_err(|err| IoError::new(RemoveFileFailed(path.to_path_buf(), err)))
 }
 
 pub fn set_permissions(path: &Path, permissions: Permissions) -> Result<(), IoError> {

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -1,47 +1,60 @@
 use crate::error::io::IoError;
 
-use crate::error::io::IoError::{
-    CopyFileFailed, CreateDirectoryFailed, ReadFileFailed, ReadPermissionsFailed, RenameFailed,
-    WriteFileFailed, WritePermissionsFailed,
+use crate::error::io::IoErrorKind::{
+    CopyFileFailed, CreateDirectoryFailed, NoParent, ReadFileFailed, ReadPermissionsFailed,
+    RenameFailed, WriteFileFailed, WritePermissionsFailed,
 };
 use std::fs::Permissions;
 use std::path::{Path, PathBuf};
 
 pub fn copy(from: &Path, to: &Path) -> Result<u64, IoError> {
-    std::fs::copy(from, to).map_err(|err| CopyFileFailed(from.to_path_buf(), to.to_path_buf(), err))
+    std::fs::copy(from, to).map_err(|err| {
+        IoError::new(CopyFileFailed(
+            Box::new(from.to_path_buf()),
+            Box::new(to.to_path_buf()),
+            err,
+        ))
+    })
 }
 
 pub fn create_dir_all(path: &Path) -> Result<(), IoError> {
-    std::fs::create_dir_all(path).map_err(|err| CreateDirectoryFailed(path.to_path_buf(), err))
+    std::fs::create_dir_all(path)
+        .map_err(|err| IoError::new(CreateDirectoryFailed(path.to_path_buf(), err)))
 }
 
 pub fn parent(path: &Path) -> Result<PathBuf, IoError> {
     match path.parent() {
-        None => Err(IoError::NoParent(path.to_path_buf())),
+        None => Err(IoError::new(NoParent(path.to_path_buf()))),
         Some(parent) => Ok(parent.to_path_buf()),
     }
 }
 
 pub fn read(path: &Path) -> Result<Vec<u8>, IoError> {
-    std::fs::read(path).map_err(|err| ReadFileFailed(path.to_path_buf(), err))
+    std::fs::read(path).map_err(|err| IoError::new(ReadFileFailed(path.to_path_buf(), err)))
 }
 
 pub fn rename(from: &Path, to: &Path) -> Result<(), IoError> {
-    std::fs::rename(from, to).map_err(|err| RenameFailed(from.to_path_buf(), to.to_path_buf(), err))
+    std::fs::rename(from, to).map_err(|err| {
+        IoError::new(RenameFailed(
+            Box::new(from.to_path_buf()),
+            Box::new(to.to_path_buf()),
+            err,
+        ))
+    })
 }
 
 pub fn read_permissions(path: &Path) -> Result<Permissions, IoError> {
     std::fs::metadata(path)
-        .map_err(|err| ReadPermissionsFailed(path.to_path_buf(), err))
+        .map_err(|err| IoError::new(ReadPermissionsFailed(path.to_path_buf(), err)))
         .map(|x| x.permissions())
 }
 
 pub fn set_permissions(path: &Path, permissions: Permissions) -> Result<(), IoError> {
     std::fs::set_permissions(path, permissions)
-        .map_err(|err| WritePermissionsFailed(path.to_path_buf(), err))
+        .map_err(|err| IoError::new(WritePermissionsFailed(path.to_path_buf(), err)))
 }
 
 pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<(), IoError> {
     std::fs::write(path.as_ref(), contents)
-        .map_err(|err| WriteFileFailed(path.as_ref().to_path_buf(), err))
+        .map_err(|err| IoError::new(WriteFileFailed(path.as_ref().to_path_buf(), err)))
 }


### PR DESCRIPTION
# Description

Started to run into clippy warnings about error types being too large, so taking steps to reduce.  Application code doesn't generally match on the types of IO errors, so it shouldn't be a burden to unbox when necessary.

# How Has This Been Tested?

```
$ chmod u-w ~/.config/dfx/identity.json
$ dfx-r identity use alice
Error: Failed to save identity manager configuration: Failed to write JSON file: Failed to write to /Users/ericswanson/.config/dfx/identity.json: Permission denied (os error 13)
```