### PR TITLE
chore: update only ic-nns-init to commit 742d0a83

### DIFF
--- a/e2e/tests-dfx/nns.bash
+++ b/e2e/tests-dfx/nns.bash
@@ -124,7 +124,7 @@ assert_nns_canister_id_matches() {
     wasm_matches nns-ledger ledger-canister_notify-method.wasm
     wasm_matches nns-root root-canister.wasm
     wasm_matches nns-cycles-minting cycles-minting-canister.wasm
-    wasm_matches nns-lifeline lifeline.wasm
+    wasm_matches nns-lifeline lifeline_canister.wasm
     wasm_matches nns-genesis-token genesis-token-canister.wasm
     wasm_matches nns-sns-wasm sns-wasm-canister.wasm
     wasm_matches internet_identity internet_identity_dev.wasm

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -83,20 +83,20 @@
     "ic-nns-init-x86_64-darwin": {
         "builtin": false,
         "description": "The ic-nns-init binary.",
-        "rev": "f24c7853befe4b85993f61d11df977a4fd721824",
-        "sha256": "1g9dyhxglzfj8scj823abgv3kil1xqwd6i7kxmharpp717yb7zz1",
+        "rev": "742d0a8399476a83878bb87c74eb46b2d8e05000",
+        "sha256": "1bp5rm6nfwdhzcv1dkiw7759l51c29mjd84pavrqsacfc65dbbj7",
         "type": "file",
-        "url": "https://download.dfinity.systems/ic/f24c7853befe4b85993f61d11df977a4fd721824/binaries/x86_64-darwin/ic-nns-init.gz",
-        "url_template": "https://download.dfinity.systems/ic/<rev>/binaries/x86_64-darwin/ic-nns-init.gz"
+        "url": "https://download.dfinity.systems/ic/742d0a8399476a83878bb87c74eb46b2d8e05000/openssl-static-binaries/x86_64-darwin/ic-nns-init.gz",
+        "url_template": "https://download.dfinity.systems/ic/<rev>/openssl-static-binaries/x86_64-darwin/ic-nns-init.gz"
     },
     "ic-nns-init-x86_64-linux": {
         "builtin": false,
         "description": "The ic-nns-init binary.",
-        "rev": "f24c7853befe4b85993f61d11df977a4fd721824",
-        "sha256": "0xai3imvnhsp88ij9rvvvvnqr710m49786b7w1ms8p0dcg449qad",
+        "rev": "742d0a8399476a83878bb87c74eb46b2d8e05000",
+        "sha256": "0lzqjwr8m5jbi9y7rayq2gp04kfyylmcgihhjqsma34q28mwnkwq",
         "type": "file",
-        "url": "https://download.dfinity.systems/ic/f24c7853befe4b85993f61d11df977a4fd721824/binaries/x86_64-linux/ic-nns-init.gz",
-        "url_template": "https://download.dfinity.systems/ic/<rev>/binaries/x86_64-linux/ic-nns-init.gz"
+        "url": "https://download.dfinity.systems/ic/742d0a8399476a83878bb87c74eb46b2d8e05000/openssl-static-binaries/x86_64-linux/ic-nns-init.gz",
+        "url_template": "https://download.dfinity.systems/ic/<rev>/openssl-static-binaries/x86_64-linux/ic-nns-init.gz"
     },
     "ic-ref-x86_64-darwin": {
         "builtin": false,

--- a/src/dfx/assets/dfx-asset-sources.toml
+++ b/src/dfx/assets/dfx-asset-sources.toml
@@ -22,8 +22,8 @@ url = 'https://download.dfinity.systems/ic/21aa2ba29bf97115aa3cdedecf0655d0cfa64
 sha256 = '9bc44e6cb015f8df65bd1ad965079bd3991c5d4d550530bbe6d5fe8356ead916'
 
 [x86_64-darwin.ic-nns-init]
-url = 'https://download.dfinity.systems/ic/f24c7853befe4b85993f61d11df977a4fd721824/binaries/x86_64-darwin/ic-nns-init.gz'
-sha256 = 'e1ffb3fc09e7deac60edf344d338ee81c639f65b6a08249946d27dfa3af42dbd'
+url = 'https://download.dfinity.systems/ic/742d0a8399476a83878bb87c74eb46b2d8e05000/openssl-static-binaries/x86_64-darwin/ic-nns-init.gz'
+sha256 = '47aed58a618e298df35697a0266b122c149aca393cce1636fbb071674dcde5ae'
 
 [x86_64-darwin.ic-starter]
 url = 'https://download.dfinity.systems/ic/21aa2ba29bf97115aa3cdedecf0655d0cfa64bf1/sdk-release/x86_64-darwin/ic-starter.gz'
@@ -76,8 +76,8 @@ url = 'https://download.dfinity.systems/ic/21aa2ba29bf97115aa3cdedecf0655d0cfa64
 sha256 = '4aca94385bf2e685761c80787202a24151ae942b46cd929ac1e10f6d4bba4555'
 
 [x86_64-linux.ic-nns-init]
-url = 'https://download.dfinity.systems/ic/f24c7853befe4b85993f61d11df977a4fd721824/binaries/x86_64-linux/ic-nns-init.gz'
-sha256 = '4de144c8630d5ca46be067197412a9209c8cedde7be72423425743bb6b1c5175'
+url = 'https://download.dfinity.systems/ic/742d0a8399476a83878bb87c74eb46b2d8e05000/openssl-static-binaries/x86_64-linux/ic-nns-init.gz'
+sha256 = '984fcb2b12980c55359610c6c72af5de4d02ee13d8ab7c7c8a4b968a3297f853'
 
 [x86_64-linux.ic-starter]
 url = 'https://download.dfinity.systems/ic/21aa2ba29bf97115aa3cdedecf0655d0cfa64bf1/sdk-release/x86_64-linux/ic-starter.gz'

--- a/src/dfx/src/lib/nns/install_nns/canisters.rs
+++ b/src/dfx/src/lib/nns/install_nns/canisters.rs
@@ -51,7 +51,7 @@ pub const NNS_CYCLES_MINTING: IcNnsInitCanister = IcNnsInitCanister {
 /// Canister used to restore functionality in an emergency.
 pub const NNS_LIFELINE: IcNnsInitCanister = IcNnsInitCanister {
     canister_name: "nns-lifeline",
-    wasm_name: "lifeline.wasm",
+    wasm_name: "lifeline_canister.wasm",
     test_wasm_name: None,
     canister_id: "rno2w-sqaaa-aaaaa-aaacq-cai",
 };


### PR DESCRIPTION

# Description

Incorporates changes from https://github.com/dfinity/sdk/pull/3074 related to ic-nns-init
 - use openssl-static-binaries
 - update filename to lifeline_canister.wasm

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
