### PR TITLE
refactor: move more wallet-related methods to wallet.rs

### DIFF
--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -2,7 +2,7 @@ use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::ic_attributes::CanisterSettings;
 use crate::lib::identity::identity_utils::CallSender;
-use crate::lib::identity::Identity;
+use crate::lib::identity::wallet::{build_wallet_canister, wallet_canister_id};
 use crate::lib::models::canister_id_store::CanisterIdStore;
 use crate::lib::operations::canister;
 use crate::lib::operations::canister::{
@@ -20,7 +20,6 @@ use ic_utils::interfaces::management_canister::attributes::{
 use ic_utils::interfaces::management_canister::CanisterStatus;
 use ic_utils::Argument;
 
-use crate::lib::identity::wallet::build_wallet_canister;
 use anyhow::{anyhow, Context};
 use candid::Principal;
 use clap::Parser;
@@ -113,7 +112,7 @@ async fn delete_canister(
                         .expect("No selected identity.")
                         .to_string();
                     // If there is no wallet, then do not attempt to withdraw the cycles.
-                    Identity::wallet_canister_id(network, &identity_name)?
+                    wallet_canister_id(network, &identity_name)?
                 }
             },
         }

--- a/src/dfx/src/commands/identity/set_wallet.rs
+++ b/src/dfx/src/commands/identity/set_wallet.rs
@@ -1,11 +1,10 @@
 use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
 use crate::lib::error::{DfxError, DfxResult};
-use crate::lib::identity::Identity;
+use crate::lib::identity::wallet::{build_wallet_canister, set_wallet_id};
 use crate::lib::models::canister_id_store::CanisterIdStore;
 use crate::lib::provider::create_agent_environment;
 
-use crate::lib::identity::wallet::build_wallet_canister;
 use anyhow::{anyhow, Context};
 use candid::Principal;
 use clap::Parser;
@@ -101,7 +100,7 @@ pub fn exec(env: &dyn Environment, opts: SetWalletOpts, network: Option<String>)
         network.name,
         canister_id
     );
-    Identity::set_wallet_id(network, &identity_name, canister_id)?;
+    set_wallet_id(network, &identity_name, canister_id)?;
     info!(log, "Wallet set successfully.");
 
     Ok(())

