### PR TITLE
refactor: concrete error types for identity_manager::rename

### DIFF
--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -27,6 +27,9 @@ pub enum IdentityError {
     #[error("Cannot create identity directory: {0}")]
     CreateIdentityDirectoryFailed(IoError),
 
+    #[error("Cannot save PEM content for an HSM.")]
+    CannotSavePemContentForHsm(),
+
     #[error("Failed to decrypt PEM file: {0}")]
     DecryptPemFileFailed(PathBuf, EncryptionError),
 
@@ -114,6 +117,9 @@ pub enum IdentityError {
     #[error("Failed to save identity manager configuration: {0}")]
     SaveIdentityManagerConfigurationFailed(StructuredFileError),
 
+    #[error("Failed to switch over default identity settings: {0}")]
+    SwitchDefaultIdentitySettingsFailed(Box<IdentityError>),
+
     #[error("Could not translate pem file to text: {0}")]
     TranslatePemContentToTextFailed(FromUtf8Error),
 
@@ -127,4 +133,7 @@ pub enum IdentityError {
 
     #[error("Cannot write PEM file: {0}")]
     WritePemFileFailed(IoError),
+
+    #[error("Failed to write PEM to keyring: {0}")]
+    WritePemToKeyringFailed(KeyringError),
 }

--- a/src/dfx/src/commands/identity/rename.rs
+++ b/src/dfx/src/commands/identity/rename.rs
@@ -1,7 +1,9 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::identity::identity_manager::IdentityManager;
+use dfx_core::error::identity::IdentityError::SwitchDefaultIdentitySettingsFailed;
 
+use anyhow::bail;
 use clap::Parser;
 use slog::info;
 
@@ -22,7 +24,11 @@ pub fn exec(env: &dyn Environment, opts: RenameOpts) -> DfxResult {
     let log = env.get_logger();
 
     let mut identity_manager = IdentityManager::new(env)?;
-    let renamed_default = identity_manager.rename(log, env, from, to)?;
+    let result = identity_manager.rename(log, env, from, to);
+    if let Err(SwitchDefaultIdentitySettingsFailed(_)) = result {
+        bail!("Failed to switch over default identity settings.  Please do this manually by running 'dfx identity use {}'", to);
+    }
+    let renamed_default = result?;
 
     info!(log, r#"Renamed identity "{}" to "{}"."#, from, to);
     if renamed_default {


### PR DESCRIPTION
# Description

Preparation to move to dfx-core crate.

Also moves a dfx-specific error message into the dfx command itself, rather than including it in the error message for the type.

# How Has This Been Tested?

Covered by CI, and tested the rename failure case manually.

```
$dfx-r identity use abc1
Using identity: "abc1".
$ chmod u-w identity.json
$ dfx-r identity rename abc1 abc4
Error: Failed to switch over default identity settings.  Please do this manually by running 'dfx identity use abc4'
```