### PR TITLE
feat: report chunks and bytes uploaded during deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 Added more detailed logging to `ic-asset`. Now, when running `dfx deploy -v` (or `-vv`), the following information will be printed:
 - The count for each `BatchOperationKind` in `CommitBatchArgs`
+- The number of chunks uploaded and the total bytes
 - The API version of both the `ic-asset` and the canister
 - (Only for `-vv`) The value of `CommitBatchArgs`
 

--- a/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
+++ b/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
@@ -43,14 +43,14 @@ pub(crate) struct ProjectAsset {
     pub(crate) encodings: HashMap<String, ProjectAssetEncoding>,
 }
 
-pub(crate) struct ChunkUploader<'a> {
-    canister: &'a Canister<'a>,
-    batch_id: &'a Nat,
+pub(crate) struct ChunkUploader<'agent> {
+    canister: Canister<'agent>,
+    batch_id: Nat,
     chunks: Arc<AtomicUsize>,
     bytes: Arc<AtomicUsize>,
 }
-impl<'a> ChunkUploader<'a> {
-    pub(crate) fn new(canister: &'a Canister, batch_id: &'a Nat) -> Self {
+impl<'agent> ChunkUploader<'agent> {
+    pub(crate) fn new(canister: Canister<'agent>, batch_id: Nat) -> Self {
         Self {
             canister,
             batch_id,
@@ -66,7 +66,7 @@ impl<'a> ChunkUploader<'a> {
     ) -> anyhow::Result<Nat> {
         self.chunks.fetch_add(1, Ordering::SeqCst);
         self.bytes.fetch_add(contents.len(), Ordering::SeqCst);
-        create_chunk(self.canister, self.batch_id, contents, semaphores).await
+        create_chunk(&self.canister, &self.batch_id, contents, semaphores).await
     }
 
     pub(crate) fn bytes(&self) -> usize {

--- a/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
+++ b/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
@@ -13,6 +13,8 @@ use mime::Mime;
 use slog::{debug, info, Logger};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 const CONTENT_ENCODING_IDENTITY: &str = "identity";
 
@@ -41,14 +43,43 @@ pub(crate) struct ProjectAsset {
     pub(crate) encodings: HashMap<String, ProjectAssetEncoding>,
 }
 
-pub(crate) struct ChunkUploadTarget<'a> {
-    pub(crate) canister: &'a Canister<'a>,
-    pub(crate) batch_id: &'a Nat,
+pub(crate) struct ChunkUploader<'a> {
+    canister: &'a Canister<'a>,
+    batch_id: &'a Nat,
+    chunks: Arc<AtomicUsize>,
+    bytes: Arc<AtomicUsize>,
+}
+impl<'a> ChunkUploader<'a> {
+    pub(crate) fn new(canister: &'a Canister, batch_id: &'a Nat) -> Self {
+        Self {
+            canister,
+            batch_id,
+            chunks: Arc::new(AtomicUsize::new(0)),
+            bytes: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub(crate) async fn create_chunk(
+        &self,
+        contents: &[u8],
+        semaphores: &Semaphores,
+    ) -> anyhow::Result<Nat> {
+        self.chunks.fetch_add(1, Ordering::SeqCst);
+        self.bytes.fetch_add(contents.len(), Ordering::SeqCst);
+        create_chunk(self.canister, self.batch_id, contents, semaphores).await
+    }
+
+    pub(crate) fn bytes(&self) -> usize {
+        self.bytes.load(Ordering::SeqCst)
+    }
+    pub(crate) fn chunks(&self) -> usize {
+        self.chunks.load(Ordering::SeqCst)
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
 async fn make_project_asset_encoding(
-    chunk_upload_target: Option<&ChunkUploadTarget<'_>>,
+    chunk_upload_target: Option<&ChunkUploader<'_>>,
     asset_descriptor: &AssetDescriptor,
     canister_assets: &HashMap<String, AssetDetails>,
     content: &Content,
@@ -88,8 +119,7 @@ async fn make_project_asset_encoding(
         vec![]
     } else if let Some(target) = chunk_upload_target {
         upload_content_chunks(
-            target.canister,
-            target.batch_id,
+            target,
             asset_descriptor,
             content,
             &sha256,
@@ -119,7 +149,7 @@ async fn make_project_asset_encoding(
 
 #[allow(clippy::too_many_arguments)]
 async fn make_encoding(
-    chunk_upload_target: Option<&ChunkUploadTarget<'_>>,
+    chunk_upload_target: Option<&ChunkUploader<'_>>,
     asset_descriptor: &AssetDescriptor,
     canister_assets: &HashMap<String, AssetDetails>,
     content: &Content,
@@ -167,7 +197,7 @@ async fn make_encoding(
 }
 
 async fn make_encodings(
-    chunk_upload_target: Option<&ChunkUploadTarget<'_>>,
+    chunk_upload_target: Option<&ChunkUploader<'_>>,
     asset_descriptor: &AssetDescriptor,
     canister_assets: &HashMap<String, AssetDetails>,
     content: &Content,
@@ -205,7 +235,7 @@ async fn make_encodings(
 }
 
 async fn make_project_asset(
-    chunk_upload_target: Option<&ChunkUploadTarget<'_>>,
+    chunk_upload_target: Option<&ChunkUploader<'_>>,
     asset_descriptor: AssetDescriptor,
     canister_assets: &HashMap<String, AssetDetails>,
     semaphores: &Semaphores,
@@ -240,7 +270,7 @@ async fn make_project_asset(
 }
 
 pub(crate) async fn make_project_assets(
-    chunk_upload_target: Option<&ChunkUploadTarget<'_>>,
+    chunk_upload_target: Option<&ChunkUploader<'_>>,
     asset_descriptors: Vec<AssetDescriptor>,
     canister_assets: &HashMap<String, AssetDetails>,
     logger: &Logger,
@@ -269,8 +299,7 @@ pub(crate) async fn make_project_assets(
 }
 
 async fn upload_content_chunks(
-    canister: &Canister<'_>,
-    batch_id: &Nat,
+    chunk_uploader: &ChunkUploader<'_>,
     asset_descriptor: &AssetDescriptor,
     content: &Content,
     sha256: &Vec<u8>,
@@ -280,7 +309,7 @@ async fn upload_content_chunks(
 ) -> anyhow::Result<Vec<Nat>> {
     if content.data.is_empty() {
         let empty = vec![];
-        let chunk_id = create_chunk(canister, batch_id, &empty, semaphores).await?;
+        let chunk_id = chunk_uploader.create_chunk(&empty, semaphores).await?;
         info!(
             logger,
             "  {}{} 1/1 (0 bytes) sha {}",
@@ -297,22 +326,24 @@ async fn upload_content_chunks(
         .chunks(MAX_CHUNK_SIZE)
         .enumerate()
         .map(|(i, data_chunk)| {
-            create_chunk(canister, batch_id, data_chunk, semaphores).map_ok(move |chunk_id| {
-                info!(
-                    logger,
-                    "  {}{} {}/{} ({} bytes) sha {} {}",
-                    &asset_descriptor.key,
-                    content_encoding_descriptive_suffix(content_encoding),
-                    i + 1,
-                    count,
-                    data_chunk.len(),
-                    hex::encode(sha256),
-                    &asset_descriptor.config
-                );
-                debug!(logger, "{:?}", &asset_descriptor.config);
+            chunk_uploader
+                .create_chunk(data_chunk, semaphores)
+                .map_ok(move |chunk_id| {
+                    info!(
+                        logger,
+                        "  {}{} {}/{} ({} bytes) sha {} {}",
+                        &asset_descriptor.key,
+                        content_encoding_descriptive_suffix(content_encoding),
+                        i + 1,
+                        count,
+                        data_chunk.len(),
+                        hex::encode(sha256),
+                        &asset_descriptor.config
+                    );
+                    debug!(logger, "{:?}", &asset_descriptor.config);
 
-                chunk_id
-            })
+                    chunk_id
+                })
         })
         .collect();
     try_join_all(chunks_futures).await

--- a/src/canisters/frontend/ic-asset/src/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/sync.rs
@@ -53,8 +53,7 @@ pub async fn upload_content_and_assemble_sync_operations(
         "Staging contents of new and changed assets in batch {}:", batch_id
     );
 
-    let chunk_uploader = ChunkUploader::new(canister, &batch_id);
-    let batch_id = batch_id.clone();
+    let chunk_uploader = ChunkUploader::new(canister.clone(), batch_id.clone());
 
     let project_assets = make_project_assets(
         Some(&chunk_uploader),

--- a/src/canisters/frontend/ic-asset/src/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/sync.rs
@@ -2,7 +2,7 @@ use crate::asset::config::{
     AssetConfig, AssetSourceDirectoryConfiguration, ASSETS_CONFIG_FILENAME_JSON,
 };
 use crate::batch_upload::operations::BATCH_UPLOAD_API_VERSION;
-use crate::batch_upload::plumbing::ChunkUploadTarget;
+use crate::batch_upload::plumbing::ChunkUploader;
 use crate::batch_upload::{
     self,
     operations::AssetDeletionReason,
@@ -53,13 +53,11 @@ pub async fn upload_content_and_assemble_sync_operations(
         "Staging contents of new and changed assets in batch {}:", batch_id
     );
 
-    let chunk_upload_target = ChunkUploadTarget {
-        canister,
-        batch_id: &batch_id,
-    };
+    let chunk_uploader = ChunkUploader::new(canister, &batch_id);
+    let batch_id = batch_id.clone();
 
     let project_assets = make_project_assets(
-        Some(&chunk_upload_target),
+        Some(&chunk_uploader),
         asset_descriptors,
         &canister_assets,
         logger,
@@ -80,6 +78,13 @@ pub async fn upload_content_and_assemble_sync_operations(
         "Count of each Batch Operation Kind: {:?}",
         commit_batch_args.group_by_kind_then_count()
     );
+    debug!(
+        logger,
+        "Chunks: {}  Bytes: {}",
+        chunk_uploader.chunks(),
+        chunk_uploader.bytes()
+    );
+
     // -vv
     trace!(logger, "Value of CommitBatch: {:?}", commit_batch_args);
 

--- a/src/canisters/frontend/ic-asset/src/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/upload.rs
@@ -3,7 +3,7 @@ use crate::batch_upload::operations::BATCH_UPLOAD_API_VERSION;
 use crate::batch_upload::{
     self,
     operations::AssetDeletionReason,
-    plumbing::{make_project_assets, AssetDescriptor, ChunkUploadTarget},
+    plumbing::{make_project_assets, AssetDescriptor, ChunkUploader},
 };
 use crate::canister_api::methods::{
     api_version::api_version,
@@ -41,10 +41,7 @@ pub async fn upload(
 
     info!(logger, "Staging contents of new and changed assets:");
 
-    let chunk_upload_target = ChunkUploadTarget {
-        canister,
-        batch_id: &batch_id,
-    };
+    let chunk_upload_target = ChunkUploader::new(canister, &batch_id);
 
     let project_assets = make_project_assets(
         Some(&chunk_upload_target),

--- a/src/canisters/frontend/ic-asset/src/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/upload.rs
@@ -41,7 +41,7 @@ pub async fn upload(
 
     info!(logger, "Staging contents of new and changed assets:");
 
-    let chunk_upload_target = ChunkUploader::new(canister, &batch_id);
+    let chunk_upload_target = ChunkUploader::new(canister.clone(), batch_id.clone());
 
     let project_assets = make_project_assets(
         Some(&chunk_upload_target),


### PR DESCRIPTION
# Description

In order to help determine what might be reasonable default limits and to show deployers how close they are to those limits, report (under `-v`) how many chunks were uploaded and the total size of those chunks.

# How Has This Been Tested?

```
[portal] aac5b3a $ dfx-wip -v deploy
...
Count of each Batch Operation Kind: {"SetAssetContent": 5903, "CreateAsset": 3582}
Chunks: 5990  Bytes: 379111924
Canister API version: 1. ic-asset API version: 1
...
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
