### PR TITLE
chore: add post install step to automatically install dfx cache

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -7,3 +7,4 @@
 . install/200_downloader.sh
 . install/300_license.sh
 . install/999_footer.sh
+. install/1000_post_install.sh

--- a/public/install/1000_post_install.sh
+++ b/public/install/1000_post_install.sh
@@ -1,0 +1,6 @@
+main() {
+  log "Installing dfx cache"
+  dfx cache install
+}
+
+main "$@" || exit $?


### PR DESCRIPTION
# Description

Normally, running any dfx command installs the cache. This PR adds support to automatically install the cache as a "post-install" step once dfx has completed installation on the user system.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
