### PR TITLE
refactor: move create_agent_environment to agent module

### DIFF
--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -1,11 +1,11 @@
 use std::path::PathBuf;
 
+use crate::lib::agent::create_agent_environment;
 use crate::lib::builders::BuildConfig;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::models::canister::CanisterPool;
 use crate::lib::models::canister_id_store::CanisterIdStore;
-use crate::lib::provider::create_agent_environment;
 use crate::NetworkOpt;
 
 use clap::Parser;

--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -1,3 +1,4 @@
+use crate::lib::agent::create_agent_environment;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::ic_attributes::CanisterSettings;
@@ -8,7 +9,6 @@ use crate::lib::operations::canister;
 use crate::lib::operations::canister::{
     deposit_cycles, start_canister, stop_canister, update_settings,
 };
-use crate::lib::provider::create_agent_environment;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::util::assets::wallet_wasm;
 use crate::util::blob_from_arguments;

--- a/src/dfx/src/commands/canister/mod.rs
+++ b/src/dfx/src/commands/canister/mod.rs
@@ -1,6 +1,6 @@
+use crate::lib::agent::create_agent_environment;
 use crate::lib::error::DfxResult;
 use crate::lib::identity::identity_utils::call_sender;
-use crate::lib::provider::create_agent_environment;
 use crate::{lib::environment::Environment, NetworkOpt};
 
 use clap::{Parser, Subcommand};

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -1,7 +1,7 @@
+use crate::lib::agent::create_agent_environment;
 use crate::lib::error::DfxResult;
 use crate::lib::identity::identity_utils::{call_sender, CallSender};
 use crate::lib::operations::canister::deploy_canisters;
-use crate::lib::provider::create_agent_environment;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::lib::{environment::Environment, named_canister};
 use crate::util::clap::validators::cycle_amount_validator;

--- a/src/dfx/src/commands/diagnose.rs
+++ b/src/dfx/src/commands/diagnose.rs
@@ -3,8 +3,8 @@ use tokio::runtime::Runtime;
 
 use crate::{
     lib::{
-        environment::Environment, error::DfxResult, migrate::migrate,
-        provider::create_agent_environment,
+        agent::create_agent_environment, environment::Environment, error::DfxResult,
+        migrate::migrate,
     },
     NetworkOpt,
 };

--- a/src/dfx/src/commands/fix.rs
+++ b/src/dfx/src/commands/fix.rs
@@ -3,8 +3,8 @@ use tokio::runtime::Runtime;
 
 use crate::{
     lib::{
-        environment::Environment, error::DfxResult, migrate::migrate,
-        provider::create_agent_environment,
+        agent::create_agent_environment, environment::Environment, error::DfxResult,
+        migrate::migrate,
     },
     NetworkOpt,
 };

--- a/src/dfx/src/commands/generate.rs
+++ b/src/dfx/src/commands/generate.rs
@@ -1,9 +1,9 @@
+use crate::lib::agent::create_anonymous_agent_environment;
 use crate::lib::builders::BuildConfig;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::models::canister::CanisterPool;
 use crate::lib::models::canister_id_store::CanisterIdStore;
-use crate::lib::provider::create_anonymous_agent_environment;
 use crate::NetworkOpt;
 
 use clap::Parser;

--- a/src/dfx/src/commands/identity/deploy_wallet.rs
+++ b/src/dfx/src/commands/identity/deploy_wallet.rs
@@ -1,6 +1,6 @@
+use crate::lib::agent::create_agent_environment;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::provider::create_agent_environment;
 use crate::lib::root_key::fetch_root_key_if_needed;
 
 use crate::lib::identity::wallet::create_wallet;

--- a/src/dfx/src/commands/identity/get_wallet.rs
+++ b/src/dfx/src/commands/identity/get_wallet.rs
@@ -1,6 +1,6 @@
+use crate::lib::agent::create_agent_environment;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::provider::create_agent_environment;
 use crate::lib::root_key::fetch_root_key_if_needed;
 
 use crate::lib::identity::wallet::get_or_create_wallet;

