### PR TITLE
chore: update welcome links

### DIFF
--- a/src/dfx/assets/welcome.txt
+++ b/src/dfx/assets/welcome.txt
@@ -7,11 +7,11 @@
 
 To learn more before you start coding, see the documentation available online:
 
-- Quick Start: https://internetcomputer.org/docs/current/developer-docs/quickstart/hello10mins/
-- SDK Developer Tools: https://internetcomputer.org/docs/current/developer-docs/build/install-upgrade-remove/
-- Motoko Language Guide: https://internetcomputer.org/docs/current/developer-docs/build/cdks/motoko-dfinity/about-this-guide
-- Motoko Quick Reference: https://internetcomputer.org/docs/current/developer-docs/build/cdks/motoko-dfinity/language-manual
-- Rust CDK Guide: https://internetcomputer.org/docs/current/developer-docs/build/cdks/cdk-rs-dfinity/
+- Quick Start: https://internetcomputer.org/docs/current/tutorials/deploy_sample_app
+- SDK Developer Tools: https://internetcomputer.org/docs/current/developer-docs/setup/install/
+- Motoko Language Guide: https://internetcomputer.org/docs/current/motoko/main/about-this-guide
+- Motoko Quick Reference: https://internetcomputer.org/docs/current/motoko/main/language-manual
+- Rust CDK Guide: https://internetcomputer.org/docs/current/developer-docs/backend/rust/
 
 If you want to work on programs right away, try the following commands to get started:
 


### PR DESCRIPTION
# Description

The links for the welcome text were out of date. This PR makes them current.
<img width="725" alt="Screenshot 2023-03-15 at 2 13 04 PM" src="https://user-images.githubusercontent.com/98767015/225445006-eb7b06b6-1dba-4603-88f1-627507f2bc97.png">
