### PR TITLE
refactor: get_identity_names: use filter_map to remove Result type

### DIFF
--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -262,13 +262,7 @@ impl IdentityManager {
             })?
             .filter_map(|entry_result| match entry_result {
                 Ok(dir_entry) => match dir_entry.file_type() {
-                    Ok(file_type) => {
-                        if file_type.is_dir() {
-                            Some(dir_entry)
-                        } else {
-                            None
-                        }
-                    }
+                    Ok(file_type) if file_type.is_dir() => Some(dir_entry),
                     _ => None,
                 },
                 _ => None,


### PR DESCRIPTION
# Description

Use `filter_map` to simplify an expression.  This removed the need to add context to an error at all.  In addition, errors were not possible anyway, since they were filtered out.

# How Has This Been Tested?

Covered by CI