### PR TITLE
fix: Use an anonymous agent for `dfx generate`

### DIFF
--- a/e2e/tests-dfx/generate.bash
+++ b/e2e/tests-dfx/generate.bash
@@ -113,3 +113,13 @@ teardown() {
     assert_file_not_exists "src/declarations/hello_backend/index.js"
     assert_file_not_exists "src/declarations/hello_backend/index.d.ts"
 }
+
+@test "dfx generate succeeds with an encrypted identity without input" {
+    dfx_start
+    dfx canister create --all
+
+    assert_command "${BATS_TEST_DIRNAME}/../assets/expect_scripts/init_alice_with_pw.exp"
+    assert_command dfx identity use alice
+    
+    assert_command timeout 30s dfx generate
+}

--- a/scripts/workflows/provision-linux.sh
+++ b/scripts/workflows/provision-linux.sh
@@ -39,7 +39,7 @@ if [ "$E2E_TEST" = "tests-dfx/certificate.bash" ]; then
     sudo tar --directory /usr/local/bin --extract --file mitmproxy.tar.gz
     echo "mitmproxy version: $(mitmproxy --version)"
 fi
-if [ "$E2E_TEST" = "tests-dfx/identity_encryption.bash" ] || [ "$E2E_TEST" = "tests-dfx/identity.bash" ]; then
+if [ "$E2E_TEST" = "tests-dfx/identity_encryption.bash" ] || [ "$E2E_TEST" = "tests-dfx/identity.bash" ] || [ "$E2E_TEST" = "tests-dfx/generate.bash" ]; then
     sudo apt-get install --yes expect
 fi
 if [ "$E2E_TEST" = "tests-dfx/pull.bash" ]; then

--- a/src/dfx/src/commands/generate.rs
+++ b/src/dfx/src/commands/generate.rs
@@ -3,7 +3,7 @@ use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::models::canister::CanisterPool;
 use crate::lib::models::canister_id_store::CanisterIdStore;
-use crate::lib::provider::create_agent_environment;
+use crate::lib::provider::create_anonymous_agent_environment;
 use crate::NetworkOpt;
 
 use clap::Parser;
@@ -22,7 +22,7 @@ pub struct GenerateOpts {
 }
 
 pub fn exec(env: &dyn Environment, opts: GenerateOpts) -> DfxResult {
-    let env = create_agent_environment(env, opts.network.network)?;
+    let env = create_anonymous_agent_environment(env, opts.network.network)?;
     let log = env.get_logger();
 
     // Read the config.
@@ -68,7 +68,6 @@ pub fn exec(env: &dyn Environment, opts: GenerateOpts) -> DfxResult {
             }
         }
     }
-
     let build_config =
         BuildConfig::from_config(&config)?.with_canisters_to_build(build_before_generate);
     let generate_config =

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -9,7 +9,6 @@ use crate::lib::progress_bar::ProgressBar;
 use anyhow::{anyhow, Context};
 use candid::Principal;
 use fn_error_context::context;
-use ic_agent::identity::AnonymousIdentity;
 use ic_agent::{Agent, Identity};
 use semver::Version;
 use slog::{warn, Logger, Record};
@@ -244,41 +243,29 @@ pub struct AgentEnvironment<'a> {
     backend: &'a dyn Environment,
     agent: Agent,
     network_descriptor: NetworkDescriptor,
