### PR TITLE
refactor: immutable replica config and DRY --clean enforcement

### DIFF
--- a/src/dfx/src/actors/mod.rs
+++ b/src/dfx/src/actors/mod.rs
@@ -42,7 +42,7 @@ pub fn start_btc_adapter_actor(
     socket_path: Option<PathBuf>,
     shutdown_controller: Addr<ShutdownController>,
     btc_adapter_pid_file_path: PathBuf,
-) -> DfxResult<Addr<BtcAdapter>> {
+) -> DfxResult<Recipient<BtcAdapterReadySubscribe>> {
     let btc_adapter_path = env.get_cache().get_binary_command_path("ic-btc-adapter")?;
 
     let actor_config = btc_adapter::Config {
@@ -55,7 +55,7 @@ pub fn start_btc_adapter_actor(
         btc_adapter_pid_file_path,
         logger: Some(env.get_logger().clone()),
     };
-    Ok(BtcAdapter::new(actor_config).start())
+    Ok(BtcAdapter::new(actor_config).start().recipient())
 }
 
 #[context("Failed to start canister http adapter actor.")]
@@ -65,7 +65,7 @@ pub fn start_canister_http_adapter_actor(
     socket_path: Option<PathBuf>,
     shutdown_controller: Addr<ShutdownController>,
     pid_file_path: PathBuf,
-) -> DfxResult<Addr<CanisterHttpAdapter>> {
+) -> DfxResult<Recipient<CanisterHttpAdapterReadySubscribe>> {
     let adapter_path = env
         .get_cache()
         .get_binary_command_path("ic-canister-http-adapter")?;
@@ -80,7 +80,7 @@ pub fn start_canister_http_adapter_actor(
         pid_file_path,
         logger: Some(env.get_logger().clone()),
     };
-    Ok(CanisterHttpAdapter::new(actor_config).start())
+    Ok(CanisterHttpAdapter::new(actor_config).start().recipient())
 }
 
 #[context("Failed to start emulator actor.")]

--- a/src/dfx/src/commands/replica.rs
+++ b/src/dfx/src/commands/replica.rs
@@ -200,20 +200,24 @@ pub fn exec(
         replica_config
     };
 
+    let effective_config = if emulator {
+        CachedConfig::emulator()
+    } else {
+        CachedConfig::replica(&replica_config)
+    };
+    if !force && previous_config_path.exists() {
+        let previous_config = load_json_file(&previous_config_path)
+            .context("Failed to read replica configuration. Run `dfx start` with `--clean`.")?;
+        if effective_config != previous_config {
+            bail!("The network configuration was changed. Run `dfx start` with `--clean`.")
+        }
+    }
+    save_json_file(&previous_config_path, &effective_config)
+        .context("Failed to write replica configuration")?;
+
     system.block_on(async move {
         let shutdown_controller = start_shutdown_controller(env)?;
         if emulator {
-            let effective_config = CachedConfig::emulator();
-            if !force && previous_config_path.exists() {
-                let previous_config = load_json_file(&previous_config_path).context(
-                    "Failed to read replica configuration. Run `dfx start` with `--clean`.",
-                )?;
-                if effective_config != previous_config {
-                    bail!("The network configuration was changed. Run `dfx start` with `--clean`.")
-                }
-            }
-            save_json_file(&previous_config_path, &effective_config)
-                .context("Failed to write replica configuration")?;
             start_emulator_actor(env, shutdown_controller, emulator_port_path)?;
         } else {
             let btc_adapter_ready_subscribe = btc_adapter_config
@@ -238,18 +242,6 @@ pub fn exec(
                     )
                 })
                 .transpose()?;
-
-            let effective_config = CachedConfig::replica(&replica_config);
-            if !force && previous_config_path.exists() {
-                let previous_config = load_json_file(&previous_config_path).context(
-                    "Failed to read replica configuration. Run `dfx start` with `--clean`.",
-                )?;
-                if effective_config != previous_config {
-                    bail!("The network configuration was changed. Run `dfx start` with `--clean`.")
-                }
-            }
-            save_json_file(&previous_config_path, &effective_config)
-                .context("Failed to write replica configuration")?;
 
             start_replica_actor(
                 env,

--- a/src/dfx/src/commands/replica.rs
+++ b/src/dfx/src/commands/replica.rs
@@ -178,12 +178,27 @@ pub fn exec(
     let canister_http_socket_path = canister_http_adapter_config
         .as_ref()
         .and_then(|cfg| cfg.get_socket_path());
-    let mut replica_config = get_config(
-        local_server_descriptor,
-        replica_port_path,
-        &state_root,
-        artificial_delay,
-    )?;
+    let replica_config = {
+        let mut replica_config = get_config(
+            local_server_descriptor,
+            replica_port_path,
+            &state_root,
+            artificial_delay,
+        )?;
+        if let Some(btc_adapter_config) = btc_adapter_config.as_ref() {
+            replica_config = replica_config.with_btc_adapter_enabled();
+            if let Some(btc_adapter_socket) = btc_adapter_config.get_socket_path() {
+                replica_config = replica_config.with_btc_adapter_socket(btc_adapter_socket);
+            }
+        }
+        if let Some(canister_http_adapter_config) = canister_http_adapter_config.as_ref() {
+            replica_config = replica_config.with_canister_http_adapter_enabled();
+            if let Some(socket_path) = canister_http_adapter_config.get_socket_path() {
+                replica_config = replica_config.with_canister_http_adapter_socket(socket_path);
+            }
+        }
+        replica_config
+    };
 
     system.block_on(async move {
         let shutdown_controller = start_shutdown_controller(env)?;
@@ -201,49 +216,29 @@ pub fn exec(
                 .context("Failed to write replica configuration")?;
             start_emulator_actor(env, shutdown_controller, emulator_port_path)?;
         } else {
-            let (btc_adapter_ready_subscribe, btc_adapter_socket_path) =
-                if let Some(ref btc_adapter_config) = btc_adapter_config {
-                    let socket_path = btc_adapter_config.get_socket_path();
-                    let ready_subscribe = start_btc_adapter_actor(
+            let btc_adapter_ready_subscribe = btc_adapter_config
+                .map(|btc_adapter_config| {
+                    start_btc_adapter_actor(
                         env,
                         btc_adapter_config_path,
-                        socket_path.clone(),
+                        btc_adapter_config.get_socket_path(),
                         shutdown_controller.clone(),
                         btc_adapter_pid_file_path,
-                    )?
-                    .recipient();
-                    (Some(ready_subscribe), socket_path)
-                } else {
-                    (None, None)
-                };
-            let (canister_http_adapter_ready_subscribe, canister_http_socket_path) =
-                if let Some(ref canister_http_adapter_config) = canister_http_adapter_config {
-                    let socket_path = canister_http_adapter_config.get_socket_path();
-                    let ready_subscribe = start_canister_http_adapter_actor(
+                    )
+                })
+                .transpose()?;
+            let canister_http_adapter_ready_subscribe = canister_http_adapter_config
+                .map(|canister_http_adapter_config| {
+                    start_canister_http_adapter_actor(
                         env,
                         canister_http_adapter_config_path,
-                        socket_path.clone(),
+                        canister_http_adapter_config.get_socket_path(),
                         shutdown_controller.clone(),
                         canister_http_adapter_pid_file_path,
-                    )?
-                    .recipient();
-                    (Some(ready_subscribe), socket_path)
-                } else {
-                    (None, None)
-                };
+                    )
+                })
+                .transpose()?;
 
-            if btc_adapter_config.is_some() {
-                replica_config = replica_config.with_btc_adapter_enabled();
-                if let Some(btc_adapter_socket) = btc_adapter_socket_path {
-                    replica_config = replica_config.with_btc_adapter_socket(btc_adapter_socket);
-                }
-            }
-            if canister_http_adapter_config.is_some() {
-                replica_config = replica_config.with_canister_http_adapter_enabled();
-                if let Some(socket_path) = canister_http_socket_path {
-                    replica_config = replica_config.with_canister_http_adapter_socket(socket_path);
-                }
-            }
             let effective_config = CachedConfig::replica(&replica_config);
             if !force && previous_config_path.exists() {
                 let previous_config = load_json_file(&previous_config_path).context(


### PR DESCRIPTION
# Description

The replica configuration was built mutably in phases.  This made it a little too easy to accidentally use before complete.  This PR makes two changes:
1. Build the replica configuration in one place, resulting in an immutable config.  Both `dfx start` and `dfx replica` do this.
2. DRY the configuration-changed `--clean` enforcement logic, now that the complete replica config is available earlier.

# How Has This Been Tested?

Covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
