### PR TITLE
refactor: move validate_pem_file to a separate file

### DIFF
--- a/src/dfx/src/lib/identity/identity_manager.rs
+++ b/src/dfx/src/lib/identity/identity_manager.rs
@@ -1,8 +1,8 @@
 use crate::lib::error::IdentityError;
 use crate::lib::identity::identity_file_locations::{IdentityFileLocations, IDENTITY_PEM};
 use crate::lib::identity::{
-    identity_utils, pem_safekeeping, Identity as DfxIdentity, ANONYMOUS_IDENTITY_NAME,
-    IDENTITY_JSON, TEMP_IDENTITY_PREFIX,
+    pem_safekeeping, pem_utils, Identity as DfxIdentity, ANONYMOUS_IDENTITY_NAME, IDENTITY_JSON,
+    TEMP_IDENTITY_PREFIX,
 };
 use dfx_core::config::directories::get_config_dfx_dir_path;
 use dfx_core::error::encryption::EncryptionError;
@@ -40,7 +40,7 @@ use std::boxed::Box;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use super::identity_utils::validate_pem_file;
+use super::pem_utils::validate_pem_file;
 use super::{keyring_mock, WALLET_CONFIG_FILENAME};
 
 const DEFAULT_IDENTITY_NAME: &str = "default";
@@ -333,7 +333,7 @@ impl IdentityManager {
                 identity_config = create_identity_config(log, mode, name, None)?;
                 let (src_pem_content, _) =
                     pem_safekeeping::load_pem_from_file(&src_pem_file, None)?;
-                identity_utils::validate_pem_file(&src_pem_content)?;
+                pem_utils::validate_pem_file(&src_pem_content)?;
                 pem_safekeeping::save_pem(
                     log,
                     self.file_locations(),

--- a/src/dfx/src/lib/identity/identity_utils.rs
+++ b/src/dfx/src/lib/identity/identity_utils.rs
@@ -1,13 +1,8 @@
 use crate::lib::error::DfxResult;
-use dfx_core::error::identity::IdentityError;
-use dfx_core::error::identity::IdentityError::{UnsupportedKeyVersion, ValidatePemContentFailed};
 
 use anyhow::Context;
 use candid::Principal;
 use fn_error_context::context;
-use ic_agent::identity::BasicIdentity;
-use ic_agent::identity::PemError;
-use ic_agent::identity::Secp256k1Identity;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum CallSender {
@@ -28,21 +23,4 @@ pub async fn call_sender(wallet: &Option<String>) -> DfxResult<CallSender> {
         CallSender::SelectedId
     };
     Ok(sender)
-}
-
-pub fn validate_pem_file(pem_content: &[u8]) -> Result<(), IdentityError> {
-    let secp_res =
-        Secp256k1Identity::from_pem(pem_content).map_err(|e| ValidatePemContentFailed(Box::new(e)));
-    if let Err(e) = secp_res {
-        let basic_identity_res = BasicIdentity::from_pem(pem_content);
-        match basic_identity_res {
-            Err(PemError::KeyRejected(rj)) if rj.description_() == "VersionNotSupported" => {
-                return Err(UnsupportedKeyVersion());
-            }
-            Err(_) => return Err(e),
-            _ => {}
-        }
-    }
-
-    Ok(())
 }

--- a/src/dfx/src/lib/identity/mod.rs
+++ b/src/dfx/src/lib/identity/mod.rs
@@ -28,6 +28,7 @@ pub mod identity_manager;
 pub mod identity_utils;
 pub mod keyring_mock;
 pub mod pem_safekeeping;
+pub mod pem_utils;
 pub mod wallet;
 
 use crate::lib::identity::identity_file_locations::IdentityFileLocations;

--- a/src/dfx/src/lib/identity/pem_utils.rs
+++ b/src/dfx/src/lib/identity/pem_utils.rs
@@ -1,0 +1,23 @@
+use dfx_core::error::identity::IdentityError;
+use dfx_core::error::identity::IdentityError::{UnsupportedKeyVersion, ValidatePemContentFailed};
+
+use ic_agent::identity::BasicIdentity;
+use ic_agent::identity::PemError;
+use ic_agent::identity::Secp256k1Identity;
+
+pub fn validate_pem_file(pem_content: &[u8]) -> Result<(), IdentityError> {
+    let secp_res =
+        Secp256k1Identity::from_pem(pem_content).map_err(|e| ValidatePemContentFailed(Box::new(e)));
+    if let Err(e) = secp_res {
+        let basic_identity_res = BasicIdentity::from_pem(pem_content);
+        match basic_identity_res {
+            Err(PemError::KeyRejected(rj)) if rj.description_() == "VersionNotSupported" => {
+                return Err(UnsupportedKeyVersion());
+            }
+            Err(_) => return Err(e),
+            _ => {}
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Move `validate_pem_file()` to a different file than `call_sender()`, in order to later move it to the dfx-core crate along with the identity manager.