### PR TITLE
refactor: remove read_identity_configuration method

### DIFF
--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -565,17 +565,6 @@ fn save_configuration(path: &Path, config: &Configuration) -> Result<(), Identit
     save_json_file(path, config).map_err(SaveIdentityManagerConfigurationFailed)
 }
 
-#[context("Failed to read identity configuration at {}.", path.to_string_lossy())]
-pub(super) fn read_identity_configuration(path: &Path) -> DfxResult<IdentityConfiguration> {
-    let content = std::fs::read_to_string(path).with_context(|| {
-        format!(
-            "Cannot read identity configuration file at '{}'.",
-            PathBuf::from(path).display()
-        )
-    })?;
-    serde_json::from_str(&content).context("Failed to deserialise identity configuration.")
-}
-
 #[context("Failed to write identity configuration.")]
 pub(super) fn write_identity_configuration(
     log: &Logger,

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -23,7 +23,7 @@ use ic_agent::Signature;
 use ic_identity_hsm::HardwareIdentity;
 use sec1::EncodeEcPrivateKey;
 use serde::{Deserialize, Serialize};
-use slog::{debug, info, trace, Logger};
+use slog::{info, trace, Logger};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -276,13 +276,7 @@ impl Identity {
 
     #[context("Failed to load identity '{}'.", name)]
     pub fn load(manager: &IdentityManager, name: &str, log: &Logger) -> DfxResult<Self> {
-        let json_path = manager.get_identity_json_path(name);
-        let config = if json_path.exists() {
-            identity_manager::read_identity_configuration(&json_path)?
-        } else {
-            debug!(log, "Found no identity configuration. Using default.");
-            IdentityConfiguration::default()
-        };
+        let config = manager.get_identity_config_or_default(name)?;
         if let Some(hsm) = config.hsm {
             Identity::hardware(name, hsm)
         } else {


### PR DESCRIPTION
# Description

Its only caller was `IdentityManager::load()`, so also DRY the whole thing by calling `get_identity_config_or_default()` instead.

This does remove a `debug!()` call.  If it's important, happy to add it to `get_identity_config_or_default()`.

This is part of removing dependencies from the identity crate to DfxResult.

# How Has This Been Tested?

Covered by CI