### PR TITLE
refactor(ic-asset): assemble_commit_batch_arguments

### DIFF
--- a/src/canisters/frontend/ic-asset/src/batch_upload/operations.rs
+++ b/src/canisters/frontend/ic-asset/src/batch_upload/operations.rs
@@ -16,8 +16,7 @@ pub(crate) fn assemble_batch_operations(
     project_assets: HashMap<String, ProjectAsset>,
     canister_assets: HashMap<String, AssetDetails>,
     asset_deletion_reason: AssetDeletionReason,
-    batch_id: Nat,
-) -> CommitBatchArguments {
+) -> Vec<BatchOperationKind> {
     let mut canister_assets = canister_assets;
 
     let mut operations = vec![];
@@ -32,6 +31,17 @@ pub(crate) fn assemble_batch_operations(
     unset_obsolete_encodings(&mut operations, &project_assets, &canister_assets);
     set_encodings(&mut operations, project_assets);
 
+    operations
+}
+
+pub(crate) fn assemble_commit_batch_arguments(
+    project_assets: HashMap<String, ProjectAsset>,
+    canister_assets: HashMap<String, AssetDetails>,
+    asset_deletion_reason: AssetDeletionReason,
+    batch_id: Nat,
+) -> CommitBatchArguments {
+    let operations =
+        assemble_batch_operations(project_assets, canister_assets, asset_deletion_reason);
     CommitBatchArguments {
         operations,
         batch_id,

--- a/src/canisters/frontend/ic-asset/src/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/sync.rs
@@ -55,7 +55,7 @@ pub async fn upload_content_and_assemble_sync_operations(
     )
     .await?;
 
-    let commit_batch_args = batch_upload::operations::assemble_batch_operations(
+    let commit_batch_args = batch_upload::operations::assemble_commit_batch_arguments(
         project_assets,
         canister_assets,
         AssetDeletionReason::Obsolete,

--- a/src/canisters/frontend/ic-asset/src/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/upload.rs
@@ -53,7 +53,7 @@ pub async fn upload(
     )
     .await?;
 
-    let commit_batch_args = batch_upload::operations::assemble_batch_operations(
+    let commit_batch_args = batch_upload::operations::assemble_commit_batch_arguments(
         project_assets,
         canister_assets,
         AssetDeletionReason::Incompatible,


### PR DESCRIPTION
# Description

Splits up a method into two parts: one that returns only batch operations for synchronization (which will be needed to compute evidence, and does not need a batch id), another that returns the whole `CommitBatchArguments`.  Doesn't affect pub interface.

# How Has This Been Tested?

Covered by existing tests.

