### PR TITLE
feat: `--artificial-delay`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## DFX
 
+### feat: --artificial-delay flag
+
+The local replica uses a 600ms delay by default when performing update calls. With `dfx start --artificial-delay <ms>`, you can decrease this value (e.g. 100ms) for faster integration tests, or increase it (e.g. 2500ms) to mimick mainnet latency for e.g. UI responsiveness checks.
+
 ### fix: make sure assetstorage did file is created as writeable.
 
 ### feat: specify id when provisional create canister

--- a/docs/cli-reference/dfx-replica.md
+++ b/docs/cli-reference/dfx-replica.md
@@ -28,6 +28,7 @@ You can use the following option with the `dfx replica` command.
 |---------------------------|-------------------------------------------------------------------------------|
 | `--port port`             | Specifies the port the local canister execution environment should listen to. |
 | `--bitcoin-node host:port` | Specifies the address of a bitcoind node.  Implies `--enable-bitcoin`. |
+| `--artificial-delay milliseconds` | Specifies the delay that an update call should incur. Default: 600ms  |
 
 ## Examples
 

--- a/docs/cli-reference/dfx-start.md
+++ b/docs/cli-reference/dfx-start.md
@@ -30,6 +30,7 @@ You can use the following option with the `dfx start` command.
 |---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--host host` | Specifies the host interface IP address and port number to bind the frontend to. The default for the local shared network is `127.0.0.1:4943`, while the default for a project-specific network is '127.0.0.1:8000'. |
 | `--bitcoin-node host:port` | Specifies the address of a bitcoind node. Implies `--enable-bitcoin`.                                                                                                                                               |
+| `--artificial-delay milliseconds` | Specifies the delay that an update call should incur. Default: 600ms |
 
 ## Examples
 

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -155,9 +155,9 @@ dfx_start() {
         # wait for it to close. Because `dfx start` leaves child processes running, we need
         # to close this pipe, otherwise Bats will wait indefinitely.
         if [[ $# -eq 0 ]]; then
-            dfx start --background --host "$FRONTEND_HOST" 3>&- # Start on random port for parallel test execution
+            dfx start --background --host "$FRONTEND_HOST" --artificial-delay 100 3>&- # Start on random port for parallel test execution
         else
-            dfx start --background "$@" 3>&-
+            dfx start --background --artificial-delay 100 "$@" 3>&-
         fi
 
         dfx_config_root="$E2E_NETWORK_DATA_DIRECTORY/replica-configuration"
@@ -187,7 +187,7 @@ dfx_start() {
 dfx_start_for_nns_install() {
     # TODO: When nns-dapp supports dynamic ports, this wait can be removed.
     assert_command timeout 300 sh -c \
-        "until dfx start --clean --background --host 127.0.0.1:8080 --verbose; do echo waiting for port 8080 to become free; sleep 3; done" \
+        "until dfx start --clean --background --host 127.0.0.1:8080 --verbose --artificial-delay 100; do echo waiting for port 8080 to become free; sleep 3; done" \
         || (echo "could not connect to replica on port 8080" && exit 1)
     assert_match "subnet type: System"
     assert_match "127.0.0.1:8080"

--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -127,6 +127,7 @@ impl Replica {
 
         let port = config.http_handler.port;
         let write_port_to = config.http_handler.write_port_to.clone();
+        let artificial_delay = config.artificial_delay;
         let replica_path = self.config.replica_path.to_path_buf();
         let ic_starter_path = self.config.ic_starter_path.to_path_buf();
 
@@ -141,6 +142,7 @@ impl Replica {
                 ic_starter_path,
                 replica_path,
                 replica_pid_path,
+                artificial_delay,
                 addr,
                 receiver,
             ),
@@ -271,6 +273,7 @@ fn replica_start_thread(
     ic_starter_path: PathBuf,
     replica_path: PathBuf,
     replica_pid_path: PathBuf,
+    artificial_delay: u32,
     addr: Addr<Replica>,
     receiver: Receiver<()>,
 ) -> DfxResult<std::thread::JoinHandle<()>> {
@@ -335,7 +338,7 @@ fn replica_start_thread(
             // The intial notary delay is set to 2500ms in the replica's
             // default subnet configuration to help running tests.
             // For our production network, we actually set them to 600ms.
-            "600",
+            &format!("{artificial_delay}"),
         ]);
 
         // This should agree with the value at

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -62,6 +62,10 @@ pub struct StartOpts {
     /// enable canister http requests
     #[clap(long, conflicts_with("emulator"))]
     enable_canister_http: bool,
+
+    /// The delay (in milliseconds) an update call should take. Lower values may be expedient in CI.
+    #[clap(long, conflicts_with("emulator"), default_value = "600")]
+    artificial_delay: u32,
 }
 
 fn ping_and_wait(frontend_url: &str) -> DfxResult {
@@ -126,6 +130,7 @@ pub fn exec(
         bitcoin_node,
         enable_bitcoin,
         enable_canister_http,
+        artificial_delay,
     }: StartOpts,
 ) -> DfxResult {
     if !background {
@@ -299,8 +304,9 @@ pub fn exec(
                 } else {
                     (None, None)
                 };
-            let mut replica_config = ReplicaConfig::new(&state_root, subnet_type, log_level)
-                .with_random_port(&replica_port_path);
+            let mut replica_config =
+                ReplicaConfig::new(&state_root, subnet_type, log_level, artificial_delay)
+                    .with_random_port(&replica_port_path);
             if btc_adapter_config.is_some() {
                 replica_config = replica_config.with_btc_adapter_enabled();
                 if let Some(btc_adapter_socket) = btc_adapter_socket_path {

--- a/src/dfx/src/lib/replica_config.rs
+++ b/src/dfx/src/lib/replica_config.rs
@@ -53,6 +53,7 @@ pub struct ReplicaConfig {
     pub btc_adapter: BtcAdapterConfig,
     pub canister_http_adapter: CanisterHttpAdapterConfig,
     pub log_level: ReplicaLogLevel,
+    pub artificial_delay: u32,
 }
 
 impl ReplicaConfig {
@@ -60,6 +61,7 @@ impl ReplicaConfig {
         state_root: &Path,
         subnet_type: ReplicaSubnetType,
         log_level: ReplicaLogLevel,
+        artificial_delay: u32,
     ) -> Self {
         ReplicaConfig {
             http_handler: HttpHandlerConfig {
@@ -85,6 +87,7 @@ impl ReplicaConfig {
                 socket_path: None,
             },
             log_level,
+            artificial_delay,
         }
     }
 


### PR DESCRIPTION
Adds back the ability to configure the artificial delay, this time with a directly configurable millisecond count. In addition it sets the delay to 100ms in CI for faster test feedback. Effectively reverts #1859. Implements SDK-894 and closes #3005. 