### PR TITLE
refactor(dfx): move `ask_for_consent` to `dfx-core` + introduce concrete error types

### DIFF
--- a/e2e/tests-dfx/mode_reinstall.bash
+++ b/e2e/tests-dfx/mode_reinstall.bash
@@ -57,7 +57,7 @@ teardown() {
         assert_match "YOU WILL LOSE ALL DATA IN THE CANISTER"
 
         assert_not_match "Installing code for canister"
-        assert_match "Refusing to install canister without approval"
+        assert_match "Refusing to install canister without approval: User declined consent."
     )
 }
 
@@ -94,7 +94,7 @@ teardown() {
         assert_match "YOU WILL LOSE ALL DATA IN THE CANISTER"
 
         assert_not_match "Installing code for canister"
-        assert_match "Refusing to install canister without approval"
+        assert_match "Refusing to install canister without approval: User declined consent."
     )
 }
 

--- a/src/dfx-core/src/cli/mod.rs
+++ b/src/dfx-core/src/cli/mod.rs
@@ -1,0 +1,16 @@
+use std::io::stdin;
+
+pub fn ask_for_consent(message: &str) -> Result<(), String> {
+    eprintln!("WARNING!");
+    eprintln!("{}", message);
+    eprintln!("Do you want to proceed? yes/No");
+    let mut input_string = String::new();
+    stdin()
+        .read_line(&mut input_string)
+        .map_err(|_err| "Unable to read input".to_string())?;
+    let input_string = input_string.trim_end();
+    if input_string != "yes" {
+        return Err("Refusing to install canister without approval".to_string());
+    }
+    Ok(())
+}

--- a/src/dfx-core/src/cli/mod.rs
+++ b/src/dfx-core/src/cli/mod.rs
@@ -9,7 +9,7 @@ pub fn ask_for_consent(message: &str) -> Result<(), UserConsent> {
     let mut input_string = String::new();
     stdin()
         .read_line(&mut input_string)
-        .map_err(|err| UserConsent::ReadError(err))?;
+        .map_err(UserConsent::ReadError)?;
     let input_string = input_string.trim_end();
     if input_string != "yes" {
         return Err(UserConsent::Declined);

--- a/src/dfx-core/src/cli/mod.rs
+++ b/src/dfx-core/src/cli/mod.rs
@@ -1,16 +1,18 @@
 use std::io::stdin;
 
-pub fn ask_for_consent(message: &str) -> Result<(), String> {
+use crate::error::cli::UserConsent;
+
+pub fn ask_for_consent(message: &str) -> Result<(), UserConsent> {
     eprintln!("WARNING!");
     eprintln!("{}", message);
     eprintln!("Do you want to proceed? yes/No");
     let mut input_string = String::new();
     stdin()
         .read_line(&mut input_string)
-        .map_err(|_err| "Unable to read input".to_string())?;
+        .map_err(|err| UserConsent::ReadError(err))?;
     let input_string = input_string.trim_end();
     if input_string != "yes" {
-        return Err("Refusing to install canister without approval".to_string());
+        return Err(UserConsent::Declined);
     }
     Ok(())
 }

--- a/src/dfx-core/src/error/cli.rs
+++ b/src/dfx-core/src/error/cli.rs
@@ -1,0 +1,10 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum UserConsent {
+    #[error("Unable to read input: {0}")]
+    ReadError(std::io::Error),
+
+    #[error("User declined consent.")]
+    Declined,
+}

--- a/src/dfx-core/src/error/mod.rs
+++ b/src/dfx-core/src/error/mod.rs
@@ -2,6 +2,7 @@ pub mod archive;
 pub mod cache;
 pub mod canister;
 pub mod canister_id_store;
+pub mod cli;
 pub mod config;
 pub mod dfx_config;
 pub mod encryption;

--- a/src/dfx-core/src/lib.rs
+++ b/src/dfx-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod canister;
+pub mod cli;
 pub mod config;
 pub mod error;
 pub mod foundation;

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -386,10 +386,11 @@ pub async fn install_canister_wasm(
         } + r#"
 This will OVERWRITE all the data and code in the canister.
 
-YOU WILL LOSE ALL DATA IN THE CANISTER.");
+YOU WILL LOSE ALL DATA IN THE CANISTER.
 
 "#;
-        ask_for_consent(&msg).map_err(|e| anyhow!(e))?;
+        ask_for_consent(&msg)
+            .map_err(|e| anyhow!("Refusing to install canister without approval: {e}"))?;
     }
     let mode_str = match mode {
         InstallMode::Install => "Installing",

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -76,11 +76,15 @@ pub async fn install_canister(
                 Ok(None) => (),
                 Ok(Some(err)) => {
                     let msg = format!("Candid interface compatibility check failed for canister '{}'.\nYou are making a BREAKING change. Other canisters or frontend clients relying on your canister may stop working.\n\n", canister_info.get_name()) + &err;
-                    ask_for_consent(&msg).map_err(|e| anyhow!(e))?;
+                    ask_for_consent(&msg).map_err(|e| {
+                        anyhow!("Refusing to install canister without approval: {e}")
+                    })?;
                 }
                 Err(e) => {
                     let msg = format!("An error occurred during Candid interface compatibility check for canister '{}'.\n\n", canister_info.get_name()) + &e.to_string();
-                    ask_for_consent(&msg).map_err(|e| anyhow!(e))?;
+                    ask_for_consent(&msg).map_err(|e| {
+                        anyhow!("Refusing to install canister without approval: {e}")
+                    })?;
                 }
             }
         }
@@ -92,11 +96,15 @@ pub async fn install_canister(
                 Ok(None) => (),
                 Ok(Some(err)) => {
                     let msg = format!("Stable interface compatibility check failed for canister '{}'.\nUpgrade will either FAIL or LOSE some stable variable data.\n\n", canister_info.get_name()) + &err;
-                    ask_for_consent(&msg).map_err(|e| anyhow!(e))?;
+                    ask_for_consent(&msg).map_err(|e| {
+                        anyhow!("Refusing to install canister without approval: {e}")
+                    })?;
                 }
                 Err(e) => {
                     let msg = format!("An error occurred during stable interface compatibility check for canister '{}'.\n\n", canister_info.get_name()) + &e.to_string();
-                    ask_for_consent(&msg).map_err(|e| anyhow!(e))?;
+                    ask_for_consent(&msg).map_err(|e| {
+                        anyhow!("Refusing to install canister without approval: {e}")
+                    })?;
                 }
             }
         }

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -8,6 +8,7 @@ use crate::lib::named_canister;
 use crate::util::assets::wallet_wasm;
 use crate::util::read_module_metadata;
 use dfx_core::canister::build_wallet_canister;
+use dfx_core::cli::ask_for_consent;
 use dfx_core::config::model::canister_id_store::CanisterIdStore;
 use dfx_core::config::model::network_descriptor::NetworkDescriptor;
 use dfx_core::identity::CallSender;
@@ -26,7 +27,6 @@ use itertools::Itertools;
 use sha2::{Digest, Sha256};
 use slog::info;
 use std::collections::HashSet;
-use std::io::stdin;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
@@ -76,11 +76,11 @@ pub async fn install_canister(
                 Ok(None) => (),
                 Ok(Some(err)) => {
                     let msg = format!("Candid interface compatibility check failed for canister '{}'.\nYou are making a BREAKING change. Other canisters or frontend clients relying on your canister may stop working.\n\n", canister_info.get_name()) + &err;
-                    ask_for_consent(&msg)?;
+                    ask_for_consent(&msg).map_err(|e| anyhow!(e))?;
                 }
                 Err(e) => {
                     let msg = format!("An error occurred during Candid interface compatibility check for canister '{}'.\n\n", canister_info.get_name()) + &e.to_string();
-                    ask_for_consent(&msg)?;
+                    ask_for_consent(&msg).map_err(|e| anyhow!(e))?;
                 }
             }
         }
