### PR TITLE
refactor: concrete error types for write_pem_to_keyring

### DIFF
--- a/src/dfx-core/src/error/keyring.rs
+++ b/src/dfx-core/src/error/keyring.rs
@@ -24,4 +24,7 @@ pub enum KeyringError {
 
     #[error("Failed to save mock keyring: {0}")]
     SaveMockKeyringFailed(StructuredFileError),
+
+    #[error("Failed to set password for keyring: {0}")]
+    SetPasswordFailed(keyring::Error),
 }

--- a/src/dfx/src/lib/identity/pem_safekeeping.rs
+++ b/src/dfx/src/lib/identity/pem_safekeeping.rs
@@ -61,7 +61,8 @@ pub(crate) fn save_pem(
         bail!("Cannot save PEM content for an HSM.")
     } else if let Some(keyring_identity) = &identity_config.keyring_identity_suffix {
         debug!(log, "Saving keyring identity.");
-        keyring_mock::write_pem_to_keyring(keyring_identity, pem_content)
+        keyring_mock::write_pem_to_keyring(keyring_identity, pem_content)?;
+        Ok(())
     } else {
         let path = locations.get_identity_pem_path(name, identity_config);
         write_pem_to_file(&path, Some(identity_config), pem_content)?;


### PR DESCRIPTION
# Description

Preparation to move to dfx-core crate

# How Has This Been Tested?

Covered by CI