### PR TITLE
feat(extensions): install from external registries 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,67 @@
 
 ## DFX
 
+### feat: dfx extension can now be installed from external registries
+
+Modifies the `dfx extension install` command to take a flag `--registry` that allows installing extensions from external registries. Here is an example:
+
+```bash
+dfx extension install your_extension --registry=https://raw.githubusercontent.com/your-org/your-repo/master/dfx-extensions-registry.json
+```
+
+The registry file is a JSON file that contains a list of extensions. Here is an example:
+
+```json
+{
+  "compatibility": {
+    "0.15.0": {
+      "your_extension": {
+        "versions": ["0.1.0"]
+      }
+    }
+  },
+  "extensions": {
+    "your_extension": {
+      "0.1.0": {
+        "homepage": "https://github.com/your-org/your-repo",
+        "authors": "Your Org",
+        "summary": "Your extension",
+        "categories": ["development"],
+        "keywords": ["cli-helper"],
+        "description": "A longer description.",
+        "subcommands": {
+          "do_something": {
+            "about": "does something",
+            "args": {
+              "the_param": {
+                "about": "some paramater",
+                "long": "the-param"
+              }
+            }
+          }
+        },
+        "binaries": {
+          "unknown-linux-gnu-x86_64": {
+            "url": "https://raw.githubusercontent.com/your-org/your-repo/master/your_extension-v0.1.0-x86_64-unknown-linux-gnu.tar.gz",
+            "sha256": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+          },
+          "apple-darwin-x86_64": {
+            "url": "https://raw.githubusercontent.com/your-org/your-repo/master/your_extension-v0.1.0-x86_64-apple-darwin.tar.gz ",
+            "sha256": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+          },
+          "apple-darwin-aarch64": {
+            "url": "https://raw.githubusercontent.com/your-org/your-repo/master/your_extension-v0.1.0-aarch64-apple-darwin.tar.gz ",
+            "sha256": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The extension must be published as a tarball (`.tag.gz`), which contains a directory named `<EXTENSION_NAME>-v<EXTENSION_VERSION>-<CPU_ARCHITECTURE>-<PLATFORM>`, which contains a binary named `your_extension`.
+
 ### feat!: Removed dfx nns and dfx sns commands
 
 Both have now been turned into the dfx extensions. In order to obtain them, please run `dfx extension install nns` and `dfx extension install sns` respectively. After the installation, you can use them as you did before: `dfx nns ...`, and `dfx sns ...`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,20 @@ The registry file is a JSON file that contains a list of extensions. Here is an 
 }
 ```
 
-The extension must be published as a tarball (`.tag.gz`), which contains a directory named `<EXTENSION_NAME>-v<EXTENSION_VERSION>-<CPU_ARCHITECTURE>-<PLATFORM>`, which contains a binary named `your_extension`.
+The extension must be published as a tarball (`.tag.gz`), which contains a directory named `<EXTENSION_NAME>-v<EXTENSION_VERSION>-<CPU_ARCHITECTURE>-<PLATFORM>`, which contains a binary named `<EXTENSION_NAME>`, here is minimal example:
+
+```bash
+mkdir test_extension-v0.1.0-x86_64-unknown-linux-gnu
+cat > test_extension-v0.1.0-x86_64-unknown-linux-gnu/test_extension << "EOF"
+#!/usr/bin/env bash
+
+echo Hello, World!
+EOF
+tar -czf test_extension-v0.1.0-x86_64-unknown-linux-gnu.tar.gz test_extension-v0.1.0-x86_64-unknown-linux-gnu
+# you'll also need to generate a sha256 hash of the tarball and put it into the registry file
+shasum -a 256 test_extension-v0.1.0-x86_64-unknown-linux-gnu.tar.gz 
+```
+
 
 ### feat!: Removed dfx nns and dfx sns commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,6 +1415,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2 0.10.7",
  "slog",
  "tar",
  "tempfile",

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -220,13 +220,12 @@ EOF
     port=$((port+1))
   done
 
-  cat > test_extension << "EOF"
+  mkdir test_extension-v0.1.0-x86_64-unknown-linux-gnu
+  cat > test_extension-v0.1.0-x86_64-unknown-linux-gnu/test_extension << "EOF"
 #!/usr/bin/env bash
 
 echo $@
 EOF
