### PR TITLE
fix: follow-up review for #2940

### DIFF
--- a/e2e/tests-dfx/pull.bash
+++ b/e2e/tests-dfx/pull.bash
@@ -14,6 +14,16 @@ teardown() {
     standard_teardown
 }
 
+export_canister_ids() {
+    local a b c
+    a=$(dfx canister id onchain_a)
+    b=$(dfx canister id onchain_b)
+    c=$(dfx canister id onchain_c)
+    export CANISTER_ID_A="$a"
+    export CANISTER_ID_B="$b"
+    export CANISTER_ID_C="$c"
+}
+
 @test "dfx build can write required metadata for pull" {
     dfx_new
     install_asset pull
@@ -55,43 +65,49 @@ teardown() {
     # app -> [a, b]
     cd onchain
 
+    dfx canister create --all
+    export_canister_ids
+
     echo -n -e \\x00asm\\x01\\x00\\x00\\x00 > src/onchain_a/main.wasm
 
     echo -n -e \\x00asm\\x01\\x00\\x00\\x00 > src/onchain_b/main.wasm
-    ic-wasm src/onchain_b/main.wasm -o src/onchain_b/main.wasm metadata "dfx:deps" -d "onchain_a:rrkah-fqaaa-aaaaa-aaaaq-cai;" -v public
+    ic-wasm src/onchain_b/main.wasm -o src/onchain_b/main.wasm metadata "dfx:deps" -d "onchain_a:$CANISTER_ID_A;" -v public
 
     echo -n -e \\x00asm\\x01\\x00\\x00\\x00 > src/onchain_c/main.wasm
-    ic-wasm src/onchain_c/main.wasm -o src/onchain_c/main.wasm metadata "dfx:deps" -d "onchain_a:rrkah-fqaaa-aaaaa-aaaaq-cai;" -v public
+    ic-wasm src/onchain_c/main.wasm -o src/onchain_c/main.wasm metadata "dfx:deps" -d "onchain_a:$CANISTER_ID_A;" -v public
 
     dfx deploy
 
-    assert_command dfx canister metadata ryjl3-tyaaa-aaaaa-aaaba-cai dfx:deps
-    assert_match "onchain_a:rrkah-fqaaa-aaaaa-aaaaq-cai;"
+    assert_command dfx canister metadata "$CANISTER_ID_B" dfx:deps
+    assert_match "onchain_a:$CANISTER_ID_A;"
 
     ## 1.2. pull onchain canisters in "app" project
     cd ../app
+    jq '.canisters.dep1.id="'"$CANISTER_ID_B"'"' dfx.json | sponge dfx.json
+    jq '.canisters.dep2.id="'"$CANISTER_ID_C"'"' dfx.json | sponge dfx.json
+
     assert_command_fail dfx pull dep1 # the overall pull fail but succeed to fetch and parse `dfx:deps` recursively
-    assert_contains "Pulling canister ryjl3-tyaaa-aaaaa-aaaba-cai...
-Pulling canister rrkah-fqaaa-aaaaa-aaaaq-cai...
-WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
-    assert_contains "ERROR: Failed to download wasm of canister ryjl3-tyaaa-aaaaa-aaaba-cai.
-\`dfx:wasm_url\` metadata not found in canister ryjl3-tyaaa-aaaaa-aaaba-cai."
-    assert_contains "ERROR: Failed to download wasm of canister rrkah-fqaaa-aaaaa-aaaaq-cai.
-\`dfx:wasm_url\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
+    assert_contains "Pulling canister $CANISTER_ID_B...
+Pulling canister $CANISTER_ID_A...
+WARN: \`dfx:deps\` metadata not found in canister $CANISTER_ID_A."
+    assert_contains "ERROR: Failed to download wasm of canister $CANISTER_ID_B.
+\`dfx:wasm_url\` metadata not found in canister $CANISTER_ID_B."
+    assert_contains "ERROR: Failed to download wasm of canister $CANISTER_ID_A.
+\`dfx:wasm_url\` metadata not found in canister $CANISTER_ID_A."
 
     ## 1.3. if not specify canister name, all pull type canisters (dep1, dep2) will be pulled
     assert_command_fail dfx pull # the overall pull fail but succeed to fetch and parse `dfx:deps` recursively
-    assert_contains "Pulling canister ryjl3-tyaaa-aaaaa-aaaba-cai...
-Pulling canister r7inp-6aaaa-aaaaa-aaabq-cai...
-Pulling canister rrkah-fqaaa-aaaaa-aaaaq-cai...
-WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
-    assert_occurs 1 "Pulling canister rrkah-fqaaa-aaaaa-aaaaq-cai..." # common dependency onchain_a is pulled only once
-    assert_contains "ERROR: Failed to download wasm of canister ryjl3-tyaaa-aaaaa-aaaba-cai.
-\`dfx:wasm_url\` metadata not found in canister ryjl3-tyaaa-aaaaa-aaaba-cai."
-    assert_contains "ERROR: Failed to download wasm of canister r7inp-6aaaa-aaaaa-aaabq-cai.
-\`dfx:wasm_url\` metadata not found in canister r7inp-6aaaa-aaaaa-aaabq-cai."
-    assert_contains "ERROR: Failed to download wasm of canister rrkah-fqaaa-aaaaa-aaaaq-cai.
-\`dfx:wasm_url\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
+    assert_contains "Pulling canister $CANISTER_ID_B...
+Pulling canister $CANISTER_ID_C...
+Pulling canister $CANISTER_ID_A...
+WARN: \`dfx:deps\` metadata not found in canister $CANISTER_ID_A."
+    assert_occurs 1 "Pulling canister $CANISTER_ID_A..." # common dependency onchain_a is pulled only once
+    assert_contains "ERROR: Failed to download wasm of canister $CANISTER_ID_B.
+\`dfx:wasm_url\` metadata not found in canister $CANISTER_ID_B."
+    assert_contains "ERROR: Failed to download wasm of canister $CANISTER_ID_C.
+\`dfx:wasm_url\` metadata not found in canister $CANISTER_ID_C."
+    assert_contains "ERROR: Failed to download wasm of canister $CANISTER_ID_A.
+\`dfx:wasm_url\` metadata not found in canister $CANISTER_ID_A."
 
     # 2. sad path: if the canister is not present on-chain
     cd ../onchain
@@ -99,8 +115,8 @@ WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
 
     cd ../app
     assert_command_fail dfx pull
-    assert_contains "Failed to fetch and parse \`dfx:deps\` metadata from canister rrkah-fqaaa-aaaaa-aaaaq-cai."
-    assert_contains "Canister rrkah-fqaaa-aaaaa-aaaaq-cai has no module."
+    assert_contains "Failed to fetch and parse \`dfx:deps\` metadata from canister $CANISTER_ID_A."
+    assert_contains "Canister $CANISTER_ID_A has no module."
 
     cd ../onchain
     dfx canister stop onchain_a
@@ -108,20 +124,20 @@ WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
 
     cd ../app
     assert_command_fail dfx pull
-    assert_contains "Failed to fetch and parse \`dfx:deps\` metadata from canister rrkah-fqaaa-aaaaa-aaaaq-cai."
-    assert_contains "Canister rrkah-fqaaa-aaaaa-aaaaq-cai not found."
+    assert_contains "Failed to fetch and parse \`dfx:deps\` metadata from canister $CANISTER_ID_A."
+    assert_contains "Canister $CANISTER_ID_A not found."
 
     # 3. sad path: if dependency metadata cannot be read (wrong format)
     cd ../onchain
     cd src/onchain_b
-    ic-wasm main.wasm -o main.wasm metadata "dfx:deps" -d "rrkah-fqaaa-aaaaa-aaaaq-cai;onchain_a" -v public
+    ic-wasm main.wasm -o main.wasm metadata "dfx:deps" -d "$CANISTER_ID_A;onchain_a" -v public
     cd ../../ # go back to root of "onchain" project
     dfx deploy
 
     cd ../app
     assert_command_fail dfx pull
-    assert_contains "Failed to fetch and parse \`dfx:deps\` metadata from canister ryjl3-tyaaa-aaaaa-aaaba-cai."
-    assert_contains "Failed to parse \`dfx:deps\` entry: rrkah-fqaaa-aaaaa-aaaaq-cai. Expected \`name:Principal\`."
+    assert_contains "Failed to fetch and parse \`dfx:deps\` metadata from canister $CANISTER_ID_B."
+    assert_contains "Failed to parse \`dfx:deps\` entry: $CANISTER_ID_A. Expected \`name:Principal\`."
 }
 
 @test "dfx pull can download wasm" {
@@ -132,9 +148,9 @@ WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
 
     WASM_CACHE="$DFX_CACHE_ROOT/.cache/dfinity/wasms/"
 
-    assert_file_not_exists "$WASM_CACHE/ryjl3-tyaaa-aaaaa-aaaba-cai/canister.wasm"
-    assert_file_not_exists "$WASM_CACHE/rrkah-fqaaa-aaaaa-aaaaq-cai/canister.wasm"
-    assert_file_not_exists "$WASM_CACHE/r7inp-6aaaa-aaaaa-aaabq-cai/canister.wasm"
+    assert_file_not_exists "$WASM_CACHE/$CANISTER_ID_B/canister.wasm"
+    assert_file_not_exists "$WASM_CACHE/$CANISTER_ID_A/canister.wasm"
+    assert_file_not_exists "$WASM_CACHE/$CANISTER_ID_C/canister.wasm"
 
     # system-wide local replica
     dfx_start
@@ -148,21 +164,21 @@ WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
     # prepare "onchain" canisters
     cd onchain
 
+    dfx canister create --all
+    export_canister_ids
+
     echo -n -e \\x00asm\\x01\\x00\\x00\\x00 > src/onchain_a/main.wasm
     ic-wasm src/onchain_a/main.wasm -o src/onchain_a/main.wasm metadata "dfx:wasm_url" -d "http://localhost:$E2E_WEB_SERVER_PORT/a.wasm" -v public
 
     echo -n -e \\x00asm\\x01\\x00\\x00\\x00 > src/onchain_b/main.wasm
     ic-wasm src/onchain_b/main.wasm -o src/onchain_b/main.wasm metadata "dfx:wasm_url" -d "http://localhost:$E2E_WEB_SERVER_PORT/b.wasm" -v public
-    ic-wasm src/onchain_b/main.wasm -o src/onchain_b/main.wasm metadata "dfx:deps" -d "onchain_a:rrkah-fqaaa-aaaaa-aaaaq-cai;" -v public
+    ic-wasm src/onchain_b/main.wasm -o src/onchain_b/main.wasm metadata "dfx:deps" -d "onchain_a:$CANISTER_ID_A;" -v public
 
     echo -n -e \\x00asm\\x01\\x00\\x00\\x00 > src/onchain_c/main.wasm
     ic-wasm src/onchain_c/main.wasm -o src/onchain_c/main.wasm metadata "dfx:wasm_url" -d "http://localhost:$E2E_WEB_SERVER_PORT/c.wasm" -v public
-    ic-wasm src/onchain_c/main.wasm -o src/onchain_c/main.wasm metadata "dfx:deps" -d "onchain_a:rrkah-fqaaa-aaaaa-aaaaq-cai;" -v public
+    ic-wasm src/onchain_c/main.wasm -o src/onchain_c/main.wasm metadata "dfx:deps" -d "onchain_a:$CANISTER_ID_A;" -v public
 
     dfx deploy
-
-    assert_command dfx canister metadata ryjl3-tyaaa-aaaaa-aaaba-cai dfx:deps
-    assert_match "onchain_a:rrkah-fqaaa-aaaaa-aaaaq-cai;"
 
     # copy wasm files to web server dir
     cp src/onchain_a/main.wasm ../www/a.wasm
@@ -171,15 +187,18 @@ WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
 
     # pull canisters in app project
     cd ../app
+    jq '.canisters.dep1.id="'"$CANISTER_ID_B"'"' dfx.json | sponge dfx.json
+    jq '.canisters.dep2.id="'"$CANISTER_ID_C"'"' dfx.json | sponge dfx.json
+
     assert_command dfx pull dep1
     
-    assert_file_exists "$WASM_CACHE/ryjl3-tyaaa-aaaaa-aaaba-cai/canister.wasm"
-    assert_file_exists "$WASM_CACHE/rrkah-fqaaa-aaaaa-aaaaq-cai/canister.wasm"
-    assert_file_not_exists "$WASM_CACHE/r7inp-6aaaa-aaaaa-aaabq-cai/canister.wasm"
+    assert_file_exists "$WASM_CACHE/$CANISTER_ID_B/canister.wasm"
+    assert_file_exists "$WASM_CACHE/$CANISTER_ID_A/canister.wasm"
+    assert_file_not_exists "$WASM_CACHE/$CANISTER_ID_C/canister.wasm"
 
     assert_command dfx pull # if not specify canister name, all pull type canisters (dep1, dep2) will be pulled
     assert_contains "The canister wasm was found in the cache." # a, b were downloaded before
-    assert_file_exists "$WASM_CACHE/r7inp-6aaaa-aaaaa-aaabq-cai/canister.wasm"
+    assert_file_exists "$WASM_CACHE/$CANISTER_ID_C/canister.wasm"
 
     # sad path 1: wasm hash doesn't match on chain
     rm -r "${WASM_CACHE:?}/"
@@ -188,16 +207,16 @@ WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
 
     cd ../app
     assert_command_fail dfx pull dep1
-    assert_contains "Failed to download wasm of canister rrkah-fqaaa-aaaaa-aaaaq-cai."
+    assert_contains "Failed to download wasm of canister $CANISTER_ID_A."
     assert_contains "Hash mismatch."
-    assert_file_exists "$WASM_CACHE/ryjl3-tyaaa-aaaaa-aaaba-cai/canister.wasm"
+    assert_file_exists "$WASM_CACHE/$CANISTER_ID_B/canister.wasm"
 
     # sad path 2: url server doesn't have the file
     rm -r "${WASM_CACHE:?}/"
     rm ../www/a.wasm
 
     assert_command_fail dfx pull dep1
-    assert_contains "Failed to download wasm of canister rrkah-fqaaa-aaaaa-aaaaq-cai."
+    assert_contains "Failed to download wasm of canister $CANISTER_ID_A."
     assert_contains "Failed to download wasm from url:"
 }
 
@@ -210,9 +229,9 @@ WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
 
     WASM_CACHE="$DFX_CACHE_ROOT/.cache/dfinity/wasms/"
 
-    assert_file_not_exists "$WASM_CACHE/ryjl3-tyaaa-aaaaa-aaaba-cai/canister.wasm"
-    assert_file_not_exists "$WASM_CACHE/rrkah-fqaaa-aaaaa-aaaaq-cai/canister.wasm"
-    assert_file_not_exists "$WASM_CACHE/r7inp-6aaaa-aaaaa-aaabq-cai/canister.wasm"
+    assert_file_not_exists "$WASM_CACHE/$CANISTER_ID_B/canister.wasm"
+    assert_file_not_exists "$WASM_CACHE/$CANISTER_ID_A/canister.wasm"
+    assert_file_not_exists "$WASM_CACHE/$CANISTER_ID_C/canister.wasm"
 
     # system-wide local replica
     dfx_start
@@ -226,6 +245,9 @@ WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
     # prepare "onchain" canisters
     cd onchain
 
+    dfx canister create --all
+    export_canister_ids
+
     echo -n -e \\x00asm\\x01\\x00\\x00\\x00 > src/onchain_a/main.wasm # to be deployed
     ic-wasm src/onchain_a/main.wasm -o src/onchain_a/main.wasm metadata "dfx:wasm_url" -d "http://localhost:$E2E_WEB_SERVER_PORT/a.wasm" -v public
     echo -n -e \\x00asm\\x01\\x00\\x00\\x00 > src/onchain_a/custom.wasm # to be download
@@ -233,16 +255,13 @@ WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
 
     echo -n -e \\x00asm\\x01\\x00\\x00\\x00 > src/onchain_b/main.wasm
     ic-wasm src/onchain_b/main.wasm -o src/onchain_b/main.wasm metadata "dfx:wasm_url" -d "http://localhost:$E2E_WEB_SERVER_PORT/b.wasm" -v public
-    ic-wasm src/onchain_b/main.wasm -o src/onchain_b/main.wasm metadata "dfx:deps" -d "onchain_a:rrkah-fqaaa-aaaaa-aaaaq-cai;" -v public
+    ic-wasm src/onchain_b/main.wasm -o src/onchain_b/main.wasm metadata "dfx:deps" -d "onchain_a:$CANISTER_ID_A;" -v public
 
     echo -n -e \\x00asm\\x01\\x00\\x00\\x00 > src/onchain_c/main.wasm
     ic-wasm src/onchain_c/main.wasm -o src/onchain_c/main.wasm metadata "dfx:wasm_url" -d "http://localhost:$E2E_WEB_SERVER_PORT/c.wasm" -v public
-    ic-wasm src/onchain_c/main.wasm -o src/onchain_c/main.wasm metadata "dfx:deps" -d "onchain_a:rrkah-fqaaa-aaaaa-aaaaq-cai;" -v public
+    ic-wasm src/onchain_c/main.wasm -o src/onchain_c/main.wasm metadata "dfx:deps" -d "onchain_a:$CANISTER_ID_A;" -v public
 
     dfx deploy
-
-    assert_command dfx canister metadata ryjl3-tyaaa-aaaaa-aaaba-cai dfx:deps
-    assert_match "onchain_a:rrkah-fqaaa-aaaaa-aaaaq-cai;"
 
     # copy wasm files to web server dir
     cp src/onchain_a/custom.wasm ../www/a.wasm
@@ -251,10 +270,13 @@ WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
 
     # pull canisters in app project
     cd ../app
+    jq '.canisters.dep1.id="'"$CANISTER_ID_B"'"' dfx.json | sponge dfx.json
+    jq '.canisters.dep2.id="'"$CANISTER_ID_C"'"' dfx.json | sponge dfx.json
+
     assert_command dfx pull
-    assert_contains "Canister rrkah-fqaaa-aaaaa-aaaaq-cai specified a custom hash:"
+    assert_contains "Canister $CANISTER_ID_A specified a custom hash:"
     
-    assert_file_exists "$WASM_CACHE/ryjl3-tyaaa-aaaaa-aaaba-cai/canister.wasm"
-    assert_file_exists "$WASM_CACHE/rrkah-fqaaa-aaaaa-aaaaq-cai/canister.wasm"
-    assert_file_exists "$WASM_CACHE/r7inp-6aaaa-aaaaa-aaabq-cai/canister.wasm"
+    assert_file_exists "$WASM_CACHE/$CANISTER_ID_B/canister.wasm"
+    assert_file_exists "$WASM_CACHE/$CANISTER_ID_A/canister.wasm"
+    assert_file_exists "$WASM_CACHE/$CANISTER_ID_C/canister.wasm"
 }

--- a/e2e/tests-dfx/pull.bash
+++ b/e2e/tests-dfx/pull.bash
@@ -70,17 +70,28 @@ teardown() {
 
     ## 1.2. pull onchain canisters in "app" project
     cd ../app
-    assert_command_fail dfx pull dep1
+    assert_command_fail dfx pull dep1 # the overall pull fail but succeed to fetch and parse `dfx:deps` recursively
     assert_contains "Pulling canister ryjl3-tyaaa-aaaaa-aaaba-cai...
 Pulling canister rrkah-fqaaa-aaaaa-aaaaq-cai...
 WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
+    assert_contains "ERROR: Failed to download wasm of canister ryjl3-tyaaa-aaaaa-aaaba-cai.
+\`dfx:wasm_url\` metadata not found in canister ryjl3-tyaaa-aaaaa-aaaba-cai."
+    assert_contains "ERROR: Failed to download wasm of canister rrkah-fqaaa-aaaaa-aaaaq-cai.
+\`dfx:wasm_url\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
 
-    assert_command_fail dfx pull # if not specify canister name, all pull type canisters (dep1, dep2) will be pulled
+    ## 1.3. if not specify canister name, all pull type canisters (dep1, dep2) will be pulled
+    assert_command_fail dfx pull # the overall pull fail but succeed to fetch and parse `dfx:deps` recursively
     assert_contains "Pulling canister ryjl3-tyaaa-aaaaa-aaaba-cai...
 Pulling canister r7inp-6aaaa-aaaaa-aaabq-cai...
 Pulling canister rrkah-fqaaa-aaaaa-aaaaq-cai...
 WARN: \`dfx:deps\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
     assert_occurs 1 "Pulling canister rrkah-fqaaa-aaaaa-aaaaq-cai..." # common dependency onchain_a is pulled only once
+    assert_contains "ERROR: Failed to download wasm of canister ryjl3-tyaaa-aaaaa-aaaba-cai.
+\`dfx:wasm_url\` metadata not found in canister ryjl3-tyaaa-aaaaa-aaaba-cai."
+    assert_contains "ERROR: Failed to download wasm of canister r7inp-6aaaa-aaaaa-aaabq-cai.
+\`dfx:wasm_url\` metadata not found in canister r7inp-6aaaa-aaaaa-aaabq-cai."
+    assert_contains "ERROR: Failed to download wasm of canister rrkah-fqaaa-aaaaa-aaaaq-cai.
+\`dfx:wasm_url\` metadata not found in canister rrkah-fqaaa-aaaaa-aaaaq-cai."
 
     # 2. sad path: if the canister is not present on-chain
     cd ../onchain

--- a/src/dfx/src/commands/pull.rs
+++ b/src/dfx/src/commands/pull.rs
@@ -17,7 +17,7 @@ use clap::Parser;
 use fn_error_context::context;
 use ic_agent::{Agent, AgentError};
 use sha2::{Digest, Sha256};
-use slog::{info, warn, Logger};
+use slog::{error, info, warn, Logger};
 use tokio::runtime::Runtime;
 
 /// Pull canisters upon which the project depends
@@ -75,7 +75,7 @@ pub fn exec(env: &dyn Environment, opts: PullOpts) -> DfxResult {
 
         for canister_id in pulled_canisters {
             if let Err(e) = download_canister_wasm(&agent_env, logger, canister_id).await {
-                warn!(
+                error!(
                     logger,
                     "Failed to download wasm of canister {canister_id}.\n{e}"
                 );

--- a/src/dfx/src/commands/pull.rs
+++ b/src/dfx/src/commands/pull.rs
@@ -212,13 +212,11 @@ async fn download_canister_wasm(
         );
     }
 
-    // write to a tempfile
-    let mut f = tempfile::NamedTempFile::new()?;
-    f.write_all(&content)?;
-
-    // move tempfile to target
+    // write to a tempfile then rename
     std::fs::create_dir_all(&wasm_dir)
         .with_context(|| format!("Failed to create dir at {:?}", &wasm_dir))?;
+    let mut f = tempfile::NamedTempFile::new_in(&wasm_dir)?;
+    f.write_all(&content)?;
     std::fs::rename(f.path(), &wasm_path)
         .with_context(|| format!("Failed to move tempfile to {:?}", &wasm_path))?;
 


### PR DESCRIPTION
# Description

This PR resolves suggestions by Eric in #2940.

1. log `error` when download fail
2. create tempfile using `new_in`
3. e2e test checks fail reason
4. replace hardcode canister id by `dfx canister id`

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
