### PR TITLE
refactor: concrete error types for Cache

### DIFF
--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -3,6 +3,7 @@ use crate::lib::error::{CacheError, DfxError, DfxResult};
 use crate::util;
 #[cfg(windows)]
 use dfx_core::config::directories::project_dirs;
+use dfx_core::error::foundation::FoundationError;
 
 use anyhow::{bail, Context};
 use fn_error_context::context;
@@ -76,7 +77,7 @@ pub fn get_cache_root() -> Result<PathBuf, CacheError> {
     // dirs-next is not used for *nix to preserve existing paths
     #[cfg(not(windows))]
     let p = {
-        let home = std::env::var_os("HOME").ok_or_else(CacheError::NoHomeInEnvironment)?;
+        let home = std::env::var_os("HOME").ok_or_else(FoundationError::NoHomeInEnvironment)?;
         let root = cache_root.unwrap_or(home);
         PathBuf::from(root).join(".cache").join("dfinity")
     };

--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -3,9 +3,9 @@ use crate::lib::error::{CacheError, DfxError, DfxResult};
 use crate::util;
 #[cfg(windows)]
 use dfx_core::config::directories::project_dirs;
-use dfx_core::error::foundation::FoundationError;
 
 use anyhow::{bail, Context};
+use dfx_core::foundation::get_user_home;
 use fn_error_context::context;
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use rand::distributions::Alphanumeric;
@@ -77,7 +77,7 @@ pub fn get_cache_root() -> Result<PathBuf, CacheError> {
     // dirs-next is not used for *nix to preserve existing paths
     #[cfg(not(windows))]
     let p = {
-        let home = std::env::var_os("HOME").ok_or_else(FoundationError::NoHomeInEnvironment)?;
+        let home = get_user_home()?;
         let root = cache_root.unwrap_or(home);
         PathBuf::from(root).join(".cache").join("dfinity")
     };

--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -76,8 +76,7 @@ pub fn get_cache_root() -> Result<PathBuf, CacheError> {
     // dirs-next is not used for *nix to preserve existing paths
     #[cfg(not(windows))]
     let p = {
-        let home = std::env::var_os("HOME")
-            .ok_or_else(|| CacheError::NoHomeInEnvironment())?;
+        let home = std::env::var_os("HOME").ok_or_else(CacheError::NoHomeInEnvironment)?;
         let root = cache_root.unwrap_or(home);
         PathBuf::from(root).join(".cache").join("dfinity")
     };

--- a/src/dfx/src/lib/error/cache.rs
+++ b/src/dfx/src/lib/error/cache.rs
@@ -9,10 +9,8 @@ pub enum CacheError {
     #[error("Cannot find cache directory at '{0}'.")]
     FindCacheDirectoryFailed(PathBuf),
 
-    // Windows paths do not require environment variables (and are found by dirs-next, which has its own errors)
-    #[cfg(not(windows))]
-    #[error("Cannot find home directory.")]
-    NoHomeInEnvironment(),
+    #[error(transparent)]
+    NoHomeInEnvironment(#[from] dfx_core::error::foundation::FoundationError),
 
     #[error("Unknown version '{0}'.")]
     UnknownVersion(String),

--- a/src/dfx/src/lib/error/cache.rs
+++ b/src/dfx/src/lib/error/cache.rs
@@ -10,7 +10,7 @@ pub enum CacheError {
     FindCacheDirectoryFailed(PathBuf),
 
     #[error(transparent)]
-    NoHomeInEnvironment(#[from] dfx_core::error::foundation::FoundationError),
+    FoundationError(#[from] dfx_core::error::foundation::FoundationError),
 
     #[error("Unknown version '{0}'.")]
     UnknownVersion(String),

--- a/src/dfx/src/lib/error/extension.rs
+++ b/src/dfx/src/lib/error/extension.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 pub enum ExtensionError {
     // errors related to extension directory management
     #[error("Cannot find cache directory '{0}': {1}")]
-    FindCacheDirectoryFailed(std::path::PathBuf, anyhow::Error),
+    FindCacheDirectoryFailed(std::path::PathBuf, crate::lib::error::CacheError),
 
     #[error("Cannot get extensions directory: {0}")]
     EnsureExtensionDirExistsFailed(dfx_core::error::io::IoError),


### PR DESCRIPTION
# Description

removing dependencies on anyhow/DfxResult in preparation to move code to the dfx-core crate

# How Has This Been Tested?

covered by CI