### PR TITLE
fix: use ubuntu-20.04 for linux publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
             binary_path: target/x86_64-apple-darwin/release
             name: x86_64-darwin
             tar: gtar
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             binary_path: target/x86_64-unknown-linux-gnu/release
             name: x86_64-linux


### PR DESCRIPTION
ubuntu-latest recently switched to ubuntu-22.04, which brings in different versions of glibc.
