### PR TITLE
refactor: IdentityManager::create_new_identity

### DIFF
--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -24,8 +24,20 @@ pub enum IdentityError {
     #[error("Cannot create an anonymous identity.")]
     CannotCreateAnonymousIdentity(),
 
+    #[error("Failed to clean up previous creation attempts: {0}")]
+    CleanupPreviousCreationAttemptsFailed(IoError),
+
+    #[error("Convert secret key to sec1 Pem failed: {0}")]
+    ConvertSecretKeyToSec1PemFailed(Box<sec1::Error>),
+
     #[error("Cannot create identity directory: {0}")]
     CreateIdentityDirectoryFailed(IoError),
+
+    #[error("Failed to create mnemonic from phrase: {0}")]
+    CreateMnemonicFromPhraseFailed(String),
+
+    #[error("Failed to create temporary identity directory: {0}")]
+    CreateTemporaryIdentityDirectoryFailed(IoError),
 
     #[error("Cannot save PEM content for an HSM.")]
     CannotSavePemContentForHsm(),
@@ -105,6 +117,9 @@ pub enum IdentityError {
     #[error("Cannot rename identity directory: {0}")]
     RenameIdentityDirectoryFailed(IoError),
 
+    #[error("Failed to rename temporary directory to permanent identity directory: {0}")]
+    RenameTemporaryIdentityDirectoryFailed(IoError),
+
     #[error("Failed to rename '{0}' to '{1}' in the global wallet config: {2}")]
     RenameWalletFailed(Box<String>, Box<String>, WalletConfigError),
 
@@ -117,8 +132,14 @@ pub enum IdentityError {
     #[error("Failed to save identity manager configuration: {0}")]
     SaveIdentityManagerConfigurationFailed(StructuredFileError),
 
+    #[error("Failed to switch back over to the identity you're replacing: {0}")]
+    SwitchBackToIdentityFailed(Box<IdentityError>),
+
     #[error("Failed to switch over default identity settings: {0}")]
     SwitchDefaultIdentitySettingsFailed(Box<IdentityError>),
+
+    #[error("Failed to temporarily switch over to anonymous identity: {0}")]
+    SwitchToAnonymousIdentityFailed(Box<IdentityError>),
 
     #[error("Could not translate pem file to text: {0}")]
     TranslatePemContentToTextFailed(FromUtf8Error),

--- a/src/dfx-core/src/error/io.rs
+++ b/src/dfx-core/src/error/io.rs
@@ -27,6 +27,9 @@ pub enum IoErrorKind {
     #[error("Failed to remove directory {0}: {1}")]
     RemoveDirectoryFailed(PathBuf, std::io::Error),
 
+    #[error("Failed to remove directory {0} and its contents: {1}")]
+    RemoveDirectoryAndContentsFailed(PathBuf, std::io::Error),
+
     #[error("Failed to remove file {0}: {1}")]
     RemoveFileFailed(PathBuf, std::io::Error),
 

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -3,8 +3,8 @@ pub mod composite;
 use crate::error::io::IoError;
 use crate::error::io::IoErrorKind::{
     CopyFileFailed, CreateDirectoryFailed, NoParent, ReadDirFailed, ReadFileFailed,
-    ReadPermissionsFailed, RemoveDirectoryFailed, RemoveFileFailed, RenameFailed, WriteFileFailed,
-    WritePermissionsFailed,
+    ReadPermissionsFailed, RemoveDirectoryAndContentsFailed, RemoveDirectoryFailed,
+    RemoveFileFailed, RenameFailed, WriteFileFailed, WritePermissionsFailed,
 };
 
 use std::fs::{Permissions, ReadDir};
@@ -60,6 +60,11 @@ pub fn read_permissions(path: &Path) -> Result<Permissions, IoError> {
 pub fn remove_dir(path: &Path) -> Result<(), IoError> {
     std::fs::remove_dir(path)
         .map_err(|err| IoError::new(RemoveDirectoryFailed(path.to_path_buf(), err)))
+}
+
+pub fn remove_dir_all(path: &Path) -> Result<(), IoError> {
+    std::fs::remove_dir_all(path)
+        .map_err(|err| IoError::new(RemoveDirectoryAndContentsFailed(path.to_path_buf(), err)))
 }
 
 pub fn remove_file(path: &Path) -> Result<(), IoError> {

--- a/src/dfx/src/commands/identity/import.rs
+++ b/src/dfx/src/commands/identity/import.rs
@@ -1,8 +1,7 @@
+use crate::commands::identity::new::create_new_dfx_identity;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::identity_manager::{
-    IdentityCreationParameters, IdentityManager, IdentityStorageMode,
-};
+use crate::lib::identity::identity_manager::{IdentityCreationParameters, IdentityStorageMode};
 
 use anyhow::Context;
 use clap::Parser;
@@ -63,7 +62,9 @@ pub fn exec(env: &dyn Environment, opts: ImportOpts) -> DfxResult {
             fs::read_to_string(opts.seed_file.unwrap()).context("Failed to read seed file")?;
         IdentityCreationParameters::SeedPhrase { mnemonic, mode }
     };
-    IdentityManager::new(env)?.create_new_identity(log, name, params, opts.force)?;
+
+    create_new_dfx_identity(env, log, name, params, opts.force)?;
+
     info!(log, r#"Imported identity: "{}"."#, name);
     Ok(())
 }


### PR DESCRIPTION
# Description

Change `IdenityManager::create_new_identity()` to use concrete error types, in preparation to move to the dfx-core crate.

# How Has This Been Tested?

Tested by making identity.json read-only just before dfx tries to revert back from the anonymous identity:

```
$ dfx identity new forced --force
$ dfx identity use forced
# set breakpoint
$ dfx identity new forced --force
$ chmod u-w ~/.config/dfx/identity.json
# continue

Error: Failed to switch back over to the identity you're replacing. Please run 'dfx identity use forced' to do it manually.
Caused by: Failed to switch back over to the identity you're replacing. Please run 'dfx identity use forced' to do it manually.
  Failed to save identity manager configuration: Failed to write JSON file: Failed to write to ~/.config/dfx/identity.json: Permission denied (os error 13)
```
