### PR TITLE
test: use valid UTF-8 characters in rust nonstandard target dir test

### DIFF
--- a/e2e/tests-dfx/rust.bash
+++ b/e2e/tests-dfx/rust.bash
@@ -45,7 +45,10 @@ teardown() {
 
 @test "rust canister can have nonstandard target dir location" {
     dfx_new_rust
-    CARGO_TARGET_DIR="$(echo -ne '\x81')"
+    # We used to set CARGO_TARGET_DIR="$(echo -ne '\x81')"
+    # But since rust 1.69, `cargo metadata` returns
+    #   error: path contains invalid UTF-8 characters
+    CARGO_TARGET_DIR="custom-target"
     export CARGO_TARGET_DIR
     dfx_start
     assert_command dfx deploy


### PR DESCRIPTION
# Description

The `"rust canister can have nonstandard target dir location"` test is failing in several PRs.

This copies a fix over from https://github.com/dfinity/sdk/pull/3095

# How Has This Been Tested?

Updates an e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

