### PR TITLE
refactor: concrete error types for get_canister_names_with_dependencies

### DIFF
--- a/e2e/tests-dfx/build_granular.bash
+++ b/e2e/tests-dfx/build_granular.bash
@@ -78,7 +78,7 @@ teardown() {
     dfx_start
     dfx canister create --all
     assert_command_fail dfx build canister_e
-    assert_match "The dependency analyzer failed: Found circular dependency: canister_e -> canister_d -> canister_e"
+    assert_match "Circular canister dependencies: canister_e -> canister_d -> canister_e"
 }
 
 @test "multiple non-cyclic dependency paths to the same canister are ok" {

--- a/src/dfx-core/src/error/dfx_config.rs
+++ b/src/dfx-core/src/error/dfx_config.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DfxConfigError {
+    #[error("Circular canister dependencies: {}", _0.join(" -> "))]
+    CanisterCircularDependency(Vec<String>),
+
+    #[error("Canister '{0}' not found.")]
+    CanisterNotFound(String),
+
+    #[error("No canisters in the configuration file.")]
+    CanistersFieldDoesNotExist(),
+
+    #[error("Failed to get canisters with their dependencies (for {}): {1}", _0.as_deref().unwrap_or("all canisters"))]
+    GetCanistersWithDependenciesFailed(Option<String>, Box<DfxConfigError>),
+}

--- a/src/dfx-core/src/error/mod.rs
+++ b/src/dfx-core/src/error/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod dfx_config;
 pub mod encryption;
 pub mod foundation;
 pub mod identity;

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -294,11 +294,12 @@ fn run_post_install_tasks(
     let pool = match pool {
         Some(pool) => pool,
         None => {
-            tmp = env
+            let deps = env
                 .get_config_or_anyhow()?
                 .get_config()
-                .get_canister_names_with_dependencies(Some(canister.get_name()))
-                .and_then(|deps| CanisterPool::load(env, false, &deps))
+                .get_canister_names_with_dependencies(Some(canister.get_name()))?;
+
+            tmp = CanisterPool::load(env, false, &deps)
                 .context("Error collecting canisters for post-install task")?;
             &tmp
         }


### PR DESCRIPTION
Also removes dependency from dfinity.rs to BuildError