-  mkdir -p test_extension-v0.1.0-x86_64-unknown-linux-gnu
-  mv test_extension test_extension-v0.1.0-x86_64-unknown-linux-gnu
   cp -r test_extension-v0.1.0-x86_64-unknown-linux-gnu test_extension-v0.1.0-aarch64-apple-darwin
   cp -r test_extension-v0.1.0-x86_64-unknown-linux-gnu  test_extension-v0.1.0-x86_64-apple-darwin
   tar -czf test_extension-v0.1.0-x86_64-unknown-linux-gnu.tar.gz test_extension-v0.1.0-x86_64-unknown-linux-gnu

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -225,11 +225,11 @@ EOF
 
 echo $@
 EOF
-  mkdir -p test_extension-v0.1.0-unknown-linux-gnu-x86_64
-  mv test_extension test_extension-v0.1.0-unknown-linux-gnu-x86_64
-  cp -r test_extension-v0.1.0-unknown-linux-gnu-x86_64 test_extension-v0.1.0-aarch64-apple-darwin
-  cp -r test_extension-v0.1.0-unknown-linux-gnu-x86_64 test_extension-v0.1.0-x86_64-apple-darwin
-  tar -czf test_extension-v0.1.0-unknown-linux-gnu-x86_64.tar.gz test_extension-v0.1.0-unknown-linux-gnu-x86_64
+  mkdir -p test_extension-v0.1.0-x86_64-unknown-linux-gnu
+  mv test_extension test_extension-v0.1.0-x86_64-unknown-linux-gnu
+  cp -r test_extension-v0.1.0-x86_64-unknown-linux-gnu test_extension-v0.1.0-aarch64-apple-darwin
+  cp -r test_extension-v0.1.0-x86_64-unknown-linux-gnu  test_extension-v0.1.0-x86_64-apple-darwin
+  tar -czf test_extension-v0.1.0-x86_64-unknown-linux-gnu.tar.gz test_extension-v0.1.0-x86_64-unknown-linux-gnu
   tar -czf test_extension-v0.1.0-aarch64-apple-darwin.tar.gz test_extension-v0.1.0-aarch64-apple-darwin
   tar -czf test_extension-v0.1.0-x86_64-apple-darwin.tar.gz test_extension-v0.1.0-x86_64-apple-darwin
   cat > registry.json <<EOF
