### PR TITLE
fix(e2e): raise `cdk-rs` version in `e2e/assets/vulnerable_rust_deps/src/hello`

### DIFF
--- a/e2e/assets/vulnerable_rust_deps/src/hello/Cargo.toml
+++ b/e2e/assets/vulnerable_rust_deps/src/hello/Cargo.toml
@@ -9,5 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 candid = "0.7.4"
 ic-cdk = "0.7"
-ic-cdk-macros = "0.6"
 time = "0.1.43"

--- a/e2e/assets/vulnerable_rust_deps/src/hello/Cargo.toml
+++ b/e2e/assets/vulnerable_rust_deps/src/hello/Cargo.toml
@@ -9,5 +9,5 @@ crate-type = ["cdylib"]
 [dependencies]
 candid = "0.7.4"
 ic-cdk = "0.7"
-ic-cdk-macros = "0.7"
+ic-cdk-macros = "0.6"
 time = "0.1.43"

--- a/e2e/assets/vulnerable_rust_deps/src/hello/Cargo.toml
+++ b/e2e/assets/vulnerable_rust_deps/src/hello/Cargo.toml
@@ -8,6 +8,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.7.4"
-ic-cdk = "0.4"
-ic-cdk-macros = "0.4"
+ic-cdk = "0.7"
+ic-cdk-macros = "0.7"
 time = "0.1.43"

--- a/e2e/assets/vulnerable_rust_deps/src/hello/src/lib.rs
+++ b/e2e/assets/vulnerable_rust_deps/src/hello/src/lib.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-#[ic_cdk_macros::query]
+#[ic_cdk::query]
 fn greet(name: String) -> String {
     let _dur = Duration::from_secs(1);
     format!("Hello, {}!", name)


### PR DESCRIPTION
# Description

recent yanking of `cdk-rs` versions has affected our e2e tests https://github.com/dfinity/sdk/actions/runs/4187258199/jobs/7257012722

this fixes the problem

# How Has This Been Tested?

CI
# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
