### PR TITLE
refactor: Identity::new, no dependency on IdentityManager

### DIFF
--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -211,13 +211,18 @@ impl IdentityManager {
             ANONYMOUS_IDENTITY_NAME => Box::new(DfxIdentity::anonymous()),
             identity_name => {
                 self.require_identity_exists(log, identity_name)?;
-                Box::new(DfxIdentity::load(self, identity_name, log)?)
+                Box::new(self.load_identity(identity_name, log)?)
             }
         };
         use ic_agent::identity::Identity;
         self.selected_identity_principal =
             Some(identity.sender().map_err(|err| anyhow!("{}", err))?);
         Ok(identity)
+    }
+
+    fn load_identity(&self, name: &str, log: &Logger) -> Result<DfxIdentity, IdentityError> {
+        let config = self.get_identity_config_or_default(name)?;
+        DfxIdentity::new(name, config, self.file_locations(), log)
     }
 
     /// Create a new identity (name -> generated key)


### PR DESCRIPTION
# Description

Simplify a dependency cycle: it doesn't really make sense to have IdentityManager call a method on Identity, passing itself, only to have that method call right back into IdentityManager.  Instead, pass parameters to Identity::new().

# How Has This Been Tested?

Covered by CI