### PR TITLE
refactor(frontend-canister): get rid of code duplication

### DIFF
--- a/src/canisters/frontend/ic-asset/src/operations.rs
+++ b/src/canisters/frontend/ic-asset/src/operations.rs
@@ -5,42 +5,63 @@ use crate::asset_canister::protocol::{
 use crate::plumbing::ProjectAsset;
 use std::collections::HashMap;
 
-pub(crate) fn delete_obsolete_assets(
+pub(crate) fn assemble_batch_operations(
+    project_assets: HashMap<String, ProjectAsset>,
+    canister_assets: HashMap<String, AssetDetails>,
+    asset_deletion_reason: AssetDeletionReason,
+) -> Vec<BatchOperationKind> {
+    let mut canister_assets = canister_assets;
+
+    let mut operations = vec![];
+
+    delete_assets(
+        &mut operations,
+        &project_assets,
+        &mut canister_assets,
+        asset_deletion_reason,
+    );
+    create_new_assets(&mut operations, &project_assets, &canister_assets);
+    unset_obsolete_encodings(&mut operations, &project_assets, &canister_assets);
+    set_encodings(&mut operations, project_assets);
+
+    operations
+}
+
+pub(crate) enum AssetDeletionReason {
+    Obsolete,
+    Incompatible,
+}
+
+pub(crate) fn delete_assets(
     operations: &mut Vec<BatchOperationKind>,
     project_assets: &HashMap<String, ProjectAsset>,
     canister_assets: &mut HashMap<String, AssetDetails>,
+    reason: AssetDeletionReason,
 ) {
     let mut deleted_canister_assets = vec![];
     for (key, canister_asset) in canister_assets.iter() {
         let project_asset = project_assets.get(key);
-        if project_asset
-            .filter(|&x| x.media_type.to_string() == canister_asset.content_type)
-            .is_none()
-        {
-            operations.push(BatchOperationKind::DeleteAsset(DeleteAssetArguments {
-                key: key.clone(),
-            }));
-            deleted_canister_assets.push(key.clone());
-        }
-    }
-    for k in deleted_canister_assets {
-        canister_assets.remove(&k);
-    }
-}
-
-pub(crate) fn delete_incompatible_assets(
-    operations: &mut Vec<BatchOperationKind>,
-    project_assets: &HashMap<String, ProjectAsset>,
-    canister_assets: &mut HashMap<String, AssetDetails>,
-) {
-    let mut deleted_canister_assets = vec![];
-    for (key, canister_asset) in canister_assets.iter() {
-        if let Some(project_asset) = project_assets.get(key) {
-            if project_asset.media_type.to_string() != canister_asset.content_type {
-                operations.push(BatchOperationKind::DeleteAsset(DeleteAssetArguments {
-                    key: key.clone(),
-                }));
-                deleted_canister_assets.push(key.clone());
+        match reason {
+            AssetDeletionReason::Obsolete => {
+                if project_asset
+                    .filter(|&x| x.media_type.to_string() == canister_asset.content_type)
+                    .is_none()
+                {
+                    operations.push(BatchOperationKind::DeleteAsset(DeleteAssetArguments {
+                        key: key.clone(),
+                    }));
+                    deleted_canister_assets.push(key.clone());
+                }
+            }
+            AssetDeletionReason::Incompatible => {
+                if let Some(project_asset) = project_assets.get(key) {
+                    if project_asset.media_type.to_string() != canister_asset.content_type {
+                        operations.push(BatchOperationKind::DeleteAsset(DeleteAssetArguments {
+                            key: key.clone(),
+                        }));
+                        deleted_canister_assets.push(key.clone());
+                    }
+                }
             }
         }
     }

--- a/src/canisters/frontend/ic-asset/src/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/upload.rs
@@ -1,11 +1,9 @@
 use crate::asset_canister::batch::{commit_batch, create_batch};
 use crate::asset_canister::list::list_assets;
-use crate::asset_canister::protocol::{AssetDetails, BatchOperationKind, CommitBatchArguments};
+use crate::asset_canister::protocol::CommitBatchArguments;
 use crate::asset_config::AssetConfig;
-use crate::operations::{
-    create_new_assets, delete_incompatible_assets, set_encodings, unset_obsolete_encodings,
-};
-use crate::plumbing::{make_project_assets, AssetDescriptor, ProjectAsset};
+use crate::operations::{assemble_batch_operations, AssetDeletionReason};
+use crate::plumbing::{make_project_assets, AssetDescriptor};
 use ic_utils::Canister;
 use slog::{info, Logger};
 use std::collections::HashMap;
@@ -43,7 +41,11 @@ pub async fn upload(
     )
     .await?;
 
-    let operations = assemble_upload_operations(project_assets, canister_assets);
+    let operations = assemble_batch_operations(
+        project_assets,
+        canister_assets,
+        AssetDeletionReason::Incompatible,
+    );
 
     info!(logger, "Committing batch.");
 
@@ -55,20 +57,4 @@ pub async fn upload(
     commit_batch(canister, args).await?;
 
     Ok(())
-}
-
-fn assemble_upload_operations(
-    project_assets: HashMap<String, ProjectAsset>,
-    canister_assets: HashMap<String, AssetDetails>,
-) -> Vec<BatchOperationKind> {
-    let mut canister_assets = canister_assets;
-
-    let mut operations = vec![];
-
-    delete_incompatible_assets(&mut operations, &project_assets, &mut canister_assets);
-    create_new_assets(&mut operations, &project_assets, &canister_assets);
-    unset_obsolete_encodings(&mut operations, &project_assets, &canister_assets);
-    set_encodings(&mut operations, project_assets);
-
-    operations
 }


### PR DESCRIPTION
# Description

Merges:
- `fn delete_obsolete_assets` and `fn delete_incompatible_assets` into `fn delete_assets`
  - introduces `enum AssetDeletionReason` to differentiate between the mode how the assets are supposed to be deleted.
-  `fn assemble_upload_operations` and `fn assemble_synchronization_operations` into `fn assemble_batch_operations`, and moves the logic into `src/operations.rs`

In preparation for:
- https://dfinity.atlassian.net/browse/SDK-819
- https://dfinity.atlassian.net/browse/SDK-565

# How Has This Been Tested?

covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] ~I have edited the CHANGELOG accordingly.~
- [ ] ~I have made corresponding changes to the documentation.~
