### PR TITLE
fix: split up asset synchronization batches in order not to exceed the per-message instruction limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 # UNRELEASED
 
-## Asset Canister 
+## Asset Canister Synchronization
 
 Added more detailed logging to `ic-asset`. Now, when running `dfx deploy -v` (or `-vv`), the following information will be printed:
 - The count for each `BatchOperationKind` in `CommitBatchArgs`
 - The API version of both the `ic-asset` and the canister
 - (Only for `-vv`) The value of `CommitBatchArgs`
+
+In order to allow larger changes without exceeding the per-message instruction limit, the sync process now:
+- sets properties of assets already in the canister separately from the rest of the batch.
+- splits up the rest of the batch into groups of up to 500 operations.
 
 # 0.14.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,6 +2006,7 @@ dependencies = [
  "hex",
  "ic-agent",
  "ic-utils",
+ "itertools 0.10.5",
  "json5",
  "mime",
  "mime_guess",

--- a/src/canisters/frontend/ic-asset/Cargo.toml
+++ b/src/canisters/frontend/ic-asset/Cargo.toml
@@ -23,6 +23,7 @@ globset = "0.4.9"
 hex = { workspace = true, features = ["serde"] }
 ic-agent = { workspace = true, features = ["pem"] }
 ic-utils = { workspace = true }
+itertools.workspace = true
 json5 = "0.4.1"
 mime.workspace = true
 mime_guess.workspace = true

--- a/src/canisters/frontend/ic-asset/src/canister_api/types/asset.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/types/asset.rs
@@ -39,7 +39,7 @@ pub struct AssetProperties {
 }
 
 /// Sets the asset with the given properties.
-#[derive(Debug, CandidType, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, CandidType, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SetAssetPropertiesArguments {
     pub key: String,
     pub max_age: Option<Option<u64>>,