-    identity_manager: Option<IdentityManager>,
+    identity_manager: IdentityManager,
 }
 
 impl<'a> AgentEnvironment<'a> {
+    #[context("Failed to create AgentEnvironment for network '{}'.", network_descriptor.name)]
     pub fn new(
         backend: &'a dyn Environment,
         network_descriptor: NetworkDescriptor,
         timeout: Duration,
+        use_identity: Option<&str>,
     ) -> DfxResult<Self> {
+        let logger = backend.get_logger().clone();
         let mut identity_manager = IdentityManager::new(backend)?;
-        let identity = identity_manager.instantiate_selected_identity(backend.get_logger())?;
+        let identity = if let Some(identity_name) = use_identity {
+            identity_manager.instantiate_identity_from_name(identity_name, &logger)?
+        } else {
+            identity_manager.instantiate_selected_identity(&logger)?
+        };
         if network_descriptor.is_ic && identity.insecure {
-            let logger = backend.get_logger().clone();
             warn!(logger, "The {} identity is not stored securely. Do not use it to control a lot of cycles/ICP. Create a new identity with `dfx identity new` \
                 and use it in mainnet-facing commands with the `--identity` flag", identity.name());
         }
-        Self::new_as(
-            backend,
-            network_descriptor,
-            identity,
-            Some(identity_manager),
-            timeout,
-        )
-    }
-
-    #[context("Failed to create AgentEnvironment for network '{}'.", network_descriptor.name)]
-    fn new_as(
-        backend: &'a dyn Environment,
-        network_descriptor: NetworkDescriptor,
-        identity: Box<dyn Identity + Send + Sync>,
-        identity_manager: Option<IdentityManager>,
-        timeout: Duration,
-    ) -> DfxResult<Self> {
         let url = network_descriptor.first_provider()?;
-        let logger = backend.get_logger().clone();
 
         Ok(AgentEnvironment {
             backend,
@@ -286,20 +273,6 @@ impl<'a> AgentEnvironment<'a> {
             network_descriptor: network_descriptor.clone(),
             identity_manager,
         })
-    }
-
-    pub fn new_anonymous(
-        backend: &'a dyn Environment,
-        network_descriptor: NetworkDescriptor,
-        timeout: Duration,
-    ) -> DfxResult<Self> {
-        Self::new_as(
-            backend,
-            network_descriptor,
-            Box::new(AnonymousIdentity),
-            None,
-            timeout,
-        )
     }
 }
 
@@ -363,17 +336,11 @@ impl<'a> Environment for AgentEnvironment<'a> {
     }
 
     fn get_selected_identity(&self) -> Option<&String> {
-        self.identity_manager
-            .as_ref()
-            .map(|mgr| mgr.get_selected_identity_name())
+        Some(self.identity_manager.get_selected_identity_name())
     }
 
     fn get_selected_identity_principal(&self) -> Option<Principal> {
-        self.identity_manager
-            .as_ref()
-            .map_or(Some(Principal::anonymous()), |mgr| {
-                mgr.get_selected_identity_principal()
-            })
+        self.identity_manager.get_selected_identity_principal()
     }
 
     fn get_effective_canister_id(&self) -> Principal {

--- a/src/dfx/src/lib/provider.rs
+++ b/src/dfx/src/lib/provider.rs
@@ -415,6 +415,21 @@ pub fn create_agent_environment<'a>(
     AgentEnvironment::new(env, network_descriptor, timeout)
 }
 
+pub fn create_anonymous_agent_environment<'a>(
+    env: &'a (dyn Environment + 'a),
+    network: Option<String>,
+) -> DfxResult<AgentEnvironment<'a>> {
+    let network_descriptor = create_network_descriptor(
+        env.get_config(),
+        env.get_networks_config(),
+        network,
+        None,
+        LocalBindDetermination::ApplyRunningWebserverPort,
+    )?;
+    let timeout = expiry_duration();
+    AgentEnvironment::new_anonymous(env, network_descriptor, timeout)
+}
+
 #[context("Failed to parse supplied provider url {}.", s)]
 pub fn command_line_provider_to_url(s: &str) -> DfxResult<String> {
     match parse_provider_url(s) {

--- a/src/dfx/src/lib/provider.rs
+++ b/src/dfx/src/lib/provider.rs
@@ -22,6 +22,8 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use url::Url;
 
+use super::identity::ANONYMOUS_IDENTITY_NAME;
+
 lazy_static! {
     static ref NETWORK_CONTEXT: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
 }
@@ -412,7 +414,7 @@ pub fn create_agent_environment<'a>(
         LocalBindDetermination::ApplyRunningWebserverPort,
     )?;
     let timeout = expiry_duration();
-    AgentEnvironment::new(env, network_descriptor, timeout)
+    AgentEnvironment::new(env, network_descriptor, timeout, None)
 }
 
 pub fn create_anonymous_agent_environment<'a>(
@@ -427,7 +429,12 @@ pub fn create_anonymous_agent_environment<'a>(
         LocalBindDetermination::ApplyRunningWebserverPort,
     )?;
     let timeout = expiry_duration();
-    AgentEnvironment::new_anonymous(env, network_descriptor, timeout)
+    AgentEnvironment::new(
+        env,
+        network_descriptor,
+        timeout,
+        Some(ANONYMOUS_IDENTITY_NAME),
+    )
 }
 
 #[context("Failed to parse supplied provider url {}.", s)]


### PR DESCRIPTION
This changes `dfx generate` to not require the current identity, as it does not use it but does use the rest of the AgentEnvironment machinery. 

Fixes #2872, SDK-916