### PR TITLE
feat(frontend-canister): dfx deploy --compute-evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,12 @@ Uploads asset changes to an asset canister (propose_commit_batch()), but does no
 
 The SNS will call `commit_proposed_batch()` to commit the changes.  If the proposal fails, the caller of `dfx deploy --by-proposal` should call `delete_batch()`.
 
+### feat: dfx deploy <frontend canister name> --compute-evidence
+
+Builds the specified asset canister, determines the batch operations required to synchronize the assets, and computes a hash ("evidence") over those batch operations.  This evidence will match the evidence computed by `dfx deploy --by-proposal`, and which will be specified in the update proposal.
+
+No permissions are required to compute evidence, so this can be called with `--identity anonymous` or any other identity.
+
 ## Asset Canister
 
 Added `validate_take_ownership()` method so that an SNS is able to add a custom call to `take_ownership()`.

--- a/docs/cli-reference/dfx-deploy.md
+++ b/docs/cli-reference/dfx-deploy.md
@@ -27,6 +27,7 @@ You can use the following options with the `dfx deploy` command.
 | `--with-cycles <number-of-cycles>` | Enables you to specify the initial number of cycles for a canister in a project.                                                                                            |
 | `--specified-id <PRINCIPAL>`       | Attempts to create the canister with this Canister ID                                                                                 |
 | `--by-proposal`                    | Upload proposed changed assets, but do not commit them.  Follow up by calling either commit_proposed_batch() or delete_batch().                                             |
