### PR TITLE
test(frontend-canister-evidence): ensure `TAG_` value uniqueness

### DIFF
--- a/src/canisters/frontend/ic-certified-assets/src/evidence.rs
+++ b/src/canisters/frontend/ic-certified-assets/src/evidence.rs
@@ -210,3 +210,23 @@ fn hash_headers(hasher: &mut Sha256, headers: Option<&HashMap<String, String>>) 
         hasher.update(TAG_NONE);
     }
 }
+
+#[test]
+fn tag_value_uniqueness() {
+    let tags = include_str!("evidence.rs")
+        .lines()
+        .filter(|l| l.starts_with("const TAG_"))
+        .map(|line| {
+            line.split(": [u8; 1] = [")
+                .nth(1)
+                .unwrap()
+                .trim_end_matches("];")
+                .parse::<u8>()
+                .unwrap()
+        });
+    assert_eq!(
+        tags.clone().count(),
+        tags.unique().count(),
+        "tag values must be unique"
+    );
+}


### PR DESCRIPTION
# Description

Simple test which ensures the values of each `TAG_` must stay unique 
<img width="490" alt="Screenshot 2023-03-23 at 13 50 22" src="https://user-images.githubusercontent.com/21069150/227209532-a61b5380-a602-4a4b-a7e1-39306e9f633b.png">

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
