### PR TITLE
refactor: concrete error types for to_socket_addr().

### DIFF
--- a/src/dfx-core/src/error/mod.rs
+++ b/src/dfx-core/src/error/mod.rs
@@ -7,5 +7,6 @@ pub mod io;
 pub mod keyring;
 pub mod load_dfx_config;
 pub mod load_networks_config;
+pub mod socket_addr_conversion;
 pub mod structured_file;
 pub mod wallet_config;

--- a/src/dfx-core/src/error/socket_addr_conversion.rs
+++ b/src/dfx-core/src/error/socket_addr_conversion.rs
@@ -1,0 +1,10 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SocketAddrConversionError {
+    #[error("Did not find any socket addresses in string '{0}'")]
+    EmptyIterator(String),
+
+    #[error("Failed to convert {0} to a socket address: {1}")]
+    ParseSocketAddrFailed(String, std::io::Error),
+}

--- a/src/dfx/src/config/dfinity.rs
+++ b/src/dfx/src/config/dfinity.rs
@@ -2,7 +2,6 @@
 use crate::config::dfinity::MetadataVisibility::Public;
 use crate::lib::bitcoin::adapter::config::BitcoinAdapterLogLevel;
 use crate::lib::canister_http::adapter::config::HttpAdapterLogLevel;
-use crate::lib::error::{DfxError, DfxResult};
 use crate::util::{PossiblyStr, SerdeVec};
 use dfx_core::config::directories::get_config_dfx_dir_path;
 use dfx_core::error::dfx_config::DfxConfigError;
@@ -19,6 +18,10 @@ use dfx_core::error::load_networks_config::LoadNetworksConfigError;
 use dfx_core::error::load_networks_config::LoadNetworksConfigError::{
     GetConfigPathFailed, LoadConfigFromFileFailed,
 };
+use dfx_core::error::socket_addr_conversion::SocketAddrConversionError;
+use dfx_core::error::socket_addr_conversion::SocketAddrConversionError::{
+    EmptyIterator, ParseSocketAddrFailed,
+};
 use dfx_core::error::structured_file::StructuredFileError;
 use dfx_core::error::structured_file::StructuredFileError::{
     DeserializeJsonFileFailed, ReadJsonFileFailed,
@@ -27,7 +30,6 @@ use dfx_core::json::save_json_file;
 
 use byte_unit::Byte;
 use candid::Principal;
-use fn_error_context::context;
 use schemars::JsonSchema;
 use serde::de::{Error as _, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -606,17 +608,13 @@ pub struct NetworksConfigInterface {
 
 impl ConfigCanistersCanister {}
 
-#[context("Failed to convert '{}' to a SocketAddress.", s)]
-pub fn to_socket_addr(s: &str) -> DfxResult<SocketAddr> {
+pub fn to_socket_addr(s: &str) -> Result<SocketAddr, SocketAddrConversionError> {
     match s.to_socket_addrs() {
         Ok(mut a) => match a.next() {
             Some(res) => Ok(res),
-            None => Err(DfxError::new(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "Empty iterator",
-            ))),
+            None => Err(EmptyIterator(s.to_string())),
         },
-        Err(err) => Err(DfxError::new(err)),
+        Err(err) => Err(ParseSocketAddrFailed(s.to_string(), err)),
     }
 }
 


### PR DESCRIPTION
Preparation to move to dfx-core crate