### PR TITLE
refactor: concrete error types for to_socket_addr().

### DIFF
--- a/src/dfx-core/src/error/mod.rs
+++ b/src/dfx-core/src/error/mod.rs
@@ -7,5 +7,6 @@ pub mod io;
 pub mod keyring;
 pub mod load_dfx_config;
 pub mod load_networks_config;
+pub mod socket_addr_conversion;
 pub mod structured_file;
 pub mod wallet_config;

--- a/src/dfx-core/src/error/socket_addr_conversion.rs
+++ b/src/dfx-core/src/error/socket_addr_conversion.rs
@@ -1,0 +1,8 @@
+use std::net::AddrParseError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SocketAddrConversionError {
+    #[error("Failed to convert {0} to a socket address: {1}")]
+    ParseSocketAddrFailed(String, AddrParseError),
+}


### PR DESCRIPTION
Also: use parse(), since this method was discarding all but the first result anyway