@@ -252,9 +252,9 @@ EOF
         "description": "A longer description.",
         "subcommands": {},
         "binaries": {
-          "unknow-linux-gnu-x86_64": {
-            "url": "http://localhost:$port/test_extension-v0.1.0-unknown-linux-gnu-x86_64.tar.gz",
-            "sha256": "$(shasum -a 256 test_extension-v0.1.0-unknown-linux-gnu-x86_64.tar.gz | cut -d ' ' -f 1)"
+          "unknown-linux-gnu-x86_64": {
+            "url": "http://localhost:$port/test_extension-v0.1.0-x86_64-unknown-linux-gnu.tar.gz",
+            "sha256": "$(shasum -a 256 test_extension-v0.1.0-x86_64-unknown-linux-gnu.tar.gz | cut -d ' ' -f 1)"
           },
           "apple-darwin-x86_64": {
             "url": "http://localhost:$port/test_extension-v0.1.0-x86_64-apple-darwin.tar.gz ",
@@ -274,7 +274,7 @@ EOF
   python3 -m http.server "$port" &
   pid=$!
 
-  # # Wait until the server is up
+  # wait until the server is up
   while ! echo exit | nc localhost "$port"; do sleep 1; done
   echo "Server is up"
   echo yes | (

--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -33,12 +33,13 @@ sec1 = { workspace = true, features = ["std"] }
 semver = { workspace = true, features = ["serde"] }
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 slog = { workspace = true, features = ["max_level_trace"] }
 tar.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tiny-bip39 = "1.0.0"
-url.workspace = true
+url = { workspace = true, features = [ "serde" ] }
 
 [dev-dependencies]
 proptest = "1.0"

--- a/src/dfx-core/src/error/extension.rs
+++ b/src/dfx-core/src/error/extension.rs
@@ -57,7 +57,7 @@ pub enum ExtensionError {
     #[error("Cannot create temporary directory at '{0}': {1}")]
     CreateTemporaryDirectoryFailed(std::path::PathBuf, std::io::Error),
 
-    #[error("Failed to download extension: checksum of the downloaded archive (sha256:{0}) (downloaded from: '{1}') doesn't match the one provided in the manifest (sha256:{2})")]
+    #[error("Failed to download extension, because the checksum of the downloaded archive (sha256:{0}) (downloaded from: '{1}') doesn't match the one provided by the manifest (sha256:{2})")]
     ChecksumMismatch(String, String, String),
 
     #[error("Platform '{0}' is not supported.")]
@@ -67,22 +67,14 @@ pub enum ExtensionError {
     #[error("Extension manifest URL '{0}' is not valid: {1}")]
     InvalidExternalManifestUrl(String, url::ParseError),
 
-    #[error("Entry 'binaries' not found in extension manifest entry.")]
-    BinaryEntryNotFoundInExtensionManifest,
+    #[error("Entry 'binaries' not found in extension manifest entry for extension '{0}' version '{1}'. Please contact the extension author.")]
+    BinaryEntryNotFoundInExtensionManifest(String, semver::Version),
 
     #[error("Entry 'extensions.{0}' not found in extension manifest entry.")]
     ExtensionNameNotFoundInManifest(String),
 
     #[error("Extension '{0}' was found in the manifest in both 'comppatibility' and 'extensions' entries, however, the latest compatible version of the extension ({1}) could not be found in 'extensions' entry. Please contact the extension author.")]
     MalformedManifestExtensionVersionNotFound(String, semver::Version),
-
-    #[error(
-        "Manifest downloaded from '{}' does not contain 'binaries' object for extension {}-v{}."
-    , _0.0, _0.1, _0.2)]
-    BinariesObejectNotFoundInManifest(Box<(url::Url, String, semver::Version)>),
-
-    #[error("Platform '{}' and architecture '{}' is not supported for extension '{}' defined in manifest downloaded from '{}'.", _0.0, _0.1, _0.2, _0.3)]
-    PlatformArchCombinationNotFoundInManifest(Box<(url::Url, String, String, String)>),
 
     #[error("Cannot save extension manifest: {0}")]
     SaveExtensionManifestFailed(crate::error::structured_file::StructuredFileError),

--- a/src/dfx-core/src/extension/manager/install.rs
+++ b/src/dfx-core/src/extension/manager/install.rs
@@ -95,7 +95,7 @@ impl ExtensionManager {
                     .join("extension.json"),
                 &extension_manifest,
             )
-            .map_err(|e| ExtensionError::SaveExtensionManifestFailed(e))?;
+            .map_err(ExtensionError::SaveExtensionManifestFailed)?;
         }
         self.finalize_installation(
             extension_name,

--- a/src/dfx-core/src/extension/manager/install.rs
+++ b/src/dfx-core/src/extension/manager/install.rs
@@ -147,12 +147,6 @@ fn process_external_registry_manifest(
     let manifest = ExternalExtensionManifest::fetch(&manifest_url)?;
     let extension_manifest = manifest.find_extension(extension_name, dfx_version)?;
     let extension_version = extension_manifest.version.clone().unwrap(); // safe to unwrap, because the value is set in find_extension
-    let extension_version = Version::parse(&extension_version).map_err(|e| {
-        ExtensionError::MalformedVersionsEntryForExtensionInCompatibilityMatrix(
-            extension_name.to_string(),
-            e,
-        )
-    })?;
     let archive_filename = get_extension_archive_name(extension_name, &extension_version)?;
     let binary_descriptor =
         extension_manifest.get_binary_descriptor(format!("{}-{}", platform, arch))?;

--- a/src/dfx-core/src/extension/manager/install.rs
+++ b/src/dfx-core/src/extension/manager/install.rs
@@ -1,15 +1,21 @@
+use crate::error::archive::ArchiveError;
 use crate::error::extension::ExtensionError;
+use crate::extension::manifest::extension::ExtensionBinariesDescriptor;
+use crate::extension::manifest::{ExtensionManifest, ExternalExtensionManifest};
 use crate::extension::{manager::ExtensionManager, manifest::ExtensionCompatibilityMatrix};
 
+use bytes::Bytes;
 use flate2::read::GzDecoder;
 use reqwest::Url;
 use semver::{BuildMetadata, Prerelease, Version};
+use sha2::{Digest, Sha256};
 use tar::Archive;
 use tempfile::{tempdir_in, TempDir};
 
 use std::io::Cursor;
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 
 const DFINITY_DFX_EXTENSIONS_RELEASES_URL: &str =
     "https://github.com/dfinity/dfx-extensions/releases/download";
@@ -18,6 +24,7 @@ impl ExtensionManager {
     pub fn install_extension(
         &self,
         extension_name: &str,
+        external_registry_manifest_url: Option<&str>,
         install_as: Option<&str>,
     ) -> Result<(), ExtensionError> {
         let effective_extension_name = install_as.unwrap_or(extension_name);
@@ -31,52 +38,45 @@ impl ExtensionManager {
             ));
         }
 
-        let extension_version = self.get_extension_compatible_version(extension_name)?;
-        let github_release_tag = get_git_release_tag(extension_name, &extension_version);
-        let extension_archive = get_extension_archive_name(extension_name, &extension_version)?;
-        let url = get_extension_download_url(&github_release_tag, &extension_archive)?;
+        let dfx_version = strip_semver(self.dfx_version.clone());
 
-        let temp_dir = self.download_and_unpack_extension_to_tempdir(url)?;
+        let (
+            extension_download_url,
+            extension_archive_filename,
+            checksum_source,
+            extension_manifest,
+        ) = match external_registry_manifest_url {
+            Some(url) => process_external_registry_manifest(url, extension_name, &dfx_version)?,
+            None => process_dfinity_registry_manifest(extension_name, &dfx_version)?,
+        };
 
-        self.finalize_installation(
+        self.process_extension_download(
+            extension_download_url,
+            &get_checksum(checksum_source)?,
             extension_name,
             effective_extension_name,
-            &extension_archive,
-            temp_dir,
-        )?;
-
-        Ok(())
+            &extension_archive_filename,
+            extension_manifest,
+        )
     }
 
-    /// Removing the prerelease tag and build metadata, because they should
-    /// not be allowed in extension manifests, and semver crate won't match
-    /// a semver with a prerelease tag or build metadata against a semver without.
-    fn dfx_version_strip_semver(&self) -> Version {
-        let mut dfx_version = self.dfx_version.clone();
-        dfx_version.pre = Prerelease::EMPTY;
-        dfx_version.build = BuildMetadata::EMPTY;
-        dfx_version
-    }
-
-    fn get_extension_compatible_version(
+    fn process_extension_download(
         &self,
+        extension_download_url: Url,
+        extension_archive_checksum: &str,
         extension_name: &str,
-    ) -> Result<Version, ExtensionError> {
-        let manifest = ExtensionCompatibilityMatrix::fetch()?;
-        let dfx_version = self.dfx_version_strip_semver();
-        manifest.find_latest_compatible_extension_version(extension_name, &dfx_version)
-    }
-
-    fn download_and_unpack_extension_to_tempdir(
-        &self,
-        download_url: Url,
-    ) -> Result<TempDir, ExtensionError> {
-        let response = reqwest::blocking::get(download_url.clone())
-            .map_err(|e| ExtensionError::ExtensionDownloadFailed(download_url.clone(), e))?;
-
-        let bytes = response
-            .bytes()
-            .map_err(|e| ExtensionError::ExtensionDownloadFailed(download_url.clone(), e))?;
+        effective_extension_name: &str,
+        extension_archive_filename: &str,
+        extension_manifest: Option<ExtensionManifest>,
+    ) -> Result<(), ExtensionError> {
+        let bytes = download(&extension_download_url)?;
+        verify_checksum(&bytes, extension_archive_checksum).map_err(|hash_of_bytes| {
+            ExtensionError::ChecksumMismatch(
+                hash_of_bytes,
+                extension_download_url.into(),
+                extension_archive_checksum.to_string(),
+            )
+        })?;
 
         crate::fs::composite::ensure_dir_exists(&self.dir)
             .map_err(ExtensionError::EnsureExtensionDirExistsFailed)?;
@@ -84,13 +84,25 @@ impl ExtensionManager {
         let temp_dir = tempdir_in(&self.dir).map_err(|e| {
             ExtensionError::CreateTemporaryDirectoryFailed(self.dir.to_path_buf(), e)
         })?;
-
-        let mut archive = Archive::new(GzDecoder::new(Cursor::new(bytes)));
-        archive
-            .unpack(temp_dir.path())
-            .map_err(|e| ExtensionError::DecompressFailed(download_url, e))?;
-
-        Ok(temp_dir)
+        extract_archive(temp_dir.path(), bytes)
+            .map_err(ArchiveError::ArchiveFileInvalidPath)
+            .map_err(|e| ExtensionError::Io(e.into()))?;
+        if let Some(extension_manifest) = extension_manifest {
+            crate::json::save_json_file(
+                &temp_dir
+                    .path()
+                    .join(extension_archive_filename)
+                    .join("extension.json"),
+                &extension_manifest,
+            )
+            .map_err(|e| ExtensionError::SaveExtensionManifestFailed(e))?;
+        }
+        self.finalize_installation(
+            extension_name,
+            effective_extension_name,
+            extension_archive_filename,
+            temp_dir,
+        )
     }
 
     fn finalize_installation(
@@ -104,20 +116,115 @@ impl ExtensionManager {
         crate::fs::rename(
             &temp_dir.path().join(extension_unarchived_dir_name),
             effective_extension_dir,
-        )?;
+        )
+        .map_err(|e| ExtensionError::Io(e.into()))?;
         if extension_name != effective_extension_name {
             // rename the binary
             crate::fs::rename(
                 &effective_extension_dir.join(extension_name),
                 &effective_extension_dir.join(effective_extension_name),
-            )?;
+            )
+            .map_err(|e| ExtensionError::Io(e.into()))?;
         }
         #[cfg(not(target_os = "windows"))]
         {
             let bin = effective_extension_dir.join(effective_extension_name);
-            crate::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o777))?;
+            crate::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o777))
+                .map_err(|e| ExtensionError::Io(e.into()))?;
         }
         Ok(())
+    }
+}
+
+fn process_external_registry_manifest(
+    manifest_url: &str,
+    extension_name: &str,
+    dfx_version: &Version,
+) -> Result<(Url, String, ChecksumSource, Option<ExtensionManifest>), ExtensionError> {
+    let (arch, platform) = get_arch_and_platform()?;
+    let manifest_url = Url::parse(manifest_url)
+        .map_err(|e| ExtensionError::InvalidExternalManifestUrl(manifest_url.to_string(), e))?;
+    let manifest = ExternalExtensionManifest::fetch(&manifest_url)?;
+    let extension_manifest = manifest.find_extension(extension_name, dfx_version)?;
+    let extension_version = extension_manifest.version.clone().unwrap(); // safe to unwrap, because the value is set in find_extension
+    let extension_version = Version::parse(&extension_version).map_err(|e| {
+        ExtensionError::MalformedVersionsEntryForExtensionInCompatibilityMatrix(
+            extension_name.to_string(),
+            e,
+        )
+    })?;
+    let archive_filename = get_extension_archive_name(extension_name, &extension_version)?;
+    let binary_descriptor =
+        extension_manifest.get_binary_descriptor(format!("{}-{}", platform, arch))?;
+
+    let download_url = binary_descriptor.url.clone();
+    let checksum_source = ChecksumSource::ExternalRegistryManifest(binary_descriptor.clone());
+
+    Ok((
+        download_url,
+        archive_filename,
+        checksum_source,
+        Some(extension_manifest),
+    ))
+}
+
+fn process_dfinity_registry_manifest(
+    extension_name: &str,
+    dfx_version: &Version,
+) -> Result<(Url, String, ChecksumSource, Option<ExtensionManifest>), ExtensionError> {
+    let extension_version = ExtensionCompatibilityMatrix::fetch()?
+        .find_latest_compatible_extension_version(extension_name, dfx_version)?;
+    let github_release_tag = get_git_release_tag(extension_name, &extension_version);
+    let archive_filename = get_extension_archive_name(extension_name, &extension_version)?;
+    let download_url = get_extension_download_url(&github_release_tag, &archive_filename)?;
+
+    let checksum_source = ChecksumSource::DfinityGithubReleases {
+        git_tag: github_release_tag,
+        archive_filename: archive_filename.clone(),
+    };
+
+    Ok((download_url, archive_filename, checksum_source, None))
+}
+
+/// Removing the prerelease tag and build metadata, because they should
+/// not be allowed in extension manifests, and semver crate won't match
+/// a semver with a prerelease tag or build metadata against a semver without.
+fn strip_semver(mut dfx_version: Version) -> Version {
+    dfx_version.pre = Prerelease::EMPTY;
+    dfx_version.build = BuildMetadata::EMPTY;
+    dfx_version
+}
+
+enum ChecksumSource {
+    ExternalRegistryManifest(ExtensionBinariesDescriptor),
+    DfinityGithubReleases {
+        git_tag: String,
+        archive_filename: String,
+    },
+}
+
+fn get_checksum(source: ChecksumSource) -> Result<String, ExtensionError> {
+    match source {
+        ChecksumSource::ExternalRegistryManifest(manifest) => Ok(manifest.sha256),
+        ChecksumSource::DfinityGithubReleases {
+            archive_filename,
+            git_tag,
+        } => {
+            let url = format!(
+                "{DFINITY_DFX_EXTENSIONS_RELEASES_URL}/{git_tag}/{archive_filename}.tar.gz.sha256",
+            );
+            let response = reqwest::blocking::get(&url)
+                .map_err(|e| ExtensionError::CompatibilityMatrixFetchError(url.to_string(), e))?;
+            let bytes = response
+                .bytes()
+                .map_err(|e| ExtensionError::CompatibilityMatrixFetchError(url.to_string(), e))?;
+            let checksum = String::from_utf8_lossy(&bytes)
+                .split_ascii_whitespace() // `sha -a 256` output is `<checksum>    <filename>`
+                .next()
+                .unwrap_or_default()
+                .to_string();
+            Ok(checksum)
+        }
     }
 }
 
