### PR TITLE
refactor: ic_asset:sync to split upload from commit

### DIFF
--- a/src/canisters/frontend/ic-asset/src/asset_canister/batch.rs
+++ b/src/canisters/frontend/ic-asset/src/asset_canister/batch.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::asset_canister::method_names::{COMMIT_BATCH, CREATE_BATCH};
 use crate::asset_canister::protocol::{
-    BatchOperationKind, CommitBatchArguments, CreateBatchRequest, CreateBatchResponse,
+    CommitBatchArguments, CreateBatchRequest, CreateBatchResponse,
 };
 use crate::retryable::retryable;
 use anyhow::bail;
@@ -44,8 +44,7 @@ pub(crate) async fn create_batch(canister: &Canister<'_>) -> anyhow::Result<Nat>
 
 pub(crate) async fn commit_batch(
     canister: &Canister<'_>,
-    batch_id: &Nat,
-    operations: Vec<BatchOperationKind>,
+    arg: CommitBatchArguments,
 ) -> anyhow::Result<()> {
     let mut retry_policy = ExponentialBackoffBuilder::new()
         .with_initial_interval(Duration::from_secs(1))
@@ -54,10 +53,6 @@ pub(crate) async fn commit_batch(
         .with_max_elapsed_time(Some(Duration::from_secs(300)))
         .build();
 
-    let arg = CommitBatchArguments {
-        batch_id,
-        operations,
-    };
     loop {
         match canister
             .update_(COMMIT_BATCH)

--- a/src/canisters/frontend/ic-asset/src/asset_canister/protocol.rs
+++ b/src/canisters/frontend/ic-asset/src/asset_canister/protocol.rs
@@ -133,9 +133,9 @@ pub enum BatchOperationKind {
 
 /// Apply all of the operations in the batch, and then remove the batch.
 #[derive(CandidType, Debug)]
-pub struct CommitBatchArguments<'a> {
+pub struct CommitBatchArguments {
     /// The batch to commit.
-    pub batch_id: &'a Nat,
+    pub batch_id: Nat,
 
     /// The operations to apply atomically.
     pub operations: Vec<BatchOperationKind>,

--- a/src/canisters/frontend/ic-asset/src/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/upload.rs
@@ -1,6 +1,6 @@
 use crate::asset_canister::batch::{commit_batch, create_batch};
 use crate::asset_canister::list::list_assets;
-use crate::asset_canister::protocol::{AssetDetails, BatchOperationKind};
+use crate::asset_canister::protocol::{AssetDetails, BatchOperationKind, CommitBatchArguments};
 use crate::asset_config::AssetConfig;
 use crate::operations::{
     create_new_assets, delete_incompatible_assets, set_encodings, unset_obsolete_encodings,
@@ -47,7 +47,12 @@ pub async fn upload(
 
     info!(logger, "Committing batch.");
 
-    commit_batch(canister, &batch_id, operations).await?;
+    let args = CommitBatchArguments {
+        batch_id,
+        operations,
+    };
+
+    commit_batch(canister, args).await?;
 
     Ok(())
 }


### PR DESCRIPTION
# Description

Splits up `ic_asset::sync()` into one part that uploads the batch contents and a second that commits it

# How Has This Been Tested?

Covered by existing e2e
