### PR TITLE
docs: Fix typo in text

### DIFF
--- a/docs/cli-reference/dfx-nns.md
+++ b/docs/cli-reference/dfx-nns.md
@@ -77,7 +77,7 @@ $ cat ~/.config/dfx/networks.json
 This is because:
 
 * The NNS canisters need to run on a system subnet.
-* Some canisters are comiled to run on only very specific canister IDs and hostname/port pairs.
+* Some canisters are compiled to run on only very specific canister IDs and hostname/port pairs.
 
 
 In addition, the local dfx server needs to be clean:


### PR DESCRIPTION
# Description

There is a typo "comiled" instead of "compiled" in the text here: https://internetcomputer.org/docs/current/references/cli-reference/dfx-nns#dfx-nns-install

# How Has This Been Tested?

No tests needed.

# Checklist:
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
  - There are no changes in function so I guess this is probably not needed.
- [x] I have made corresponding changes to the documentation.