@@ -138,17 +245,48 @@ fn get_extension_archive_name(
     extension_name: &str,
     extension_version: &Version,
 ) -> Result<String, ExtensionError> {
+    let (arch, platform) = get_arch_and_platform()?;
     Ok(format!(
-        "{extension_name}-v{extension_version}-{arch}-{platform}",
-        platform = match std::env::consts::OS {
-            "linux" => "unknown-linux-gnu",
-            "macos" => "apple-darwin",
-            // "windows" => "pc-windows-msvc",
-            unsupported_platform =>
-                return Err(ExtensionError::PlatformNotSupported(
-                    unsupported_platform.to_string()
-                )),
-        },
-        arch = std::env::consts::ARCH,
+        "{extension_name}-v{extension_version}-{arch}-{platform}"
     ))
+}
+
+fn get_arch_and_platform() -> Result<(&'static str, &'static str), ExtensionError> {
+    let platform = match std::env::consts::OS {
+        "linux" => "unknown-linux-gnu",
+        "macos" => "apple-darwin",
+        // "windows" => "pc-windows-msvc",
+        unsupported_platform => {
+            return Err(ExtensionError::PlatformNotSupported(
+                unsupported_platform.to_string(),
+            ))
+        }
+    };
+    let arch = std::env::consts::ARCH;
+    Ok((arch, platform))
+}
+
+fn download(download_url: &Url) -> Result<Bytes, ExtensionError> {
+    let response = reqwest::blocking::get(download_url.clone())
+        .map_err(|e| ExtensionError::ExtensionDownloadFailed(download_url.clone(), e))?;
+    let bytes = response
+        .bytes()
+        .map_err(|e| ExtensionError::ExtensionDownloadFailed(download_url.clone(), e))?;
+    Ok(bytes)
+}
+
+fn verify_checksum(bytes: &Bytes, checksum: &str) -> Result<(), String> {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let hash = hasher.finalize();
+    let hash = hex::encode(hash);
+    if hash != checksum {
+        return Err(hash);
+    }
+    Ok(())
+}
+
+fn extract_archive(path: &Path, bytes: Bytes) -> Result<(), std::io::Error> {
+    let mut archive = Archive::new(GzDecoder::new(Cursor::new(bytes)));
+    archive.unpack(path)
 }

