### PR TITLE
refactor: deploy_canisters() force_reinstall bool -> DeployMode variant

### DIFF
--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -4,6 +4,7 @@ mod install_canister;
 
 pub use create_canister::create_canister;
 pub use deploy_canisters::deploy_canisters;
+pub use deploy_canisters::DeployMode;
 use fn_error_context::context;
 use ic_utils::Argument;
 pub use install_canister::{install_canister, install_canister_wasm, install_wallet};


### PR DESCRIPTION
# Description

Context: Upcoming changes will add `dfx deploy <canister> --by-proposal` and `dfx deploy <canister> --compute-evidence`.

This PR changes the `force_reinstall` boolean used by `deploy_canisters()` into a `DeployMode` variant.  


Some intended benefits:
- Performs the check for deploying to a remote canister check earlier, before trying to create or build canisters.
- Eliminates some duplicate code that can't ever be executed, by storing the canister name with the relevant variant.
- Makes room for the upcoming`--by-proposal` and `--compute-evidence` modes, which won't work in conjunction with `dfx deploy <canister> --mode=reinstall`.  

# How Has This Been Tested?

Covered by existing e2e tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
