### PR TITLE
feat: Includes motoko-dev-server in new motoko projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## DFX
 
+### feat: Includes motoko-dev-server in new motoko projects
+
+The Motoko project now includes a few new quality-of-life enhancements:
+
+- `npm start` now starts the `motoko-dev-server` in addition to the `webpack` server.
+  - This means that you can now use the `motoko-dev-server` to hot-reload your motoko canisters and frontends as you make changes.
+- `mops` package manager is now included and configured
+  - This installs the `motoko-base` and `test` libraries
+- hello world now includes a `lib.mo` and `lib.test.mo` file
+  - This demonstrates write tests for your canisters and run them with `npm run test:motoko`
+
 ### fix: make sure assetstorage did file is created as writeable.
 
 ### feat: specify id when provisional create canister
@@ -15,12 +26,12 @@ When creating a canister on non-mainnet replica, you can now specify the caniste
 `dfx deploy <CANISTER_NAME> --specified-id <PRINCIPAL>`
 
 You can specify the ID in the range of `[0, u64::MAX / 2]`.
-If not specify the ID, the canister will be created in the range of `[u64::MAX / 2 + 1, u64::MAX]`. 
+If not specify the ID, the canister will be created in the range of `[u64::MAX / 2 + 1, u64::MAX]`.
 This canister ID allocation behavior only applies to the replica, not the emulator (ic-ref).
 
 ### feat: dfx nns install --ledger-accounts
 
-`dfx nns install` now takes an option `--ledger-accounts` to initialize the ledger canister with these accounts. 
+`dfx nns install` now takes an option `--ledger-accounts` to initialize the ledger canister with these accounts.
 
 ### fix: update Rust canister template.
 
@@ -28,12 +39,13 @@ This canister ID allocation behavior only applies to the replica, not the emulat
 
 ### chore: change the default Internet Computer gateway domain to `icp0.io`
 
-By default, DFX now uses the `icp0.io` domain to connect to Internet Computer as opposed to using `ic0.app`. 
+By default, DFX now uses the `icp0.io` domain to connect to Internet Computer as opposed to using `ic0.app`.
 Canisters communicating with `ic0.app` will continue to function nominally.
 
 ### feat: --no-asset-upgrade
 
 ### fix: `dfx generate` no longer requires non-Motoko canisters to have a canister ID
+
 Previously, non-Motoko canisters required that the canister was created before `dfx generate` could be called.
 This requirement is now lifted for all canisters except for canisters of type `"motoko"` or canisters that are listed in (transitive) dependencies of a canister of type `"motoko"`.
 It is planned to lift this requirement for Motoko canisters as well, but this requires more work.
@@ -68,7 +80,7 @@ Added `is_aliased` field to `get_asset_properties` and `set_asset_properties`.
 
 Added partial support for proposal-based asset updates:
 
-- Batch ids are now stable.  With upcoming changes to support asset updates by proposal,
+- Batch ids are now stable. With upcoming changes to support asset updates by proposal,
   having the asset canister not reuse batch ids will make it easier to verify that a particular
   batch has been proposed.
 - Added methods:
@@ -76,7 +88,7 @@ Added partial support for proposal-based asset updates:
   - delete_batch() deletes a batch, intended for use after propose_commit_batch if cancellation needed
   - compute_evidence() computes a hash ("evidence") over the proposed batch arguments
 
-Added `api_version` endpoint. With upcoming changes we will introduce breaking changes to asset canister's batch upload process. New endpoint will help `ic-asset` with differentiation between API version, and allow it to support all versions of the asset canister. 
+Added `api_version` endpoint. With upcoming changes we will introduce breaking changes to asset canister's batch upload process. New endpoint will help `ic-asset` with differentiation between API version, and allow it to support all versions of the asset canister.
 
 ## Dependencies
 
@@ -124,6 +136,7 @@ Added validate_grant_permission() and validate_revoke_permission() methods per S
 This allows users to download SNS canister WASMs.
 
 ### fix: fixed error text
+
 - `dfx nns install` had the wrong instructions for setting up the local replica type
 
 ### fix: creating an identity with `--force` no longer switches to the newly created identity
@@ -131,7 +144,8 @@ This allows users to download SNS canister WASMs.
 ### feat(frontend-canister)!: reworked to use permissions-based access control
 
 The permissions are as follows:
-- ManagePermissions: Can grant and revoke permissions to any principal.  Controllers implicitly have this permission.
+
+- ManagePermissions: Can grant and revoke permissions to any principal. Controllers implicitly have this permission.
 - Prepare: Can call create_batch and create_chunk
 - Commit: Can call commit_batch and methods that manipulate assets directly, as well as any method permitted by Prepare.
 
@@ -139,6 +153,7 @@ For upgraded frontend canisters, all authorized principals will be granted the C
 For newly deployed frontend canisters, the initializer (first deployer of the canister) will be granted the Commit permission.
 
 Added three new methods:
+
 - list_permitted: lists principals with a given permission.
   - Callable by anyone.
 - grant_permission: grants a single permission to a principal
@@ -147,7 +162,8 @@ Added three new methods:
   - Any principal can revoke its own permissions.
   - Only Controllers and principals with the ManagePermissions permission can revoke the permissions of other principals.
 
-Altered the behavior of the existing authorization-related methods to operate only on the "Commit" permission.  In this way, they are backwards-compatible.
+Altered the behavior of the existing authorization-related methods to operate only on the "Commit" permission. In this way, they are backwards-compatible.
+
 - authorize(principal): same as grant_permission(principal, Commit)
 - deauthorize(principal): same as revoke_permission(permission, Commit)
 - list_authorized(): same as list_permitted(Commit)
@@ -155,16 +171,17 @@ Altered the behavior of the existing authorization-related methods to operate on
 ### fix(frontend-canister)!: removed ability of some types of authorized principals to manage the ACL
 
 It used to be the case that any authorized principal could authorize and deauthorize any other principal.
-This is no longer the case.  See rules above for grant_permission and revoke_permission.
+This is no longer the case. See rules above for grant_permission and revoke_permission.
 
 ### feat(frontend-canister)!: default secure configuration for assets in frontend project template
 
