### PR TITLE
refactor: inline Identity::create into IdentityManager::create_new_identity

### DIFF
--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -5,13 +5,11 @@
 use crate::lib::config::get_config_dfx_dir_path;
 use crate::lib::environment::Environment;
 use crate::lib::error::{DfxResult, IdentityError};
-use crate::lib::identity::identity_manager::IdentityStorageMode;
 use crate::lib::network::network_descriptor::{NetworkDescriptor, NetworkTypeDescriptor};
 use dfx_core::config::directories::get_shared_network_data_directory;
 use dfx_core::error::identity::IdentityError::{
-    GenerateFreshEncryptionConfigurationFailed, GetConfigDirectoryFailed,
-    GetSharedNetworkDataDirectoryFailed, InstantiateHardwareIdentityFailed, ReadIdentityFileFailed,
-    RenameWalletFailed,
+    GetConfigDirectoryFailed, GetSharedNetworkDataDirectoryFailed,
+    InstantiateHardwareIdentityFailed, ReadIdentityFileFailed, RenameWalletFailed,
 };
 use dfx_core::error::wallet_config::WalletConfigError;
 use dfx_core::error::wallet_config::WalletConfigError::{
@@ -19,16 +17,14 @@ use dfx_core::error::wallet_config::WalletConfigError::{
 };
 use dfx_core::json::{load_json_file, save_json_file};
 
-use anyhow::{bail, Context};
-use bip39::{Language, Mnemonic};
+use anyhow::Context;
 use candid::Principal;
 use fn_error_context::context;
 use ic_agent::identity::{AnonymousIdentity, BasicIdentity, Secp256k1Identity};
 use ic_agent::Signature;
 use ic_identity_hsm::HardwareIdentity;
-use sec1::EncodeEcPrivateKey;
 use serde::{Deserialize, Serialize};
-use slog::{info, trace, Logger};
+use slog::{info, Logger};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -75,169 +71,6 @@ pub struct Identity {
 }
 
 impl Identity {
-    /// Creates a new identity.
-    ///
-    /// `force`: If the identity already exists, remove it and re-create.
-    pub fn create(
-        log: &Logger,
-        manager: &mut IdentityManager,
-        name: &str,
-        parameters: IdentityCreationParameters,
-        force: bool,
-    ) -> DfxResult {
-        trace!(log, "Creating identity '{name}'.");
-        let identity_in_use = manager.get_selected_identity_name().clone();
-        // cannot delete an identity in use. Use anonymous identity temporarily if we force-overwrite the identity currently in use
-        let temporarily_use_anonymous_identity = identity_in_use == name && force;
-
-        if manager.require_identity_exists(log, name).is_ok() {
-            trace!(log, "Identity already exists.");
-            if force {
-                if temporarily_use_anonymous_identity {
-                    manager
-                        .use_identity_named(log, ANONYMOUS_IDENTITY_NAME)
-                        .context("Failed to temporarily switch over to anonymous identity.")?;
-                }
-                manager.remove(log, name, true, None)?;
-            } else {
-                bail!("Identity already exists.");
-            }
-        }
-
-        fn create(identity_dir: &Path) -> DfxResult {
-            std::fs::create_dir_all(identity_dir).with_context(|| {
-                format!(
-                    "Cannot create temporary identity directory at '{0}'.",
-                    identity_dir.display(),
-                )
-            })
-        }
-        fn create_identity_config(
-            log: &Logger,
-            mode: IdentityStorageMode,
-            name: &str,
-            hardware_config: Option<HardwareIdentityConfiguration>,
-        ) -> DfxResult<IdentityConfiguration> {
-            if let Some(hsm) = hardware_config {
-                Ok(IdentityConfiguration {
-                    hsm: Some(hsm),
-                    ..Default::default()
-                })
-            } else {
-                match mode {
-                    IdentityStorageMode::Keyring => {
-                        if keyring_mock::keyring_available(log) {
-                            Ok(IdentityConfiguration {
-                                keyring_identity_suffix: Some(String::from(name)),
-                                ..Default::default()
-                            })
-                        } else {
-                            Ok(IdentityConfiguration {
-                                encryption: Some(
-                                    identity_manager::EncryptionConfiguration::new()
-                                        .map_err(GenerateFreshEncryptionConfigurationFailed)?,
-                                ),
-                                ..Default::default()
-                            })
-                        }
-                    }
-                    IdentityStorageMode::PasswordProtected => Ok(IdentityConfiguration {
-                        encryption: Some(
-                            identity_manager::EncryptionConfiguration::new()
-                                .map_err(GenerateFreshEncryptionConfigurationFailed)?,
-                        ),
-                        ..Default::default()
-                    }),
-                    IdentityStorageMode::Plaintext => Ok(IdentityConfiguration::default()),
-                }
-            }
-        }
-
-        // Use a temporary directory to prepare all identity parts in so that we don't end up with broken parts if the
-        // creation process fails half-way through.
-        let temp_identity_name = format!("{}{}", TEMP_IDENTITY_PREFIX, name);
-        let temp_identity_dir = manager.get_identity_dir_path(&temp_identity_name);
-        if temp_identity_dir.exists() {
-            // clean traces from previous identity creation attempts
-            std::fs::remove_dir_all(&temp_identity_dir).with_context(|| {
-                format!(
-                    "Failed to clean up previous creation attempts at {}.",
-                    temp_identity_dir.to_string_lossy()
-                )
-            })?;
-        }
-
-        let identity_config;
-        match parameters {
-            IdentityCreationParameters::Pem { mode } => {
-                let (pem_content, mnemonic) = identity_manager::generate_key()?;
-                identity_config = create_identity_config(log, mode, name, None)?;
-                pem_safekeeping::save_pem(
-                    log,
-                    manager.file_locations(),
-                    &temp_identity_name,
-                    &identity_config,
-                    pem_content.as_slice(),
-                )?;
-                eprintln!("Your seed phrase for identity '{name}': {}\nThis can be used to reconstruct your key in case of emergency, so write it down in a safe place.", mnemonic.phrase());
-            }
-            IdentityCreationParameters::PemFile { src_pem_file, mode } => {
-                identity_config = create_identity_config(log, mode, name, None)?;
-                let (src_pem_content, _) =
-                    pem_safekeeping::load_pem_from_file(&src_pem_file, None)?;
-                identity_utils::validate_pem_file(&src_pem_content)?;
-                pem_safekeeping::save_pem(
-                    log,
-                    manager.file_locations(),
-                    &temp_identity_name,
-                    &identity_config,
-                    src_pem_content.as_slice(),
-                )?;
-            }
-            IdentityCreationParameters::Hardware { hsm } => {
-                identity_config =
-                    create_identity_config(log, IdentityStorageMode::default(), name, Some(hsm))?;
-                create(&temp_identity_dir)?;
-            }
-            IdentityCreationParameters::SeedPhrase { mnemonic, mode } => {
-                identity_config = create_identity_config(log, mode, name, None)?;
-                let mnemonic = Mnemonic::from_phrase(&mnemonic, Language::English)?;
-                let key = identity_manager::mnemonic_to_key(&mnemonic)?;
-                let pem = key.to_sec1_pem(k256::pkcs8::LineEnding::CRLF)?;
-                let pem_content = pem.as_bytes();
-                pem_safekeeping::save_pem(
-                    log,
-                    manager.file_locations(),
-                    &temp_identity_name,
-                    &identity_config,
-                    pem_content,
-                )?;
-            }
-        }
-        let identity_config_location = manager.get_identity_json_path(&temp_identity_name);
-        identity_manager::save_identity_configuration(
-            log,
-            &identity_config_location,
-            &identity_config,
-        )?;
-
-        // Everything is created. Now move from the temporary directory to the actual identity location.
-        let identity_dir = manager.get_identity_dir_path(name);
-        std::fs::rename(&temp_identity_dir, &identity_dir).with_context(|| {
-            format!(
-                "Failed to move temporary directory {} to permanent identity directory {}.",
-                temp_identity_dir.to_string_lossy(),
-                identity_dir.to_string_lossy()
-            )
-        })?;
-
-        if temporarily_use_anonymous_identity {
-            manager.use_identity_named(log, &identity_in_use)
-                .with_context(||format!("Failed to switch back over to the identity you're replacing. Please run 'dfx identity use {}' to do it manually.", name))?;
-        }
-        Ok(())
-    }
-
     pub fn anonymous() -> Self {
         Self {
             name: ANONYMOUS_IDENTITY_NAME.to_string(),


### PR DESCRIPTION
# Description

`IdentityManager::create_new_identity()` used to call `Identity::create()`, passing `self`, which in turn called right back into IdentityManager to do a bunch of things.

This PR inlines `Identity::create()` into this single caller.  There are no changes to the moved code.

There may be some opportunity/rationale for refactoring parts of this method back into Identity, but that is not done here.

# How Has This Been Tested?

Covered by CI.