--- a/src/dfx-core/src/extension/manifest/compatibility_matrix.rs
+++ b/src/dfx-core/src/extension/manifest/compatibility_matrix.rs
@@ -29,7 +29,6 @@ impl ExtensionCompatibilityMatrix {
                 e,
             )
         })?;
-
         resp.json()
             .map_err(ExtensionError::MalformedCompatibilityMatrix)
     }

--- a/src/dfx-core/src/extension/manifest/external_extension.rs
+++ b/src/dfx-core/src/extension/manifest/external_extension.rs
@@ -1,0 +1,51 @@
+use crate::error::extension::ExtensionError;
+
+use super::{ExtensionCompatibilityMatrix, ExtensionManifest};
+
+use reqwest::Url;
+use semver::Version;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize)]
+pub struct ExternalExtensionManifest {
+    pub compatibility: ExtensionCompatibilityMatrix,
+    pub extensions: HashMap<String, HashMap<Version, ExtensionManifest>>,
+}
+
+impl ExternalExtensionManifest {
+    pub fn fetch(url: &Url) -> Result<Self, ExtensionError> {
+        let resp = reqwest::blocking::get(url.clone())
+            .map_err(|e| ExtensionError::CompatibilityMatrixFetchError(url.to_string(), e))?;
+        resp.json()
+            .map_err(ExtensionError::MalformedCompatibilityMatrix)
+    }
+
+    pub fn find_extension(
+        &self,
+        extension_name: &str,
+        dfx_version: &Version,
+    ) -> Result<ExtensionManifest, ExtensionError> {
+        let extension_version = self
+            .compatibility
+            .find_latest_compatible_extension_version(extension_name, dfx_version)?;
+        let mut manifest = self
+            .extensions
+            .get(extension_name)
+            .ok_or_else(|| {
+                ExtensionError::ExtensionNameNotFoundInManifest(extension_name.to_string())
+            })?
+            .clone()
+            .get(&extension_version)
+            .ok_or_else(|| {
+                ExtensionError::MalformedManifestExtensionVersionNotFound(
+                    extension_name.to_string(),
+                    extension_version.clone(),
+                )
+            })?
+            .clone();
+        manifest.version.replace(extension_version.to_string());
+        manifest.name.replace(extension_name.to_string());
+        Ok(manifest)
+    }
+}

