### PR TITLE
refactor: move network_to_pathcompat to dfx-core

### DIFF
--- a/src/dfx-core/src/lib.rs
+++ b/src/dfx-core/src/lib.rs
@@ -4,3 +4,4 @@ pub mod foundation;
 pub mod fs;
 pub mod identity;
 pub mod json;
+pub mod util;

--- a/src/dfx-core/src/util/mod.rs
+++ b/src/dfx-core/src/util/mod.rs
@@ -1,0 +1,3 @@
+pub fn network_to_pathcompat(network_name: &str) -> String {
+    network_name.replace(|c: char| !c.is_ascii_alphanumeric(), "_")
+}

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -2,11 +2,11 @@ use crate::config::dfx_version_str;
 use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use dfx_core::config::model::dfinity::{Config, Profile};
-
 use crate::lib::models::canister::CanisterPool;
 use crate::lib::provider::get_network_context;
-use crate::util::{self, check_candid_file};
+use crate::util::check_candid_file;
+use dfx_core::config::model::dfinity::{Config, Profile};
+use dfx_core::util;
 
 use anyhow::{bail, Context};
 use candid::Principal as CanisterId;

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -4,10 +4,10 @@ use crate::lib::canister_info::custom::CustomCanisterInfo;
 use crate::lib::canister_info::motoko::MotokoCanisterInfo;
 use crate::lib::error::DfxResult;
 use crate::lib::provider::get_network_context;
-use crate::util;
 use dfx_core::config::model::dfinity::{
     CanisterDeclarationsConfig, CanisterMetadataSection, CanisterTypeProperties, Config,
 };
+use dfx_core::util;
 
 use crate::lib::metadata::config::CanisterMetadataConfig;
 use anyhow::{anyhow, Context};

--- a/src/dfx/src/lib/provider.rs
+++ b/src/dfx/src/lib/provider.rs
@@ -2,7 +2,6 @@ use crate::lib::network::local_server_descriptor::{
     LocalNetworkScopeDescriptor, LocalServerDescriptor,
 };
 use crate::lib::network::network_descriptor::{NetworkDescriptor, NetworkTypeDescriptor};
-use crate::util;
 use dfx_core::config::directories::get_shared_network_data_directory;
 use dfx_core::config::model::dfinity::{
     Config, ConfigDefaults, ConfigLocalProvider, ConfigNetwork, NetworkType, NetworksConfig,
@@ -14,6 +13,7 @@ use dfx_core::error::network_config::NetworkConfigError::{
     ParseProviderUrlFailed, ReadWebserverPortFailed,
 };
 use dfx_core::identity::WALLET_CONFIG_FILENAME;
+use dfx_core::util;
 
 use lazy_static::lazy_static;
 use slog::{debug, info, warn, Logger};

--- a/src/dfx/src/util/mod.rs
+++ b/src/dfx/src/util/mod.rs
@@ -60,10 +60,6 @@ pub fn expiry_duration() -> Duration {
     Duration::from_secs(60 * 5)
 }
 
-pub fn network_to_pathcompat(network_name: &str) -> String {
-    network_name.replace(|c: char| !c.is_ascii_alphanumeric(), "_")
-}
-
 /// Deserialize and print return values from canister method.
 #[context("Failed to deserialize idl blob: Invalid data.")]
 pub fn print_idl_blob(


### PR DESCRIPTION
provider.rs references this method, so move it to the dfx-core crate