### PR TITLE
refactor: remove unused reference to Environment

### DIFF
--- a/src/dfx/src/commands/canister/mod.rs
+++ b/src/dfx/src/commands/canister/mod.rs
@@ -64,7 +64,7 @@ pub fn exec(env: &dyn Environment, opts: CanisterOpts) -> DfxResult {
     let runtime = Runtime::new().expect("Unable to create a runtime");
 
     runtime.block_on(async {
-        let call_sender = call_sender(&agent_env, &opts.wallet).await?;
+        let call_sender = call_sender(&opts.wallet).await?;
         match opts.subcmd {
             SubCommand::Call(v) => call::exec(&agent_env, v, &call_sender).await,
             SubCommand::Create(v) => create::exec(&agent_env, v, &call_sender).await,

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -107,7 +107,7 @@ pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
 
     let runtime = Runtime::new().expect("Unable to create a runtime");
 
-    let call_sender = runtime.block_on(call_sender(&env, &opts.wallet))?;
+    let call_sender = runtime.block_on(call_sender(&opts.wallet))?;
     let proxy_sender;
     let create_call_sender = if !opts.no_wallet && !matches!(call_sender, CallSender::Wallet(_)) {
         let wallet = runtime.block_on(get_or_create_wallet_canister(

--- a/src/dfx/src/lib/identity/identity_utils.rs
+++ b/src/dfx/src/lib/identity/identity_utils.rs
@@ -1,4 +1,3 @@
-use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use dfx_core::error::identity::IdentityError;
 use dfx_core::error::identity::IdentityError::{UnsupportedKeyVersion, ValidatePemContentFailed};
@@ -19,7 +18,7 @@ pub enum CallSender {
 // Determine whether the selected Identity
 // or the provided wallet canister ID should be the Sender of the call.
 #[context("Failed to determine call sender.")]
-pub async fn call_sender(_env: &dyn Environment, wallet: &Option<String>) -> DfxResult<CallSender> {
+pub async fn call_sender(wallet: &Option<String>) -> DfxResult<CallSender> {
     let sender = if let Some(id) = wallet {
         CallSender::Wallet(
             Principal::from_text(id)


### PR DESCRIPTION
Remove an unused parameter, and by doing so, a dependency on Environment.