--- a/src/dfx/src/commands/quickstart.rs
+++ b/src/dfx/src/commands/quickstart.rs
@@ -15,7 +15,7 @@ use crate::{
     lib::{
         environment::Environment,
         error::DfxResult,
-        identity::Identity,
+        identity::wallet::{set_wallet_id, wallet_canister_id},
         ledger_types::{Memo, NotifyError},
         nns_types::{
             account_identifier::AccountIdentifier,
@@ -46,7 +46,7 @@ pub fn exec(env: &dyn Environment) -> DfxResult {
         let xdr_per_icp = Decimal::from_i128_with_scale(xdr_conversion_rate as i128, 4);
         let icp_per_tc = xdr_per_icp.inv();
         eprintln!("Conversion rate: 1 ICP <> {xdr_per_icp} XDR");
-        let wallet = Identity::wallet_canister_id(env.get_network_descriptor(), ident)?;
+        let wallet = wallet_canister_id(env.get_network_descriptor(), ident)?;
         if let Some(wallet) = wallet {
             step_print_wallet(agent, wallet).await?;
         } else if Confirm::new()
@@ -99,7 +99,7 @@ async fn step_import_wallet(env: &dyn Environment, agent: &Agent, ident: &str) -
             .await?;
         WalletCanister::create(agent, id).await?
     };
-    Identity::set_wallet_id(env.get_network_descriptor(), ident, id)?;
+    set_wallet_id(env.get_network_descriptor(), ident, id)?;
     eprintln!("Successfully imported wallet {id}.");
     if let Ok(balance) = wallet.wallet_balance().await {
         eprintln!(
@@ -205,7 +205,7 @@ async fn step_finish_wallet(
     install_wallet(env, agent, wallet, InstallMode::Install)
         .await
         .context("Failed to install the wallet code to the canister")?;
-    Identity::set_wallet_id(env.get_network_descriptor(), ident, wallet)
+    set_wallet_id(env.get_network_descriptor(), ident, wallet)
         .context("Failed to record the wallet's principal as your associated wallet")?;
     install_spinner.finish_with_message("Installed the wallet code to the canister");
     eprintln!("Success! Run this command again at any time to print all this information again.");

--- a/src/dfx/src/commands/wallet/redeem_faucet_coupon.rs
+++ b/src/dfx/src/commands/wallet/redeem_faucet_coupon.rs
@@ -2,7 +2,7 @@ use crate::commands::wallet::get_wallet;
 use crate::lib::diagnosis::DiagnosedError;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::Identity;
+use crate::lib::identity::wallet::set_wallet_id;
 use crate::lib::models::canister_id_store::CanisterIdStore;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::util::{format_as_trillions, pretty_thousand_separators};
@@ -89,7 +89,7 @@ pub async fn exec(env: &dyn Environment, opts: RedeemFaucetCouponOpts) -> DfxRes
                 log,
                 "Redeemed coupon {} for a new wallet: {}", opts.coupon_code, &new_wallet_address
             );
-            Identity::set_wallet_id(env.get_network_descriptor(), identity, new_wallet_address)
+            set_wallet_id(env.get_network_descriptor(), identity, new_wallet_address)
                 .with_context(|| {
                     DiagnosedError::new(
                         format!(

--- a/src/dfx/src/commands/wallet/upgrade.rs
+++ b/src/dfx/src/commands/wallet/upgrade.rs
@@ -1,6 +1,6 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::Identity;
+use crate::lib::identity::wallet::wallet_canister_id;
 use crate::lib::operations::canister::install_wallet;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use anyhow::{anyhow, bail};
@@ -21,16 +21,15 @@ pub async fn exec(env: &dyn Environment, _opts: UpgradeOpts) -> DfxResult {
     // Network descriptor will always be set.
     let network = env.get_network_descriptor();
 
-    let canister_id =
-        if let Some(principal) = Identity::wallet_canister_id(network, &identity_name)? {
-            principal
-        } else {
-            bail!(
-                "There is no wallet defined for identity '{}' on network '{}'.  Nothing to do.",
-                identity_name,
-                &network.name
-            );
-        };
+    let canister_id = if let Some(principal) = wallet_canister_id(network, &identity_name)? {
+        principal
+    } else {
+        bail!(
+            "There is no wallet defined for identity '{}' on network '{}'.  Nothing to do.",
+            identity_name,
+            &network.name
+        );
+    };
 
     let agent = env
         .get_agent()

--- a/src/dfx/src/lib/identity/wallet.rs
+++ b/src/dfx/src/lib/identity/wallet.rs
@@ -1,10 +1,18 @@
+use crate::lib::config::get_config_dfx_dir_path;
 use crate::lib::diagnosis::DiagnosedError;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::Identity;
-use crate::lib::network::network_descriptor::NetworkDescriptor;
+use crate::lib::identity::{
+    Identity, WalletGlobalConfig, WalletNetworkMap, WALLET_CONFIG_FILENAME,
+};
+use crate::lib::network::network_descriptor::{NetworkDescriptor, NetworkTypeDescriptor};
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::util::assets::wallet_wasm;
 use crate::Environment;
+use dfx_core::error::wallet_config::WalletConfigError;
+use dfx_core::error::wallet_config::WalletConfigError::{
+    EnsureWalletConfigDirFailed, GetWalletConfigPathFailed, SaveWalletConfigFailed,
+};
+use dfx_core::json::save_json_file;
 
 use anyhow::{anyhow, bail, Context};
 use candid::Principal;
@@ -14,6 +22,8 @@ use ic_utils::call::AsyncCall;
 use ic_utils::interfaces::management_canister::builders::InstallMode;
 use ic_utils::interfaces::{ManagementCanister, WalletCanister};
 use slog::info;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 /// Gets the currently configured wallet canister. If none exists yet and `create` is true, then this creates a new wallet. WARNING: Creating a new wallet costs ICP!
 ///
@@ -25,7 +35,7 @@ pub async fn get_or_create_wallet(
     network: &NetworkDescriptor,
     name: &str,
 ) -> DfxResult<Principal> {
-    match Identity::wallet_canister_id(network, name)? {
+    match wallet_canister_id(network, name)? {
         None => {
             // If the network is not the IC, we ignore the error and create a new wallet for the identity.
             if !network.is_ic && std::env::var("DFX_DISABLE_AUTO_WALLET").is_err() {
@@ -40,6 +50,29 @@ pub async fn get_or_create_wallet(
         }
         Some(principal) => Ok(principal),
     }
+}
+
+pub fn get_wallet_config_path(
+    network: &NetworkDescriptor,
+    name: &str,
+) -> Result<PathBuf, WalletConfigError> {
+    Ok(match &network.r#type {
+        NetworkTypeDescriptor::Persistent => {
+            // Using the global
+            get_config_dfx_dir_path()
+                .map_err(|e| {
+                    GetWalletConfigPathFailed(
+                        Box::new(name.to_string()),
+                        Box::new(network.name.clone()),
+                        e,
+                    )
+                })?
+                .join("identity")
+                .join(name)
+                .join(WALLET_CONFIG_FILENAME)
+        }
+        NetworkTypeDescriptor::Ephemeral { wallet_config_path } => wallet_config_path.clone(),
+    })
 }
 
 #[context("Failed to create wallet for identity '{}' on network '{}'.", name, network.name)]
@@ -100,7 +133,7 @@ pub async fn create_wallet(
         .await
         .context("Failed to store wallet wasm.")?;
 
-    Identity::set_wallet_id(network, name, canister_id)?;
+    set_wallet_id(network, name, canister_id)?;
 
     info!(
         env.get_logger(),
@@ -148,4 +181,79 @@ pub async fn get_or_create_wallet_canister<'env>(
         build_wallet_canister(wallet_canister_id, env).await
     }
     .await
+}
+
+pub fn set_wallet_id(
+    network: &NetworkDescriptor,
+    name: &str,
+    id: Principal,
+) -> Result<(), WalletConfigError> {
+    let (wallet_path, mut config) = wallet_config(network, name)?;
+    // Update the wallet map in it.
+    let identities = &mut config.identities;
+    let network_map = identities
+        .entry(name.to_string())
+        .or_insert(WalletNetworkMap {
+            networks: BTreeMap::new(),
+        });
+
+    network_map.networks.insert(network.name.clone(), id);
+
+    Identity::save_wallet_config(&wallet_path, &config)
+}
+
+#[allow(dead_code)]
+pub fn remove_wallet_id(network: &NetworkDescriptor, name: &str) -> Result<(), WalletConfigError> {
+    let (wallet_path, mut config) = wallet_config(network, name)?;
+    // Update the wallet map in it.
+    let identities = &mut config.identities;
+    let network_map = identities
+        .entry(name.to_string())
+        .or_insert(WalletNetworkMap {
+            networks: BTreeMap::new(),
+        });
+
+    network_map.networks.remove(&network.name);
+
+    dfx_core::fs::composite::ensure_parent_dir_exists(&wallet_path)
+        .map_err(EnsureWalletConfigDirFailed)?;
+
+    save_json_file(&wallet_path, &config).map_err(SaveWalletConfigFailed)
+}
+
+pub fn wallet_canister_id(
+    network: &NetworkDescriptor,
+    name: &str,
+) -> Result<Option<Principal>, WalletConfigError> {
+    let wallet_path = get_wallet_config_path(network, name)?;
+    if !wallet_path.exists() {
+        return Ok(None);
+    }
+
+    let config = Identity::load_wallet_config(&wallet_path)?;
+
+    let maybe_wallet_principal = config
+        .identities
+        .get(name)
+        .and_then(|wallet_network| wallet_network.networks.get(&network.name).cloned());
+    Ok(maybe_wallet_principal)
+}
+
+fn wallet_config(
+    network: &NetworkDescriptor,
+    name: &str,
+) -> Result<(PathBuf, WalletGlobalConfig), WalletConfigError> {
+    let wallet_path = get_wallet_config_path(network, name)?;
+
+    // Read the config file.
+    Ok((
+        wallet_path.clone(),
+        if wallet_path.exists() {
+            Identity::load_wallet_config(&wallet_path)?
+        } else {
+            WalletGlobalConfig {
+                identities: BTreeMap::new(),
+            }
+        },
+    ))
 }

--- a/src/dfx/src/lib/migrate.rs
+++ b/src/dfx/src/lib/migrate.rs
@@ -10,6 +10,7 @@ use ic_utils::{
 };
 use itertools::Itertools;
 
+use crate::lib::identity::wallet::wallet_canister_id;
 use crate::lib::operations::canister::install_wallet;
 
 use super::{
@@ -28,7 +29,7 @@ pub async fn migrate(env: &dyn Environment, network: &NetworkDescriptor, fix: bo
     let mut mgr = env.new_identity_manager()?;
     let ident = mgr.instantiate_selected_identity(env.get_logger())?;
     let mut did_migrate = false;
-    let wallet = if let Some(principal) = Identity::wallet_canister_id(network, ident.name())? {
+    let wallet = if let Some(principal) = wallet_canister_id(network, ident.name())? {
         principal
     } else {
         bail!("No wallet found; nothing to do");


### PR DESCRIPTION
These don't need to go to the dfx-core crate right away, or maybe ever.