+| `--compute-evidence`               | Build a frontend canister, determine batch operations required to synchronize asset canister contents, and compute a hash over those operations.  Displays this hash ("evidence"), which should match the evidence displayed by `dfx deploy --by-proposal`. |
 
 ### Arguments
 

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -93,6 +93,10 @@ check_permission_failure() {
   assert_command dfx deploy e2e_project_frontend --by-proposal --identity prepare
   assert_contains "Proposed commit of batch 2 with evidence cc6b5aab7ed38606774878fb33c17fccd02983d8415fb27dfb8dae50dc099fb1.  Either commit it by proposal, or delete it."
 
+  assert_command dfx deploy e2e_project_frontend --compute-evidence --identity anonymous
+  # shellcheck disable=SC2154
+  assert_eq "cc6b5aab7ed38606774878fb33c17fccd02983d8415fb27dfb8dae50dc099fb1" "$stdout"
+
   ID=$(dfx canister id e2e_project_frontend)
   PORT=$(get_webserver_port)
 
@@ -157,6 +161,10 @@ check_permission_failure() {
   dfx canister call e2e_project_frontend list_permitted '(record { permission = variant { Commit }; })'
   assert_command dfx deploy e2e_project_frontend --by-proposal --identity prepare
   assert_contains "Proposed commit of batch 2 with evidence 1b45c8b1d0deec88ac032590e0f1cd9ab407f796e827aac880f4ffb035fdc200.  Either commit it by proposal, or delete it."
+
+  assert_command dfx deploy e2e_project_frontend --compute-evidence --identity anonymous
+  # shellcheck disable=SC2154
+  assert_eq "1b45c8b1d0deec88ac032590e0f1cd9ab407f796e827aac880f4ffb035fdc200" "$stdout"
 
   ID=$(dfx canister id e2e_project_frontend)
   PORT=$(get_webserver_port)

--- a/src/canisters/frontend/ic-asset/src/batch_upload/operations.rs
+++ b/src/canisters/frontend/ic-asset/src/batch_upload/operations.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 pub(crate) const BATCH_UPLOAD_API_VERSION: u16 = 0;
 
 pub(crate) fn assemble_batch_operations(
-    project_assets: HashMap<String, ProjectAsset>,
+    project_assets: &HashMap<String, ProjectAsset>,
     canister_assets: HashMap<String, AssetDetails>,
     asset_deletion_reason: AssetDeletionReason,
 ) -> Vec<BatchOperationKind> {
@@ -23,12 +23,12 @@ pub(crate) fn assemble_batch_operations(
 
     delete_assets(
         &mut operations,
-        &project_assets,
+        project_assets,
         &mut canister_assets,
         asset_deletion_reason,
     );
-    create_new_assets(&mut operations, &project_assets, &canister_assets);
-    unset_obsolete_encodings(&mut operations, &project_assets, &canister_assets);
+    create_new_assets(&mut operations, project_assets, &canister_assets);
+    unset_obsolete_encodings(&mut operations, project_assets, &canister_assets);
     set_encodings(&mut operations, project_assets);
 
     operations
@@ -41,7 +41,7 @@ pub(crate) fn assemble_commit_batch_arguments(
     batch_id: Nat,
 ) -> CommitBatchArguments {
     let operations =
-        assemble_batch_operations(project_assets, canister_assets, asset_deletion_reason);
+        assemble_batch_operations(&project_assets, canister_assets, asset_deletion_reason);
     CommitBatchArguments {
         operations,
         batch_id,
@@ -148,10 +148,10 @@ pub(crate) fn unset_obsolete_encodings(
 
 pub(crate) fn set_encodings(
     operations: &mut Vec<BatchOperationKind>,
-    project_assets: HashMap<String, ProjectAsset>,
+    project_assets: &HashMap<String, ProjectAsset>,
 ) {
     for (key, project_asset) in project_assets {
-        for (content_encoding, v) in project_asset.encodings {
+        for (content_encoding, v) in &project_asset.encodings {
             if v.already_in_place {
                 continue;
             }
@@ -159,9 +159,9 @@ pub(crate) fn set_encodings(
             operations.push(BatchOperationKind::SetAssetContent(
                 SetAssetContentArguments {
                     key: key.clone(),
-                    content_encoding,
-                    chunk_ids: v.chunk_ids,
-                    sha256: Some(v.sha256),
+                    content_encoding: content_encoding.clone(),
+                    chunk_ids: v.chunk_ids.clone(),
+                    sha256: Some(v.sha256.clone()),
                 },
             ));
         }

--- a/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
+++ b/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
@@ -99,6 +99,14 @@ async fn make_project_asset_encoding(
         )
         .await?
     } else {
+        info!(
+            logger,
+            "  {}{} ({} bytes) sha {} will be uploaded",
+            &asset_descriptor.key,
+            content_encoding_descriptive_suffix(content_encoding),
+            content.data.len(),
+            hex::encode(&sha256),
+        );
         vec![]
     };
 

--- a/src/canisters/frontend/ic-asset/src/evidence/mod.rs
+++ b/src/canisters/frontend/ic-asset/src/evidence/mod.rs
@@ -1,0 +1,159 @@
+use crate::asset::content::Content;
+use crate::asset::content_encoder::ContentEncoder::Gzip;
+use crate::batch_upload::operations::assemble_batch_operations;
+use crate::batch_upload::operations::AssetDeletionReason::Obsolete;
+use crate::batch_upload::plumbing::{make_project_assets, ProjectAsset};
+use crate::canister_api::methods::list::list_assets;
+use crate::canister_api::types::batch_upload::common::{
+    ClearArguments, CreateAssetArguments, DeleteAssetArguments, SetAssetContentArguments,
+    UnsetAssetContentArguments,
+};
+use crate::canister_api::types::batch_upload::v0::BatchOperationKind;
+use crate::sync::gather_asset_descriptors;
+use ic_utils::Canister;
+use sha2::{Digest, Sha256};
+use slog::Logger;
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+
+const TAG_FALSE: [u8; 1] = [0];
+const TAG_TRUE: [u8; 1] = [1];
+
+const TAG_NONE: [u8; 1] = [2];
+const TAG_SOME: [u8; 1] = [3];
+
+const TAG_CREATE_ASSET: [u8; 1] = [4];
+const TAG_SET_ASSET_CONTENT: [u8; 1] = [5];
+const TAG_UNSET_ASSET_CONTENT: [u8; 1] = [6];
+const TAG_DELETE_ASSET: [u8; 1] = [7];
+const TAG_CLEAR: [u8; 1] = [8];
+
+/// Compute the hash ("evidence") over the batch operations required to update the assets
+pub async fn compute_evidence(
+    canister: &Canister<'_>,
+    dirs: &[&Path],
+    logger: &Logger,
+) -> anyhow::Result<String> {
+    let asset_descriptors = gather_asset_descriptors(dirs, logger)?;
+
+    let canister_assets = list_assets(canister).await?;
+
+    let project_assets =
+        make_project_assets(None, asset_descriptors, &canister_assets, logger).await?;
+
+    let mut operations = assemble_batch_operations(&project_assets, canister_assets, Obsolete);
+    operations.sort();
+
+    let mut sha = Sha256::new();
+    for op in operations {
+        hash_operation(&mut sha, &op, &project_assets)?;
+    }
+    let evidence: [u8; 32] = sha.finalize().into();
+
+    Ok(hex::encode(evidence))
+}
+
+fn hash_operation(
+    hasher: &mut Sha256,
+    op: &BatchOperationKind,
+    project_assets: &HashMap<String, ProjectAsset>,
+) -> anyhow::Result<()> {
+    match op {
+        BatchOperationKind::CreateAsset(args) => hash_create_asset(hasher, args),
+        BatchOperationKind::SetAssetContent(args) => {
+            hash_set_asset_content(hasher, args, project_assets)?
+        }
+        BatchOperationKind::UnsetAssetContent(args) => hash_unset_asset_content(hasher, args),
+        BatchOperationKind::DeleteAsset(args) => hash_delete_asset(hasher, args),
+        BatchOperationKind::Clear(args) => hash_clear(hasher, args),
+    };
+    Ok(())
+}
+
+fn hash_create_asset(hasher: &mut Sha256, args: &CreateAssetArguments) {
+    hasher.update(TAG_CREATE_ASSET);
+    hasher.update(&args.key);
+    hasher.update(&args.content_type);
+    if let Some(max_age) = args.max_age {
+        hasher.update(TAG_SOME);
+        hasher.update(max_age.to_be_bytes());
+    } else {
+        hasher.update(TAG_NONE);
+    }
+    hash_headers(hasher, args.headers.as_ref());
+    hash_opt_bool(hasher, args.allow_raw_access);
+    hash_opt_bool(hasher, args.enable_aliasing);
+}
+
+fn hash_set_asset_content(
+    hasher: &mut Sha256,
+    args: &SetAssetContentArguments,
+    project_assets: &HashMap<String, ProjectAsset>,
+) -> anyhow::Result<()> {
+    hasher.update(TAG_SET_ASSET_CONTENT);
+    hasher.update(&args.key);
+    hasher.update(&args.content_encoding);
+    hash_opt_vec_u8(hasher, args.sha256.as_ref());
+
+    let project_asset = project_assets.get(&args.key).unwrap();
+    let ad = &project_asset.asset_descriptor;
+
+    let content = {
+        let identity = Content::load(&ad.source)?;
+        if args.content_encoding == "identity" {
+            identity
+        } else if args.content_encoding == "gzip" {
+            identity.encode(&Gzip)?
+        } else {
+            unreachable!("unhandled content encoder");
+        }
+    };
+    hasher.update(&content.data);
+    Ok(())
+}
+
+fn hash_unset_asset_content(hasher: &mut Sha256, args: &UnsetAssetContentArguments) {
+    hasher.update(TAG_UNSET_ASSET_CONTENT);
+    hasher.update(&args.key);
+    hasher.update(&args.content_encoding);
+}
+
+fn hash_delete_asset(hasher: &mut Sha256, args: &DeleteAssetArguments) {
+    hasher.update(TAG_DELETE_ASSET);
+    hasher.update(&args.key);
+}
+
+fn hash_clear(hasher: &mut Sha256, _args: &ClearArguments) {
+    hasher.update(TAG_CLEAR);
+}
+
+fn hash_opt_bool(hasher: &mut Sha256, b: Option<bool>) {
+    if let Some(b) = b {
+        hasher.update(TAG_SOME);
+        hasher.update(if b { TAG_TRUE } else { TAG_FALSE });
+    } else {
+        hasher.update(TAG_NONE);
+    }
+}
+
+fn hash_opt_vec_u8(hasher: &mut Sha256, buf: Option<&Vec<u8>>) {
+    if let Some(buf) = buf {
+        hasher.update(TAG_SOME);
+        hasher.update(buf);
+    } else {
+        hasher.update(TAG_NONE);
+    }
+}
+
+fn hash_headers(hasher: &mut Sha256, headers: Option<&BTreeMap<String, String>>) {
+    if let Some(headers) = headers {
+        hasher.update(TAG_SOME);
+        for k in headers.keys() {
+            let v = headers.get(k).unwrap();
+            hasher.update(k);
+            hasher.update(v);
+        }
+    } else {
+        hasher.update(TAG_NONE);
+    }
+}

--- a/src/canisters/frontend/ic-asset/src/lib.rs
+++ b/src/canisters/frontend/ic-asset/src/lib.rs
@@ -34,9 +34,11 @@
 mod asset;
 mod batch_upload;
 mod canister_api;
+mod evidence;
 mod sync;
 mod upload;
 
+pub use evidence::compute_evidence;
 pub use sync::prepare_sync_for_proposal;
 pub use sync::sync;
 pub use upload::upload;

--- a/src/canisters/frontend/ic-asset/src/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/sync.rs
@@ -135,7 +135,7 @@ fn include_entry(entry: &walkdir::DirEntry, config: &AssetConfig) -> bool {
     }
 }
 
-fn gather_asset_descriptors(
+pub(crate) fn gather_asset_descriptors(
     dirs: &[&Path],
     logger: &Logger,
 ) -> anyhow::Result<Vec<AssetDescriptor>> {


### PR DESCRIPTION
# Description

Adds `dfx deploy <frontend canister name> --compute-evidence`, which computes a hash ("evidence") over the batch operations required to synchronize the assets in the canister.  Anyone can use this to verify the asset evidence presented in an SNS proposal that updates assets.

Fixes https://dfinity.atlassian.net/browse/SDK-970

# How Has This Been Tested?

Updated e2e tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