@@ -92,11 +92,11 @@ pub async fn install_canister(
                 Ok(None) => (),
                 Ok(Some(err)) => {
                     let msg = format!("Stable interface compatibility check failed for canister '{}'.\nUpgrade will either FAIL or LOSE some stable variable data.\n\n", canister_info.get_name()) + &err;
-                    ask_for_consent(&msg)?;
+                    ask_for_consent(&msg).map_err(|e| anyhow!(e))?;
                 }
                 Err(e) => {
                     let msg = format!("An error occurred during stable interface compatibility check for canister '{}'.\n\n", canister_info.get_name()) + &e.to_string();
-                    ask_for_consent(&msg)?;
+                    ask_for_consent(&msg).map_err(|e| anyhow!(e))?;
                 }
             }
         }
@@ -381,7 +381,7 @@ This will OVERWRITE all the data and code in the canister.
 YOU WILL LOSE ALL DATA IN THE CANISTER.");
 
 "#;
-        ask_for_consent(&msg)?;
+        ask_for_consent(&msg).map_err(|e| anyhow!(e))?;
     }
     let mode_str = match mode {
         InstallMode::Install => "Installing",
@@ -451,21 +451,5 @@ pub async fn install_wallet(
         .call_and_wait()
         .await
         .context("Failed to store wallet wasm in container.")?;
-    Ok(())
-}
-
-fn ask_for_consent(message: &str) -> DfxResult {
-    eprintln!("WARNING!");
-    eprintln!("{}", message);
-    eprintln!("Do you want to proceed? yes/No");
-    let mut input_string = String::new();
-    stdin()
-        .read_line(&mut input_string)
-        .map_err(|err| anyhow!(err))
-        .context("Unable to read input")?;
-    let input_string = input_string.trim_end();
-    if input_string != "yes" {
-        bail!("Refusing to install canister without approval");
-    }
     Ok(())
 }


### PR DESCRIPTION
-------

# Description

Moves `ask_for_consent` to `dfx-core`. In preparation for moving `install_canister_wasm` to `dfx-core` crate.


# How Has This Been Tested?

covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).