### PR TITLE
refactor: methods that read canister info from state tree

### DIFF
--- a/src/dfx/src/commands/canister/info.rs
+++ b/src/dfx/src/commands/canister/info.rs
@@ -1,13 +1,14 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::root_key::fetch_root_key_if_needed;
+use crate::lib::state_tree::canister_info::{
+    read_state_tree_canister_controllers, read_state_tree_canister_module_hash,
+};
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::anyhow;
 use candid::Principal;
 use clap::Parser;
-use ic_agent::AgentError;
-use serde_cbor::Value;
-use std::convert::TryFrom;
+use itertools::Itertools;
 
 /// Get the hash of a canister’s WASM module and its current controllers.
 #[derive(Parser)]
@@ -28,58 +29,19 @@ pub async fn exec(env: &dyn Environment, opts: InfoOpts) -> DfxResult {
         .or_else(|_| canister_id_store.get(callee_canister))?;
 
     fetch_root_key_if_needed(env).await?;
-    let controller_blob = match agent
-        .read_state_canister_info(canister_id, "controllers")
-        .await
-    {
-        Err(AgentError::LookupPathUnknown(_) | AgentError::LookupPathAbsent(_)) => {
-            bail!("Canister {canister_id} does not exist.")
-        }
-        r => r.with_context(|| format!("Failed to read controllers of canister {canister_id}."))?,
-    };
-    let cbor: Value = serde_cbor::from_slice(&controller_blob)
-        .map_err(|_| anyhow!("Invalid cbor data in controllers canister info."))?;
-    let controllers = if let Value::Array(vec) = cbor {
-        vec.into_iter()
-            .map(|elem: Value| {
-                if let Value::Bytes(bytes) = elem {
-                    Ok(Principal::try_from(&bytes)
-                        .with_context(|| {
-                            format!(
-                                "Failed to construct principal of controller from bytes ({}).",
-                                hex::encode(&bytes)
-                            )
-                        })?
-                        .to_text())
-                } else {
-                    bail!(
-                        "Expected element in controllers to be of type bytes, got {:?}",
-                        elem
-                    );
-                }
-            })
-            .collect::<DfxResult<Vec<String>>>()
-    } else {
-        bail!("Expected controllers to be an array, but got {:?}", cbor);
-    }
-    .context("Failed to determine controllers.")?;
 
-    let module_hash_hex = match agent
-        .read_state_canister_info(canister_id, "module_hash")
-        .await
-    {
-        Ok(blob) => format!("0x{}", hex::encode(&blob)),
-        // If the canister is empty, this path does not exist.
-        // The replica doesn't support negative lookups, therefore if the canister
-        // is empty, the replica will return lookup_path([], Pruned _) = Unknown
-        Err(AgentError::LookupPathUnknown(_)) | Err(AgentError::LookupPathAbsent(_)) => {
-            "None".to_string()
-        }
-        Err(x) => bail!(x),
-    };
+    let controllers_sorted: Vec<_> = read_state_tree_canister_controllers(agent, canister_id)
+        .await?
+        .ok_or_else(|| anyhow!("Canister {canister_id} does not exist."))?
+        .iter()
+        .map(Principal::to_text)
+        .sorted()
+        .collect();
 
-    let mut controllers_sorted = controllers;
-    controllers_sorted.sort();
+    let module_hash_hex = match read_state_tree_canister_module_hash(agent, canister_id).await? {
+        None => "None".to_string(),
+        Some(blob) => format!("0x{}", hex::encode(&blob)),
+    };
 
     println!(
         "Controllers: {}\nModule hash: {}",

--- a/src/dfx/src/commands/wallet/upgrade.rs
+++ b/src/dfx/src/commands/wallet/upgrade.rs
@@ -3,9 +3,10 @@ use crate::lib::error::DfxResult;
 use crate::lib::identity::wallet::wallet_canister_id;
 use crate::lib::operations::canister::install_wallet;
 use crate::lib::root_key::fetch_root_key_if_needed;
+use crate::lib::state_tree::canister_info::read_state_tree_canister_module_hash;
+
 use anyhow::{anyhow, bail};
 use clap::Parser;
-use ic_agent::AgentError;
 use ic_utils::interfaces::management_canister::builders::InstallMode;
 
 /// Upgrade the wallet's Wasm module to the current Wasm bundled with DFX.
@@ -36,19 +37,12 @@ pub async fn exec(env: &dyn Environment, _opts: UpgradeOpts) -> DfxResult {
         .ok_or_else(|| anyhow!("Cannot get HTTP client from environment."))?;
 
     fetch_root_key_if_needed(env).await?;
-    match agent
-        .read_state_canister_info(canister_id, "module_hash")
-        .await
+    if read_state_tree_canister_module_hash(agent, canister_id)
+        .await?
+        .is_none()
     {
-        // If the canister is empty, this path does not exist.
-        // The replica doesn't support negative lookups, therefore if the canister
-        // is empty, the replica will return lookup_path([], Pruned _) = Unknown
-        Err(AgentError::LookupPathUnknown(_)) | Err(AgentError::LookupPathAbsent(_)) => {
-            bail!("The cycles wallet canister is empty. Try running `dfx identity deploy-wallet` to install code for the cycles wallet in this canister.")
-        }
-        Err(x) => bail!(x),
-        _ => {}
-    };
+        bail!("The cycles wallet canister is empty. Try running `dfx identity deploy-wallet` to install code for the cycles wallet in this canister.")
+    }
 
     let agent = env
         .get_agent()

--- a/src/dfx/src/lib/mod.rs
+++ b/src/dfx/src/lib/mod.rs
@@ -30,5 +30,6 @@ pub mod replica_config;
 pub mod root_key;
 pub mod sign;
 pub mod sns;
+pub mod state_tree;
 pub mod toolchain;
 pub mod wasm;

--- a/src/dfx/src/lib/state_tree/canister_info.rs
+++ b/src/dfx/src/lib/state_tree/canister_info.rs
@@ -1,0 +1,69 @@
+use crate::lib::error::DfxResult;
+
+use anyhow::{anyhow, bail, Context};
+use candid::Principal;
+use ic_agent::{Agent, AgentError};
+use serde_cbor::Value;
+
+pub async fn read_state_tree_canister_controllers(
+    agent: &Agent,
+    canister_id: Principal,
+) -> DfxResult<Option<Vec<Principal>>> {
+    let controller_blob = match agent
+        .read_state_canister_info(canister_id, "controllers")
+        .await
+    {
+        Err(AgentError::LookupPathUnknown(_) | AgentError::LookupPathAbsent(_)) => {
+            return Ok(None);
+        }
+        r => r.with_context(|| format!("Failed to read controllers of canister {canister_id}."))?,
+    };
+    let cbor: Value = serde_cbor::from_slice(&controller_blob)
+        .map_err(|_| anyhow!("Invalid cbor data in controllers canister info."))?;
+    let controllers = if let Value::Array(vec) = cbor {
+        vec.into_iter()
+            .map(|elem: Value| {
+                if let Value::Bytes(bytes) = elem {
+                    Ok(Principal::try_from(&bytes).with_context(|| {
+                        format!(
+                            "Failed to construct principal of controller from bytes ({}).",
+                            hex::encode(&bytes)
+                        )
+                    })?)
+                } else {
+                    bail!(
+                        "Expected element in controllers to be of type bytes, got {:?}",
+                        elem
+                    );
+                }
+            })
+            .collect::<DfxResult<Vec<Principal>>>()
+    } else {
+        bail!("Expected controllers to be an array, but got {:?}", cbor);
+    }
+    .context("Failed to determine controllers.")?;
+
+    Ok(Some(controllers))
+}
+
+/// None can indicate either of these, but we can't tell from here:
+/// - the canister doesn't exist
+/// - the canister exists but does not have a module installed
+pub async fn read_state_tree_canister_module_hash(
+    agent: &Agent,
+    canister_id: Principal,
+) -> DfxResult<Option<Vec<u8>>> {
+    let module_hash = match agent
+        .read_state_canister_info(canister_id, "module_hash")
+        .await
+    {
+        Ok(blob) => Some(blob),
+        // If the canister is empty, this path does not exist.
+        // The replica doesn't support negative lookups, therefore if the canister
+        // is empty, the replica will return lookup_path([], Pruned _) = Unknown
+        Err(AgentError::LookupPathUnknown(_)) | Err(AgentError::LookupPathAbsent(_)) => None,
+        Err(x) => bail!(x),
+    };
+
+    Ok(module_hash)
+}

--- a/src/dfx/src/lib/state_tree/mod.rs
+++ b/src/dfx/src/lib/state_tree/mod.rs
@@ -1,0 +1,1 @@
+pub mod canister_info;


### PR DESCRIPTION
# Description

Upcoming work to support the bitcoin canister needs to determine if a canister exists, what its controllers are, and whether or not it has been installed (has a module hash).

Extracted methods from the `canister info` command for this purpose, while letting the command continue to handle formatting of output.  This turned out to simplify a few other places that also read the module hash.

# How Has This Been Tested?

Covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
