### PR TITLE
refactor: get_running_webserver_bind_address concrete error types

### DIFF
--- a/src/dfx-core/src/error/io.rs
+++ b/src/dfx-core/src/error/io.rs
@@ -27,6 +27,9 @@ pub enum IoErrorKind {
     #[error("Failed to read permissions of {0}: {1}")]
     ReadPermissionsFailed(PathBuf, std::io::Error),
 
+    #[error("Failed to read {0} as string: {1}")]
+    ReadToStringFailed(PathBuf, std::io::Error),
+
     #[error("Failed to remove directory {0}: {1}")]
     RemoveDirectoryFailed(PathBuf, std::io::Error),
 

--- a/src/dfx-core/src/error/network_config.rs
+++ b/src/dfx-core/src/error/network_config.rs
@@ -1,3 +1,6 @@
+use crate::error::io::IoError;
+use std::num::ParseIntError;
+use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -5,6 +8,12 @@ pub enum NetworkConfigError {
     #[error("Did not find any providers for network '{0}'")]
     NoProvidersForNetwork(String),
 
+    #[error("Failed to parse contents of {0} as a port value: {1}")]
+    ParsePortValueFailed(Box<PathBuf>, Box<ParseIntError>),
+
     #[error("Failed to parse URL '{0}': {1}")]
     ParseProviderUrlFailed(Box<String>, url::ParseError),
+
+    #[error("Failed to read webserver port: {0}")]
+    ReadWebserverPortFailed(IoError),
 }

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -3,8 +3,8 @@ pub mod composite;
 use crate::error::io::IoError;
 use crate::error::io::IoErrorKind::{
     CanonicalizePathFailed, CopyFileFailed, CreateDirectoryFailed, NoParent, ReadDirFailed,
-    ReadFileFailed, ReadPermissionsFailed, RemoveDirectoryAndContentsFailed, RemoveDirectoryFailed,
-    RemoveFileFailed, RenameFailed, WriteFileFailed, WritePermissionsFailed,
+    ReadFileFailed, ReadPermissionsFailed, ReadToStringFailed, RemoveDirectoryAndContentsFailed,
+    RemoveDirectoryFailed, RemoveFileFailed, RenameFailed, WriteFileFailed, WritePermissionsFailed,
 };
 
 use std::fs::{Permissions, ReadDir};
@@ -39,6 +39,11 @@ pub fn parent(path: &Path) -> Result<PathBuf, IoError> {
 
 pub fn read(path: &Path) -> Result<Vec<u8>, IoError> {
     std::fs::read(path).map_err(|err| IoError::new(ReadFileFailed(path.to_path_buf(), err)))
+}
+
+pub fn read_to_string(path: &Path) -> Result<String, IoError> {
+    std::fs::read_to_string(path)
+        .map_err(|err| IoError::new(ReadToStringFailed(path.to_path_buf(), err)))
 }
 
 pub fn read_dir(path: &Path) -> Result<ReadDir, IoError> {


### PR DESCRIPTION
# Description

Concrete error types for looking up the webserver port, in preparation to move to dfx-core crate.

# How Has This Been Tested?

Covered by CI