### PR TITLE
fix: make dfx deploy and icx-asset not retry permissions failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Added the ability to configure the WASM module used for assets canisters through
 
 ### feat: dfx pull can download wasm
 
+### fix: dfx deploy and icx-asset no longer retry on permission failure
+
 ## Asset Canister
 
 Added `validate_take_ownership()` method so that an SNS is able to add a custom call to `take_ownership()`.

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -40,7 +40,8 @@ check_permission_failure() {
   assert_command dfx deploy
   echo "new file content" > 'src/e2e_project_frontend/assets/new_file.txt'
 
-  assert_command dfx deploy --identity anonymous
+  assert_command_fail dfx deploy --identity anonymous
+  assert_contains "Caller does not have Prepare permission"
 }
 
 @test "validation methods" {

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -34,6 +34,15 @@ check_permission_failure() {
     fi
 }
 
+@test "dfx deploy does not retry forever on permissions failure" {
+  install_asset assetscanister
+  dfx_start
+  assert_command dfx deploy
+  echo "new file content" > 'src/e2e_project_frontend/assets/new_file.txt'
+
+  assert_command dfx deploy --identity anonymous
+}
+
 @test "validation methods" {
   assert_command dfx identity new controller --storage-mode plaintext
   assert_command dfx identity use controller

--- a/src/canisters/frontend/ic-asset/src/retryable.rs
+++ b/src/canisters/frontend/ic-asset/src/retryable.rs
@@ -15,6 +15,15 @@ pub(crate) fn retryable(agent_error: &AgentError) -> bool {
             reject_code,
             reject_message,
         } if *reject_code == 4 && reject_message.contains("is not authorized") => false,
+        AgentError::ReplicaError {
+            reject_code,
+            reject_message,
+        } if *reject_code == 4
+            && reject_message.contains("Caller does not have")
+            && reject_message.contains("permission") =>
+        {
+            false
+        }
         AgentError::HttpError(HttpErrorPayload {
             status,
             content_type: _,


### PR DESCRIPTION
# Description

When updating the permissions system in the asset canister, I overlooked a place where `dfx deploy` and `icx-asset` check for a permissions-related error message.

Added an e2e test that exercises `dfx deploy` with a permissions failure, and updated the retryable logic to account for the new error message as well as the old.

# How Has This Been Tested?

Added an e2e test.

Reviewers can test by:
1. check out the first commit in this PR and `cargo build`
2. `bats -f "dfx deploy does not retry forever on permissions failure" e2e/tests-dfx/assetscanister.bash`
3. notice that the test never finishes
4. check out the final commit and `cargo build`
5. repeat bats command and notice that it completes

