### PR TITLE
chore: clarify new identity help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Added the ability to configure the WASM module used for assets canisters through
 
 ### fix: dfx deploy and icx-asset no longer retry on permission failure
 
+### chore: clarify `dfx identity new` help text
+
 ## Asset Canister
 
 Added `validate_take_ownership()` method so that an SNS is able to add a custom call to `take_ownership()`.

--- a/src/dfx/src/commands/identity/new.rs
+++ b/src/dfx/src/commands/identity/new.rs
@@ -16,7 +16,7 @@ use slog::{info, warn, Logger};
 /// Creates a new identity.
 #[derive(Parser)]
 pub struct NewIdentityOpts {
-    /// The identity to create.
+    /// The name of the identity to create.
     new_identity: String,
 
     #[cfg_attr(


### PR DESCRIPTION
# Description

Clarifies `dfx identity new` help text

This is a quick fix. Proper documentation and validation will happen in [SDK-1032](https://dfinity.atlassian.net/browse/SDK-1032)

# How Has This Been Tested?

Not at all

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-1032]: https://dfinity.atlassian.net/browse/SDK-1032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