### PR TITLE
style(frontend-canister): rename `container_asset{s}` to `canister_asset{s}`

### DIFF
--- a/src/canisters/frontend/ic-asset/src/operations.rs
+++ b/src/canisters/frontend/ic-asset/src/operations.rs
@@ -8,54 +8,54 @@ use std::collections::HashMap;
 pub(crate) fn delete_obsolete_assets(
     operations: &mut Vec<BatchOperationKind>,
     project_assets: &HashMap<String, ProjectAsset>,
-    container_assets: &mut HashMap<String, AssetDetails>,
+    canister_assets: &mut HashMap<String, AssetDetails>,
 ) {
-    let mut deleted_container_assets = vec![];
-    for (key, container_asset) in container_assets.iter() {
+    let mut deleted_canister_assets = vec![];
+    for (key, canister_asset) in canister_assets.iter() {
         let project_asset = project_assets.get(key);
         if project_asset
-            .filter(|&x| x.media_type.to_string() == container_asset.content_type)
+            .filter(|&x| x.media_type.to_string() == canister_asset.content_type)
             .is_none()
         {
             operations.push(BatchOperationKind::DeleteAsset(DeleteAssetArguments {
                 key: key.clone(),
             }));
-            deleted_container_assets.push(key.clone());
+            deleted_canister_assets.push(key.clone());
         }
     }
-    for k in deleted_container_assets {
-        container_assets.remove(&k);
+    for k in deleted_canister_assets {
+        canister_assets.remove(&k);
     }
 }
 
 pub(crate) fn delete_incompatible_assets(
     operations: &mut Vec<BatchOperationKind>,
     project_assets: &HashMap<String, ProjectAsset>,
-    container_assets: &mut HashMap<String, AssetDetails>,
+    canister_assets: &mut HashMap<String, AssetDetails>,
 ) {
-    let mut deleted_container_assets = vec![];
-    for (key, container_asset) in container_assets.iter() {
+    let mut deleted_canister_assets = vec![];
+    for (key, canister_asset) in canister_assets.iter() {
         if let Some(project_asset) = project_assets.get(key) {
-            if project_asset.media_type.to_string() != container_asset.content_type {
+            if project_asset.media_type.to_string() != canister_asset.content_type {
                 operations.push(BatchOperationKind::DeleteAsset(DeleteAssetArguments {
                     key: key.clone(),
                 }));
-                deleted_container_assets.push(key.clone());
+                deleted_canister_assets.push(key.clone());
             }
         }
     }
-    for k in deleted_container_assets {
-        container_assets.remove(&k);
+    for k in deleted_canister_assets {
+        canister_assets.remove(&k);
     }
 }
 
 pub(crate) fn create_new_assets(
     operations: &mut Vec<BatchOperationKind>,
     project_assets: &HashMap<String, ProjectAsset>,
-    container_assets: &HashMap<String, AssetDetails>,
+    canister_assets: &HashMap<String, AssetDetails>,
 ) {
     for (key, project_asset) in project_assets {
-        if !container_assets.contains_key(key) {
+        if !canister_assets.contains_key(key) {
             let max_age = project_asset
                 .asset_descriptor
                 .config
@@ -82,9 +82,9 @@ pub(crate) fn create_new_assets(
 pub(crate) fn unset_obsolete_encodings(
     operations: &mut Vec<BatchOperationKind>,
     project_assets: &HashMap<String, ProjectAsset>,
-    container_assets: &HashMap<String, AssetDetails>,
+    canister_assets: &HashMap<String, AssetDetails>,
 ) {
-    for (key, details) in container_assets {
+    for (key, details) in canister_assets {
         // delete_obsolete_assets handles the case where key is not found in project_assets
         if let Some(project_asset) = project_assets.get(key) {
             for encoding_details in &details.encodings {

--- a/src/canisters/frontend/ic-asset/src/plumbing.rs
+++ b/src/canisters/frontend/ic-asset/src/plumbing.rs
@@ -46,7 +46,7 @@ async fn make_project_asset_encoding(
     canister: &Canister<'_>,
     batch_id: &Nat,
     asset_descriptor: &AssetDescriptor,
-    container_assets: &HashMap<String, AssetDetails>,
+    canister_assets: &HashMap<String, AssetDetails>,
     content: &Content,
     content_encoding: &str,
     semaphores: &Semaphores,
@@ -54,23 +54,23 @@ async fn make_project_asset_encoding(
 ) -> anyhow::Result<ProjectAssetEncoding> {
     let sha256 = content.sha256();
 
-    let already_in_place =
-        if let Some(container_asset) = container_assets.get(&asset_descriptor.key) {
-            if container_asset.content_type != content.media_type.to_string() {
-                false
-            } else if let Some(container_asset_encoding_sha256) = container_asset
-                .encodings
-                .iter()
-                .find(|details| details.content_encoding == content_encoding)
-                .and_then(|details| details.sha256.as_ref())
-            {
-                container_asset_encoding_sha256 == &sha256
-            } else {
-                false
-            }
+    let already_in_place = if let Some(canister_asset) = canister_assets.get(&asset_descriptor.key)
+    {
+        if canister_asset.content_type != content.media_type.to_string() {
+            false
+        } else if let Some(canister_asset_encoding_sha256) = canister_asset
+            .encodings
+            .iter()
+            .find(|details| details.content_encoding == content_encoding)
+            .and_then(|details| details.sha256.as_ref())
+        {
+            canister_asset_encoding_sha256 == &sha256
         } else {
             false
-        };
+        }
+    } else {
+        false
+    };
 
     let chunk_ids = if already_in_place {
         info!(
@@ -108,7 +108,7 @@ async fn make_encoding(
     canister: &Canister<'_>,
     batch_id: &Nat,
     asset_descriptor: &AssetDescriptor,
-    container_assets: &HashMap<String, AssetDetails>,
+    canister_assets: &HashMap<String, AssetDetails>,
     content: &Content,
     encoder: &Option<ContentEncoder>,
     semaphores: &Semaphores,
@@ -120,7 +120,7 @@ async fn make_encoding(
                 canister,
                 batch_id,
                 asset_descriptor,
-                container_assets,
+                canister_assets,
                 content,
                 CONTENT_ENCODING_IDENTITY,
                 semaphores,
@@ -140,7 +140,7 @@ async fn make_encoding(
                     canister,
                     batch_id,
                     asset_descriptor,
-                    container_assets,
+                    canister_assets,
                     &encoded,
                     &content_encoding,
                     semaphores,
@@ -159,7 +159,7 @@ async fn make_encodings(
     canister: &Canister<'_>,
     batch_id: &Nat,
     asset_descriptor: &AssetDescriptor,
-    container_assets: &HashMap<String, AssetDetails>,
+    canister_assets: &HashMap<String, AssetDetails>,
     content: &Content,
     semaphores: &Semaphores,
     logger: &Logger,
@@ -176,7 +176,7 @@ async fn make_encodings(
                 canister,
                 batch_id,
                 asset_descriptor,
-                container_assets,
+                canister_assets,
                 content,
                 maybe_encoder,
                 semaphores,
@@ -199,7 +199,7 @@ async fn make_project_asset(
     canister: &Canister<'_>,
     batch_id: &Nat,
     asset_descriptor: AssetDescriptor,
-    container_assets: &HashMap<String, AssetDetails>,
+    canister_assets: &HashMap<String, AssetDetails>,
     semaphores: &Semaphores,
     logger: &Logger,
 ) -> anyhow::Result<ProjectAsset> {
@@ -218,7 +218,7 @@ async fn make_project_asset(
         canister,
         batch_id,
         &asset_descriptor,
-        container_assets,
+        canister_assets,
         &content,
         semaphores,
         logger,
@@ -236,7 +236,7 @@ pub(crate) async fn make_project_assets(
     canister: &Canister<'_>,
     batch_id: &Nat,
     asset_descriptors: Vec<AssetDescriptor>,
-    container_assets: &HashMap<String, AssetDetails>,
+    canister_assets: &HashMap<String, AssetDetails>,
     logger: &Logger,
 ) -> anyhow::Result<HashMap<String, ProjectAsset>> {
     let semaphores = Semaphores::new();
@@ -248,7 +248,7 @@ pub(crate) async fn make_project_assets(
                 canister,
                 batch_id,
                 loc.clone(),
-                container_assets,
+                canister_assets,
                 &semaphores,
                 logger,
             )

--- a/src/canisters/frontend/ic-asset/src/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/sync.rs
@@ -23,7 +23,7 @@ pub async fn upload_content_and_assemble_sync_operations(
 ) -> anyhow::Result<CommitBatchArguments> {
     let asset_descriptors = gather_asset_descriptors(dirs, logger)?;
 
-    let container_assets = list_assets(canister).await?;
+    let canister_assets = list_assets(canister).await?;
 
     info!(logger, "Starting batch.");
 
@@ -35,12 +35,12 @@ pub async fn upload_content_and_assemble_sync_operations(
         canister,
         &batch_id,
         asset_descriptors,
-        &container_assets,
+        &canister_assets,
         logger,
     )
     .await?;
 
-    let operations = assemble_synchronization_operations(project_assets, container_assets);
+    let operations = assemble_synchronization_operations(project_assets, canister_assets);
     Ok(CommitBatchArguments {
         batch_id,
         operations,
@@ -153,15 +153,15 @@ fn gather_asset_descriptors(
 
 fn assemble_synchronization_operations(
     project_assets: HashMap<String, ProjectAsset>,
-    container_assets: HashMap<String, AssetDetails>,
+    canister_assets: HashMap<String, AssetDetails>,
 ) -> Vec<BatchOperationKind> {
-    let mut container_assets = container_assets;
+    let mut canister_assets = canister_assets;
 
     let mut operations = vec![];
 
-    delete_obsolete_assets(&mut operations, &project_assets, &mut container_assets);
-    create_new_assets(&mut operations, &project_assets, &container_assets);
-    unset_obsolete_encodings(&mut operations, &project_assets, &container_assets);
+    delete_obsolete_assets(&mut operations, &project_assets, &mut canister_assets);
+    create_new_assets(&mut operations, &project_assets, &canister_assets);
+    unset_obsolete_encodings(&mut operations, &project_assets, &canister_assets);
     set_encodings(&mut operations, project_assets);
 
     operations

--- a/src/canisters/frontend/ic-asset/src/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/upload.rs
@@ -26,7 +26,7 @@ pub async fn upload(
         })
         .collect();
 
-    let container_assets = list_assets(canister).await?;
+    let canister_assets = list_assets(canister).await?;
 
     info!(logger, "Starting batch.");
 
@@ -38,12 +38,12 @@ pub async fn upload(
         canister,
         &batch_id,
         asset_descriptors,
-        &container_assets,
+        &canister_assets,
         logger,
     )
     .await?;
 
-    let operations = assemble_upload_operations(project_assets, container_assets);
+    let operations = assemble_upload_operations(project_assets, canister_assets);
 
     info!(logger, "Committing batch.");
 
@@ -59,15 +59,15 @@ pub async fn upload(
 
 fn assemble_upload_operations(
     project_assets: HashMap<String, ProjectAsset>,
-    container_assets: HashMap<String, AssetDetails>,
+    canister_assets: HashMap<String, AssetDetails>,
 ) -> Vec<BatchOperationKind> {
-    let mut container_assets = container_assets;
+    let mut canister_assets = canister_assets;
 
     let mut operations = vec![];
 
-    delete_incompatible_assets(&mut operations, &project_assets, &mut container_assets);
-    create_new_assets(&mut operations, &project_assets, &container_assets);
-    unset_obsolete_encodings(&mut operations, &project_assets, &container_assets);
+    delete_incompatible_assets(&mut operations, &project_assets, &mut canister_assets);
+    create_new_assets(&mut operations, &project_assets, &canister_assets);
+    unset_obsolete_encodings(&mut operations, &project_assets, &canister_assets);
     set_encodings(&mut operations, project_assets);
 
     operations


### PR DESCRIPTION
# Description

I found `container` to be a bit confusing (as if it would refer to `Containerization`). I believe `canister` will reflect intent better.
