### PR TITLE
refactor: Box some fields in error types

### DIFF
--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -37,7 +37,7 @@ pub enum IdentityError {
     EncryptPemFileFailed(PathBuf, EncryptionError),
 
     #[error("Failed to generate a fresh secp256k1 key: {0}")]
-    GenerateFreshSecp256k1KeyFailed(sec1::Error),
+    GenerateFreshSecp256k1KeyFailed(Box<sec1::Error>),
 
     #[error("Failed to get legacy pem path: {0}")]
     GetLegacyPemPathFailed(FoundationError),

--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -58,7 +58,7 @@ pub enum IdentityError {
     MigrateLegacyIdentityFailed(IoError),
 
     #[error("Cannot read identity file '{0}': {1:#}")]
-    ReadIdentityFileFailed(String, PemError),
+    ReadIdentityFileFailed(String, Box<PemError>),
 
     #[error("Failed to remove identity directory: {0}")]
     RemoveIdentityDirectoryFailed(IoError),

--- a/src/dfx-core/src/error/structured_file.rs
+++ b/src/dfx-core/src/error/structured_file.rs
@@ -5,13 +5,13 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum StructuredFileError {
     #[error("Failed to parse contents of {0} as json: {1}")]
-    DeserializeJsonFileFailed(PathBuf, serde_json::Error),
+    DeserializeJsonFileFailed(Box<PathBuf>, serde_json::Error),
 
     #[error("Failed to read JSON file: {0}")]
     ReadJsonFileFailed(IoError),
 
     #[error("Failed to serialize JSON to {0}: {1}")]
-    SerializeJsonFileFailed(PathBuf, serde_json::Error),
+    SerializeJsonFileFailed(Box<PathBuf>, serde_json::Error),
 
     #[error("Failed to write JSON file: {0}")]
     WriteJsonFileFailed(IoError),

--- a/src/dfx-core/src/json/mod.rs
+++ b/src/dfx-core/src/json/mod.rs
@@ -13,11 +13,11 @@ pub fn load_json_file<T: for<'a> serde::de::Deserialize<'a>>(
     let content = crate::fs::read(path).map_err(ReadJsonFileFailed)?;
 
     serde_json::from_slice(content.as_ref())
-        .map_err(|err| DeserializeJsonFileFailed(path.to_path_buf(), err))
+        .map_err(|err| DeserializeJsonFileFailed(Box::new(path.to_path_buf()), err))
 }
 
 pub fn save_json_file<T: Serialize>(path: &Path, value: &T) -> Result<(), StructuredFileError> {
     let content = serde_json::to_string_pretty(&value)
-        .map_err(|err| SerializeJsonFileFailed(path.to_path_buf(), err))?;
+        .map_err(|err| SerializeJsonFileFailed(Box::new(path.to_path_buf()), err))?;
     crate::fs::write(path, content).map_err(WriteJsonFileFailed)
 }

--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -636,7 +636,7 @@ pub(super) fn generate_key() -> Result<(Vec<u8>, Mnemonic), IdentityError> {
     let secret = mnemonic_to_key(&mnemonic)?;
     let pem = secret
         .to_sec1_pem(LineEnding::CRLF)
-        .map_err(IdentityError::GenerateFreshSecp256k1KeyFailed)?;
+        .map_err(|e| IdentityError::GenerateFreshSecp256k1KeyFailed(Box::new(e)))?;
     Ok((pem.as_bytes().to_vec(), mnemonic))
 }
 

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -243,7 +243,7 @@ impl Identity {
     fn basic(name: &str, pem_content: &[u8], was_encrypted: bool) -> DfxResult<Self> {
         let inner = Box::new(
             BasicIdentity::from_pem(pem_content)
-                .map_err(|e| IdentityError::ReadIdentityFileFailed(name.into(), e))?,
+                .map_err(|e| IdentityError::ReadIdentityFileFailed(name.into(), Box::new(e)))?,
         );
 
         Ok(Self {
@@ -256,7 +256,7 @@ impl Identity {
     fn secp256k1(name: &str, pem_content: &[u8], was_encrypted: bool) -> DfxResult<Self> {
         let inner = Box::new(
             Secp256k1Identity::from_pem(pem_content)
-                .map_err(|e| IdentityError::ReadIdentityFileFailed(name.into(), e))?,
+                .map_err(|e| IdentityError::ReadIdentityFileFailed(name.into(), Box::new(e)))?,
         );
 
         Ok(Self {


### PR DESCRIPTION
# Description

The size of the IdentityError type was approaching the default limits for clippy warnings about error types being too large.  This PR boxes some data on the critical "path", reducing the size (as measured on darwin build) from 96 bytes to 56 bytes, which is less than half of the default limit.

# How Has This Been Tested?

Covered by CI