--- a/src/dfx/src/commands/identity/set_wallet.rs
+++ b/src/dfx/src/commands/identity/set_wallet.rs
@@ -1,9 +1,9 @@
+use crate::lib::agent::create_agent_environment;
 use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
 use crate::lib::error::{DfxError, DfxResult};
 use crate::lib::identity::wallet::{build_wallet_canister, set_wallet_id};
 use crate::lib::models::canister_id_store::CanisterIdStore;
-use crate::lib::provider::create_agent_environment;
 
 use anyhow::{anyhow, Context};
 use candid::Principal;

--- a/src/dfx/src/commands/ledger/mod.rs
+++ b/src/dfx/src/commands/ledger/mod.rs
@@ -1,3 +1,4 @@
+use crate::lib::agent::create_agent_environment;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::ledger_types::{
@@ -7,7 +8,6 @@ use crate::lib::ledger_types::{
 };
 use crate::lib::nns_types::account_identifier::{AccountIdentifier, Subaccount};
 use crate::lib::nns_types::icpts::ICPTs;
-use crate::lib::provider::create_agent_environment;
 use crate::NetworkOpt;
 
 use anyhow::{anyhow, bail, Context};

--- a/src/dfx/src/commands/nns/mod.rs
+++ b/src/dfx/src/commands/nns/mod.rs
@@ -1,8 +1,8 @@
 //! Code for the command line `dfx nns`.
 #![warn(clippy::missing_docs_in_private_items)]
+use crate::lib::agent::create_agent_environment;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::provider::create_agent_environment;
 
 use clap::Parser;
 use tokio::runtime::Runtime;

--- a/src/dfx/src/commands/pull.rs
+++ b/src/dfx/src/commands/pull.rs
@@ -5,7 +5,7 @@ use crate::lib::identity::identity_utils::CallSender;
 use crate::lib::metadata::names::{DFX_DEPS, DFX_WASM_HASH, DFX_WASM_URL};
 use crate::lib::operations::canister::get_canister_status;
 use crate::lib::root_key::fetch_root_key_if_needed;
-use crate::lib::{environment::Environment, provider::create_agent_environment};
+use crate::lib::{agent::create_agent_environment, environment::Environment};
 use crate::NetworkOpt;
 use dfx_core::config::model::dfinity::CanisterTypeProperties;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};

--- a/src/dfx/src/commands/quickstart.rs
+++ b/src/dfx/src/commands/quickstart.rs
@@ -14,6 +14,7 @@ use tokio::runtime::Runtime;
 use crate::{
     commands::ledger::{create_canister::MEMO_CREATE_CANISTER, notify_create, transfer_cmc},
     lib::{
+        agent::create_agent_environment,
         environment::Environment,
         error::DfxResult,
         identity::wallet::{set_wallet_id, wallet_canister_id},
@@ -26,7 +27,6 @@ use crate::{
             canister::install_wallet,
             ledger::{balance, xdr_permyriad_per_icp},
         },
-        provider::create_agent_environment,
     },
     util::assets::wallet_wasm,
 };

--- a/src/dfx/src/commands/remote/generate_binding.rs
+++ b/src/dfx/src/commands/remote/generate_binding.rs
@@ -1,7 +1,7 @@
+use crate::lib::agent::create_agent_environment;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::models::canister::CanisterPool;
-use crate::lib::provider::create_agent_environment;
 use crate::util::check_candid_file;
 
 use anyhow::Context;

--- a/src/dfx/src/commands/wallet/mod.rs
+++ b/src/dfx/src/commands/wallet/mod.rs
@@ -1,6 +1,6 @@
+use crate::lib::agent::create_agent_environment;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::provider::create_agent_environment;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::NetworkOpt;
 

