### PR TITLE
refactor: Remove dependencies on Environment from IdentityManager/Identity

### DIFF
--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -3,7 +3,6 @@ use crate::lib::error::DfxResult;
 use crate::lib::ic_attributes::{
     get_compute_allocation, get_freezing_threshold, get_memory_allocation, CanisterSettings,
 };
-use crate::lib::identity::identity_manager::IdentityManager;
 use crate::lib::identity::identity_utils::CallSender;
 use crate::lib::identity::wallet::get_or_create_wallet_canister;
 use crate::lib::operations::canister::create_canister;
@@ -103,7 +102,7 @@ pub async fn exec(
                                 Ok(env.get_selected_identity_principal().unwrap())
                             } else {
                                 let identity_name = controller;
-                                IdentityManager::new(env)?
+                                env.new_identity_manager()?
                                     .instantiate_identity_from_name(identity_name, env.get_logger())
                                     .and_then(|identity| {
                                         identity.sender().map_err(GetIdentityPrincipalFailed)

--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -4,7 +4,6 @@ use crate::lib::error::{DfxError, DfxResult};
 use crate::lib::ic_attributes::{
     get_compute_allocation, get_freezing_threshold, get_memory_allocation, CanisterSettings,
 };
-use crate::lib::identity::identity_manager::IdentityManager;
 use crate::lib::identity::identity_utils::CallSender;
 use crate::lib::models::canister_id_store::CanisterIdStore;
 use crate::lib::operations::canister::{get_canister_status, update_settings};
@@ -245,7 +244,7 @@ fn controller_to_principal(env: &dyn Environment, controller: &str) -> DfxResult
                 Ok(env.get_selected_identity_principal().unwrap())
             } else {
                 let identity_name = controller;
-                IdentityManager::new(env)?
+                env.new_identity_manager()?
                     .instantiate_identity_from_name(identity_name, env.get_logger())
                     .and_then(|identity| identity.sender().map_err(GetIdentityPrincipalFailed))
                     .map_err(DfxError::new)

--- a/src/dfx/src/commands/identity/export.rs
+++ b/src/dfx/src/commands/identity/export.rs
@@ -1,6 +1,5 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::identity_manager::IdentityManager;
 
 use clap::Parser;
 
@@ -14,7 +13,7 @@ pub struct ExportOpts {
 pub fn exec(env: &dyn Environment, opts: ExportOpts) -> DfxResult {
     let name = opts.exported_identity.as_str();
 
-    let pem = IdentityManager::new(env)?.export(env.get_logger(), name)?;
+    let pem = env.new_identity_manager()?.export(env.get_logger(), name)?;
     print!("{}", pem);
 
     Ok(())

--- a/src/dfx/src/commands/identity/list.rs
+++ b/src/dfx/src/commands/identity/list.rs
@@ -1,6 +1,5 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::identity_manager::IdentityManager;
 
 use clap::Parser;
 use std::io::Write;
@@ -10,7 +9,7 @@ use std::io::Write;
 pub struct ListOpts {}
 
 pub fn exec(env: &dyn Environment, _opts: ListOpts) -> DfxResult {
-    let mgr = IdentityManager::new(env)?;
+    let mgr = env.new_identity_manager()?;
     let identities = mgr.get_identity_names(env.get_logger())?;
     let current_identity = mgr.get_selected_identity_name();
     for identity in identities {

--- a/src/dfx/src/commands/identity/new.rs
+++ b/src/dfx/src/commands/identity/new.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::identity::identity_manager::{
-    HardwareIdentityConfiguration, IdentityCreationParameters, IdentityManager, IdentityStorageMode,
+    HardwareIdentityConfiguration, IdentityCreationParameters, IdentityStorageMode,
 };
 use crate::util::clap::validators::is_hsm_key_id;
 use dfx_core::error::identity::IdentityError::SwitchBackToIdentityFailed;
@@ -93,7 +93,8 @@ pub fn create_new_dfx_identity(
     force: bool,
 ) -> DfxResult {
     let result =
-        IdentityManager::new(env)?.create_new_identity(log, name, creation_parameters, force);
+        env.new_identity_manager()?
+            .create_new_identity(log, name, creation_parameters, force);
     if let Err(SwitchBackToIdentityFailed(underlying)) = result {
         Err(*underlying).with_context(||format!("Failed to switch back over to the identity you're replacing. Please run 'dfx identity use {}' to do it manually.", name))?;
     } else {

--- a/src/dfx/src/commands/identity/principal.rs
+++ b/src/dfx/src/commands/identity/principal.rs
@@ -1,6 +1,5 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::identity_manager::IdentityManager;
 
 use anyhow::anyhow;
 use clap::Parser;
@@ -11,7 +10,9 @@ use ic_agent::identity::Identity;
 pub struct GetPrincipalOpts {}
 
 pub fn exec(env: &dyn Environment, _opts: GetPrincipalOpts) -> DfxResult {
-    let identity = IdentityManager::new(env)?.instantiate_selected_identity(env.get_logger())?;
+    let identity = env
+        .new_identity_manager()?
+        .instantiate_selected_identity(env.get_logger())?;
     let principal_id = identity
         .as_ref()
         .sender()

--- a/src/dfx/src/commands/identity/remove.rs
+++ b/src/dfx/src/commands/identity/remove.rs
@@ -1,6 +1,5 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::identity_manager::IdentityManager;
 
 use clap::Parser;
 use slog::info;
@@ -21,7 +20,8 @@ pub fn exec(env: &dyn Environment, opts: RemoveOpts) -> DfxResult {
 
     let log = env.get_logger();
 
-    IdentityManager::new(env)?.remove(log, name, opts.drop_wallets, Some(log))?;
+    env.new_identity_manager()?
+        .remove(log, name, opts.drop_wallets, Some(log))?;
 
     info!(log, r#"Removed identity "{}"."#, name);
     Ok(())

--- a/src/dfx/src/commands/identity/rename.rs
+++ b/src/dfx/src/commands/identity/rename.rs
@@ -1,6 +1,5 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::identity_manager::IdentityManager;
 use dfx_core::error::identity::IdentityError::SwitchDefaultIdentitySettingsFailed;
 
 use anyhow::bail;
@@ -23,8 +22,8 @@ pub fn exec(env: &dyn Environment, opts: RenameOpts) -> DfxResult {
 
     let log = env.get_logger();
 
-    let mut identity_manager = IdentityManager::new(env)?;
-    let result = identity_manager.rename(log, env, from, to);
+    let mut identity_manager = env.new_identity_manager()?;
+    let result = identity_manager.rename(log, env.get_project_temp_dir(), from, to);
     if let Err(SwitchDefaultIdentitySettingsFailed(_)) = result {
         bail!("Failed to switch over default identity settings.  Please do this manually by running 'dfx identity use {}'", to);
     }

--- a/src/dfx/src/commands/identity/use.rs
+++ b/src/dfx/src/commands/identity/use.rs
@@ -1,6 +1,5 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::{DfxError, DfxResult};
-use crate::lib::identity::identity_manager::IdentityManager;
 
 use clap::Parser;
 use slog::info;
@@ -18,7 +17,7 @@ pub fn exec(env: &dyn Environment, opts: UseOpts) -> DfxResult {
     let log = env.get_logger();
     info!(log, r#"Using identity: "{}"."#, identity);
 
-    IdentityManager::new(env)?
+    env.new_identity_manager()?
         .use_identity_named(log, identity)
         .map_err(DfxError::new)
 }

--- a/src/dfx/src/commands/identity/whoami.rs
+++ b/src/dfx/src/commands/identity/whoami.rs
@@ -1,6 +1,5 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::identity_manager::IdentityManager;
 
 use clap::Parser;
 
@@ -9,7 +8,7 @@ use clap::Parser;
 pub struct WhoAmIOpts {}
 
 pub fn exec(env: &dyn Environment, _opts: WhoAmIOpts) -> DfxResult {
-    let mgr = IdentityManager::new(env)?;
+    let mgr = env.new_identity_manager()?;
     let identity = mgr.get_selected_identity_name();
     println!("{}", identity);
     Ok(())

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -8,6 +8,7 @@ use crate::lib::progress_bar::ProgressBar;
 
 use anyhow::{anyhow, Context};
 use candid::Principal;
+use dfx_core::error::identity::IdentityError;
 use fn_error_context::context;
 use ic_agent::{Agent, Identity};
 use semver::Version;
@@ -47,6 +48,10 @@ pub trait Environment {
     fn get_verbose_level(&self) -> i64;
     fn new_spinner(&self, message: Cow<'static, str>) -> ProgressBar;
     fn new_progress(&self, message: &str) -> ProgressBar;
+
+    fn new_identity_manager(&self) -> Result<IdentityManager, IdentityError> {
+        IdentityManager::new(self.get_logger(), self.get_identity_override())
+    }
 
     // Explicit lifetimes are actually needed for mockall to work properly.
     #[allow(clippy::needless_lifetimes)]
@@ -255,7 +260,7 @@ impl<'a> AgentEnvironment<'a> {
         use_identity: Option<&str>,
     ) -> DfxResult<Self> {
         let logger = backend.get_logger().clone();
-        let mut identity_manager = IdentityManager::new(backend)?;
+        let mut identity_manager = backend.new_identity_manager()?;
         let identity = if let Some(identity_name) = use_identity {
             identity_manager.instantiate_identity_from_name(identity_name, &logger)?
         } else {

--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -1,5 +1,4 @@
 use crate::lib::config::get_config_dfx_dir_path;
-use crate::lib::environment::Environment;
 use crate::lib::error::IdentityError;
 use crate::lib::identity::identity_file_locations::{IdentityFileLocations, IDENTITY_PEM};
 use crate::lib::identity::{
@@ -165,7 +164,7 @@ pub struct IdentityManager {
 }
 
 impl IdentityManager {
-    pub fn new(env: &dyn Environment) -> Result<Self, IdentityError> {
+    pub fn new(logger: &Logger, identity_override: &Option<String>) -> Result<Self, IdentityError> {
         let config_dfx_dir_path = get_config_dfx_dir_path().map_err(GetConfigDirectoryFailed)?;
         let identity_root_path = config_dfx_dir_path.join("identity");
         let identity_json_path = config_dfx_dir_path.join("identity.json");
@@ -173,10 +172,9 @@ impl IdentityManager {
         let configuration = if identity_json_path.exists() {
             load_configuration(&identity_json_path)?
         } else {
-            initialize(env.get_logger(), &identity_json_path, &identity_root_path)?
+            initialize(logger, &identity_json_path, &identity_root_path)?
         };
 
-        let identity_override = env.get_identity_override();
         let selected_identity = identity_override
             .clone()
             .unwrap_or_else(|| configuration.default.clone());
@@ -191,7 +189,7 @@ impl IdentityManager {
         };
 
         if let Some(identity) = identity_override {
-            mgr.require_identity_exists(env.get_logger(), identity)?;
+            mgr.require_identity_exists(logger, identity)?;
         }
 
         Ok(mgr)
@@ -480,7 +478,7 @@ impl IdentityManager {
     pub fn rename(
         &mut self,
         log: &Logger,
-        env: &dyn Environment,
+        project_temp_dir: Option<PathBuf>,
         from: &str,
         to: &str,
     ) -> Result<bool, IdentityError> {
@@ -497,7 +495,7 @@ impl IdentityManager {
             return Err(IdentityError::IdentityAlreadyExists());
         }
 
-        DfxIdentity::map_wallets_to_renamed_identity(env, from, to)?;
+        DfxIdentity::map_wallets_to_renamed_identity(project_temp_dir, from, to)?;
         dfx_core::fs::rename(&from_dir, &to_dir).map_err(RenameIdentityDirectoryFailed)?;
         if let Some(keyring_identity_suffix) = &identity_config.keyring_identity_suffix {
             debug!(log, "Migrating keyring content.");

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -3,7 +3,6 @@
 //! Wallets are a map of network-identity, but don't have their own types or manager
 //! type.
 use crate::lib::config::get_config_dfx_dir_path;
-use crate::lib::environment::Environment;
 use crate::lib::error::IdentityError;
 use crate::lib::network::network_descriptor::{NetworkDescriptor, NetworkTypeDescriptor};
 use dfx_core::config::directories::get_shared_network_data_directory;
@@ -294,7 +293,7 @@ impl Identity {
 
     // used for dfx identity rename foo bar
     pub fn map_wallets_to_renamed_identity(
-        env: &dyn Environment,
+        project_temp_dir: Option<PathBuf>,
         original_identity: &str,
         renamed_identity: &str,
     ) -> Result<(), IdentityError> {
@@ -320,7 +319,7 @@ impl Identity {
                 shared_local_network_wallet_path,
             )?;
         }
-        if let Some(temp_dir) = env.get_project_temp_dir() {
+        if let Some(temp_dir) = project_temp_dir {
             let local_wallet_path = temp_dir.join("local").join(WALLET_CONFIG_FILENAME);
             if local_wallet_path.exists() {
                 Identity::rename_wallet_global_config_key(

--- a/src/dfx/src/lib/migrate.rs
+++ b/src/dfx/src/lib/migrate.rs
@@ -13,11 +13,8 @@ use itertools::Itertools;
 use crate::lib::operations::canister::install_wallet;
 
 use super::{
-    environment::Environment,
-    error::DfxResult,
-    identity::{Identity, IdentityManager},
-    models::canister_id_store::CanisterIdStore,
-    network::network_descriptor::NetworkDescriptor,
+    environment::Environment, error::DfxResult, identity::Identity,
+    models::canister_id_store::CanisterIdStore, network::network_descriptor::NetworkDescriptor,
     root_key::fetch_root_key_if_needed,
 };
 
@@ -28,7 +25,7 @@ pub async fn migrate(env: &dyn Environment, network: &NetworkDescriptor, fix: bo
     let agent = env
         .get_agent()
         .expect("Could not get agent from environment");
-    let mut mgr = IdentityManager::new(env)?;
+    let mut mgr = env.new_identity_manager()?;
     let ident = mgr.instantiate_selected_identity(env.get_logger())?;
     let mut did_migrate = false;
     let wallet = if let Some(principal) = Identity::wallet_canister_id(network, ident.name())? {


### PR DESCRIPTION
# Description

Make it so IdentityManager and Identity no longer depend on Environment, in preparation to move them to the dfx-core create.

See [SDK-918](https://dfinity.atlassian.net/browse/SDK-918)

# How Has This Been Tested?

Covered by CI

[SDK-918]: https://dfinity.atlassian.net/browse/SDK-918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