### PR TITLE
fix: order batch operations to delete/remove data before create/add

### DIFF
--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -91,11 +91,11 @@ check_permission_failure() {
   dfx identity get-principal --identity prepare
   dfx canister call e2e_project_frontend list_permitted '(record { permission = variant { Commit }; })'
   assert_command dfx deploy e2e_project_frontend --by-proposal --identity prepare
-  assert_contains "Proposed commit of batch 2 with evidence cc6b5aab7ed38606774878fb33c17fccd02983d8415fb27dfb8dae50dc099fb1.  Either commit it by proposal, or delete it."
+  assert_contains "Proposed commit of batch 2 with evidence 31e0bf262cabcbbbeb65a9544ba33c7caf88423fe03f68148d31b2e4ca50cdb1.  Either commit it by proposal, or delete it."
 
   assert_command dfx deploy e2e_project_frontend --compute-evidence --identity anonymous
   # shellcheck disable=SC2154
-  assert_eq "cc6b5aab7ed38606774878fb33c17fccd02983d8415fb27dfb8dae50dc099fb1" "$stdout"
+  assert_eq "31e0bf262cabcbbbeb65a9544ba33c7caf88423fe03f68148d31b2e4ca50cdb1" "$stdout"
 
   ID=$(dfx canister id e2e_project_frontend)
   PORT=$(get_webserver_port)
@@ -108,13 +108,13 @@ check_permission_failure() {
   assert_command curl --fail -vv --output encoded-compressed-1.gz -H "Accept-Encoding: gzip" http://localhost:"$PORT"/notreally.js?canisterId="$ID"
   assert_match "content-encoding: gzip"
 
-  wrong_commit_args='(record { batch_id = 2; evidence = blob "\cc\6b\5a\ab\7e\d3\86\06\77\48\78\fb\33\c1\7f\cc\d1\29\83\d8\41\5f\b2\7d\fb\8d\ae\50\dc\09\9f\b1" } )'
+  wrong_commit_args='(record { batch_id = 2; evidence = blob "\31\e0\bf\26\2c\ab\cb\bb\eb\65\a9\54\4b\a2\3c\7c\af\88\42\3f\e0\3f\68\14\8d\31\b2\e4\ca\50\cd\b1" } )'
   assert_command_fail dfx canister call e2e_project_frontend commit_proposed_batch "$wrong_commit_args" --identity commit
   assert_match "batch computed evidence .* does not match presented evidence"
 
-  commit_args='(record { batch_id = 2; evidence = blob "\cc\6b\5a\ab\7e\d3\86\06\77\48\78\fb\33\c1\7f\cc\d0\29\83\d8\41\5f\b2\7d\fb\8d\ae\50\dc\09\9f\b1" } )'
+  commit_args='(record { batch_id = 2; evidence = blob "\31\e0\bf\26\2c\ab\cb\bb\eb\65\a9\54\4b\a3\3c\7c\af\88\42\3f\e0\3f\68\14\8d\31\b2\e4\ca\50\cd\b1" } )'
   assert_command dfx canister call e2e_project_frontend validate_commit_proposed_batch "$commit_args" --identity commit
-  assert_contains "commit proposed batch 2 with evidence cc6b"
+  assert_contains "commit proposed batch 2 with evidence 31e0"
   assert_command dfx canister call e2e_project_frontend commit_proposed_batch "$commit_args" --identity commit
   assert_eq "()"
 

--- a/src/canisters/frontend/ic-asset/src/canister_api/types/batch_upload/v0.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/types/batch_upload/v0.rs
@@ -5,20 +5,20 @@ use candid::{CandidType, Nat};
 #[derive(CandidType, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[allow(dead_code)]
 pub enum BatchOperationKind {
-    /// Create a new asset.
-    CreateAsset(CreateAssetArguments),
-
-    /// Assign content to an asset by encoding.
-    SetAssetContent(SetAssetContentArguments),
-
-    /// Remove content from an asset by encoding.
-    UnsetAssetContent(UnsetAssetContentArguments),
+    /// Clear all state from the asset canister.
+    Clear(ClearArguments),
 
     /// Remove an asset altogether.
     DeleteAsset(DeleteAssetArguments),
 
-    /// Clear all state from the asset canister.
-    Clear(ClearArguments),
+    /// Create a new asset.
+    CreateAsset(CreateAssetArguments),
+
+    /// Remove content from an asset by encoding.
+    UnsetAssetContent(UnsetAssetContentArguments),
+
+    /// Assign content to an asset by encoding.
+    SetAssetContent(SetAssetContentArguments),
 }
 
 /// Apply all of the operations in the batch, and then remove the batch.


### PR DESCRIPTION
# Description

The asset synchronization code sorts batch operations before submitting them to an asset canister for later commit by proposal.  This is for deterministic hash ("evidence") computation.

I forgot to reorder the BatchOperationKind to reflect the intended sort order of operations in this case.

See [assemble_batch_operations](https://github.com/dfinity/sdk/blob/master/src/canisters/frontend/ic-asset/src/batch_upload/operations.rs#L24) for the expected order:
1. delete assets
2. create assets
3. unset asset content
4. set asset content

The benefit of this ordering is that we delete/remove obsolete data before creating/adding new data, which could have the effect of making room for the new data.  I don't expect that this comes up very much, though.

The previous order (defined by place in the enum) isn't wrong exactly, in the sense that it will work: assets are created before setting their content.

# How Has This Been Tested?

Updated the relevant e2e test.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
Nothing in the changelog or docs, because this is expected behavior.