--- a/src/dfx/src/lib/agent.rs
+++ b/src/dfx/src/lib/agent.rs
@@ -1,0 +1,44 @@
+use crate::lib::environment::AgentEnvironment;
+use crate::lib::error::DfxResult;
+use crate::lib::provider::{create_network_descriptor, LocalBindDetermination};
+use crate::util::expiry_duration;
+use crate::Environment;
+use dfx_core::identity::ANONYMOUS_IDENTITY_NAME;
+
+use fn_error_context::context;
+
+#[context("Failed to create AgentEnvironment.")]
+pub fn create_agent_environment<'a>(
+    env: &'a (dyn Environment + 'a),
+    network: Option<String>,
+) -> DfxResult<AgentEnvironment<'a>> {
+    let network_descriptor = create_network_descriptor(
+        env.get_config(),
+        env.get_networks_config(),
+        network,
+        None,
+        LocalBindDetermination::ApplyRunningWebserverPort,
+    )?;
+    let timeout = expiry_duration();
+    AgentEnvironment::new(env, network_descriptor, timeout, None)
+}
+
+pub fn create_anonymous_agent_environment<'a>(
+    env: &'a (dyn Environment + 'a),
+    network: Option<String>,
+) -> DfxResult<AgentEnvironment<'a>> {
+    let network_descriptor = create_network_descriptor(
+        env.get_config(),
+        env.get_networks_config(),
+        network,
+        None,
+        LocalBindDetermination::ApplyRunningWebserverPort,
+    )?;
+    let timeout = expiry_duration();
+    AgentEnvironment::new(
+        env,
+        network_descriptor,
+        timeout,
+        Some(ANONYMOUS_IDENTITY_NAME),
+    )
+}

--- a/src/dfx/src/lib/mod.rs
+++ b/src/dfx/src/lib/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod builders;
 pub mod call_bundled;
 pub mod canister_info;

--- a/src/dfx/src/lib/provider.rs
+++ b/src/dfx/src/lib/provider.rs
@@ -1,10 +1,9 @@
-use crate::lib::environment::{AgentEnvironment, Environment};
 use crate::lib::error::DfxResult;
 use crate::lib::network::local_server_descriptor::{
     LocalNetworkScopeDescriptor, LocalServerDescriptor,
 };
 use crate::lib::network::network_descriptor::{NetworkDescriptor, NetworkTypeDescriptor};
-use crate::util::{self, expiry_duration};
+use crate::util;
 use dfx_core::config::directories::get_shared_network_data_directory;
 use dfx_core::config::model::dfinity::{
     Config, ConfigDefaults, ConfigLocalProvider, ConfigNetwork, NetworkType, NetworksConfig,
@@ -14,7 +13,7 @@ use dfx_core::error::network_config::NetworkConfigError;
 use dfx_core::error::network_config::NetworkConfigError::{
     NoProvidersForNetwork, ParsePortValueFailed, ParseProviderUrlFailed, ReadWebserverPortFailed,
 };
-use dfx_core::identity::{ANONYMOUS_IDENTITY_NAME, WALLET_CONFIG_FILENAME};
+use dfx_core::identity::WALLET_CONFIG_FILENAME;
 
 use anyhow::{anyhow, bail, Context};
 use fn_error_context::context;
@@ -391,42 +390,6 @@ fn get_running_webserver_bind_address(
     } else {
         Ok(local_bind)
     }
-}
-
-#[context("Failed to create AgentEnvironment.")]
-pub fn create_agent_environment<'a>(
-    env: &'a (dyn Environment + 'a),
-    network: Option<String>,
-) -> DfxResult<AgentEnvironment<'a>> {
-    let network_descriptor = create_network_descriptor(
-        env.get_config(),
-        env.get_networks_config(),
-        network,
-        None,
-        LocalBindDetermination::ApplyRunningWebserverPort,
-    )?;
-    let timeout = expiry_duration();
-    AgentEnvironment::new(env, network_descriptor, timeout, None)
-}
-
-pub fn create_anonymous_agent_environment<'a>(
-    env: &'a (dyn Environment + 'a),
-    network: Option<String>,
-) -> DfxResult<AgentEnvironment<'a>> {
-    let network_descriptor = create_network_descriptor(
-        env.get_config(),
-        env.get_networks_config(),
-        network,
-        None,
-        LocalBindDetermination::ApplyRunningWebserverPort,
-    )?;
-    let timeout = expiry_duration();
-    AgentEnvironment::new(
-        env,
-        network_descriptor,
-        timeout,
-        Some(ANONYMOUS_IDENTITY_NAME),
-    )
 }
 
 pub fn command_line_provider_to_url(s: &str) -> Result<String, NetworkConfigError> {


### PR DESCRIPTION
Move `create_agent_environment()` and `create_anonymous_agent_environment()` out of provider.rs to a different module, in preparation for moving provider.rs to the dfx-core crate.

