### PR TITLE
refactor: move wallet canister creation methods to wallet.rs

### DIFF
--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -2,13 +2,13 @@ use crate::lib::diagnosis::DiagnosedError;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::identity::identity_utils::CallSender;
-use crate::lib::identity::Identity;
 use crate::lib::models::canister_id_store::CanisterIdStore;
 use crate::lib::operations::canister::get_local_cid_and_candid_path;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::util::clap::validators::{cycle_amount_validator, file_or_stdin_validator};
 use crate::util::{arguments_from_file, blob_from_arguments, get_candid_type, print_idl_blob};
 
+use crate::lib::identity::wallet::build_wallet_canister;
 use anyhow::{anyhow, Context};
 use candid::Principal as CanisterId;
 use candid::{CandidType, Decode, Deserialize, Principal};
@@ -301,7 +301,7 @@ pub async fn exec(
                     .context("Failed query call.")?
             }
             CallSender::Wallet(wallet_id) => {
-                let wallet = Identity::build_wallet_canister(*wallet_id, env).await?;
+                let wallet = build_wallet_canister(*wallet_id, env).await?;
                 do_wallet_call(
                     &wallet,
                     &CallIn {
@@ -334,7 +334,7 @@ pub async fn exec(
                     .context("Failed update call.")?
             }
             CallSender::Wallet(wallet_id) => {
-                let wallet = Identity::build_wallet_canister(*wallet_id, env).await?;
+                let wallet = build_wallet_canister(*wallet_id, env).await?;
                 let mut args = Argument::default();
                 args.set_raw_arg(arg_value);
 
@@ -363,7 +363,7 @@ pub async fn exec(
                     .context("Failed update call.")?
             }
             CallSender::Wallet(wallet_id) => {
-                let wallet = Identity::build_wallet_canister(*wallet_id, env).await?;
+                let wallet = build_wallet_canister(*wallet_id, env).await?;
                 do_wallet_call(
                     &wallet,
                     &CallIn {

--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -5,7 +5,6 @@ use crate::lib::ic_attributes::{
 };
 use crate::lib::identity::identity_manager::IdentityManager;
 use crate::lib::identity::identity_utils::CallSender;
-use crate::lib::identity::Identity;
 use crate::lib::operations::canister::create_canister;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::util::clap::validators::cycle_amount_validator;
@@ -13,6 +12,7 @@ use crate::util::clap::validators::{
     compute_allocation_validator, freezing_threshold_validator, memory_allocation_validator,
 };
 
+use crate::lib::identity::wallet::get_or_create_wallet_canister;
 use anyhow::{anyhow, bail, Context};
 use candid::Principal as CanisterId;
 use clap::Parser;
@@ -76,7 +76,7 @@ pub async fn exec(
 
     let proxy_sender;
     if !opts.no_wallet && !matches!(call_sender, CallSender::Wallet(_)) {
-        let wallet = Identity::get_or_create_wallet_canister(
+        let wallet = get_or_create_wallet_canister(
             env,
             env.get_network_descriptor(),
             env.get_selected_identity().expect("No selected identity"),

--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -20,6 +20,7 @@ use ic_utils::interfaces::management_canister::attributes::{
 use ic_utils::interfaces::management_canister::CanisterStatus;
 use ic_utils::Argument;
 
+use crate::lib::identity::wallet::build_wallet_canister;
 use anyhow::{anyhow, Context};
 use candid::Principal;
 use clap::Parser;
@@ -208,7 +209,7 @@ async fn delete_canister(
                             cycles_to_withdraw,
                             dank_target_principal
                         );
-                        let wallet = Identity::build_wallet_canister(canister_id, env).await?;
+                        let wallet = build_wallet_canister(canister_id, env).await?;
                         let opt_principal = Some(dank_target_principal);
                         wallet
                             .call(

--- a/src/dfx/src/commands/canister/deposit_cycles.rs
+++ b/src/dfx/src/commands/canister/deposit_cycles.rs
@@ -1,11 +1,12 @@
+use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::identity::identity_utils::CallSender;
 use crate::lib::models::canister_id_store::CanisterIdStore;
 use crate::lib::operations::canister;
 use crate::lib::root_key::fetch_root_key_if_needed;
-use crate::lib::{environment::Environment, identity::Identity};
 use crate::util::clap::validators::cycle_amount_validator;
 
+use crate::lib::identity::wallet::get_or_create_wallet_canister;
 use anyhow::Context;
 use candid::Principal;
 use clap::Parser;
@@ -65,7 +66,7 @@ pub async fn exec(
 
     // choose default wallet if no wallet is specified
     if call_sender == &CallSender::SelectedId {
-        let wallet = Identity::get_or_create_wallet_canister(
+        let wallet = get_or_create_wallet_canister(
             env,
             env.get_network_descriptor(),
             env.get_selected_identity().expect("No selected identity"),

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -3,12 +3,13 @@ use crate::lib::identity::identity_utils::{call_sender, CallSender};
 use crate::lib::operations::canister::deploy_canisters;
 use crate::lib::provider::create_agent_environment;
 use crate::lib::root_key::fetch_root_key_if_needed;
-use crate::lib::{environment::Environment, identity::Identity, named_canister};
+use crate::lib::{environment::Environment, named_canister};
 use crate::util::clap::validators::cycle_amount_validator;
 use crate::NetworkOpt;
 use std::collections::BTreeMap;
 
 use crate::lib::canister_info::CanisterInfo;
+use crate::lib::identity::wallet::get_or_create_wallet_canister;
 use crate::lib::models::canister_id_store::CanisterIdStore;
 use crate::lib::network::network_descriptor::NetworkDescriptor;
 use anyhow::{anyhow, bail, Context};
@@ -109,7 +110,7 @@ pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
     let call_sender = runtime.block_on(call_sender(&env, &opts.wallet))?;
     let proxy_sender;
     let create_call_sender = if !opts.no_wallet && !matches!(call_sender, CallSender::Wallet(_)) {
-        let wallet = runtime.block_on(Identity::get_or_create_wallet_canister(
+        let wallet = runtime.block_on(get_or_create_wallet_canister(
             &env,
             env.get_network_descriptor(),
             env.get_selected_identity().expect("No selected identity"),

--- a/src/dfx/src/commands/identity/deploy_wallet.rs
+++ b/src/dfx/src/commands/identity/deploy_wallet.rs
@@ -1,9 +1,9 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::Identity;
 use crate::lib::provider::create_agent_environment;
 use crate::lib::root_key::fetch_root_key_if_needed;
 
+use crate::lib::identity::wallet::create_wallet;
 use anyhow::bail;
 use candid::Principal as CanisterId;
 use clap::Parser;
@@ -32,7 +32,7 @@ pub fn exec(env: &dyn Environment, opts: DeployWalletOpts, network: Option<Strin
     match CanisterId::from_text(&canister_id) {
         Ok(id) => {
             runtime.block_on(async {
-                Identity::create_wallet(&agent_env, network, &identity_name, Some(id)).await?;
+                create_wallet(&agent_env, network, &identity_name, Some(id)).await?;
                 DfxResult::Ok(())
             })?;
         }

--- a/src/dfx/src/commands/identity/get_wallet.rs
+++ b/src/dfx/src/commands/identity/get_wallet.rs
@@ -1,9 +1,9 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::Identity;
 use crate::lib::provider::create_agent_environment;
 use crate::lib::root_key::fetch_root_key_if_needed;
 
+use crate::lib::identity::wallet::get_or_create_wallet;
 use clap::Parser;
 use tokio::runtime::Runtime;
 
@@ -26,7 +26,7 @@ pub fn exec(env: &dyn Environment, _opts: GetWalletOpts, network: Option<String>
     runtime.block_on(async {
         println!(
             "{}",
-            Identity::get_or_create_wallet(&agent_env, network, &identity_name).await?
+            get_or_create_wallet(&agent_env, network, &identity_name).await?
         );
         DfxResult::Ok(())
     })?;

--- a/src/dfx/src/commands/identity/set_wallet.rs
+++ b/src/dfx/src/commands/identity/set_wallet.rs
@@ -5,6 +5,7 @@ use crate::lib::identity::Identity;
 use crate::lib::models::canister_id_store::CanisterIdStore;
 use crate::lib::provider::create_agent_environment;
 
+use crate::lib::identity::wallet::build_wallet_canister;
 use anyhow::{anyhow, Context};
 use candid::Principal;
 use clap::Parser;
@@ -70,7 +71,7 @@ pub fn exec(env: &dyn Environment, opts: SetWalletOpts, network: Option<String>)
                     "Checking availability of the canister on the network..."
                 );
 
-                let canister = Identity::build_wallet_canister(canister_id, env).await?;
+                let canister = build_wallet_canister(canister_id, env).await?;
                 let balance = canister.wallet_balance().await;
 
                 match balance {

--- a/src/dfx/src/commands/wallet/mod.rs
+++ b/src/dfx/src/commands/wallet/mod.rs
@@ -1,10 +1,10 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::Identity;
 use crate::lib::provider::create_agent_environment;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::NetworkOpt;
 
+use crate::lib::identity::wallet::get_or_create_wallet_canister;
 use anyhow::Context;
 use candid::utils::ArgumentDecoder;
 use candid::CandidType;
@@ -90,7 +90,7 @@ where
         .to_string();
     // Network descriptor will always be set.
     let network = env.get_network_descriptor();
-    let wallet = Identity::get_or_create_wallet_canister(env, network, &identity_name).await?;
+    let wallet = get_or_create_wallet_canister(env, network, &identity_name).await?;
 
     let out: O = wallet
         .query_(method)
@@ -127,6 +127,6 @@ async fn get_wallet(env: &dyn Environment) -> DfxResult<WalletCanister<'_>> {
     // Network descriptor will always be set.
     let network = env.get_network_descriptor();
     fetch_root_key_if_needed(env).await?;
-    let wallet = Identity::get_or_create_wallet_canister(env, network, &identity_name).await?;
+    let wallet = get_or_create_wallet_canister(env, network, &identity_name).await?;
     Ok(wallet)
 }

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -8,23 +8,19 @@ use crate::lib::environment::Environment;
 use crate::lib::error::{DfxResult, IdentityError};
 use crate::lib::identity::identity_manager::IdentityStorageMode;
 use crate::lib::network::network_descriptor::{NetworkDescriptor, NetworkTypeDescriptor};
-use crate::lib::root_key::fetch_root_key_if_needed;
 use dfx_core::error::wallet_config::WalletConfigError;
 use dfx_core::error::wallet_config::WalletConfigError::{
     EnsureWalletConfigDirFailed, LoadWalletConfigFailed, SaveWalletConfigFailed,
 };
 use dfx_core::json::{load_json_file, save_json_file};
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{bail, Context};
 use bip39::{Language, Mnemonic};
 use candid::Principal;
 use fn_error_context::context;
 use ic_agent::identity::{AnonymousIdentity, BasicIdentity, Secp256k1Identity};
-use ic_agent::{AgentError, Signature};
+use ic_agent::Signature;
 use ic_identity_hsm::HardwareIdentity;
-use ic_utils::call::AsyncCall;
-use ic_utils::interfaces::management_canister::builders::InstallMode;
-use ic_utils::interfaces::{ManagementCanister, WalletCanister};
 use sec1::EncodeEcPrivateKey;
 use serde::{Deserialize, Serialize};
 use slog::{debug, info, trace, Logger};
@@ -35,13 +31,12 @@ pub mod identity_manager;
 pub mod identity_utils;
 pub mod keyring_mock;
 pub mod pem_safekeeping;
-use crate::util::assets::wallet_wasm;
+pub mod wallet;
+
 pub use identity_manager::{
     HardwareIdentityConfiguration, IdentityConfiguration, IdentityCreationParameters,
     IdentityManager,
 };
-
-use super::diagnosis::DiagnosedError;
 
 pub const ANONYMOUS_IDENTITY_NAME: &str = "anonymous";
 pub const IDENTITY_PEM: &str = "identity.pem";
@@ -487,104 +482,6 @@ impl Identity {
         Ok(())
     }
 
-    #[context("Failed to create wallet for identity '{}' on network '{}'.", name, network.name)]
-    pub async fn create_wallet(
-        env: &dyn Environment,
-        network: &NetworkDescriptor,
-        name: &str,
-        some_canister_id: Option<Principal>,
-    ) -> DfxResult<Principal> {
-        fetch_root_key_if_needed(env).await?;
-        let mgr = ManagementCanister::create(
-            env.get_agent()
-                .ok_or_else(|| anyhow!("Cannot get HTTP client from environment."))?,
-        );
-        info!(
-            env.get_logger(),
-            "Creating a wallet canister on the {} network.", network.name
-        );
-
-        let wasm = wallet_wasm(env.get_logger())?;
-
-        let canister_id = match some_canister_id {
-            Some(id) => id,
-            None => {
-                mgr.create_canister()
-                    .as_provisional_create_with_amount(None)
-                    .with_effective_canister_id(env.get_effective_canister_id())
-                    .call_and_wait()
-                    .await
-                    .context("Failed create canister call.")?
-                    .0
-            }
-        };
-
-        match mgr
-            .install_code(&canister_id, wasm.as_slice())
-            .with_mode(InstallMode::Install)
-            .call_and_wait()
-            .await
-        {
-            Err(AgentError::ReplicaError {
-                reject_code: 5,
-                reject_message,
-            }) if reject_message.contains("not empty") => {
-                bail!(
-                    r#"The wallet canister "{canister_id}" already exists for user "{name}" on "{}" network."#,
-                    network.name
-                )
-            }
-            res => res.context("Failed while installing wasm.")?,
-        }
-
-        let wallet = Identity::build_wallet_canister(canister_id, env).await?;
-
-        wallet
-            .wallet_store_wallet_wasm(wasm)
-            .call_and_wait()
-            .await
-            .context("Failed to store wallet wasm.")?;
-
-        Identity::set_wallet_id(network, name, canister_id)?;
-
-        info!(
-            env.get_logger(),
-            r#"The wallet canister on the "{}" network for user "{}" is "{}""#,
-            network.name,
-            name,
-            canister_id,
-        );
-
-        Ok(canister_id)
-    }
-
-    /// Gets the currently configured wallet canister. If none exists yet and `create` is true, then this creates a new wallet. WARNING: Creating a new wallet costs ICP!
-    ///
-    /// While developing locally, this always creates a new wallet, even if `create` is false.
-    /// This can be inhibited by setting the DFX_DISABLE_AUTO_WALLET env var.
-    #[context("Failed to get wallet for identity '{}' on network '{}'.", name, network.name)]
-    pub async fn get_or_create_wallet(
-        env: &dyn Environment,
-        network: &NetworkDescriptor,
-        name: &str,
-    ) -> DfxResult<Principal> {
-        match Identity::wallet_canister_id(network, name)? {
-            None => {
-                // If the network is not the IC, we ignore the error and create a new wallet for the identity.
-                if !network.is_ic && std::env::var("DFX_DISABLE_AUTO_WALLET").is_err() {
-                    Identity::create_wallet(env, network, name, None).await
-                } else {
-                    Err(DiagnosedError::new(format!("This command requires a configured wallet, but the combination of identity '{}' and network '{}' has no wallet set.", name, network.name),
-                    "To use an identity with a configured wallet you can do one of the following:\n\
-                    - Run the command for a network where you have a wallet configured. To do so, add '--network <network name>' to your command.\n\
-                    - Switch to an identity that has a wallet configured using 'dfx identity use <identity name>'.\n\
-                    - Configure a wallet for this identity/network combination: 'dfx identity set-wallet <wallet id> --network <network name>'.".to_string())).context("Wallet not configured.")
-                }
-            }
-            Some(principal) => Ok(principal),
-        }
-    }
-
     #[context("Failed to get wallet canister id for identity '{}' on network '{}'.", name, network.name)]
     pub fn wallet_canister_id(
         network: &NetworkDescriptor,
@@ -602,43 +499,6 @@ impl Identity {
             .get(name)
             .and_then(|wallet_network| wallet_network.networks.get(&network.name).cloned());
         Ok(maybe_wallet_principal)
-    }
-
-    #[context("Failed to construct wallet canister caller.")]
-    pub async fn build_wallet_canister(
-        id: Principal,
-        env: &dyn Environment,
-    ) -> DfxResult<WalletCanister<'_>> {
-        Ok(WalletCanister::from_canister(
-            ic_utils::Canister::builder()
-                .with_agent(
-                    env.get_agent()
-                        .ok_or_else(|| anyhow!("Cannot get HTTP client from environment."))?,
-                )
-                .with_canister_id(id)
-                .build()
-                .unwrap(),
-        )
-        .await?)
-    }
-
-    /// Gets the currently configured wallet canister. If none exists yet and `create` is true, then this creates a new wallet. WARNING: Creating a new wallet costs ICP!
-    ///
-    /// While developing locally, this always creates a new wallet, even if `create` is false.
-    /// This can be inhibited by setting the DFX_DISABLE_AUTO_WALLET env var.
-    #[allow(clippy::needless_lifetimes)]
-    #[context("Failed to get wallet canister caller for identity '{}' on network '{}'.", name, network.name)]
-    pub async fn get_or_create_wallet_canister<'env>(
-        env: &'env dyn Environment,
-        network: &NetworkDescriptor,
-        name: &str,
-    ) -> DfxResult<WalletCanister<'env>> {
-        // without this async block, #[context] gives a spurious error
-        async {
-            let wallet_canister_id = Identity::get_or_create_wallet(env, network, name).await?;
-            Identity::build_wallet_canister(wallet_canister_id, env).await
-        }
-        .await
     }
 }
 

--- a/src/dfx/src/lib/identity/wallet.rs
+++ b/src/dfx/src/lib/identity/wallet.rs
@@ -1,0 +1,151 @@
+use crate::lib::diagnosis::DiagnosedError;
+use crate::lib::error::DfxResult;
+use crate::lib::identity::Identity;
+use crate::lib::network::network_descriptor::NetworkDescriptor;
+use crate::lib::root_key::fetch_root_key_if_needed;
+use crate::util::assets::wallet_wasm;
+use crate::Environment;
+
+use anyhow::{anyhow, bail, Context};
+use candid::Principal;
+use fn_error_context::context;
+use ic_agent::AgentError;
+use ic_utils::call::AsyncCall;
+use ic_utils::interfaces::management_canister::builders::InstallMode;
+use ic_utils::interfaces::{ManagementCanister, WalletCanister};
+use slog::info;
+
+/// Gets the currently configured wallet canister. If none exists yet and `create` is true, then this creates a new wallet. WARNING: Creating a new wallet costs ICP!
+///
+/// While developing locally, this always creates a new wallet, even if `create` is false.
+/// This can be inhibited by setting the DFX_DISABLE_AUTO_WALLET env var.
+#[context("Failed to get wallet for identity '{}' on network '{}'.", name, network.name)]
+pub async fn get_or_create_wallet(
+    env: &dyn Environment,
+    network: &NetworkDescriptor,
+    name: &str,
+) -> DfxResult<Principal> {
+    match Identity::wallet_canister_id(network, name)? {
+        None => {
+            // If the network is not the IC, we ignore the error and create a new wallet for the identity.
+            if !network.is_ic && std::env::var("DFX_DISABLE_AUTO_WALLET").is_err() {
+                create_wallet(env, network, name, None).await
+            } else {
+                Err(DiagnosedError::new(format!("This command requires a configured wallet, but the combination of identity '{}' and network '{}' has no wallet set.", name, network.name),
+                                        "To use an identity with a configured wallet you can do one of the following:\n\
+                    - Run the command for a network where you have a wallet configured. To do so, add '--network <network name>' to your command.\n\
+                    - Switch to an identity that has a wallet configured using 'dfx identity use <identity name>'.\n\
+                    - Configure a wallet for this identity/network combination: 'dfx identity set-wallet <wallet id> --network <network name>'.".to_string())).context("Wallet not configured.")
+            }
+        }
+        Some(principal) => Ok(principal),
+    }
+}
+
+#[context("Failed to create wallet for identity '{}' on network '{}'.", name, network.name)]
+pub async fn create_wallet(
+    env: &dyn Environment,
+    network: &NetworkDescriptor,
+    name: &str,
+    some_canister_id: Option<Principal>,
+) -> DfxResult<Principal> {
+    fetch_root_key_if_needed(env).await?;
+    let mgr = ManagementCanister::create(
+        env.get_agent()
+            .ok_or_else(|| anyhow!("Cannot get HTTP client from environment."))?,
+    );
+    info!(
+        env.get_logger(),
+        "Creating a wallet canister on the {} network.", network.name
+    );
+
+    let wasm = wallet_wasm(env.get_logger())?;
+
+    let canister_id = match some_canister_id {
+        Some(id) => id,
+        None => {
+            mgr.create_canister()
+                .as_provisional_create_with_amount(None)
+                .with_effective_canister_id(env.get_effective_canister_id())
+                .call_and_wait()
+                .await
+                .context("Failed create canister call.")?
+                .0
+        }
+    };
+
+    match mgr
+        .install_code(&canister_id, wasm.as_slice())
+        .with_mode(InstallMode::Install)
+        .call_and_wait()
+        .await
+    {
+        Err(AgentError::ReplicaError {
+            reject_code: 5,
+            reject_message,
+        }) if reject_message.contains("not empty") => {
+            bail!(
+                r#"The wallet canister "{canister_id}" already exists for user "{name}" on "{}" network."#,
+                network.name
+            )
+        }
+        res => res.context("Failed while installing wasm.")?,
+    }
+
+    let wallet = build_wallet_canister(canister_id, env).await?;
+
+    wallet
+        .wallet_store_wallet_wasm(wasm)
+        .call_and_wait()
+        .await
+        .context("Failed to store wallet wasm.")?;
+
+    Identity::set_wallet_id(network, name, canister_id)?;
+
+    info!(
+        env.get_logger(),
+        r#"The wallet canister on the "{}" network for user "{}" is "{}""#,
+        network.name,
+        name,
+        canister_id,
+    );
+
+    Ok(canister_id)
+}
+
+#[context("Failed to construct wallet canister caller.")]
+pub async fn build_wallet_canister(
+    id: Principal,
+    env: &dyn Environment,
+) -> DfxResult<WalletCanister<'_>> {
+    Ok(WalletCanister::from_canister(
+        ic_utils::Canister::builder()
+            .with_agent(
+                env.get_agent()
+                    .ok_or_else(|| anyhow!("Cannot get HTTP client from environment."))?,
+            )
+            .with_canister_id(id)
+            .build()
+            .unwrap(),
+    )
+    .await?)
+}
+
+/// Gets the currently configured wallet canister. If none exists yet and `create` is true, then this creates a new wallet. WARNING: Creating a new wallet costs ICP!
+///
+/// While developing locally, this always creates a new wallet, even if `create` is false.
+/// This can be inhibited by setting the DFX_DISABLE_AUTO_WALLET env var.
+#[allow(clippy::needless_lifetimes)]
+#[context("Failed to get wallet canister caller for identity '{}' on network '{}'.", name, network.name)]
+pub async fn get_or_create_wallet_canister<'env>(
+    env: &'env dyn Environment,
+    network: &NetworkDescriptor,
+    name: &str,
+) -> DfxResult<WalletCanister<'env>> {
+    // without this async block, #[context] gives a spurious error
+    async {
+        let wallet_canister_id = get_or_create_wallet(env, network, name).await?;
+        build_wallet_canister(wallet_canister_id, env).await
+    }
+    .await
+}

--- a/src/dfx/src/lib/operations/canister/create_canister.rs
+++ b/src/dfx/src/lib/operations/canister/create_canister.rs
@@ -2,10 +2,10 @@ use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::ic_attributes::CanisterSettings;
 use crate::lib::identity::identity_utils::CallSender;
-use crate::lib::identity::Identity;
 use crate::lib::models::canister_id_store::CanisterIdStore;
 use crate::lib::provider::get_network_context;
 
+use crate::lib::identity::wallet::build_wallet_canister;
 use anyhow::{anyhow, bail, Context};
 use fn_error_context::context;
 use ic_agent::agent_error::HttpErrorPayload;
@@ -101,7 +101,7 @@ pub async fn create_canister(
                     res.context("Canister creation call failed.")?.0
                 }
                 CallSender::Wallet(wallet_id) => {
-                    let wallet = Identity::build_wallet_canister(*wallet_id, env).await?;
+                    let wallet = build_wallet_canister(*wallet_id, env).await?;
                     // amount has been validated by cycle_amount_validator
                     let cycles = with_cycles.map_or(
                         CANISTER_CREATE_FEE + CANISTER_INITIAL_CYCLE_BALANCE,

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -3,7 +3,6 @@ use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::identity::identity_utils::CallSender;
-use crate::lib::identity::Identity;
 use crate::lib::installers::assets::post_install_store_assets;
 use crate::lib::models::canister::CanisterPool;
 use crate::lib::models::canister_id_store::CanisterIdStore;
@@ -12,6 +11,7 @@ use crate::lib::network::network_descriptor::NetworkDescriptor;
 use crate::util::assets::wallet_wasm;
 use crate::util::read_module_metadata;
 
+use crate::lib::identity::wallet::build_wallet_canister;
 use anyhow::{anyhow, bail, Context};
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
@@ -182,7 +182,7 @@ pub async fn install_canister(
     }
     if canister_info.is_assets() {
         if let CallSender::Wallet(wallet_id) = call_sender {
-            let wallet = Identity::build_wallet_canister(*wallet_id, env).await?;
+            let wallet = build_wallet_canister(*wallet_id, env).await?;
             let identity_name = env.get_selected_identity().expect("No selected identity.");
             info!(
                 log,
@@ -397,7 +397,7 @@ YOU WILL LOSE ALL DATA IN THE CANISTER.");
                 .context("Failed to install wasm.")?;
         }
         CallSender::Wallet(wallet_id) => {
-            let wallet = Identity::build_wallet_canister(*wallet_id, env).await?;
+            let wallet = build_wallet_canister(*wallet_id, env).await?;
             let install_args = CanisterInstall {
                 mode,
                 canister_id,
@@ -432,7 +432,7 @@ pub async fn install_wallet(
         .call_and_wait()
         .await
         .context("Failed to install wallet wasm.")?;
-    let wallet = Identity::build_wallet_canister(id, env).await?;
+    let wallet = build_wallet_canister(id, env).await?;
     wallet
         .wallet_store_wallet_wasm(wasm)
         .call_and_wait()

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -13,8 +13,8 @@ use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::ic_attributes::CanisterSettings as DfxCanisterSettings;
 use crate::lib::identity::identity_utils::CallSender;
-use crate::lib::identity::Identity;
 
+use crate::lib::identity::wallet::build_wallet_canister;
 use anyhow::{anyhow, Context};
 use candid::utils::ArgumentDecoder;
 use candid::CandidType;
@@ -58,7 +58,7 @@ where
                 .context("Update call (without wallet) failed.")?
         }
         CallSender::Wallet(wallet_id) => {
-            let wallet = Identity::build_wallet_canister(*wallet_id, env).await?;
+            let wallet = build_wallet_canister(*wallet_id, env).await?;
             let out: O = wallet
                 .call(
                     Principal::management_canister(),


### PR DESCRIPTION
# Description

`get_or_create_wallet()` can generate a `DiagnosedError` in some circumstances.  If we were to move this code to the dfx-core crate, I'm not sure how this would fit with concrete error types.  But we don't need to solve that today, because the code we're going to make available in dfx-core doesn't need to create wallet canisters.

This PR moves `get_or_create_wallet()` and the methods that it depends on to a separate file.

# How Has This Been Tested?

Covered by CI