### PR TITLE
docs: Add environment variable setup to contributing docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,16 +33,22 @@ If there is already an entry in the 'Unreleased' section, change it; if not, add
 1. Install bats and bats-support 0.3.0. See the CI provisioning scripts for examples:
     - [Linux](../scripts/workflows/provision-linux.sh)
     - [Darwin](../scripts/workflows/provision-darwin.sh)
-2. Export `BATSLIB` to your bats-support directory, typically:
+1. Export `BATSLIB` to your bats-support directory, typically:
     ``` bash
     $ export BATSLIB=/usr/local/lib/bats-support
     ```
-3. Build dfx and add its target directory to your path:
+1. Build dfx and add its target directory to your path:
     ``` bash
     sdk $ cargo build
     sdk $ export PATH="$(pwd)/target/debug:$PATH"
     ```
-4. Install `jq`.
+1. Set up the environment variables required by the e2e tests:
+    ``` bash
+    export archive="$(pwd)/e2e/archive"
+    export utils="$(pwd)/e2e/utils"
+    export assets="$(pwd)/e2e/assets"
+    ```
+1. Install `jq`.
 
 #### Running End-to-End Tests
 


### PR DESCRIPTION
# Description

Added environment variables required to run the following e2e tests:
https://github.com/dfinity/sdk/blob/9bfaa1d1daaf92bb941eb939a6d7f57eaa7c6707/e2e/tests-dfx/nns.bash#L181
https://github.com/dfinity/sdk/blob/9bfaa1d1daaf92bb941eb939a6d7f57eaa7c6707/e2e/utils/_.bash#L315

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