--- a/src/canisters/frontend/ic-asset/src/canister_api/types/batch_upload/common.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/types/batch_upload/common.rs
@@ -36,7 +36,7 @@ pub struct CreateChunkResponse {
 
 /// Create a new asset.  Has no effect if the asset already exists and the content type matches.
 /// Traps if the asset already exists but with a different content type.
-#[derive(CandidType, Debug, PartialOrd, PartialEq, Eq, Ord)]
+#[derive(CandidType, Clone, Debug, PartialOrd, PartialEq, Eq, Ord)]
 pub struct CreateAssetArguments {
     /// The key identifies the asset.
     pub key: String,
@@ -53,7 +53,7 @@ pub struct CreateAssetArguments {
 }
 
 /// Set the data for a particular content encoding for the given asset.
-#[derive(CandidType, Debug, PartialOrd, PartialEq, Eq, Ord)]
+#[derive(CandidType, Clone, Debug, PartialOrd, PartialEq, Eq, Ord)]
 pub struct SetAssetContentArguments {
     /// The key identifies the asset.
     pub key: String,
@@ -66,7 +66,7 @@ pub struct SetAssetContentArguments {
 }
 
 /// Remove a specific content encoding for the asset.
-#[derive(CandidType, Debug, PartialOrd, PartialEq, Eq, Ord)]
+#[derive(CandidType, Clone, Debug, PartialOrd, PartialEq, Eq, Ord)]
 pub struct UnsetAssetContentArguments {
     /// The key identifies the asset.
     pub key: String,
@@ -75,14 +75,14 @@ pub struct UnsetAssetContentArguments {
 }
 
 /// Remove the specified asset.
-#[derive(CandidType, Debug, PartialOrd, PartialEq, Eq, Ord)]
+#[derive(CandidType, Clone, Debug, PartialOrd, PartialEq, Eq, Ord)]
 pub struct DeleteAssetArguments {
     /// The key identifies the asset to delete.
     pub key: String,
 }
 
 /// Remove all assets, batches, and chunks, and reset the next batch and chunk IDs.
-#[derive(CandidType, Debug, PartialOrd, PartialEq, Eq, Ord)]
+#[derive(CandidType, Clone, Debug, PartialOrd, PartialEq, Eq, Ord)]
 pub struct ClearArguments {}
 
 /// Compute a hash over the proposed CommitBatchArguments.  This may take more than one call.

--- a/src/canisters/frontend/ic-asset/src/canister_api/types/batch_upload/v1.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/types/batch_upload/v1.rs
@@ -10,7 +10,7 @@ use crate::canister_api::types::{
 use candid::{CandidType, Nat};
 
 /// Batch operations that can be applied atomically.
-#[derive(CandidType, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(CandidType, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum BatchOperationKind {
     #[allow(dead_code)]
     /// Clear all state from the asset canister.

--- a/src/canisters/frontend/ic-asset/src/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/sync.rs
@@ -20,7 +20,9 @@ use crate::canister_api::types::batch_upload::{
     common::ComputeEvidenceArguments, v1::CommitBatchArguments,
 };
 
+use crate::canister_api::types::batch_upload::v1::BatchOperationKind;
 use anyhow::{anyhow, bail, Context};
+use candid::Nat;
 use ic_utils::Canister;
 use slog::{debug, info, trace, warn, Logger};
 use std::collections::HashMap;
@@ -98,11 +100,50 @@ pub async fn sync(canister: &Canister<'_>, dirs: &[&Path], logger: &Logger) -> a
             warn!(logger, "The asset canister is running an old version of the API. It will not be able to set assets properties.");
             commit_batch(canister, commit_batch_args_v0).await
         }
-        BATCH_UPLOAD_API_VERSION.. => commit_batch(canister, commit_batch_args).await,
+        BATCH_UPLOAD_API_VERSION.. => commit_in_stages(canister, commit_batch_args, logger).await,
     };
     response.context("Failed to synchronize frontend canister with project assets.")?;
 
     Ok(())
+}
+
+async fn commit_in_stages(
+    canister: &Canister<'_>,
+    commit_batch_args: CommitBatchArguments,
+    logger: &Logger,
+) -> anyhow::Result<()> {
+    // Note that SetAssetProperties operations are only generated for assets that
+    // already exist, since CreateAsset operations set all properties.
+    let (set_properties_operations, other_operations): (Vec<_>, Vec<_>) = commit_batch_args
+        .operations
+        .into_iter()
+        .partition(|op| matches!(op, BatchOperationKind::SetAssetProperties(_)));
+    let batch_id = commit_batch_args.batch_id;
+
+    for operations in set_properties_operations.chunks(500) {
+        info!(logger, "Setting properties of {} assets.", operations.len());
+        commit_batch(
+            canister,
+            CommitBatchArguments {
+                batch_id: Nat::from(0),
+                operations: operations.into(),
+            },
+        )
+        .await?
+    }
+    info!(
+        logger,
+        "Committing batch with {} operations.",
+        other_operations.len()
+    );
+    commit_batch(
+        canister,
+        CommitBatchArguments {
+            batch_id,
+            operations: other_operations,
+        },
+    )
+    .await
 }
 
 /// Stage changes and propose the batch for commit.


### PR DESCRIPTION
# Description

Deploys to the portal are failing with dfx 0.14.0, by exceeding the per-message instruction limit.  Two factors are in play:

1. dfx 0.14.0 updates asset properties that have changed.  Since many assets were created by dfx 0.12.1 or earlier and have no properties set at all, that means dfx 0.14.0 is trying to update them all at once.
2. dfx 0.14.0 adds v2 certification, which means more calculations for certification.

This PR implements two changes:
1. Submit all `SetAssetProperties` operations separately, in small groups, before submitting other batch operations.  This seems reasonable because updating an asset's properties should be a safe operation independent of changes to other assets or to an asset's content.
2. Submit batch operations in groups of 500 operations.  This is less awesome, because changes aren't atomic.  For example, if renaming an asset, this will first delete the asset, then later create the replacement, then later set its content.  See https://dfinity.atlassian.net/browse/SDK-1101 for followup work.

Fixes https://dfinity.atlassian.net/browse/SDK-1100

# How Has This Been Tested?

Clone https://github.com/dfinity/portal and follow instructions in readme

```
$ git checkout aac5b3a6e7680d9a9486429cdcabe5a53d4ff9ee
$ DFX_VERSION=0.12.1 dfx deploy
$ git checkout master
$ DFX_VERSION=0.14.0 dfx deploy
# notice it fails
$ dfx-wip -v deploy # this branch
# notice it succeeds
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