--- a/src/dfx-core/src/extension/manifest/external_extension.rs
+++ b/src/dfx-core/src/extension/manifest/external_extension.rs
@@ -44,7 +44,8 @@ impl ExternalExtensionManifest {
                 )
             })?
             .clone();
-        manifest.version.replace(extension_version.to_string());
+        // TODO: maybe serde can do this for us?
+        manifest.version.replace(extension_version);
         manifest.name.replace(extension_name.to_string());
         Ok(manifest)
     }

--- a/src/dfx-core/src/extension/manifest/mod.rs
+++ b/src/dfx-core/src/extension/manifest/mod.rs
@@ -12,3 +12,12 @@ pub mod extension;
 pub use extension::ExtensionManifest;
 /// File name for the file describing the extension.
 pub use extension::MANIFEST_FILE_NAME;
+
+pub mod external_extension;
+/// In order for extensions stored in external repositories to be consumable by dfx,
+/// the repository maintainers must provide a URL to a JSON file with the following structure.
+/// This file is an amalgamation of the compatibility.json file and the combined manifest.json
+/// files for each individual extension, as they exist in the DFINITY extension repository.
+/// The file must respect the following constraint: for every version of every extension
+/// listed under the “compatibility” key, there should be a corresponding entry under the “extensions” key.
+pub use external_extension::ExternalExtensionManifest;

