### PR TITLE
refactor(ic-asset): add Option to not upload chunks

### DIFF
--- a/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
+++ b/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
@@ -41,10 +41,14 @@ pub(crate) struct ProjectAsset {
     pub(crate) encodings: HashMap<String, ProjectAssetEncoding>,
 }
 
+pub(crate) struct ChunkUploadTarget<'a> {
+    pub(crate) canister: &'a Canister<'a>,
+    pub(crate) batch_id: &'a Nat,
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn make_project_asset_encoding(
-    canister: &Canister<'_>,
-    batch_id: &Nat,
+    chunk_upload_target: Option<&ChunkUploadTarget<'_>>,
     asset_descriptor: &AssetDescriptor,
     canister_assets: &HashMap<String, AssetDetails>,
     content: &Content,
@@ -82,10 +86,10 @@ async fn make_project_asset_encoding(
             hex::encode(&sha256),
         );
         vec![]
-    } else {
+    } else if let Some(target) = chunk_upload_target {
         upload_content_chunks(
-            canister,
-            batch_id,
+            target.canister,
+            target.batch_id,
             asset_descriptor,
             content,
             &sha256,
@@ -94,6 +98,8 @@ async fn make_project_asset_encoding(
             logger,
         )
         .await?
+    } else {
+        vec![]
     };
 
     Ok(ProjectAssetEncoding {
@@ -105,8 +111,7 @@ async fn make_project_asset_encoding(
 
 #[allow(clippy::too_many_arguments)]
 async fn make_encoding(
-    canister: &Canister<'_>,
-    batch_id: &Nat,
+    chunk_upload_target: Option<&ChunkUploadTarget<'_>>,
     asset_descriptor: &AssetDescriptor,
     canister_assets: &HashMap<String, AssetDetails>,
     content: &Content,
@@ -117,8 +122,7 @@ async fn make_encoding(
     match encoder {
         None => {
             let identity_asset_encoding = make_project_asset_encoding(
-                canister,
-                batch_id,
+                chunk_upload_target,
                 asset_descriptor,
                 canister_assets,
                 content,
@@ -137,8 +141,7 @@ async fn make_encoding(
             if encoded.data.len() < content.data.len() {
                 let content_encoding = format!("{}", encoder);
                 let project_asset_encoding = make_project_asset_encoding(
-                    canister,
-                    batch_id,
+                    chunk_upload_target,
                     asset_descriptor,
                     canister_assets,
                     &encoded,
@@ -156,8 +159,7 @@ async fn make_encoding(
 }
 
 async fn make_encodings(
-    canister: &Canister<'_>,
-    batch_id: &Nat,
+    chunk_upload_target: Option<&ChunkUploadTarget<'_>>,
     asset_descriptor: &AssetDescriptor,
     canister_assets: &HashMap<String, AssetDetails>,
     content: &Content,
@@ -173,8 +175,7 @@ async fn make_encodings(
         .iter()
         .map(|maybe_encoder| {
             make_encoding(
-                canister,
-                batch_id,
+                chunk_upload_target,
                 asset_descriptor,
                 canister_assets,
                 content,
@@ -196,8 +197,7 @@ async fn make_encodings(
 }
 
 async fn make_project_asset(
-    canister: &Canister<'_>,
-    batch_id: &Nat,
+    chunk_upload_target: Option<&ChunkUploadTarget<'_>>,
     asset_descriptor: AssetDescriptor,
     canister_assets: &HashMap<String, AssetDetails>,
     semaphores: &Semaphores,
@@ -215,8 +215,7 @@ async fn make_project_asset(
     let content = Content::load(&asset_descriptor.source)?;
 
     let encodings = make_encodings(
-        canister,
-        batch_id,
+        chunk_upload_target,
         &asset_descriptor,
         canister_assets,
         &content,
@@ -233,8 +232,7 @@ async fn make_project_asset(
 }
 
 pub(crate) async fn make_project_assets(
-    canister: &Canister<'_>,
-    batch_id: &Nat,
+    chunk_upload_target: Option<&ChunkUploadTarget<'_>>,
     asset_descriptors: Vec<AssetDescriptor>,
     canister_assets: &HashMap<String, AssetDetails>,
     logger: &Logger,
@@ -245,8 +243,7 @@ pub(crate) async fn make_project_assets(
         .iter()
         .map(|loc| {
             make_project_asset(
-                canister,
-                batch_id,
+                chunk_upload_target,
                 loc.clone(),
                 canister_assets,
                 &semaphores,

--- a/src/canisters/frontend/ic-asset/src/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/sync.rs
@@ -1,6 +1,7 @@
 use crate::asset::config::{
     AssetConfig, AssetSourceDirectoryConfiguration, ASSETS_CONFIG_FILENAME_JSON,
 };
+use crate::batch_upload::plumbing::ChunkUploadTarget;
 use crate::batch_upload::{
     self,
     operations::AssetDeletionReason,
@@ -41,9 +42,13 @@ pub async fn upload_content_and_assemble_sync_operations(
         "Staging contents of new and changed assets in batch {}:", batch_id
     );
 
-    let project_assets = make_project_assets(
+    let chunk_upload_target = ChunkUploadTarget {
         canister,
-        &batch_id,
+        batch_id: &batch_id,
+    };
+
+    let project_assets = make_project_assets(
+        Some(&chunk_upload_target),
         asset_descriptors,
         &canister_assets,
         logger,

--- a/src/canisters/frontend/ic-asset/src/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/upload.rs
@@ -1,4 +1,5 @@
 use crate::asset::config::AssetConfig;
+use crate::batch_upload::plumbing::ChunkUploadTarget;
 use crate::batch_upload::{
     self,
     operations::AssetDeletionReason,
@@ -39,9 +40,13 @@ pub async fn upload(
 
     info!(logger, "Staging contents of new and changed assets:");
 
-    let project_assets = make_project_assets(
+    let chunk_upload_target = ChunkUploadTarget {
         canister,
-        &batch_id,
+        batch_id: &batch_id,
+    };
+
+    let project_assets = make_project_assets(
+        Some(&chunk_upload_target),
         asset_descriptors,
         &canister_assets,
         logger,


### PR DESCRIPTION
# Description

In order to compute evidence for an asset update proposal, we will need to determine the update operations without actually uploading any content chunks.  This is a small refactor makes this possible, though all current code still uploads the content.

Does not affect any public interfaces.

# How Has This Been Tested?

Covered by existing tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

