### PR TITLE
feat: Allow bypassing asset canister upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## DFX 
 
+### feat: --no-asset-upgrade
+
+By specifying the `--no-asset-upgrade` flag in `dfx deploy` or `dfx canister install`, you can ensure that the asset canister itself is not upgraded, but instead only the assets themselves are installed.
+
 ### feat: Add DFX_ASSETS_WASM
 
 Added the ability to configure the WASM module used for assets canisters through the environment variable `DFX_ASSETS_WASM`.

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-too-many-arguments-threshold = 12
+too-many-arguments-threshold = 16

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -171,3 +171,13 @@ teardown() {
     assert_command dfx canister install e2e_project_backend
     assert_command timeout -s9 20s dfx canister install e2e_project_backend --mode reinstall -y # if -y does not work, hangs without stdin
 }
+
+@test "--no-asset-upgrade skips asset upgrade" {
+    dfx_start
+    use_asset_wasm 0.12.1
+    dfx deploy
+    use_default_asset_wasm
+    assert_command dfx canister install e2e_project_frontend --mode upgrade --no-asset-upgrade
+    assert_command dfx canister info e2e_project_frontend
+    assert_contains db07e7e24f6f8ddf53c33a610713259a7c1eb71c270b819ebd311e2d223267f0
+}

--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -59,6 +59,10 @@ pub struct CanisterInstallOpts {
     /// so this is not recommended outside of CI.
     #[clap(long, short)]
     yes: bool,
+
+    /// Skips upgrading the asset canister, to only install the assets themselves.
+    #[clap(long)]
+    no_asset_upgrade: bool,
 }
 
 pub async fn exec(
@@ -144,6 +148,7 @@ pub async fn exec(
                 None,
                 opts.yes,
                 env_file.as_deref(),
+                !opts.no_asset_upgrade,
             )
             .await
         }
@@ -186,6 +191,7 @@ pub async fn exec(
                     None,
                     opts.yes,
                     env_file.as_deref(),
+                    !opts.no_asset_upgrade,
                 )
                 .await?;
             }

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -81,6 +81,10 @@ pub struct DeployOpts {
     /// so this is not recommended outside of CI.
     #[clap(long, short)]
     yes: bool,
+
+    /// Skips upgrading the asset canister, to only install the assets themselves.
+    #[clap(long)]
+    no_asset_upgrade: bool,
 }
 
 pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
@@ -143,6 +147,7 @@ pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
         create_call_sender,
         opts.yes,
         env_file,
+        !opts.no_asset_upgrade,
     ))?;
 
     display_urls(&env)

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -33,6 +33,7 @@ pub async fn deploy_canisters(
     create_call_sender: &CallSender,
     skip_consent: bool,
     env_file: Option<PathBuf>,
+    assets_upgrade: bool,
 ) -> DfxResult {
     let log = env.get_logger();
 
@@ -108,6 +109,7 @@ pub async fn deploy_canisters(
         pool,
         skip_consent,
         env_file.as_deref(),
+        assets_upgrade,
     )
     .await?;
 
@@ -226,6 +228,7 @@ async fn install_canisters(
     pool: CanisterPool,
     skip_consent: bool,
     env_file: Option<&Path>,
+    assets_upgrade: bool,
 ) -> DfxResult {
     info!(env.get_logger(), "Installing canisters...");
 
@@ -264,6 +267,7 @@ async fn install_canisters(
             Some(&pool),
             skip_consent,
             env_file,
+            assets_upgrade,
         )
         .await?;
     }

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -43,6 +43,7 @@ pub async fn install_canister(
     pool: Option<&CanisterPool>,
     skip_consent: bool,
     env_file: Option<&Path>,
+    assets_upgrade: bool,
 ) -> DfxResult {
     let log = env.get_logger();
     let network = env.get_network_descriptor();
@@ -114,7 +115,7 @@ pub async fn install_canister(
             "Module hash {} is already installed.",
             hex::encode(installed_module_hash.as_ref().unwrap())
         );
-    } else {
+    } else if assets_upgrade || canister_info.is_assets() {
         install_canister_wasm(
             env,
             agent,


### PR DESCRIPTION
Adds the `--no-asset-upgrade` flag, which allows installing assets without upgrading the canister module itself. Implements SDK-974.