### PR TITLE
feat: Add dfx sns download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## DFX
 
+### feat: Add dfx sns download
+
+This allows users to download SNS canister WASMs.
+
 ### fix: fixed error text
 - `dfx nns install` had the wrong instructions for setting up the local replica type
 

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -31,7 +31,7 @@ base64 = "0.13.0"
 byte-unit = { version = "4.0.14", features = ["serde"] }
 bytes = "1.2.1"
 candid = { version = "0.8.2", features = [ "random" ] }
-clap = { version = "3.1.6", features = [ "derive" ] }
+clap = { version = "3.1.6", features = [ "derive", "env" ] }
 console = "0.15.0"
 crc32fast = "1.3.2"
 crossbeam = "0.8.1"

--- a/src/dfx/src/commands/sns/download.rs
+++ b/src/dfx/src/commands/sns/download.rs
@@ -22,6 +22,8 @@ pub struct SnsDownloadOpts {
 /// Executes the command line `dfx sns import`.
 pub fn exec(env: &dyn Environment, opts: SnsDownloadOpts) -> DfxResult {
     let runtime = Runtime::new().expect("Unable to create a runtime");
-    let ic_commit = opts.ic_commit.unwrap_or_else(|| replica_rev().to_string());
+    let ic_commit = opts.ic_commit.unwrap_or_else(|| {
+        std::env::var("DFX_IC_COMMIT").unwrap_or_else(|_| replica_rev().to_string())
+    });
     runtime.block_on(download_sns_wasms(env, &ic_commit, &opts.wasms_dir))
 }

--- a/src/dfx/src/commands/sns/download.rs
+++ b/src/dfx/src/commands/sns/download.rs
@@ -12,7 +12,7 @@ use tokio::runtime::Runtime;
 #[derive(Parser)]
 pub struct SnsDownloadOpts {
     /// IC commit of SNS canister WASMs to download
-    #[clap(long)]
+    #[clap(long, env("DFX_IC_COMMIT"))]
     ic_commit: Option<String>,
     /// Path to store downloaded SNS canister WASMs
     #[clap(long, default_value = ".")]
@@ -22,8 +22,6 @@ pub struct SnsDownloadOpts {
 /// Executes the command line `dfx sns import`.
 pub fn exec(env: &dyn Environment, opts: SnsDownloadOpts) -> DfxResult {
     let runtime = Runtime::new().expect("Unable to create a runtime");
-    let ic_commit = opts.ic_commit.unwrap_or_else(|| {
-        std::env::var("DFX_IC_COMMIT").unwrap_or_else(|_| replica_rev().to_string())
-    });
+    let ic_commit = opts.ic_commit.unwrap_or_else(|| replica_rev().to_string());
     runtime.block_on(download_sns_wasms(env, &ic_commit, &opts.wasms_dir))
 }

--- a/src/dfx/src/commands/sns/download.rs
+++ b/src/dfx/src/commands/sns/download.rs
@@ -1,0 +1,27 @@
+//! Code for the command line `dfx sns import`
+use crate::lib::error::DfxResult;
+use crate::lib::info::replica_rev;
+use crate::lib::nns::install_nns::download_sns_wasms;
+use crate::Environment;
+use std::path::PathBuf;
+
+use clap::Parser;
+use tokio::runtime::Runtime;
+
+/// Downloads the SNS canister WASMs
+#[derive(Parser)]
+pub struct SnsDownloadOpts {
+    /// IC commit of SNS canister WASMs to download
+    #[clap(long)]
+    ic_commit: Option<String>,
+    /// Path to store downloaded SNS canister WASMs
+    #[clap(long, default_value = ".")]
+    wasms_dir: PathBuf,
+}
+
+/// Executes the command line `dfx sns import`.
+pub fn exec(env: &dyn Environment, opts: SnsDownloadOpts) -> DfxResult {
+    let runtime = Runtime::new().expect("Unable to create a runtime");
+    let ic_commit = opts.ic_commit.unwrap_or_else(|| replica_rev().to_string());
+    runtime.block_on(download_sns_wasms(env, &ic_commit, &opts.wasms_dir))
+}

--- a/src/dfx/src/commands/sns/mod.rs
+++ b/src/dfx/src/commands/sns/mod.rs
@@ -2,6 +2,7 @@
 #![warn(clippy::missing_docs_in_private_items)]
 use crate::{
     commands::sns::config::SnsConfigOpts,
+    commands::sns::download::SnsDownloadOpts,
     commands::sns::import::SnsImportOpts,
     lib::{environment::Environment, error::DfxResult},
 };
@@ -10,6 +11,7 @@ use clap::Parser;
 
 mod config;
 mod deploy;
+mod download;
 mod import;
 
 /// Options for `dfx sns`.
@@ -33,6 +35,9 @@ enum SubCommand {
     /// Subcommand for importing sns API definitions and canister IDs.
     #[clap(hide(true))]
     Import(SnsImportOpts),
+    /// Subcommand for downloading SNS WASMs.
+    #[clap(hide(true))]
+    Download(SnsDownloadOpts),
 }
 
 /// Executes `dfx sns` and its subcommands.
@@ -41,5 +46,6 @@ pub fn exec(env: &dyn Environment, cmd: SnsOpts) -> DfxResult {
         SubCommand::Config(v) => config::exec(env, v),
         SubCommand::Import(v) => import::exec(env, v),
         SubCommand::Deploy(v) => deploy::exec(env, v),
+        SubCommand::Download(v) => download::exec(env, v),
     }
 }

--- a/src/dfx/src/lib/nns/install_nns.rs
+++ b/src/dfx/src/lib/nns/install_nns.rs
@@ -462,11 +462,22 @@ pub async fn download_nns_wasms(env: &dyn Environment) -> anyhow::Result<()> {
             download_ic_repo_wasm(test_wasm_name, &ic_commit, wasm_dir).await?;
         }
     }
+    download_sns_wasms(env, &ic_commit, wasm_dir).await?;
+    Ok(())
+}
+
+/// Downloads all the core SNS wasms.
+#[context("Failed to download SNS wasm files.")]
+pub async fn download_sns_wasms(
+    _env: &dyn Environment,
+    ic_commit: &str,
+    wasms_dir: &Path,
+) -> anyhow::Result<()> {
     try_join_all(
         SNS_CANISTERS
             .iter()
             .map(|SnsCanisterInstallation { wasm_name, .. }| {
-                download_ic_repo_wasm(wasm_name, &ic_commit, wasm_dir)
+                download_ic_repo_wasm(wasm_name, ic_commit, wasms_dir)
             }),
     )
     .await?;


### PR DESCRIPTION
Adding a new command to download SNS canister WASMs. This is needed for SNS testflight without installing NNS, i.e., without running `dfx nns install`. 