### PR TITLE
feat: make confirmation dialogue more accepting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Canisters communicating with `ic0.app` will continue to function nominally.
 
 ### feat: --no-asset-upgrade
 
+### feat: confirmation dialogues are no longer case sensitive and accept 'y' in addition to 'yes'
+
 ### fix: `dfx generate` no longer requires non-Motoko canisters to have a canister ID
 Previously, non-Motoko canisters required that the canister was created before `dfx generate` could be called.
 This requirement is now lifted for all canisters except for canisters of type `"motoko"` or canisters that are listed in (transitive) dependencies of a canister of type `"motoko"`.

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -1235,8 +1235,7 @@ CHERRIES" "$stdout"
         "enable_aliasing": false
       }
     ]' > src/e2e_project_frontend/assets/.ic-assets.json5
-    # '--mode reinstall --yes' can be removed once SDK-817 is implemented
-    dfx deploy e2e_project_frontend --mode reinstall --yes
+    dfx deploy e2e_project_frontend
     
     assert_command curl --fail -vv http://localhost:"$PORT"/test_alias_file.html?canisterId="$ID"
     # shellcheck disable=SC2154

--- a/e2e/tests-dfx/mode_reinstall.bash
+++ b/e2e/tests-dfx/mode_reinstall.bash
@@ -132,3 +132,35 @@ teardown() {
     assert_command dfx canister call hello_backend read
     assert_eq "(2 : nat)"
 }
+
+@test "confirmation dialogue accepts multiple forms of 'yes'" {
+    dfx_start
+    dfx deploy
+
+    # if the pipe is alone with assert_command, $stdout, $stderr etc will not be available,
+    # so all the assert_match calls will fail.  http://mywiki.wooledge.org/BashFAQ/024
+    echo yes | (
+        assert_command dfx deploy --mode=reinstall hello_backend
+
+        assert_match "YOU WILL LOSE ALL DATA IN THE CANISTER"
+        assert_match "Reinstalling code for canister hello_backend"
+    )
+    echo y | (
+        assert_command dfx deploy --mode=reinstall hello_backend
+
+        assert_match "YOU WILL LOSE ALL DATA IN THE CANISTER"
+        assert_match "Reinstalling code for canister hello_backend"
+    )
+    echo YES | (
+        assert_command dfx deploy --mode=reinstall hello_backend
+
+        assert_match "YOU WILL LOSE ALL DATA IN THE CANISTER"
+        assert_match "Reinstalling code for canister hello_backend"
+    )
+    echo YeS | (
+        assert_command dfx deploy --mode=reinstall hello_backend
+
+        assert_match "YOU WILL LOSE ALL DATA IN THE CANISTER"
+        assert_match "Reinstalling code for canister hello_backend"
+    )
+}

--- a/src/dfx-core/src/cli/mod.rs
+++ b/src/dfx-core/src/cli/mod.rs
@@ -10,8 +10,8 @@ pub fn ask_for_consent(message: &str) -> Result<(), UserConsent> {
     stdin()
         .read_line(&mut input_string)
         .map_err(UserConsent::ReadError)?;
-    let input_string = input_string.trim_end();
-    if input_string != "yes" {
+    let input_string = input_string.trim_end().to_lowercase();
+    if input_string != "yes" && input_string != "y" {
         return Err(UserConsent::Declined);
     }
     Ok(())


### PR DESCRIPTION
# Description

Confirmation dialogues are no longer case sensitive and accept 'y' in addition to 'yes'.

Fixes [SDK-956](https://dfinity.atlassian.net/browse/SDK-956)

# How Has This Been Tested?

Added e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
