### PR TITLE
docs: `CONTRIBUTING.md` improvements and fixes

### DIFF
--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -77,7 +77,7 @@ jobs:
         git commit -m "chore: update replica version to ${{ env.REPLICA_VERSION }}"
         git push origin chore-update-replica-${{ env.REPLICA_VERSION }} 
       
-    - name: create Pull Request, with CHANGELOG.adoc entry suggestion 
+    - name: create Pull Request, with CHANGELOG.md entry suggestion 
       uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.NIV_UPDATER_TOKEN }} # act on behalf of https://github.com/dfinity-bot 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,17 @@ This is done via `./scripts/update-frontend-canister.sh --release-build`. You ne
 Then update `CHANGELOG.md` to include the newest sha2 hash (*not* git commit hash) and a link to your PR.
 If there is already an entry in the 'Unreleased' section, change it; if not, add a new one. See the example in [#2699](https://github.com/pull/2699/commits/c191ce5ac529de4499c50a0d2bc70ac6a3cb3afc). This step can be automated by running `./scripts/update-frontend-canister.sh --changelog`.
 
-### End-to-End Tests
+## End-to-End Tests
 
 #### Setup
 
-1. Install `bats`. See the CI provisioning scripts for examples:
+1. Install `bats`, `jq` and `sponge`. See the CI provisioning scripts for examples (search for the line with the comment `# Install Bats + moreutils.`):
     - [Linux](../scripts/workflows/provision-linux.sh)
     - [Darwin](../scripts/workflows/provision-darwin.sh)
+1. Download `bats-support` (which is included as this repository' submodule) 
+    ```bash
+    git submodule update --init --recursive
+    ```
 1. Build dfx and add its target directory to your path:
     ``` bash
     sdk $ cargo build
@@ -43,11 +47,6 @@ If there is already an entry in the 'Unreleased' section, change it; if not, add
     export archive="$(pwd)/e2e/archive"
     export utils="$(pwd)/e2e/utils"
     export assets="$(pwd)/e2e/assets"
-    ```
-1. Install `jq` and `sponge`.
-1. Download all of this repository' submodules (which includes `bats-support`)
-    ```bash
-    git submodule update --init --recursive
     ```
 
 #### Running End-to-End Tests
@@ -97,8 +96,8 @@ What that means is your PR title should start with one of the following prefix:
 - Head over to [the GitHub Action](https://github.com/dfinity/sdk/actions/workflows/update-replica-version.yml).
 - Click "Run workflow" button, choose appropriate options (you're probably fine with using defaults), and click "Run workflow" (the green one). 
 - Depending on the selected options, the workflow will run anything between 3 to 35 minutes. After that time, a new PR will be created.
-- The PR contains the content that needs to be pasted into CHANGELOG.adoc, as well as the link for editing the CHANGELOG.adoc directly on the branch of that PR.
-- After making changes to the CHANGELOG.adoc file, PR is ready for review.
+- The PR contains the content that needs to be pasted into CHANGELOG.md, as well as the link for editing the CHANGELOG.md directly on the branch of that PR.
+- After making changes to the CHANGELOG.md file, PR is ready for review.
 
 #### Locally
 To update the replica to a given $SHA from the dfinity repo, execute the following:

--- a/scripts/update-ic-ref.sh
+++ b/scripts/update-ic-ref.sh
@@ -16,4 +16,4 @@ niv update ic-ref-x86_64-darwin -a version=$VERSION
 echo "Writing asset sources"
 ./scripts/write-dfx-asset-sources.sh
 
-echo "Done. Don't forget to update CHANGELOG.adoc"
+echo "Done. Don't forget to update CHANGELOG.md"

--- a/scripts/update-motoko.sh
+++ b/scripts/update-motoko.sh
@@ -17,4 +17,4 @@ niv update motoko-x86_64-linux -a version=$VERSION
 echo "Writing asset sources"
 ./scripts/write-dfx-asset-sources.sh
 
-echo "Done. Don't forget to update CHANGELOG.adoc"
+echo "Done. Don't forget to update CHANGELOG.md"

--- a/scripts/update-replica.sh
+++ b/scripts/update-replica.sh
@@ -38,4 +38,4 @@ for arg in "$@"; do
     fi
 done
 
-echo "Done. Don't forget to update CHANGELOG.adoc"
+echo "Done. Don't forget to update CHANGELOG.md"

--- a/scripts/workflows/provision-darwin.sh
+++ b/scripts/workflows/provision-darwin.sh
@@ -7,6 +7,7 @@ export
 # Enter temporary directory.
 pushd /tmp
 
+# Install Bats + moreutils.
 brew install coreutils moreutils
 
 # Install Bats.


### PR DESCRIPTION
# Description

- `End-to-End Tests` no longer appears as if it would be a child of `## Developing ic-certified-assets` (i.e. changed from being header-level-3 to header-level-2)
- simplifies the instructions for setting up e2e tests
- replaces all `CONTRIBUTING.adoc` with `CONTRIBUTING.md`
- moves `CONTRIBUTING.md` from `/.github/CONTRIBUTING.md` to `/CONTRIBUTING.md`

# How Has This Been Tested?

N/A

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] ~I have edited the CHANGELOG accordingly.~
- [x] I have made corresponding changes to the documentation.
