### PR TITLE
feat: Get identity from env var if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ By specifying the `--no-asset-upgrade` flag in `dfx deploy` or `dfx canister ins
 
 ### feat: Get identity from env var if present
 
-The identity may be specified using the environment variable `DFX_DENTITY`.
+The identity may be specified using the environment variable `DFX_IDENTITY`.
 
 ### feat: Add DFX_ASSETS_WASM
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 By specifying the `--no-asset-upgrade` flag in `dfx deploy` or `dfx canister install`, you can ensure that the asset canister itself is not upgraded, but instead only the assets themselves are installed.
 
+### feat: Get identity from env var if present
+
+The identity may be specified using the environment variable `DFX_DENTITY`.
+
 ### feat: Add DFX_ASSETS_WASM
 
 Added the ability to configure the WASM module used for assets canisters through the environment variable `DFX_ASSETS_WASM`.

--- a/docs/cli-reference/dfx-identity.md
+++ b/docs/cli-reference/dfx-identity.md
@@ -314,6 +314,11 @@ For example, you might store the wallet canister identifier in an environment va
 
 Use the `dfx identity use` command to specify the user identity you want to active. You should note that the identities you have available to use are global. They are not confined to a specific project context. Therefore, you can use any identity you have previously created in any project.
 
+The identity used by a command is:
+- the identity specified in the command with `--identity <NAME>`, if defined
+- else the identity specified by the environment variable `export DFX_IDENTITY=<NAME>`, if defined
+- the identity specified by `dfx identity use <NAME>`.
+
 ### Basic usage
 
 ``` bash

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -389,6 +389,19 @@ default'
     assert_eq '2vxsx-fae'
 }
 
+@test "identity use: is overridden by env var DFX_IDENTITY" {
+    assert_command dfx identity new dan
+    assert_command dfx identity new frank
+    assert_command dfx identity use dan
+    assert_command dfx identity whoami
+    assert_eq 'dan'
+    DFX_IDENTITY=frank
+    export DFX_IDENTITY
+    assert_command dfx identity whoami
+    assert_eq 'frank'
+}
+
+
 ##
 ## dfx identity whoami
 ##

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -392,6 +392,7 @@ default'
 @test "identity use: is overridden by env var DFX_IDENTITY" {
     assert_command dfx identity new dan
     assert_command dfx identity new frank
+    assert_command dfx identity new alice
     assert_command dfx identity use dan
     assert_command dfx identity whoami
     assert_eq 'dan'
@@ -399,6 +400,8 @@ default'
     export DFX_IDENTITY
     assert_command dfx identity whoami
     assert_eq 'frank'
+    assert_command dfx identity whoami --identity alice
+    assert_eq 'alice'
 }
 
 

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -37,7 +37,7 @@ pub struct CliOpts {
     logfile: Option<String>,
 
     /// The user identity to run this command as. It contains your principal as well as some things DFX associates with it like the wallet.
-    #[clap(long, global(true))]
+    #[clap(long, env("DFX_IDENTITY"), global(true))]
     identity: Option<String>,
 
     /// The effective canister id for provisional canister creation must be a canister id in the canister ranges of the subnet on which new canisters should be created.
@@ -180,9 +180,7 @@ fn print_error_and_diagnosis(err: Error, error_diagnosis: Diagnosis) {
 fn main() {
     let cli_opts = CliOpts::parse();
     let (verbose_level, log) = setup_logging(&cli_opts);
-    let identity = cli_opts
-        .identity
-        .or_else(|| std::env::var("DFX_IDENTITY").ok());
+    let identity = cli_opts.identity;
     let effective_canister_id = cli_opts.provisional_create_canister_effective_canister_id;
     let command = cli_opts.command;
     let mut error_diagnosis: Diagnosis = NULL_DIAGNOSIS;

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -180,7 +180,9 @@ fn print_error_and_diagnosis(err: Error, error_diagnosis: Diagnosis) {
 fn main() {
     let cli_opts = CliOpts::parse();
     let (verbose_level, log) = setup_logging(&cli_opts);
-    let identity = cli_opts.identity.or_else(|| std::env::var("DFX_IDENTITY").ok());
+    let identity = cli_opts
+        .identity
+        .or_else(|| std::env::var("DFX_IDENTITY").ok());
     let effective_canister_id = cli_opts.provisional_create_canister_effective_canister_id;
     let command = cli_opts.command;
     let mut error_diagnosis: Diagnosis = NULL_DIAGNOSIS;

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -180,7 +180,7 @@ fn print_error_and_diagnosis(err: Error, error_diagnosis: Diagnosis) {
 fn main() {
     let cli_opts = CliOpts::parse();
     let (verbose_level, log) = setup_logging(&cli_opts);
-    let identity = cli_opts.identity;
+    let identity = cli_opts.identity.or_else(|| std::env::var("DFX_IDENTITY").ok());
     let effective_canister_id = cli_opts.provisional_create_canister_effective_canister_id;
     let command = cli_opts.command;
     let mut error_diagnosis: Diagnosis = NULL_DIAGNOSIS;


### PR DESCRIPTION
# Description
`dfx identity use` changes global state.  This means that one script that sets a default identity for its own purposes can interfere with another running concurrently.

This PR proposes a mechanism of scoping a default identity to the current shell.  The identity for a command is:
- as specified by `--identity XXX`, if present, else
- as specified by the environment variable `DFX_IDENTITY=XXX`, if present, else
- as specified by `dfx identity use`
The second of these is scoped to the local shell.

# How Has This Been Tested?
- I have run `DFX_IDENTITY=default cargo run -- identity whoami` and similar commands locally.
- I have included a CI test in this PR.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