-- Secure HTTP headers, preventing several typical security vulnerabilities (e.g. XSS, clickjacking, and many more). For more details, see comments in `headers` section in [default `.ic-assets.json5`](https://raw.githubusercontent.com/dfinity/sdk/master/src/dfx/assets/new_project_node_files/src/__project_name___frontend/src/.ic-assets.json5). 
+- Secure HTTP headers, preventing several typical security vulnerabilities (e.g. XSS, clickjacking, and many more). For more details, see comments in `headers` section in [default `.ic-assets.json5`](https://raw.githubusercontent.com/dfinity/sdk/master/src/dfx/assets/new_project_node_files/src/__project_name___frontend/src/.ic-assets.json5).
 - Configures `allow_raw_access` option in starter `.ic-assets.json5` config files, with the value set to its default value (which is `false`). We are showing that configuration in the default starter projects for the sake of easier discoverability, even though its value is set to the default.
 
 ### feat(frontend-canister)!: add `allow_raw_access` config option
 
 By default, the frontend canister will now restrict the access of traffic to the `<canister-id>.raw.ic0.app` domain, and will automatically redirect all requests to the certified domain (`<canister-id>.ic0.app`), unless configured explicitly. Below is an example configuration to allow access to the `robots.txt` file from the "raw" domain:
+
 ```json
 [
   {
@@ -174,31 +191,33 @@ By default, the frontend canister will now restrict the access of traffic to the
 ]
 ```
 
-**Important**: Note that any assets already uploaded to an asset canister will be protected by this redirection, because at present the asset synchronization process does not update the `allow_raw_access` property, or any other properties, after creating an asset.  This also applies to assets that are deployed without any configuration, and later configured to allow raw access.
+**Important**: Note that any assets already uploaded to an asset canister will be protected by this redirection, because at present the asset synchronization process does not update the `allow_raw_access` property, or any other properties, after creating an asset. This also applies to assets that are deployed without any configuration, and later configured to allow raw access.
 At the present time, there are two ways to reconfigure an existing asset:
+
 1. re-create the asset
-    1. delete the asset in your project's directory 
-    1. execute `dfx deploy`
-    1. re-create the asset in your project's directory
-    1. modify `.ic-assets.json` acordingly 
-    1. execute `dfx deploy`
-2. via manual candid call 
-    ```
-    dfx canister call PROJECT_NAME_frontend set_asset_properties '( record { key="/robots.txt"; allow_raw_access=opt(opt(true)) })'
-    ```
+   1. delete the asset in your project's directory
+   1. execute `dfx deploy`
+   1. re-create the asset in your project's directory
+   1. modify `.ic-assets.json` acordingly
+   1. execute `dfx deploy`
+2. via manual candid call
+   ```
+   dfx canister call PROJECT_NAME_frontend set_asset_properties '( record { key="/robots.txt"; allow_raw_access=opt(opt(true)) })'
+   ```
 
 ### feat(frontend-canister): pretty print asset properties when deploying assets to the canister
 
 ### feat(frontend-canister): add take_ownership() method
 
-Callable only by a controller.  Clears list of authorized principals and adds the caller (controller) as the only authorized principal.
+Callable only by a controller. Clears list of authorized principals and adds the caller (controller) as the only authorized principal.
 
 ### feat(ic-ref):
+
 - `effective_canister_id` used for `provisional_create_canister_with_cycles` is passed as an command-line argument (defaults to `rwlgt-iiaaa-aaaaa-aaaaa-cai` if not provided or upon parse failure)
 
 ### feat(frontend-canister): add `get_asset_properties` and `set_asset_properties` to frontend canister
 
-As part of creating the support for future work, it's now possible to get and set AssetProperties for assets in frontend canister. 
+As part of creating the support for future work, it's now possible to get and set AssetProperties for assets in frontend canister.
 
 ### feat: write canister metadata sections for dfx pull
 
@@ -208,7 +227,7 @@ Similar to how this argument works in `dfx canister call`, this argument allows 
 
 ### feat: Add support for a default network key
 
-A remote canister ID can now be specified for the `__default` network.  If specified, `dfx` will assume that the canister is remote at the specified canister ID for all networks that don't have a dedicated entry.
+A remote canister ID can now be specified for the `__default` network. If specified, `dfx` will assume that the canister is remote at the specified canister ID for all networks that don't have a dedicated entry.
 
 ### feat: use OS-native keyring for pem file storage
 
@@ -229,6 +248,7 @@ The flag `--disable-encryption` is deprecated in favour of `--storage-mode plain
 ### feat(frontend-canister): better control and overview for asset canister authorized principals
 
 The asset canister now has two new functions:
+
 - Query function `list_authorized` displays a list of all principals that are currently authorized to change assets and the list of authorized principals.
 - Update function `deauthorize` that removes a principal from the list of authorized principals. It can be called by authorized principals and cotrollers of the canister.
 
@@ -256,6 +276,7 @@ The number of cycles left in the canister is bumped a little bit so that people 
 ## Dependencies
 
 Updated candid to 0.8.4
+
 - Bug fix in TS bindings
 - Pretty print numbers
 
@@ -316,27 +337,29 @@ This incorporates the following executed proposals:
 
 ### feat(frontend-canister): add warning if config is provided in `.ic-assets.json` but not used
 
-### fix(frontend-canister): Allow overwriting default HTTP Headers for assets in frontend canister 
+### fix(frontend-canister): Allow overwriting default HTTP Headers for assets in frontend canister
 
 Allows to overwrite `Content-Type`, `Content-Encoding`, and `Cache-Control` HTTP headers with custom values via `.ic-assets.json5` config file. Example `.ic-assets.json5` file:
+
 ```json5
 [
-    {
-        "match": "web-gz.data.gz",
-        "headers": {
-            "Content-Type": "application/octet-stream",
-            "Content-Encoding": "gzip"
-        }
-    }
+  {
+    match: "web-gz.data.gz",
+    headers: {
+      "Content-Type": "application/octet-stream",
+      "Content-Encoding": "gzip",
+    },
+  },
 ]
 ```
-This change will trigger the update process for frontend canister (new module hash: `2ff0513123f11c57716d889ca487083fac7d94a4c9434d5879f8d0342ad9d759`). 
+
+This change will trigger the update process for frontend canister (new module hash: `2ff0513123f11c57716d889ca487083fac7d94a4c9434d5879f8d0342ad9d759`).
 
 ### feat: warn if an unencrypted identity is used on mainnet
 
 ### fix: Save SNS canister IDs
 
-SNS canister IDs were not being parsed reliably.  Now the candid file is being specified explicitly, which resolves the issue in at least some cases.
+SNS canister IDs were not being parsed reliably. Now the candid file is being specified explicitly, which resolves the issue in at least some cases.
 
 ### feat: NNS usability improvements
 
@@ -375,6 +398,7 @@ This can be disabled by setting the field `"enable_aliasing"` to `false` in a ru
 This change will trigger frontend canister upgrades upon redeploying any asset canister.
 
 ### fix: Only kill main process on `dfx stop`
+
 Removes misleading panics when running `dfx stop`.
 
 ### feat: `dfx nns install` works offline if all assets have been cached.
@@ -382,6 +406,7 @@ Removes misleading panics when running `dfx stop`.
 ### feat: Initialise the nns with an account controlled by a secp256k1 key
 
 This enables easy access to toy ICP using command line tools and this key:
+
 ```
 -----BEGIN EC PRIVATE KEY-----
 MHQCAQEEICJxApEbuZznKFpV+VKACRK30i6+7u5Z13/DOl18cIC+oAcGBSuBBAAK
@@ -389,13 +414,16 @@ oUQDQgAEPas6Iag4TUx+Uop+3NhE6s3FlayFtbwdhRVjvOar0kPTfE/N8N6btRnd
 74ly5xXEBNSXiENyxhEuzOZrIWMCNQ==
 -----END EC PRIVATE KEY-----
 ```
+
 For example, you can create an identity in dfx by putting this key in the file `ident-1.pem` and importing it:
+
 ```
 dfx identity import ident-1 ident-1.pem
 dfx --identity ident-1 ledger balance
 ```
 
 ### feat: default to run ic-wasm shrink when build canisters
+
 This behavior applies to Motoko, Rust and Custom canisters.
 If you want to disable this behavior, you can config it in dfx.json:
 
@@ -409,9 +437,9 @@ If you want to disable this behavior, you can config it in dfx.json:
 
 It's now possible to define custom wasm metadata sections and their visibility in dfx.json.
 
-At present, dfx can only add wasm metadata sections to canisters that are in wasm format.  It cannot add metadata sections to compressed canisters.  Since the frontend canister is now compressed, this means that at present it is not possible to add custom metadata sections to the frontend canister.
+At present, dfx can only add wasm metadata sections to canisters that are in wasm format. It cannot add metadata sections to compressed canisters. Since the frontend canister is now compressed, this means that at present it is not possible to add custom metadata sections to the frontend canister.
 
-dfx no longer adds `candid:service` metadata to canisters of type `"custom"` by default.  If you want dfx to add your canister's candid definition to your custom canister, you can do so like this:
+dfx no longer adds `candid:service` metadata to canisters of type `"custom"` by default. If you want dfx to add your canister's candid definition to your custom canister, you can do so like this:
 
 ```
     "my_canister_name": {
@@ -426,11 +454,11 @@ dfx no longer adds `candid:service` metadata to canisters of type `"custom"` by 
     },
 ```
 
-This changelog entry doesn't go into all of the details of the possible configuration.  For that, please see [concepts/canister-metadata](docs/concepts/canister-metadata.md) and the docs in the JSON schema.
+This changelog entry doesn't go into all of the details of the possible configuration. For that, please see [concepts/canister-metadata](docs/concepts/canister-metadata.md) and the docs in the JSON schema.
 
 ### fix: Valid canister-based env vars
 
-Hyphens are not valid in shell environment variables, but do occur in canister names such as `smiley-dapp`. This poses a problem for vars with names such as `CANISTER_ID_${CANISTER_NAME}`.  With this change, hyphens are replaced with underscores in environment variables.  The canister id of `smiley-dapp` will be available as `CANISTER_ID_smiley_dapp`.  Other environment variables are unaffected.
+Hyphens are not valid in shell environment variables, but do occur in canister names such as `smiley-dapp`. This poses a problem for vars with names such as `CANISTER_ID_${CANISTER_NAME}`. With this change, hyphens are replaced with underscores in environment variables. The canister id of `smiley-dapp` will be available as `CANISTER_ID_smiley_dapp`. Other environment variables are unaffected.
 
 ### feat: Add dfx sns deploy
 
@@ -473,6 +501,7 @@ Previously the did files and wasms could be incompatible.
 `dfx start` and `dfx replica` now ignore the `--enable-canister-http` parameter.
 
 You can still disable the canister http feature through configuration:
+
 - ~/.config/dfx/networks.json: `.local.canister_http.enabled=false`
 - dfx.json (project-specific networks) : `.networks.local.canister_http.enabled=false`
 
@@ -484,7 +513,8 @@ You can still disable the canister http feature through configuration:
 
 ### feat: deploy NNS canisters
 
-A developer is now able to install NNS canisters, including back end canisters such as ledger and governance, and front end canisters such as nns-dapp and internet-identity, on their local DFX server.  Usage:
+A developer is now able to install NNS canisters, including back end canisters such as ledger and governance, and front end canisters such as nns-dapp and internet-identity, on their local DFX server. Usage:
+
 ```
 dfx start --clean --background
 dfx nns install
@@ -519,13 +549,13 @@ When creating a new identity with `dfx identity new`, whereas previously it woul
 
 ### chore: update Candid UI canister with commit 528a4b04807904899f67b919a88597656e0cd6fa
 
-* Allow passing did files larger than 2KB.
-* Better integration with Motoko Playground.
+- Allow passing did files larger than 2KB.
+- Better integration with Motoko Playground.
 
 ### feat: simplify verification of assets served by asset canister
 
-* SHA256 hashes of all assets are displayed when deploying the asset canister.
-* A query method is added to the asset canister that returns the entire asset hash tree together with the certificate containing the certified variables of the asset canister.
+- SHA256 hashes of all assets are displayed when deploying the asset canister.
+- A query method is added to the asset canister that returns the entire asset hash tree together with the certificate containing the certified variables of the asset canister.
 
 ### breaking change: dfx canister update-settings --compute-allocation always fails
 
@@ -533,6 +563,7 @@ See https://forum.dfinity.org/t/fixing-incorrect-compute-allocation-fee/14830
 
 Until the rollout is complete, `dfx canister update-settings --compute-allocation <N>`
 will fail with an error from the replica such as the following:
+
 ```
 The Replica returned an error: code 1, message: "Canister requested a compute allocation of 1% which cannot be satisfied because the Subnet's remaining compute capacity is 0%"
 ```
@@ -555,12 +586,12 @@ The running replica port and url are generally useful information. Previously th
 
 Instead, the build process relies on `ic-wasm` to provide candid metadata for the canister, and
 shrinking the canister size by stripping debug symbols and unused fuctions.
-Additionally, after build step, the `.wasm` file is archived with `gzip`. 
+Additionally, after build step, the `.wasm` file is archived with `gzip`.
 
 ### chore: Move all `frontend canister`-related code into the SDK repo
 
 | from (`repository` `path`)                  | to (path in `dfinity/sdk` repository)          | summary                                                                                     |
-|:--------------------------------------------|:-----------------------------------------------|:--------------------------------------------------------------------------------------------|
+| :------------------------------------------ | :--------------------------------------------- | :------------------------------------------------------------------------------------------ |
 | `dfinity/cdk-rs` `/src/ic-certified-assets` | `/src/canisters/frontend/ic-certified-asset`   | the core of the frontend canister                                                           |
 | `dfinity/certified-assets` `/`              | `/src/canisters/frontend/ic-frontend-canister` | wraps `ic-certified-assets` to build the canister wasm                                      |
 | `dfinity/agent-rs` `/ic-asset`              | `/src/canisters/frontend/ic-asset`             | library facilitating interactions with frontend canister (e.g. uploading or listing assets) |
@@ -570,17 +601,19 @@ Additionally, after build step, the `.wasm` file is archived with `gzip`.
 
 Both `.ic-assets.json` and `.ic-assets.json5` are valid filenames config filename, though both will get parsed
 as if they were [JSON5](https://json5.org/) format. Example content of the `.ic-assets.json5` file:
+
 ```json5
 // comment
 [
   {
-    "match": "*", // comment
+    match: "*", // comment
     /*
     keys below not wrapped in quotes
-*/  cache: { max_age: 999 }, // trailing comma 
+*/ cache: { max_age: 999 }, // trailing comma
   },
 ]
 ```
+
 - Learn more about JSON5: https://json5.org/
 
 ### fix: Update nns binaries unless `NO_CLOBBER` is set
@@ -589,7 +622,7 @@ Previously existing NNS binaries were not updated regardless of the `NO_CLOBBER`
 
 ### feat!: Support installing canisters not in dfx.json
 
-`install_canister_wasm` used to fail if installing a canister not listed in dfx.json.  This use case is now supported.
+`install_canister_wasm` used to fail if installing a canister not listed in dfx.json. This use case is now supported.
 
 ### feat: print the dashboard URL on startup
 
@@ -603,30 +636,32 @@ In combination with the "system-wide dfx start" feature, there is a potential di
 
 Since previous versions of dfx populate dfx.json with a `networks.local` definition that specifies port 8000, the behavior for existing projects won't change.
 
-However, if you've edited dfx.json and removed the `networks.local` definition, the behavior within the project will change: dfx will connect to the shared local network on port 4943 rather than to the project-specific network on port 8000.  You would need to edit webpack.config.js to match.  If you have scripts, you can run the new command `dfx info webserver-port` from the project directory to retrieve the port value.
+However, if you've edited dfx.json and removed the `networks.local` definition, the behavior within the project will change: dfx will connect to the shared local network on port 4943 rather than to the project-specific network on port 8000. You would need to edit webpack.config.js to match. If you have scripts, you can run the new command `dfx info webserver-port` from the project directory to retrieve the port value.
 
 ### feat!: "system-wide dfx start"
 
-By default, dfx now manages the replica process in a way that is independent of any given dfx project.  We've called this feature "system-wide dfx", even though it's actually specific to your user
+By default, dfx now manages the replica process in a way that is independent of any given dfx project. We've called this feature "system-wide dfx", even though it's actually specific to your user
 (storing data files under $HOME), because we think it communicates the idea adequately.
 
 The intended benefits:
+
 - deploying dapps from separate projects alongside one another, similar to working with separate dapps on mainnet
 - run `dfx start` from any directory
 - run `dfx stop` from any directory, rather than having to remember where you last ran `dfx start`
 
-We're calling this the "shared local network."  `dfx start` and `dfx stop` will manage this network when run outside any project directory, or when a project's dfx.json does not define the `local` network.  The dfx.json template for new projects no longer defines any networks.
+We're calling this the "shared local network." `dfx start` and `dfx stop` will manage this network when run outside any project directory, or when a project's dfx.json does not define the `local` network. The dfx.json template for new projects no longer defines any networks.
 
-We recommend that you remove the `local` network definition from dfx.json and instead use the shared local network.  As mentioned above, doing so will make dfx use port 4943 rather than port 8000.
+We recommend that you remove the `local` network definition from dfx.json and instead use the shared local network. As mentioned above, doing so will make dfx use port 4943 rather than port 8000.
 
 See [Local Server Configuration](docs/cli-reference/dfx-start.md#local-server-configuration) for details.
 
 dfx now stores data and control files in one of three places, rather than directly under `.dfx/`:
+
 - `.dfx/network/local` (for projects in which dfx.json defines the local network)
 - `$HOME/.local/share/dfx/network/local` (for the shared local network on Linux)
 - `$HOME/Library/Application Support/org.dfinity.dfx/network/local` (for the shared local network on MacOS)
 
-There is also a new configuration file: `$HOME/.config/dfx/networks.json`.  Its [schema](docs/networks-json-schema.json) is the same as the `networks` element in dfx.json.  Any networks you define here will be available from any project, unless a project's dfx.json defines a network with the same name.  See [The Shared Local Network](docs/cli-reference/dfx-start.md#the-shared-local-network) for the default definitions that dfx provides if this file does not exist or does not define a `local` network.
+There is also a new configuration file: `$HOME/.config/dfx/networks.json`. Its [schema](docs/networks-json-schema.json) is the same as the `networks` element in dfx.json. Any networks you define here will be available from any project, unless a project's dfx.json defines a network with the same name. See [The Shared Local Network](docs/cli-reference/dfx-start.md#the-shared-local-network) for the default definitions that dfx provides if this file does not exist or does not define a `local` network.
 
 ### fix: `dfx start` and `dfx stop` will take into account dfx/replica processes from dfx <= 0.11.x
 
@@ -656,7 +691,7 @@ This displays the path to your user's `networks.json` file where all networks ar
 
 ### feat: dfx schema --for networks
 
-The `dfx schema` command can now display the schema for either dfx.json or for networks.json.  By default, it still displays the schema for dfx.json.
+The `dfx schema` command can now display the schema for either dfx.json or for networks.json. By default, it still displays the schema for dfx.json.
 
 ```bash
 dfx schema --for networks
@@ -668,8 +703,8 @@ If you have a pre-initialized agent in your JS code, you can now pass it to crea
 
 ```js
 const plugActor = createActor(canisterId, {
-  agent: plugAgent
-})
+  agent: plugAgent,
+});
 ```
 
 ### feat!: option for nodejs compatibility in dfx generate
@@ -707,10 +742,12 @@ If the active identity has a wallet configured already, the faucet will top up t
 
 Alternative faucets can be used, assuming they follow the same interface. To direct dfx to a different faucet, use the `--faucet <alternative faucet id>` flag.
 The expected interface looks like the following candid functions:
-``` candid
+
+```candid
 redeem: (text) -> (principal);
 redeem_to_wallet: (text, principal) -> (nat);
 ```
+
 The function `redeem` takes a coupon code and returns the principal to an already-installed wallet that is controlled by the identity that called the function.
 The function `redeem_to_wallet` takes a coupon code and a wallet (or any other canister) principal, deposits the cycles into that canister and returns how many cycles were deposited.
 
@@ -732,13 +769,17 @@ When installing a new WASM module to a canister, DFX will now wait for the updat
 ### feat: move all the flags to the end
 
 Command flags have been moved to a more traditional location; they are no longer positioned per subcommand, but instead are able to be all positioned after the final subcommand. In prior versions, a command might look like:
+
 ```bash
 dfx --identity alice canister --network ic --wallet "$WALLET" create --all
 ```
+
 This command can now be written:
+
 ```bash
 dfx canister create --all --network ic --wallet "$WALLET" --identity alice
 ```
+
 The old syntax is still available, though, so you don't need to migrate your scripts.
 
 ### feat!: changed update-settings syntax
@@ -747,7 +788,7 @@ When using `dfx canister update-settings`, it is easy to mistake `--controller` 
 
 ### feat!: removed the internal webserver
 
-This is a breaking change.  The only thing this was still serving was the /_/candid endpoint.  If you need to retrieve the candid interface for a local canister, you can use `dfx canister metadata <canister> candid:service`.
+This is a breaking change. The only thing this was still serving was the /\_/candid endpoint. If you need to retrieve the candid interface for a local canister, you can use `dfx canister metadata <canister> candid:service`.
 
 ### fix: dfx wallet upgrade: improved error messages:
 
@@ -761,15 +802,16 @@ Canister creation fee was calculated with 1T cycles instead of 0.1T.
 ### fix: dfx deploy and dfx canister install write .old.did files under .dfx/
 
 When dfx deploy and dfx canister install upgrade a canister, they ensure that the
-new candid interface is compatible with the previous candid interface.  They write
-a file with extension .old.did that contains the previous interface.  In some
-circumstances these files could be written in the project directory.  dfx now
+new candid interface is compatible with the previous candid interface. They write
+a file with extension .old.did that contains the previous interface. In some
+circumstances these files could be written in the project directory. dfx now
 always writes them under the .dfx/ directory.
 
 ### fix: dfx canister install now accepts arbitrary canister ids
 
 This fixes the following error:
-``` bash
+
+```bash
 > dfx canister install --wasm ~/counter.wasm eop7r-riaaa-aaaak-qasxq-cai
 Error: Failed while determining if canister 'eop7r-riaaa-aaaak-qasxq-cai' is remote on network 'ic'.
 Caused by: Failed while determining if canister 'eop7r-riaaa-aaaak-qasxq-cai' is remote on network 'ic'.
@@ -782,6 +824,7 @@ Caused by: Failed while determining if canister 'eop7r-riaaa-aaaak-qasxq-cai' is
 It is now possible to specify the replica's log level. Possible values are `critical`, `error`, `warning`, `info`, `debug`, and `trace`.
 The log level defaults to the level 'error'. Debug prints (e.g. `Debug.print("...")` in Motoko) still show up in the console.
 The log level can be specified in the following places (See [system-wide dfx start](#feat-system-wide-dfx-start) for more detailed explanations on the network types):
+
 - In file `networks.json` in the field `<network name>.replica.log_level` for shared networks.
 - In file `dfx.json` in the field `networks.<network name>.replica.log_level` for project-specific networks.
 - In file `dfx.json` in the field `defaults.replica.log_level` for project-specific networks. Requires a project-specific network to be run, otherwise this will have no effect.
@@ -810,10 +853,10 @@ It is still possible to pin the dfx version by adding `"dfx":"<dfx version to pi
 ### fix: Small grammar change to identity password decryption prompt
 
 The prompt for entering your passphrase in order to decrypt an identity password read:
-    "Please enter a passphrase for your identity"
-However, at that point, it isn't "a" passphrase.  It's either your passphrase, or incorrect.
+"Please enter a passphrase for your identity"
+However, at that point, it isn't "a" passphrase. It's either your passphrase, or incorrect.
 Changed the text in this case to read:
-    "Please enter the passphrase for your identity"
+"Please enter the passphrase for your identity"
 
 ### chore: add retry logic to dfx download script
 
@@ -835,6 +878,7 @@ This also incorporates the following executed proposals:
 - [87631](https://dashboard.internetcomputer.org/proposal/87631)
 - [86738](https://dashboard.internetcomputer.org/proposal/86738)
 - [86279](https://dashboard.internetcomputer.org/proposal/86279)
+
 * [85007](https://dashboard.internetcomputer.org/proposal/85007)
 * [84391](https://dashboard.internetcomputer.org/proposal/84391)
 * [83786](https://dashboard.internetcomputer.org/proposal/83786)
@@ -857,6 +901,7 @@ This also incorporates the following executed proposals:
 ### ic-ref
 
 Updated ic-ref to 0.0.1-1fba03ee
+
 - introduce awaitKnown
 - trivial implementation of idle_cycles_burned_per_day
 
@@ -864,13 +909,13 @@ Updated ic-ref to 0.0.1-1fba03ee
 
 - See https://github.com/dfinity/motoko/blob/master/Changelog.md#073-2022-11-01
 
-
 ### Cycles wallet
 
 - Module hash: b944b1e5533064d12e951621d5045d5291bcfd8cf9d60c28fef02c8fdb68e783
 - https://github.com/dfinity/cycles-wallet/commit/fa86dd3a65b2509ca1e0c2bb9d7d4c5be95de378
 
 ### Frontend canister:
+
 - Module hash: 6c8f7a094060b096c35e4c4499551e7a8a29ee0f86c456e521c09480ebbaa8ab
 - https://github.com/dfinity/sdk/pull/2720
 
@@ -905,34 +950,38 @@ Patches a JavaScript language binding compatibility issue encountered in web bro
 dfx is now capable of displaying the schema for `dfx.json`. You can see the schema by running `dfx schema` or write the schema to a file with `dfx schema --outfile path/to/file/schema.json`.
 
 ### feat: support for configuring assets in assets canister
+
 - The `.ic-assets.json` file should be placed inside directory with assets, or its subdirectories. Multiple config files can be used (nested in subdirectories). Example of `.ic-assets.json` file format:
-``` json
+
+```json
 [
-    {
-        "match": ".*",
-        "cache": {
-            "max_age": 20
-        },
-        "headers": {
-            "X-Content-Type-Options": "nosniff"
-        },
-        "ignore": false
+  {
+    "match": ".*",
+    "cache": {
+      "max_age": 20
     },
-    {
-        "match": "**/*",
-        "headers": null
+    "headers": {
+      "X-Content-Type-Options": "nosniff"
     },
-    {
-        "match": "file.json",
-        "ignore": true
-    }
+    "ignore": false
+  },
+  {
+    "match": "**/*",
+    "headers": null
+  },
+  {
+    "match": "file.json",
+    "ignore": true
+  }
 ]
 ```
+
 - Configuring assets works only during asset creation - any changes to `.ic-assets.json` files won't have any effect effect for assets that have already been created. We are working on follow up implementation with improvements to handle updating these properties.
 - `headers` from multiple applicable rules are being stacked/concatenated, unless `null` is specified, which resets/empties the headers.
 - Both `"headers": {}` and absence of `headers` field don't have any effect on end result.
 - Valid JSON format is required, i.e. the array of maps, `match` field is required. Only the following fields are accepted: `cache`, `ignore`, `headers`, `match`. The glob pattern has to be valid.
 - The way matching rules work:
+
   1. The most deeply nested config file takes precedence over the one in parent dir. In other words, properties from a rule matching a file in a subdirectory override properties from a rule matching a file in a parent directory
   2. Order of rules within file matters - last rule in config file takes precedence over the first one
 
@@ -941,7 +990,6 @@ dfx is now capable of displaying the schema for `dfx.json`. You can see the sche
   2. The `.ignore` field overrides this, if present.
   3. If a directory is ignored, file and directories within it cannot be un-ignored.
   4. A file can be ignored and un-ignored many times, as long as any of its parent directories haven't been ignored.
-
 
 ### fix: Allow `dfx deploy` to not take arguments for canisters not being installed
 
@@ -975,17 +1023,17 @@ A test key id "Secp256k1:dfx_test_key" is ready to be used by locally created ca
 Updated replica to elected commit 6e86169e98904047833ba6133e5413d2758d90eb.
 This incorporates the following executed proposals:
 
-* [72225](https://dashboard.internetcomputer.org/proposal/72225)
-* [71669](https://dashboard.internetcomputer.org/proposal/71669)
-* [71164](https://dashboard.internetcomputer.org/proposal/71164)
-* [70375](https://dashboard.internetcomputer.org/proposal/70375)
-* [70002](https://dashboard.internetcomputer.org/proposal/70002)
+- [72225](https://dashboard.internetcomputer.org/proposal/72225)
+- [71669](https://dashboard.internetcomputer.org/proposal/71669)
+- [71164](https://dashboard.internetcomputer.org/proposal/71164)
+- [70375](https://dashboard.internetcomputer.org/proposal/70375)
+- [70002](https://dashboard.internetcomputer.org/proposal/70002)
 
 # 0.11.0
 
 ## DFX
 
-### feat: renamed canisters in new projects to <project>_frontend and <project>_backend
+### feat: renamed canisters in new projects to <project>\_frontend and <project>\_backend
 
 The names of canisters created for new projects have changed.
 After `dfx new <project>`, the canister names are:
@@ -999,10 +1047,10 @@ After `dfx new <project>`, the canister names are:
 
 For example, to query a canister's candid service definition: `dfx canister metadata hello_backend candid:service`
 
-### refactor: deprecate /_/candid internal webserver
+### refactor: deprecate /\_/candid internal webserver
 
-The dfx internal webserver now only services the /_/candid endpoint.  This
-is now deprecated.  If you were using this to query candid definitions, you
+The dfx internal webserver now only services the /\_/candid endpoint. This
+is now deprecated. If you were using this to query candid definitions, you
 can instead use `dfx canister metadata`.
 
 ### refactor: optimize from ic-wasm
@@ -1014,8 +1062,9 @@ The actual optimization was kept the same.
 ### feat: Read dfx canister call argument from a file or stdin
 
 Enables passing large arguments that cannot be passed directly in the command line using the `--argument-file` flag. For example:
- * Named file: `dfx canister call --argument-file ./my/argument/file.txt my_canister_name greet`
- * Stdin: `echo '( null )' | dfx canister call --argument-file - my_canister_name greet`
+
+- Named file: `dfx canister call --argument-file ./my/argument/file.txt my_canister_name greet`
+- Stdin: `echo '( null )' | dfx canister call --argument-file - my_canister_name greet`
 
 ### fix: Use default setting for BTC adapter idle seconds
 
@@ -1039,18 +1088,18 @@ By default, a log level of "info" is used, which is relatively quiet. Users can 
 
 This includes the following changes:
 
-* Fetch did file from canister metadata
-* Better flamegraph support
-* Fix bigint error for vec nat8 type
+- Fetch did file from canister metadata
+- Better flamegraph support
+- Fix bigint error for vec nat8 type
 
 ### feat: dfx will look up the port of the running webserver from .dfx/webserver-port, if present
 
-After `dfx start --host 127.0.0.1:0`, the dfx webserver will listen on an ephemeral port.  It stores the port value in .dfx/webserver-port.  dfx will now look for this file, and if a port is contained within, use that port to connect to the dfx webserver.
+After `dfx start --host 127.0.0.1:0`, the dfx webserver will listen on an ephemeral port. It stores the port value in .dfx/webserver-port. dfx will now look for this file, and if a port is contained within, use that port to connect to the dfx webserver.
 
 ### fix: dfx commands once again work from any subdirectory of a dfx project
 
 Running `dfx deploy`, `dfx canister id`, `dfx canister call` and so forth work as expected
-if run from within any subdirectory of a dfx project.  Previously, this would create
+if run from within any subdirectory of a dfx project. Previously, this would create
 canister_ids.json or .dfx/local/canister_ids.json within the subdirectory.
 
 ### feat: Post-installation tasks
@@ -1062,7 +1111,7 @@ You can now add your own custom post-installation/post-deployment tasks to any c
 Assets are now uploaded directly from their source directories, rather than first being copied
 to an output directory.
 
-If you're using `dfx deploy`, you won't see any change in functionality.  If you're running
+If you're using `dfx deploy`, you won't see any change in functionality. If you're running
 `dfx canister install --mode=upgrade`, changed files in asset source directories will
 be detected and uploaded even without an intervening `dfx build`.
 
@@ -1100,7 +1149,7 @@ Resolves an issue where `webpack-cli` was was breaking when users tried to run `
 ### feat: Support for new ledger notify function
 
 Ledger 7424ea8 deprecates the existing `notify` function with a switch parameter between creating and topping up a canister, and introduces two
-functions for doing the same. This should *mostly* be invisible to users, except that previously, if `dfx ledger create-canister` or `dfx ledger top-up`
+functions for doing the same. This should _mostly_ be invisible to users, except that previously, if `dfx ledger create-canister` or `dfx ledger top-up`
 failed, you would call `dfx ledger notify` after correcting the issue. In order to support the change, this command has been changed to two subcommands:
 `dfx ledger notify create-canister` and `dfx ledger notify top-up`.
 
@@ -1132,7 +1181,7 @@ The candid file specified in the field `canisters.<canister name>.candid` of dfx
 ### fix: btc/canister http adapter socket not found by replica after restart
 
 After running `dfx start --enable-bitcoin` twice in a row (stopping dfx in between), the second
-launched replica would fail to connect to the btc adapter.  This is because ic-starter
+launched replica would fail to connect to the btc adapter. This is because ic-starter
 does not write a new configuration file if one already exists, so the configuration file
 used by the replica referred to one socket path, while dfx passed a different socket path
 to the btc adapter.
@@ -1151,7 +1200,6 @@ a dfx process that is starting.
 ### fix: dfx ping no longer creates a default identity
 
 dfx ping now uses the anonymous identity, and no longer requires dfx.json to be present.
-
 
 ### fix: Initialize replica with bitcoin regtest flag
 
@@ -1175,7 +1223,8 @@ If one of these four fields is set for the local network, the corresponding fiel
 in `defaults` will be ignored.
 
 Example:
-``` json
+
+```json
 {
   "networks": {
     "local": {
@@ -1203,26 +1252,27 @@ Updated Motoko from 0.6.28 to 0.6.29.
 Updated replica to elected commit 8993849de5fab76e796d67750facee55a0bf6649.
 This incorporates the following executed proposals:
 
-* [69804](https://dashboard.internetcomputer.org/proposal/69804)
-* [67990](https://dashboard.internetcomputer.org/proposal/67990)
-* [67483](https://dashboard.internetcomputer.org/proposal/67483)
-* [66895](https://dashboard.internetcomputer.org/proposal/66895)
-* [66888](https://dashboard.internetcomputer.org/proposal/66888)
-* [65530](https://dashboard.internetcomputer.org/proposal/65530)
-* [65327](https://dashboard.internetcomputer.org/proposal/65327)
-* [65043](https://dashboard.internetcomputer.org/proposal/65043)
-* [64355](https://dashboard.internetcomputer.org/proposal/64355)
-* [63228](https://dashboard.internetcomputer.org/proposal/63228)
-* [62143](https://dashboard.internetcomputer.org/proposal/62143)
+- [69804](https://dashboard.internetcomputer.org/proposal/69804)
+- [67990](https://dashboard.internetcomputer.org/proposal/67990)
+- [67483](https://dashboard.internetcomputer.org/proposal/67483)
+- [66895](https://dashboard.internetcomputer.org/proposal/66895)
+- [66888](https://dashboard.internetcomputer.org/proposal/66888)
+- [65530](https://dashboard.internetcomputer.org/proposal/65530)
+- [65327](https://dashboard.internetcomputer.org/proposal/65327)
+- [65043](https://dashboard.internetcomputer.org/proposal/65043)
+- [64355](https://dashboard.internetcomputer.org/proposal/64355)
+- [63228](https://dashboard.internetcomputer.org/proposal/63228)
+- [62143](https://dashboard.internetcomputer.org/proposal/62143)
 
 ### ic-ref
 
 Updated ic-ref to 0.0.1-173cbe84
- - add ic0.performance_counter system interface
- - add system API for ECDSA signing
- - allow optional "error_code" field in responses
- - support gzip-compressed canister modules
- - enable canisters to send HTTP requests
+
+- add ic0.performance_counter system interface
+- add system API for ECDSA signing
+- allow optional "error_code" field in responses
+- support gzip-compressed canister modules
+- enable canisters to send HTTP requests
 
 # 0.10.1
 
@@ -1236,9 +1286,11 @@ lead to an annoying "too many open files" error.
 ### fix: HSMs are once again supported on Linux
 
 On Linux, dfx 0.10.0 failed any operation with an HSM with the following error:
+
 ```
 Error: IO: Dynamic loading not supported
 ```
+
 The fix was to once again dynamically-link the Linux build.
 
 ### feat: error explanation and fixing instructions engine
@@ -1262,7 +1314,8 @@ The behavior for identities without any configured wallets is unchanged.
 ### feat: bitcoin integration: dfx now generates the bitcoin adapter config file
 
 dfx command-line parameters for bitcoin integration:
-``` bash
+
+```bash
 dfx start   --enable-bitcoin  # use default node 127.0.0.1:18444
 dfx start   --enable-bitcoin --bitcoin-node <node>
 ```
@@ -1270,6 +1323,7 @@ dfx start   --enable-bitcoin --bitcoin-node <node>
 The above examples also work for dfx replica.
 
 These default to values from dfx.json:
+
 ```
 .defaults.bitcoin.nodes
 .defaults.bitcoin.enabled
@@ -1278,7 +1332,6 @@ These default to values from dfx.json:
 The --bitcoin-node parameter, if specified on the command line, implies --enable-bitcoin.
 
 If --enable-bitcoin or .defaults.bitcoin.enabled is set, then dfx start/replica will launch the ic-btc-adapter process and configure the replica to communicate with it.
-
 
 ### feat: print wallet balance in a human readable form #2184
 
@@ -1289,12 +1342,14 @@ New flag `--precise` added to `dfx wallet balance`. Allows to get exact amount o
 ### feat: canister http integration
 
 dfx command-line parameters for canister http requests integration:
+
 ```
 dfx start --enable-canister-http
 dfx replica --enable-canister-http
 ```
 
 This defaults to the following value in dfx.json:
+
 ```
 .defaults.canister_http.enabled
 ```
@@ -1320,22 +1375,22 @@ Updated Motoko from 0.6.26 to 0.6.28.
 Updated replica to elected commit b90edb9897718730f65e92eb4ff6057b1b25f766.
 This incorporates the following executed proposals:
 
-* [61004](https://dashboard.internetcomputer.org/proposal/61004)
-* [60222](https://dashboard.internetcomputer.org/proposal/60222)
-* [59187](https://dashboard.internetcomputer.org/proposal/59187)
-* [58479](https://dashboard.internetcomputer.org/proposal/58479)
-* [58376](https://dashboard.internetcomputer.org/proposal/58376)
-* [57843](https://dashboard.internetcomputer.org/proposal/57843)
-* [57395](https://dashboard.internetcomputer.org/proposal/57395)
+- [61004](https://dashboard.internetcomputer.org/proposal/61004)
+- [60222](https://dashboard.internetcomputer.org/proposal/60222)
+- [59187](https://dashboard.internetcomputer.org/proposal/59187)
+- [58479](https://dashboard.internetcomputer.org/proposal/58479)
+- [58376](https://dashboard.internetcomputer.org/proposal/58376)
+- [57843](https://dashboard.internetcomputer.org/proposal/57843)
+- [57395](https://dashboard.internetcomputer.org/proposal/57395)
 
 ## icx-proxy
 
 Updated icx-proxy to commit c312760a62b20931431ba45e5b0168ee79ea5cda
 
-* Added gzip and deflate body decoding before certification validation.
-* Fixed unzip and streaming bugs
-* Added Prometheus metrics endpoint
-* Added root and invalid ssl and dns mapping
+- Added gzip and deflate body decoding before certification validation.
+- Fixed unzip and streaming bugs
+- Added Prometheus metrics endpoint
+- Added root and invalid ssl and dns mapping
 
 # 0.10.0
 
@@ -1343,10 +1398,9 @@ Updated icx-proxy to commit c312760a62b20931431ba45e5b0168ee79ea5cda
 
 ### feat: Use null as default value for opt arguments
 
-
 Before this, `deploy`ing a canister with an `opt Foo` init argument without specifying an `--argument` would lead to an error:
 
-``` bash
+```bash
 $ dfx deploy
 Error: Invalid data: Expected arguments but found none.
 ```
@@ -1377,7 +1431,7 @@ dfx will once again display 'dfx is already running' if dfx is already running,
 rather than 'Address already in use'.
 
 As a consequence, after `dfx start` failed to notice that dfx was already running,
-it would replace .dfx/pid with an empty file.  Later invocations of `dfx stop`
+it would replace .dfx/pid with an empty file. Later invocations of `dfx stop`
 would display no output and return a successful exit code, but leave dfx running.
 
 ### fix: dfx canister update-settings <canister id> works even if the canister id is not known to the project.
@@ -1388,8 +1442,8 @@ This makes the behavior match the usage text of the command:
 ### feat: dfx deploy --upgrade-unchanged or dfx canister install --mode upgrade --upgrade-unchanged
 
 When upgrading a canister, `dfx deploy` and `dfx canister install` skip installing the .wasm
-if the wasm hash did not change.  This avoids a round trip through stable memory for all
-assets on every dfx deploy, for example.  By passing this argument, dfx will instead
+if the wasm hash did not change. This avoids a round trip through stable memory for all
+assets on every dfx deploy, for example. By passing this argument, dfx will instead
 install the wasm even if its hash matches the already-installed wasm.
 
 ### feat: Introduce DFX_CACHE_ROOT environment variable
@@ -1405,11 +1459,12 @@ Previously, `dfx canister call --with-cycles 1` would silently ignore the `--wit
 ### feat: Configure subnet type of local replica
 
 The local replica sets its parameters according to the subnet type defined in defaults.replica.subnet_type, defaulting to 'application' when none is specified.
-This makes it less likely to accidentally hit the 'cycles limit exceeded' error in production.  Since the previous default was `system`, you may see these types errors in development instead.
+This makes it less likely to accidentally hit the 'cycles limit exceeded' error in production. Since the previous default was `system`, you may see these types errors in development instead.
 Possible values for defaults.replica.subnet_type are: "application", "verifiedapplication", "system"
 
 Example how to specify the subnet type:
-``` json
+
+```json
 {
   "defaults": {
     "replica": {
@@ -1430,7 +1485,8 @@ If you decide to use a password, your key will never be written to disk in plain
 In case you don't want to enter your password all the time and want to take the risk of storing your private key in plain text, you can use the `--disable-encryption` flag.
 
 The `default` identity as well as already existing identities will NOT be encrypted. If you want to encrypt an existing identity, use the following commands:
-``` bash
+
+```bash
 dfx identity export identity_name > identity.pem
 # if you have set old_identity_name as the identity that is used by default, switch to a different one
 dfx identity use other_identity
@@ -1460,12 +1516,14 @@ But when trying to create an identity with that name, it was considered to be al
 ### feat: dfx start and dfx replica can now launch the ic-btc-adapter process
 
 Added command-line parameters:
-``` bash
+
+```bash
 dfx start   --enable-bitcoin --btc-adapter-config <path>
 dfx replica --enable-bitcoin --btc-adapter-config <path>
 ```
 
 These default to values from dfx.json:
+
 ```
 .defaults.bitcoin.btc_adapter_config
 .defaults.bitcoin.enabled
@@ -1501,14 +1559,14 @@ Updated to version 0.14.0 of agent-rs
 Updated replica to elected commit b3788091fbdb8bed7e527d2df4cc5e50312f476c.
 This incorporates the following executed proposals:
 
-* [57150](https://dashboard.internetcomputer.org/proposal/57150)
-* [54964](https://dashboard.internetcomputer.org/proposal/54964)
-* [53702](https://dashboard.internetcomputer.org/proposal/53702)
-* [53231](https://dashboard.internetcomputer.org/proposal/53231)
-* [53134](https://dashboard.internetcomputer.org/proposal/53134)
-* [52627](https://dashboard.internetcomputer.org/proposal/52627)
-* [52144](https://dashboard.internetcomputer.org/proposal/52144)
-* [50282](https://dashboard.internetcomputer.org/proposal/50282)
+- [57150](https://dashboard.internetcomputer.org/proposal/57150)
+- [54964](https://dashboard.internetcomputer.org/proposal/54964)
+- [53702](https://dashboard.internetcomputer.org/proposal/53702)
+- [53231](https://dashboard.internetcomputer.org/proposal/53231)
+- [53134](https://dashboard.internetcomputer.org/proposal/53134)
+- [52627](https://dashboard.internetcomputer.org/proposal/52627)
+- [52144](https://dashboard.internetcomputer.org/proposal/52144)
+- [50282](https://dashboard.internetcomputer.org/proposal/50282)
 
 Added the ic-btc-adapter binary to the cache.
 
@@ -1526,7 +1584,7 @@ Updated Motoko from 0.6.25 to 0.6.26.
 
 In preparation for BTC integration, added configuration for the bitcoind port:
 
-``` json
+```json
 {
   "canisters": {},
   "defaults": {
@@ -1541,23 +1599,23 @@ In preparation for BTC integration, added configuration for the bitcoind port:
 
 Updated icx-proxy to commit 594b6c81cde6da4e08faee8aa8e5a2e6ae815602, now static-linked.
 
-* upgrade HTTP calls upon canister request
-* no longer proxies /_/raw to the dfx internal webserver
-* allows for generic StreamingCallback tokens
+- upgrade HTTP calls upon canister request
+- no longer proxies /\_/raw to the dfx internal webserver
+- allows for generic StreamingCallback tokens
 
 ## Replica
 
 Updated replica to blessed commit d004accc3904e24dddb13a11d93451523e1a8a5f.
 This incorporates the following executed proposals:
 
-* [49653](https://dashboard.internetcomputer.org/proposal/49653)
-* [49011](https://dashboard.internetcomputer.org/proposal/49011)
-* [48427](https://dashboard.internetcomputer.org/proposal/48427)
-* [47611](https://dashboard.internetcomputer.org/proposal/47611)
-* [47512](https://dashboard.internetcomputer.org/proposal/47512)
-* [47472](https://dashboard.internetcomputer.org/proposal/47472)
-* [45984](https://dashboard.internetcomputer.org/proposal/45984)
-* [45982](https://dashboard.internetcomputer.org/proposal/45982)
+- [49653](https://dashboard.internetcomputer.org/proposal/49653)
+- [49011](https://dashboard.internetcomputer.org/proposal/49011)
+- [48427](https://dashboard.internetcomputer.org/proposal/48427)
+- [47611](https://dashboard.internetcomputer.org/proposal/47611)
+- [47512](https://dashboard.internetcomputer.org/proposal/47512)
+- [47472](https://dashboard.internetcomputer.org/proposal/47472)
+- [45984](https://dashboard.internetcomputer.org/proposal/45984)
+- [45982](https://dashboard.internetcomputer.org/proposal/45982)
 
 ## Motoko
 
@@ -1572,8 +1630,8 @@ Updated Motoko from 0.6.21 to 0.6.25.
 Newly deployed Motoko canisters now embed the Candid interface and Motoko stable signatures in the Wasm module.
 `dfx deploy` and `dfx canister install` will automatically check
 
-	1) the backward compatible of Candid interface in both upgrade and reinstall mode;
-	2) the type safety of Motoko stable variable type in upgrade mode to avoid accidentally lossing data;
+    1) the backward compatible of Candid interface in both upgrade and reinstall mode;
+    2) the type safety of Motoko stable variable type in upgrade mode to avoid accidentally lossing data;
 
 See [Upgrade compatibility](https://internetcomputer.org/docs/language-guide/compatibility) for more details.
 
@@ -1581,13 +1639,13 @@ See [Upgrade compatibility](https://internetcomputer.org/docs/language-guide/com
 
 The three canister types that use a custom build tool - `assets`, `rust`, and `custom` - now all support the same set of environment variables during the build task:
 
-* `DFX_VERSION` - The version of DFX that was used to build the canister.
-* `DFX_NETWORK` - The network name being built for. Usually `ic` or `local`.
-* `CANISTER_ID_{canister}` - The canister principal ID of the canister `{canister}` registered in `dfx.json`.
-* `CANISTER_CANDID_PATH_{canister}` - The path to the Candid interface file for the canister `{canister}` among your canister's dependencies.
-* `CANISTER_CANDID_{canister}` (deprecated) - the same as `CANISTER_CANDID_PATH_{canister}`.  This is provided for backwards compatibility with `rust` and `custom` canisters, and will be removed in dfx 0.10.0.
-* `CANISTER_ID` - Same as `CANISTER_ID_{self}`, where `{self}` is the name of _this_ canister.
-* `CANISTER_CANDID_PATH` - Same as `CANISTER_CANDID_PATH_{self}`, where `{self}` is the name of _this_ canister.
+- `DFX_VERSION` - The version of DFX that was used to build the canister.
+- `DFX_NETWORK` - The network name being built for. Usually `ic` or `local`.
+- `CANISTER_ID_{canister}` - The canister principal ID of the canister `{canister}` registered in `dfx.json`.
+- `CANISTER_CANDID_PATH_{canister}` - The path to the Candid interface file for the canister `{canister}` among your canister's dependencies.
+- `CANISTER_CANDID_{canister}` (deprecated) - the same as `CANISTER_CANDID_PATH_{canister}`. This is provided for backwards compatibility with `rust` and `custom` canisters, and will be removed in dfx 0.10.0.
+- `CANISTER_ID` - Same as `CANISTER_ID_{self}`, where `{self}` is the name of _this_ canister.
+- `CANISTER_CANDID_PATH` - Same as `CANISTER_CANDID_PATH_{self}`, where `{self}` is the name of _this_ canister.
 
 ### feat: Support for local ledger calls
 
@@ -1595,7 +1653,8 @@ If you have an installation of the ICP Ledger (see [Ledger Installation Guide](h
 `--ledger-canister-id` parameter.
 
 Some examples:
-``` bash
+
+```bash
 $ dfx ledger \
   --network local \
   balance \
@@ -1614,7 +1673,7 @@ Transfer sent at block height: 1
 The `dfx ledger account-id` can now compute addresses of principals and canisters.
 The command also supports ledger subaccounts now.
 
-``` bash
+```bash
 dfx ledger account-id --of-principal 53zcu-tiaaa-aaaaa-qaaba-cai
 dfx ledger --network small02 account-id --of-canister ledger_demo
 dfx ledger account-id --of-principal 53zcu-tiaaa-aaaaa-qaaba-cai --subaccount 0000000000000000000000000000000000000000000000000000000000000001
@@ -1640,9 +1699,9 @@ Caused by:
 
 dfx now calls `transfer` rather than `send_dfx`, and sets the created_at_time field in order to retry the following commands:
 
-* dfx ledger create-canister
-* dfx ledger top-up
-* dfx ledger transfer
+- dfx ledger create-canister
+- dfx ledger top-up
+- dfx ledger transfer
 
 ### feat: Remote canister support
 
@@ -1652,7 +1711,8 @@ that is, a canister that already exists on that network and is managed by some o
 Motoko, Rust, and custom canisters may be configured in this way.
 
 This is the general format of the configuration in dfx.json:
-``` json
+
+```json
 {
   "canisters": {
     "<canister name>": {
@@ -1672,14 +1732,15 @@ The canister will not be created or installed on these remote networks.
 For other networks, the canister will be created and installed as usual.
 
 The "candid" field, if set within the remote object, specifies the candid file to build against when
-building other canisters on a network for which the canister is remote.  This definition can differ
+building other canisters on a network for which the canister is remote. This definition can differ
 from the candid definitions for local builds.
 
 For example, if have an installation of the ICP Ledger (see [Ledger Installation Guide](https://github.com/dfinity/ic/tree/master/rs/rosetta-api/ledger_canister#deploying-locally))
-in your dfx.json, you could configure the canister ID of the Ledger canister on the ic network as below.  In this case,
+in your dfx.json, you could configure the canister ID of the Ledger canister on the ic network as below. In this case,
 the private interfaces would be available for local builds, but only the public interfaces would be available
 when building for `--network ic`.
-``` json
+
+```json
 {
   "canisters": {
     "ledger": {
@@ -1696,7 +1757,7 @@ when building for `--network ic`.
     "app": {
       "type": "motoko",
       "main": "src/app/main.mo",
-      "dependencies": [ "ledger" ]
+      "dependencies": ["ledger"]
     }
   }
 }
@@ -1712,7 +1773,7 @@ This way, you can define public update/query functions to aid in local testing, 
 when building/deploying to mainnet, references to methods not found in `ledger.public.did`
 will be reports as compilation errors.
 
-``` json
+```json
 {
   "canisters": {
     "ledger": {
@@ -1728,7 +1789,7 @@ will be reports as compilation errors.
     "app": {
       "type": "motoko",
       "main": "src/app/main.mo",
-      "dependencies": [ "ledger" ]
+      "dependencies": ["ledger"]
     }
   }
 }
@@ -1741,7 +1802,8 @@ It's now possible to generate the interface of a remote canister using a .did fi
 Currently, dfx can generate .mo, .rs, .ts, and .js bindings.
 
 This is how you specify how to generate the bindings in dfx.json:
-``` json
+
+```json
 {
   "canisters": {
     "<canister name>": {
@@ -1759,25 +1821,25 @@ This is how you specify how to generate the bindings in dfx.json:
 
 Upgraded from a432156f24faa16d387c9d36815f7ddc5d50e09f to ab8e3f5a04f0f061b8157c2889f8f5de05f952bb
 
-* Support 128-bit system api for cycles
-* Include canister_ranges in the state tree
-* Removed limit on cycles in a canister
+- Support 128-bit system api for cycles
+- Include canister_ranges in the state tree
+- Removed limit on cycles in a canister
 
 ## Replica
 
 Updated replica to blessed commit 04fe8b0a1262f07c0cec1fdfa838a37607370a61.
 This incorporates the following executed proposals:
 
-* [45091](https://dashboard.internetcomputer.org/proposal/45091)
-* [43635](https://dashboard.internetcomputer.org/proposal/43635)
-* [43633](https://dashboard.internetcomputer.org/proposal/43633)
-* [42783](https://dashboard.internetcomputer.org/proposal/42783)
-* [42410](https://dashboard.internetcomputer.org/proposal/42410)
-* [40908](https://dashboard.internetcomputer.org/proposal/40908)
-* [40647](https://dashboard.internetcomputer.org/proposal/40647)
-* [40328](https://dashboard.internetcomputer.org/proposal/40328)
-* [39791](https://dashboard.internetcomputer.org/proposal/39791)
-* [38541](https://dashboard.internetcomputer.org/proposal/38541)
+- [45091](https://dashboard.internetcomputer.org/proposal/45091)
+- [43635](https://dashboard.internetcomputer.org/proposal/43635)
+- [43633](https://dashboard.internetcomputer.org/proposal/43633)
+- [42783](https://dashboard.internetcomputer.org/proposal/42783)
+- [42410](https://dashboard.internetcomputer.org/proposal/42410)
+- [40908](https://dashboard.internetcomputer.org/proposal/40908)
+- [40647](https://dashboard.internetcomputer.org/proposal/40647)
+- [40328](https://dashboard.internetcomputer.org/proposal/40328)
+- [39791](https://dashboard.internetcomputer.org/proposal/39791)
+- [38541](https://dashboard.internetcomputer.org/proposal/38541)
 
 ## Motoko
 
@@ -1793,13 +1855,16 @@ Breaking change: Canister commands, except for `dfx canister create`, will make 
 
 When working with existing canisters, use the `--wallet` flag in conjunction with `dfx identity get-wallet` in order to restore the old behavior.
 
-You will need to upgrade your wallet and each of your existing canisters to work with the new system.  To do so, execute the following in each of your dfx projects:
-``` bash
+You will need to upgrade your wallet and each of your existing canisters to work with the new system. To do so, execute the following in each of your dfx projects:
+
+```bash
 dfx wallet upgrade
 dfx canister --wallet "$(dfx identity get-wallet)" update-settings --all --add-controller "$(dfx identity get-principal)"
 ```
+
 To upgrade projects that you have deployed to the IC mainnet, execute the following:
-``` bash
+
+```bash
 dfx wallet --network ic upgrade
 dfx canister --network ic --wallet "$(dfx identity --network ic get-wallet)" update-settings --all --add-controller "$(dfx identity get-principal)"
 ```
@@ -1824,17 +1889,17 @@ Fixed a defect in asset synchronization where no retries would be attempted afte
 
 Updated Motoko from 0.6.11 to 0.6.20.
 
-* Implement type union/intersection
-* Transform for-loops on arrays into while-loops
-* Tighten typing rules for type annotations in patterns
-* Candid decoding: skip vec any fast
-* Bump up MAX_HP_FOR_GC from 1GB to 3GB
-* Candid decoder: Trap if a principal value is too large
-* Eliminate bignum calls from for-iteration on arrays
-* Improve scheduling
-* Improve performance of bignum equality
-* Stable signatures: frontend, metadata, command-line args
-* Added heartbeat support
+- Implement type union/intersection
+- Transform for-loops on arrays into while-loops
+- Tighten typing rules for type annotations in patterns
+- Candid decoding: skip vec any fast
+- Bump up MAX_HP_FOR_GC from 1GB to 3GB
+- Candid decoder: Trap if a principal value is too large
+- Eliminate bignum calls from for-iteration on arrays
+- Improve scheduling
+- Improve performance of bignum equality
+- Stable signatures: frontend, metadata, command-line args
+- Added heartbeat support
 
 ## Cycles wallet
 
@@ -1846,17 +1911,17 @@ Updated Motoko from 0.6.11 to 0.6.20.
 Updated replica to blessed commit 75138bbf11e201aac47266f07bee289dc18a082b.
 This incorporates the following executed proposals:
 
-* [33828](https://dashboard.internetcomputer.org/proposal/33828)
-* [31275](https://dashboard.internetcomputer.org/proposal/31275)
-* [31165](https://dashboard.internetcomputer.org/proposal/31165)
-* [30392](https://dashboard.internetcomputer.org/proposal/30392)
-* [30078](https://dashboard.internetcomputer.org/proposal/30078)
-* [29235](https://dashboard.internetcomputer.org/proposal/29235)
-* [28784](https://dashboard.internetcomputer.org/proposal/28784)
-* [27975](https://dashboard.internetcomputer.org/proposal/27975)
-* [26833](https://dashboard.internetcomputer.org/proposal/26833)
-* [25343](https://dashboard.internetcomputer.org/proposal/25343)
-* [23633](https://dashboard.internetcomputer.org/proposal/23633)
+- [33828](https://dashboard.internetcomputer.org/proposal/33828)
+- [31275](https://dashboard.internetcomputer.org/proposal/31275)
+- [31165](https://dashboard.internetcomputer.org/proposal/31165)
+- [30392](https://dashboard.internetcomputer.org/proposal/30392)
+- [30078](https://dashboard.internetcomputer.org/proposal/30078)
+- [29235](https://dashboard.internetcomputer.org/proposal/29235)
+- [28784](https://dashboard.internetcomputer.org/proposal/28784)
+- [27975](https://dashboard.internetcomputer.org/proposal/27975)
+- [26833](https://dashboard.internetcomputer.org/proposal/26833)
+- [25343](https://dashboard.internetcomputer.org/proposal/25343)
+- [23633](https://dashboard.internetcomputer.org/proposal/23633)
 
 # 0.8.4
 
@@ -1865,7 +1930,8 @@ This incorporates the following executed proposals:
 ### feat: "rust" canister type
 
 You can now declare "rust" canisters in dfx.json.
-``` json
+
+```json
 {
   "canisters": {
     "canister_name": {
@@ -1881,13 +1947,13 @@ Don't forget to place a `Cargo.toml` in your project root.
 Then dfx will build the rust canister with your rust toolchain.
 Please also make sure that you have added the WebAssembly compilation target.
 
-``` bash
+```bash
 rustup target add wasm32-unknown-unknown
 ```
 
 You can also create new dfx project with a default rust canister.
 
-``` bash
+```bash
 dfx new --type=rust <project-name>
 ```
 
@@ -1913,7 +1979,7 @@ and no longer works with `--all`.
 
 ## Replica
 
-The included replica now supports canister_heartbeat.  This only works with rust canisters for the time being,
+The included replica now supports canister_heartbeat. This only works with rust canisters for the time being,
 and does not work with the emulator (`dfx start --emulator`).
 
 # 0.8.3
@@ -1927,7 +1993,7 @@ This has always been broken, even before dfx 0.7.0.
 
 ### fix: replica and ic-starter linux binaries no longer reference /nix/store
 
-This means `dfx start` will work again on linux.  This bug was introduced in dfx 0.8.2.
+This means `dfx start` will work again on linux. This bug was introduced in dfx 0.8.2.
 
 ### feat: replaced --no_artificial_delay option with a sensible default.
 
@@ -1939,7 +2005,7 @@ we have set the same default for dfx and removed the option.
 
 Updated Motoko from 0.6.10 to 0.6.11.
 
-* Assertion error messages are now reproducible (#2821)
+- Assertion error messages are now reproducible (#2821)
 
 # 0.8.2
 
@@ -1995,22 +2061,22 @@ You will need to upgrade your wallet with `dfx wallet upgrade`, or `dfx wallet -
 
 The included replica now supports public spec 0.18.0
 
-* Canisters can now have more than one controller
-* Adds support for 64-bit stable memory
-* The replica now goes through an initialization sequence, reported in its status
-as `replica_health_status`.  Until this reports as `healthy`, queries or updates will
-fail.
-** `dfx start --background` waits to exit until `replica_health_status` is `healthy`.
-** If you run `dfx start` without `--background`, you can call `dfx ping --wait-healthy`
-to wait until the replica is healthy.
+- Canisters can now have more than one controller
+- Adds support for 64-bit stable memory
+- The replica now goes through an initialization sequence, reported in its status
+  as `replica_health_status`. Until this reports as `healthy`, queries or updates will
+  fail.
+  ** `dfx start --background` waits to exit until `replica_health_status` is `healthy`.
+  ** If you run `dfx start` without `--background`, you can call `dfx ping --wait-healthy`
+  to wait until the replica is healthy.
 
 ## Motoko
 
 Updated Motoko from 0.6.7 to 0.6.10
 
-* add Debug.trap : Text -> None (motoko-base #288)
-* Introduce primitives for `Int` ⇔ `Float` conversions (#2733)
-* Fix crashing bug for formatting huge floats (#2737)
+- add Debug.trap : Text -> None (motoko-base #288)
+- Introduce primitives for `Int` ⇔ `Float` conversions (#2733)
+- Fix crashing bug for formatting huge floats (#2737)
 
 # 0.8.1
 
@@ -2018,7 +2084,7 @@ Updated Motoko from 0.6.7 to 0.6.10
 
 ### feat: dfx generate types command
 
-``` bash
+```bash
 dfx generate
 ```
 
@@ -2028,34 +2094,35 @@ You can control what will be generated and how with corresponding configuration 
 
 Under dfx.json → "canisters" → "<canister_name>", developers can add a "declarations" config. Options are:
 
-* "output" → directory to place declarations for that canister | default is "src/declarations/<canister_name>"
+- "output" → directory to place declarations for that canister | default is "src/declarations/<canister_name>"
 
-* "bindings" → [] list of options, ("js", "ts", "did", "mo") | default is "js", "ts", "did"
+- "bindings" → [] list of options, ("js", "ts", "did", "mo") | default is "js", "ts", "did"
 
-* "env_override" → a string that will replace process.env.{canister_name_uppercase}_CANISTER_ID in the "src/dfx/assets/language_bindings/canister.js" template.
+- "env_override" → a string that will replace process.env.{canister_name_uppercase}\_CANISTER_ID in the "src/dfx/assets/language_bindings/canister.js" template.
 
 js declarations output
 
-* index.js (generated from "src/dfx/assets/language_bindings/canister.js" template)
+- index.js (generated from "src/dfx/assets/language_bindings/canister.js" template)
 
-* <canister_name>.did.js - candid js binding output
+- <canister_name>.did.js - candid js binding output
 
 ts declarations output
 
-  * <canister_name>.did.d.ts - candid ts binding output
+- <canister_name>.did.d.ts - candid ts binding output
 
 did declarations output
 
-  * <canister_name>.did - candid did binding output
+- <canister_name>.did - candid did binding output
 
 mo declarations output
 
-  * <canister_name>.mo - candid mo binding output
+- <canister_name>.mo - candid mo binding output
 
 ### feat: dfx now supports the anonymous identity
 
 Use it with either of these forms:
-``` bash
+
+```bash
 dfx identity use anonymous
 dfx --identity anonymous ...
 ```
@@ -2066,7 +2133,7 @@ Default identities are the pem files generated by `dfx identity new ...` which c
 They are located at `~/.config/dfx/identity/xxx/identity.pem`.
 Now, you can copy such pem file to another computer and import it there.
 
-``` bash
+```bash
 dfx identity new alice
 cp ~/.config/dfx/identity/xxx/identity.pem alice.pem
 # copy the pem file to another computer, then
@@ -2085,7 +2152,7 @@ Define DFX_WALLET_WASM in the environment to use a different wasm module when cr
 ### fix: trust full asset SHA-256 hashes provided by the caller
 
 When the caller provides SHA-256 hashes (which dfx does), the asset canister will no longer
-recompute these hashes when committing the changes.  These recomputations were causing
+recompute these hashes when committing the changes. These recomputations were causing
 canisters to run out of cycles, or to attempt to exceed the maximum cycle limit per update.
 
 # 0.8.0
@@ -2101,17 +2168,17 @@ but ended up only writing to the wallets.json file if --force was passed.
 
 ### chore: updating dependencies
 
-* Support for the latest version of the {IC} specification and replica.
+- Support for the latest version of the {IC} specification and replica.
 
-* Updating to latest versions of Motoko, Candid, and agent-rs
+- Updating to latest versions of Motoko, Candid, and agent-rs
 
 ### feat: Type Inference Update
 
-* Changes to `dfx new` project template and JavaScript codegen to support type inference in IDE's
+- Changes to `dfx new` project template and JavaScript codegen to support type inference in IDE's
 
-* Adding webpack dev server to project template
+- Adding webpack dev server to project template
 
-* Migration path documented at https://sdk.dfinity.org/docs/release-notes/0.8.0-rn.html
+- Migration path documented at https://sdk.dfinity.org/docs/release-notes/0.8.0-rn.html
 
 # 0.7.7
 
@@ -2122,16 +2189,16 @@ Breaking changes to frontend code generation, documented in 0.8.0
 ### feat: deploy and canister install will now only upgrade a canister if the wasm actually changed
 
 dfx deploy and dfx canister install now compare the hash of the already-installed module
-with the hash of the built canister's wasm output.  If they are the same, they leave the canister
-in place rather than upgrade it.  They will still synchronize assets to an asset canister regardless
+with the hash of the built canister's wasm output. If they are the same, they leave the canister
+in place rather than upgrade it. They will still synchronize assets to an asset canister regardless
 of the result of this comparison.
-
 
 # 0.7.6
 
 ## icx-proxy
 
 The streaming callback mechanism now requires the following record structure for the token:
+
 ```
 type StreamingCallbackToken = record {
     key: text;
@@ -2339,12 +2406,13 @@ Users can sign the message on an air-gapped computer which is secure to host pri
 
 #### Note
 
-* `sign` and `send` currently don't proxy through wallet canister. Users should use the subcommands with `dfx canister --no-wallet sign ...`.
+- `sign` and `send` currently don't proxy through wallet canister. Users should use the subcommands with `dfx canister --no-wallet sign ...`.
 
-* The `sign` option `--expire-after` will set the `ingress_expiry` to a future timestamp which is current plus the duration.
-Then users can send the message during a 5 minutes time window ending in that `ingress_expiry` timestamp. Sending the message earlier or later than the time window will both result in a replica error.
+- The `sign` option `--expire-after` will set the `ingress_expiry` to a future timestamp which is current plus the duration.
+  Then users can send the message during a 5 minutes time window ending in that `ingress_expiry` timestamp. Sending the message earlier or later than the time window will both result in a replica error.
 
 ### feat: implement the HTTP Request proposal in dfx' bootstrap webserver. +
+
 And add support for http requests in the base storage canister (with a default to `/index.html`).
 
 This does not support other encodings than `identity` for now (and doesn't even return any headers). This support will be added to the upgraded asset storage canister built in #1482.
@@ -2359,7 +2427,7 @@ Renamed the `project_name` in our own generated assets to `canister_name`, for t
 
 You can now a generate private key via OpenSSL or a simlar tool, import it into dfx, and use it to sign an ingress message.
 
-``` bash
+```bash
 openssl ecparam -name secp256k1 -genkey -out identity.pem
 dfx identity import <name> identity.pem
 dfx identity use <name>
@@ -2370,24 +2438,24 @@ dfx canister call ...
 
 ### feat: The asset canister can now store assets that exceed the message ingress limit (2 MB)
 
-* Please note that neither the JS agent nor the HTTP server have been updated yet to server such large assets.
-* The existing interface is left in place for backwards-compatibility, but deprecated:
-** retrieve(): use get() and get_chunk() instead
-** store(): use create_batch(), create_chunk(), and commit_batch() instead
-** list(): use keys() instead
+- Please note that neither the JS agent nor the HTTP server have been updated yet to server such large assets.
+- The existing interface is left in place for backwards-compatibility, but deprecated:
+  ** retrieve(): use get() and get_chunk() instead
+  ** store(): use create_batch(), create_chunk(), and commit_batch() instead
+  \*\* list(): use keys() instead
 
 # 0.6.25
 
 ## DFX
 
-- feat: dfx now provides CANISTER_ID_<canister_name> environment variables for all canisters to "npm build" when building the frontend.
+- feat: dfx now provides CANISTER*ID*<canister_name> environment variables for all canisters to "npm build" when building the frontend.
 
 ## Agents
 
 ### Rust Agent
 
 - feat: AgentError due to request::Error will now include the reqwest error message
-in addition to "Could not reach the server"
+  in addition to "Could not reach the server"
 - feat: Add secp256k1 support (dfx support to follow)
 
 # 0.6.24
@@ -2400,12 +2468,13 @@ Added option to `dfx canister create` and `dfx deploy` commands: `--with-cycles 
 This allows the user to specify the initial cycle balance of a canister created by their wallet.
 This option is a no-op for the Sodium network.
 
-``` bash
+```bash
 dfx canister create --with-cycles 8000000000 some_canister
 dfx deploy --with-cycles 8000000000
 ```
 
 Help string:
+
 ```
 Specifies the initial cycle balance to deposit into the newly
 created canister. The specified amount needs to take the
@@ -2418,7 +2487,7 @@ from the wallet's cycle balance
 This feature adds a new dfx command `toolchain` which have intuitive subcommands.
 The toolchain specifiers can be a complete version number, major minor version, or a tag name.
 
-``` bash
+```bash
 dfx toolchain install 0.6.24 # complete version
 dfx toolchain install 0.6    # major minor
 dfx toolchain install latest # tag name
@@ -2431,7 +2500,8 @@ dfx toolchain uninstall latest
 
 Now that the Mercury Alpha application subnetwork is up and we are getting ready to onboard devs, the dfx error message for wallet creation has changed:
 For example,
-``` bash
+
+```bash
 dfx canister --network=alpha create hello
 Creating canister "hello"...
 Creating the canister using the wallet canister...
@@ -2447,7 +2517,7 @@ Please submit your Principal ("dfx identity get-principal") in the intake form t
 This feature adds the deploy-wallet subcommand to the dfx identity.
 The User provides the ID of the canister onto which the wallet WASM is deployed.
 
-``` bash
+```bash
 dfx identity deploy-wallet --help
 dfx-identity-deploy-wallet
 Installs the wallet WASM to the provided canister id
@@ -2477,9 +2547,9 @@ FLAGS:
 
 - There have been updates, improvements, and new sample apps added to the [examples](https://github.com/dfinity/examples/tree/master/motoko) repository.
 
-    All of Motoko sample apps in the [examples](https://github.com/dfinity/examples/tree/master/motoko) repository have been updated to work with the latest release of the SDK.
+  All of Motoko sample apps in the [examples](https://github.com/dfinity/examples/tree/master/motoko) repository have been updated to work with the latest release of the SDK.
 
-    There are new sample apps to illustrate using arrays ([Quicksort](https://github.com/dfinity/examples/tree/master/motoko/quicksort)) and building create/read/update/delete (CRUD) operations for a web application [Superheroes](https://github.com/dfinity/examples/tree/master/motoko/superheroes).
+  There are new sample apps to illustrate using arrays ([Quicksort](https://github.com/dfinity/examples/tree/master/motoko/quicksort)) and building create/read/update/delete (CRUD) operations for a web application [Superheroes](https://github.com/dfinity/examples/tree/master/motoko/superheroes).
 
 - The [LinkedUp](https://github.com/dfinity/linkedup) sample application has been updated to work with the latest release of Motoko and the SDK.
 

--- a/src/dfx/assets/new_project_motoko_files/__dot__gitignore
+++ b/src/dfx/assets/new_project_motoko_files/__dot__gitignore
@@ -16,3 +16,9 @@ src/declarations/
 # frontend code
 node_modules/
 dist/
+
+# backend code
+.mops
+
+# environment variables
+.env

--- a/src/dfx/assets/new_project_motoko_files/dfx.json
+++ b/src/dfx/assets/new_project_motoko_files/dfx.json
@@ -17,8 +17,7 @@
   },
   "defaults": {
     "build": {
-      "packtool": "",
-      "args": ""
+      "packtool": "npm run --silent sources"
     }
   },
   "output_env_file": ".env"

--- a/src/dfx/assets/new_project_motoko_files/mops.toml
+++ b/src/dfx/assets/new_project_motoko_files/mops.toml
@@ -1,0 +1,5 @@
+[dependencies]
+base = "0.8.5"
+
+[dev-dependencies]
+test = "1.0.1"

--- a/src/dfx/assets/new_project_motoko_files/src/__project_name___backend/lib.mo
+++ b/src/dfx/assets/new_project_motoko_files/src/__project_name___backend/lib.mo
@@ -1,0 +1,14 @@
+import Text "mo:base/Text";
+import Iter "mo:base/Iter";
+import Buffer "mo:base/Buffer";
+import List "mo:base/List";
+module {
+  /**
+    * A simple of example of a Motoko method.
+    * @param {Text} name - The name to greet. 
+    * @return {Text} A greeting.
+    */
+  public func greet(name : Text) : Text {
+    "Hello, " # name # "!";
+  };
+};

--- a/src/dfx/assets/new_project_motoko_files/src/__project_name___backend/lib.test.mo
+++ b/src/dfx/assets/new_project_motoko_files/src/__project_name___backend/lib.test.mo
@@ -1,0 +1,15 @@
+import { test; suite } "mo:test";
+import Lib "./lib";
+
+suite(
+  "Methods",
+  func() : () {
+    test(
+      "greet",
+      func() {
+        let result = Lib.greet("developer");
+        assert (result == "Hello, developer!");
+      },
+    );
+  },
+);

--- a/src/dfx/assets/new_project_motoko_files/src/__project_name___backend/main.mo
+++ b/src/dfx/assets/new_project_motoko_files/src/__project_name___backend/main.mo
@@ -1,5 +1,7 @@
+import Lib "lib";
+
 actor {
   public query func greet(name : Text) : async Text {
-    return "Hello, " # name # "!";
+    return Lib.greet(name);
   };
 };

--- a/src/dfx/assets/new_project_node_files/package.json
+++ b/src/dfx/assets/new_project_node_files/package.json
@@ -2,13 +2,18 @@
   "name": "{project_name}_frontend",
   "version": "0.1.0",
   "description": "Internet Computer starter application",
-  "keywords": ["Internet Computer", "Motoko", "JavaScript", "Canister"],
+  "keywords": [
+    "Internet Computer",
+    "Motoko",
+    "JavaScript",
+    "Canister"
+  ],
   "scripts": {
     "build": "webpack",
+    "generate": "dfx generate {project_name}_backend",
     "prebuild": "npm run generate",
-    "start": "webpack serve --mode development --env development",
     "prestart": "npm run generate",
-    "generate": "dfx generate {project_name}_backend"
+    {motoko_scripts}{rust_scripts}
   },
   "devDependencies": {
     "@dfinity/agent": "{js_agent_version}",
@@ -19,9 +24,13 @@
     "copy-webpack-plugin": "^11.0.0",
     "events": "3.3.0",
     "html-webpack-plugin": "5.5.0",
+    "ic-mops": "^0.8.7",
+    "mo-dev": "^0.5.4",
+    "npm-run-all": "^4.1.5",
     "process": "0.11.10",
     "stream-browserify": "3.0.0",
     "terser-webpack-plugin": "^5.3.3",
+    "typescript": "^5.0.2",
     "util": "0.12.4",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",

--- a/src/dfx/assets/new_project_node_files/tsconfig.json
+++ b/src/dfx/assets/new_project_node_files/tsconfig.json
@@ -1,0 +1,112 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "lib": [
+      "DOM"
+    ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "ES2022" /* Specify what module code is generated. */,
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "nodenext" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
+    // "checkJs": true /* Enable error reporting in type-checked JavaScript files. */,
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx"]
+}

--- a/src/dfx/assets/new_project_rust_files/__dot__gitignore
+++ b/src/dfx/assets/new_project_rust_files/__dot__gitignore
@@ -19,3 +19,6 @@ target/
 # frontend code
 node_modules/
 dist/
+
+# environment variables
+.env

--- a/src/dfx/src/commands/new.rs
+++ b/src/dfx/src/commands/new.rs
@@ -252,6 +252,29 @@ fn scaffold_frontend_code(
             project_name_str.to_uppercase(),
         );
 
+        let mut motoko_package_json_scripts = "";
+        let mut rust_package_json_scripts = "";
+
+        if variables.get("type").unwrap() == "motoko" {
+            motoko_package_json_scripts = "    \"sources\": \"mops sources\",
+            \"start:backend\": \"mo-dev --generate --deploy -y\",
+            \"start:frontend\": \"webpack serve --mode development --env development\",
+            \"start\": \"run-p start:frontend start:backend\",
+            \"postinstall\": \"mops install\",
+            \"test:motoko\": \"mo-test\"";
+        } else if variables.get("type").unwrap() == "rust" {
+            rust_package_json_scripts =
+                "    \"start\": \"webpack serve --mode development --env development\"";
+        }
+        variables.insert(
+            "motoko_scripts".to_string(),
+            motoko_package_json_scripts.to_string(),
+        );
+        variables.insert(
+            "rust_scripts".to_string(),
+            rust_package_json_scripts.to_string(),
+        );
+
         let mut new_project_node_files = assets::new_project_node_files()?;
         write_files_from_entries(
             log,
@@ -390,6 +413,7 @@ pub fn exec(env: &dyn Environment, opts: NewOpts) -> DfxResult {
     let variables: BTreeMap<String, String> = [
         ("project_name".to_string(), project_name_str.to_string()),
         ("dfx_version".to_string(), version_str.clone()),
+        ("type".to_string(), opts.r#type.clone()),
         ("dot".to_string(), ".".to_string()),
     ]
     .iter()


### PR DESCRIPTION
# Description

The Motoko project now includes a few new quality-of-life enhancements:

- `npm start` now starts the `motoko-dev-server` in addition to the `webpack` server.
  - This means that you can now use the `motoko-dev-server` to hot-reload your motoko canisters and frontends as you make changes.
- `mops` package manager is now included and configured
  - This installs the `motoko-base` and `test` libraries
- hello world now includes a `lib.mo` and `lib.test.mo` file
  - This demonstrates write tests for your canisters and run them with `npm run test:motoko`

Fixes #SDK-991

# How Has This Been Tested?

Manually compiling the rust and motoko new projects
- dfx deploy
  - visiting the webpage
- npm start
  - visiting the webpage

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