--- a/src/dfx/src/lib/project/import.rs
+++ b/src/dfx/src/lib/project/import.rs
@@ -3,7 +3,6 @@ use dfx_core::config::model::canister_id_store;
 use dfx_core::config::model::canister_id_store::CanisterIds;
 use dfx_core::config::model::dfinity::Config;
 
-use hyper_rustls::ConfigBuilderExt;
 use reqwest::{Client, StatusCode};
 use serde::Deserialize;
 use serde_json::{Map, Value};

--- a/src/dfx/src/util/mod.rs
+++ b/src/dfx/src/util/mod.rs
@@ -10,7 +10,6 @@ use candid::parser::typing::pretty_check_file;
 use candid::types::{value::IDLValue, Function, Type, TypeEnv, TypeInner};
 use candid::IDLArgs;
 use fn_error_context::context;
-use hyper_rustls::ConfigBuilderExt;
 #[cfg(unix)]
 use net2::unix::UnixTcpBuilderExt;
 use net2::{TcpBuilder, TcpListenerExt};


### PR DESCRIPTION
# Description

Modifies the `extension install` command to take a flag `--registry` that allows the registry to install from to be specified at runtime

`dfx extension install foo --registry <other-compatibility.json>`

Implements https://dfinity.atlassian.net/browse/SDK-963

# How Has This Been Tested?
added e2e test


# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.