### PR TITLE
feat: add option to provide a custom build command to asset canister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 # UNRELEASED
 
+## feat: add optional custom build command for asset canisters
+
+The custom build command can be set in `dfx.json` the same way it is set for `custom` type canisters. If the command is not provided, DFX will fallback to the default `npm run build` command.
+
+```json
+{
+  "canisters": {
+    "ui": {
+      "type": "assets",
+      "build": ["<custom build command>"]
+    }
+  }
+}
+```
+
 ## Asset Canister Synchronization
 
 Added more detailed logging to `ic-asset`. Now, when running `dfx deploy -v` (or `-vv`), the following information will be printed:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,8 @@ If there is already an entry in the 'Unreleased' section, change it; if not, add
 #### Setup
 
 1. Install `bats`, `jq` and `sponge`. See the CI provisioning scripts for examples (search for the line with the comment `# Install Bats + moreutils.`):
-    - [Linux](../scripts/workflows/provision-linux.sh)
-    - [Darwin](../scripts/workflows/provision-darwin.sh)
+    - [Linux](./scripts/workflows/provision-linux.sh)
+    - [Darwin](./scripts/workflows/provision-darwin.sh)
 1. Download `bats-support` (which is included as this repository' submodule) 
     ```bash
     git submodule update --init --recursive

--- a/docs/dfx-json-schema.json
+++ b/docs/dfx-json-schema.json
@@ -222,6 +222,16 @@
                 "type": "string"
               }
             },
+            "build": {
+              "title": "Build Commands",
+              "description": "Commands that are executed in order to produce this canister's assets. Expected to produce assets in one of the paths specified by the 'source' field. Optional if there is no build necessary or the assets can be built using the default `npm run build` command.",
+              "default": [],
+              "allOf": [
+                {
+                  "$ref": "#/definitions/SerdeVec_for_String"
+                }
+              ]
+            },
             "type": {
               "type": "string",
               "enum": [

--- a/e2e/tests-dfx/frontend.bash
+++ b/e2e/tests-dfx/frontend.bash
@@ -81,3 +81,19 @@ teardown() {
     assert_command curl -vv http://localhost:"$PORT"/index.js?canisterId="$ID"
     assert_match "< x-key: x-value"
 }
+
+@test "dfx uses a custom build command if one is provided" {
+    jq '.canisters.dfx_test_frontend.source = ["dist/dfx_test_frontend/"]' dfx.json | sponge dfx.json
+    jq '.scripts["custom-build"] = "cp -r ./src/e2e_project_frontend/assets/ ./dist/e2e_project_frontend"' package.json | sponge package.json
+
+    dfx_start
+    dfx canister create --all
+    dfx build
+    dfx canister install --all
+
+    ID=$(dfx canister id e2e_project_frontend)
+    PORT=$(get_webserver_port)
+
+    assert_command curl -vv http://localhost:"$PORT"/sample-asset.txt?canisterId="$ID"
+    assert_match "This is a sample asset!"
+}

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -257,6 +257,13 @@ pub enum CanisterTypeProperties {
         /// # Asset Source Folder
         /// Folders from which assets are uploaded.
         source: Vec<PathBuf>,
+
+        /// # Build Commands
+        /// Commands that are executed in order to produce this canister's assets.
+        /// Expected to produce assets in one of the paths specified by the 'source' field.
+        /// Optional if there is no build necessary or the assets can be built using the default `npm run build` command.
+        #[schemars(default)]
+        build: SerdeVec<String>,
     },
     /// # Custom-Specific Properties
     Custom {
@@ -979,6 +986,7 @@ impl<'de> Visitor<'de> for PropertiesVisitor {
             },
             Some("assets") => CanisterTypeProperties::Assets {
                 source: source.ok_or_else(|| missing_field("source"))?,
+                build: build.unwrap_or_default(),
             },
             Some("custom") => CanisterTypeProperties::Custom {
                 build: build.unwrap_or_default(),

--- a/src/dfx/src/lib/builders/assets.rs
+++ b/src/dfx/src/lib/builders/assets.rs
@@ -7,6 +7,7 @@ use crate::lib::environment::Environment;
 use crate::lib::error::{BuildError, DfxError, DfxResult};
 use crate::lib::models::canister::CanisterPool;
 use crate::util;
+use console::style;
 use dfx_core::config::cache::Cache;
 use dfx_core::config::model::network_descriptor::NetworkDescriptor;
 
@@ -22,6 +23,10 @@ use std::sync::Arc;
 struct AssetsBuilderExtra {
     /// A list of canister names to use as dependencies.
     dependencies: Vec<CanisterId>,
+    /// A command to run to build this canister's assets. This is optional if
+    /// the canister does not have a frontend or can be built using the default
+    /// `npm run build` command.
+    build: Vec<String>,
 }
 
 impl AssetsBuilderExtra {
@@ -38,8 +43,13 @@ impl AssetsBuilderExtra {
                     )
             })
             .collect::<DfxResult<Vec<CanisterId>>>().with_context( || format!("Failed to collect dependencies (canister ids) of canister {}.", info.get_name()))?;
+        let info = info.as_info::<AssetsCanisterInfo>()?;
+        let build = info.get_build_tasks().to_owned();
 
-        Ok(AssetsBuilderExtra { dependencies })
+        Ok(AssetsBuilderExtra {
+            dependencies,
+            build,
+        })
     }
 }
 pub struct AssetsBuilder {
@@ -94,17 +104,10 @@ impl CanisterBuilder for AssetsBuilder {
         info: &CanisterInfo,
         config: &BuildConfig,
     ) -> DfxResult {
-        let dependencies = info.get_dependencies()
-            .iter()
-            .map(|name| {
-                pool.get_first_canister_with_name(name)
-                    .map(|c| c.canister_id())
-                    .map_or_else(
-                        || Err(anyhow!("A canister with the name '{}' was not found in the current project.", name.clone())),
-                        DfxResult::Ok,
-                    )
-            })
-            .collect::<DfxResult<Vec<CanisterId>>>().with_context( || format!("Failed to collect dependencies (canister ids) of canister {}.", info.get_name()))?;
+        let AssetsBuilderExtra {
+            build,
+            dependencies,
+        } = AssetsBuilderExtra::try_from(info, pool)?;
 
         let vars = super::get_and_write_environment_variables(
             info,
@@ -119,6 +122,7 @@ impl CanisterBuilder for AssetsBuilder {
             info.get_workspace_root(),
             &config.network_name,
             vars,
+            &build,
         )?;
 
         let assets_canister_info = info.as_info::<AssetsCanisterInfo>()?;
@@ -188,11 +192,31 @@ fn build_frontend(
     project_root: &Path,
     network_name: &str,
     vars: Vec<super::Env<'_>>,
+    build: &[String],
 ) -> DfxResult {
+    let custom_build_frontend = !build.is_empty();
     let build_frontend = project_root.join("package.json").exists();
-    // If there is not a package.json, we don't have a frontend and can quit early.
+    // If there is no package.json or custom build command, we don't have a frontend and can quit early.
 
-    if build_frontend {
+    if custom_build_frontend {
+        for command in build {
+            slog::info!(
+                logger,
+                r#"{} '{}'"#,
+                style("Executing").green().bold(),
+                command
+            );
+
+            // First separate everything as if it was read from a shell.
+            let args = shell_words::split(command)
+                .with_context(|| format!("Cannot parse command '{}'.", command))?;
+            // No commands, noop.
+            if !args.is_empty() {
+                super::run_command(args, &vars, project_root)
+                    .with_context(|| format!("Failed to run {}.", command))?;
+            }
+        }
+    } else if build_frontend {
         // Frontend build.
         slog::info!(logger, "Building frontend...");
         let mut cmd = std::process::Command::new("npm");

--- a/src/dfx/src/lib/builders/custom.rs
+++ b/src/dfx/src/lib/builders/custom.rs
@@ -4,7 +4,7 @@ use crate::lib::builders::{
 use crate::lib::canister_info::custom::CustomCanisterInfo;
 use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
-use crate::lib::error::{BuildError, DfxError, DfxResult};
+use crate::lib::error::DfxResult;
 use crate::lib::models::canister::CanisterPool;
 
 use crate::lib::wasm::file::is_wasm_format;
@@ -22,7 +22,6 @@ use slog::Logger;
 use std::fs;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 use url::Url;
 
 /// Set of extras that can be specified in the dfx.json.
@@ -141,7 +140,7 @@ impl CanisterBuilder for CustomBuilder {
                 .with_context(|| format!("Cannot parse command '{}'.", command))?;
             // No commands, noop.
             if !args.is_empty() {
-                run_command(args, &vars, info.get_workspace_root())
+                super::run_command(args, &vars, info.get_workspace_root())
                     .with_context(|| format!("Failed to run {}.", command))?;
             }
         }
@@ -204,36 +203,6 @@ impl CanisterBuilder for CustomBuilder {
         })?;
 
         Ok(output_idl_path)
-    }
-}
-
-fn run_command(args: Vec<String>, vars: &[super::Env<'_>], cwd: &Path) -> DfxResult<()> {
-    let (command_name, arguments) = args.split_first().unwrap();
-    let canonicalized = cwd
-        .join(command_name)
-        .canonicalize()
-        .or_else(|_| which::which(command_name))
-        .map_err(|_| anyhow!("Cannot find command or file {command_name}"))?;
-    let mut cmd = Command::new(&canonicalized);
-
-    cmd.args(arguments)
-        .current_dir(cwd)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
-
-    for (key, value) in vars {
-        cmd.env(key.as_ref(), value);
-    }
-
-    let output = cmd
-        .output()
-        .with_context(|| format!("Error executing custom build step {cmd:#?}"))?;
-    if output.status.success() {
-        Ok(())
-    } else {
-        Err(DfxError::new(BuildError::CustomToolError(
-            output.status.code(),
-        )))
     }
 }
 

--- a/src/dfx/src/lib/canister_info/assets.rs
+++ b/src/dfx/src/lib/canister_info/assets.rs
@@ -12,6 +12,7 @@ pub struct AssetsCanisterInfo {
 
     output_wasm_path: PathBuf,
     output_idl_path: PathBuf,
+    build: Vec<String>,
 }
 
 impl AssetsCanisterInfo {
@@ -23,6 +24,9 @@ impl AssetsCanisterInfo {
     }
     pub fn get_output_idl_path(&self) -> &Path {
         self.output_idl_path.as_path()
+    }
+    pub fn get_build_tasks(&self) -> &[String] {
+        &self.build
     }
 
     #[context("Failed to assert source paths.")]
@@ -49,17 +53,18 @@ impl AssetsCanisterInfo {
 }
 
 impl CanisterInfoFactory for AssetsCanisterInfo {
-    fn create(info: &CanisterInfo) -> DfxResult<AssetsCanisterInfo> {
+    fn create(info: &CanisterInfo) -> DfxResult<Self> {
         let input_root = info.get_workspace_root().to_path_buf();
         // If there are no "source" field, we just ignore this.
-        let source_paths = if let CanisterTypeProperties::Assets { source } = &info.type_specific {
-            source.clone()
-        } else {
-            bail!(
-                "Attempted to construct an assets canister from a type:{} canister config",
-                info.type_specific.name()
-            )
-        };
+        let (source_paths, build) =
+            if let CanisterTypeProperties::Assets { source, build } = info.type_specific.clone() {
+                (source, build.into_vec())
+            } else {
+                bail!(
+                    "Attempted to construct an assets canister from a type:{} canister config",
+                    info.type_specific.name()
+                )
+            };
 
         let output_root = info.get_output_root();
 
@@ -71,6 +76,7 @@ impl CanisterInfoFactory for AssetsCanisterInfo {
             source_paths,
             output_wasm_path,
             output_idl_path,
+            build,
         })
     }
 }


### PR DESCRIPTION
# Description

This PR adds the ability to provide a custom command when building assets canisters. If no command is provided, it will fallback to the current `npm run build` command.

# How Has This Been Tested?

I have tested this in my own project over the last week. I can also add e2e tests, but would like to gather feedback from the SDK team on this first since it's a new feature.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added e2e tests.
