### PR TITLE
chore: --disable-encryption is deprecated. Use --storage-mode in e2e

### DIFF
--- a/e2e/tests-dfx/create.bash
+++ b/e2e/tests-dfx/create.bash
@@ -133,7 +133,7 @@ teardown() {
 
 @test "create accepts --controller <controller> named parameter, with controller by identity name" {
     dfx_start
-    dfx identity new --disable-encryption alice
+    dfx identity new --storage-mode plaintext alice
     ALICE_PRINCIPAL=$(dfx identity get-principal --identity alice)
     
     
@@ -147,7 +147,7 @@ teardown() {
 
 @test "create accepts --controller <controller> named parameter, with controller by identity principal" {
     dfx_start
-    dfx identity new --disable-encryption alice
+    dfx identity new --storage-mode plaintext alice
     ALICE_PRINCIPAL=$(dfx identity get-principal --identity alice)
     ALICE_WALLET=$(dfx identity get-wallet --identity alice)
 
@@ -162,7 +162,7 @@ teardown() {
 
 @test "create accepts --controller <controller> named parameter, with controller by wallet principal" {
     dfx_start
-    dfx identity new --disable-encryption alice
+    dfx identity new --storage-mode plaintext alice
     ALICE_WALLET=$(dfx identity get-wallet --identity alice)
 
     assert_command dfx canister create --all --controller "${ALICE_WALLET}"
@@ -178,8 +178,8 @@ teardown() {
     # there is a different code path if the specified controller happens to be
     # the currently selected identity.
     dfx_start
-    dfx identity new --disable-encryption alice
-    dfx identity new --disable-encryption bob
+    dfx identity new --storage-mode plaintext alice
+    dfx identity new --storage-mode plaintext bob
     BOB_PRINCIPAL=$(dfx identity get-principal --identity bob)
 
     dfx identity use bob
@@ -196,8 +196,8 @@ teardown() {
 
 @test "create single controller accepts --controller <controller> named parameter, with controller by identity name" {
     dfx_start
-    dfx identity new --disable-encryption alice
-    dfx identity new --disable-encryption bob
+    dfx identity new --storage-mode plaintext alice
+    dfx identity new --storage-mode plaintext bob
     ALICE_PRINCIPAL=$(dfx identity get-principal --identity alice)
     BOB_PRINCIPAL=$(dfx identity get-principal --identity bob)
 
@@ -221,8 +221,8 @@ teardown() {
 
 @test "create canister with multiple controllers" {
     dfx_start
-    dfx identity new --disable-encryption alice
-    dfx identity new --disable-encryption bob
+    dfx identity new --storage-mode plaintext alice
+    dfx identity new --storage-mode plaintext bob
     ALICE_PRINCIPAL=$(dfx identity get-principal --identity alice)
     BOB_PRINCIPAL=$(dfx identity get-principal --identity bob)
     # awk step is to avoid trailing space
@@ -247,8 +247,8 @@ teardown() {
     use_wallet_wasm 0.7.2
 
     dfx_start
-    dfx identity new --disable-encryption alice
-    dfx identity new --disable-encryption bob
+    dfx identity new --storage-mode plaintext alice
+    dfx identity new --storage-mode plaintext bob
 
     assert_command_fail dfx canister create --all --controller alice --controller bob --identity alice
     assert_match "The wallet canister must be upgraded: The installed wallet does not support multiple controllers."

--- a/e2e/tests-dfx/ed25519.bash
+++ b/e2e/tests-dfx/ed25519.bash
@@ -14,7 +14,7 @@ teardown() {
 
 @test "can call a canister using an ed25519 identity" {
     install_asset ed25519
-    assert_command dfx identity import --disable-encryption ed25519 identity.pem
+    assert_command dfx identity import --storage-mode plaintext ed25519 identity.pem
     dfx_new # This installs replica and other binaries
     dfx identity use ed25519
     install_asset whoami

--- a/e2e/tests-dfx/error_context.bash
+++ b/e2e/tests-dfx/error_context.bash
@@ -44,7 +44,7 @@ teardown() {
 
     # can't write it?
     chmod u=r,go= "$E2E_SHARED_LOCAL_NETWORK_DATA_DIRECTORY/wallets.json"
-    assert_command dfx identity new --disable-encryption alice
+    assert_command dfx identity new --storage-mode plaintext alice
     assert_command_fail dfx identity get-wallet --identity alice
     assert_match "Failed to write to .*/local/wallets.json"
     assert_match "Permission denied"

--- a/e2e/tests-dfx/error_diagnosis.bash
+++ b/e2e/tests-dfx/error_diagnosis.bash
@@ -22,7 +22,7 @@ teardown() {
     assert_command dfx canister status hello_backend
 
     # create a non-controller ID
-    assert_command dfx identity new alice --disable-encryption
+    assert_command dfx identity new alice --storage-mode plaintext
     assert_command dfx identity use alice
 
     # calling canister status with different identity provokes HTTP 403
@@ -34,7 +34,7 @@ teardown() {
 @test "Instruct user to set a wallet" {
     dfx_new hello
     install_asset greet
-    assert_command dfx identity new alice --disable-encryption
+    assert_command dfx identity new alice --storage-mode plaintext
     assert_command dfx identity use alice
 
     # this will fail because no wallet is configured for alice on network ic

--- a/e2e/tests-dfx/identity.bash
+++ b/e2e/tests-dfx/identity.bash
@@ -18,7 +18,7 @@ teardown() {
 @test "identity get-principal: the get-principal is the same as sender id" {
     install_asset identity
     dfx_start
-    assert_command dfx identity new --disable-encryption jose
+    assert_command dfx identity new --storage-mode plaintext jose
 
     PRINCIPAL_ID=$(dfx identity get-principal --identity jose)
 
@@ -38,7 +38,7 @@ teardown() {
 @test "identity get-principal (anonymous): the get-principal is the same as sender id" {
     install_asset identity
     dfx_start
-    assert_command dfx identity new --disable-encryption jose
+    assert_command dfx identity new --storage-mode plaintext jose
 
     ANONYMOUS_PRINCIPAL_ID="2vxsx-fae"
 
@@ -108,8 +108,8 @@ teardown() {
 @test "after using a specific identity while creating a canister, that user is the initializer" {
     install_asset identity
     dfx_start
-    assert_command dfx identity new --disable-encryption alice
-    assert_command dfx identity new --disable-encryption bob
+    assert_command dfx identity new --storage-mode plaintext alice
+    assert_command dfx identity new --storage-mode plaintext bob
 
     dfx canister create --all --identity alice
     assert_command dfx build --identity alice
@@ -138,7 +138,7 @@ teardown() {
 @test "after renaming an identity, the renamed identity is still initializer" {
     install_asset identity
     dfx_start
-    assert_command dfx identity new --disable-encryption alice
+    assert_command dfx identity new --storage-mode plaintext alice
 
     dfx canister create --all --identity alice
     assert_command dfx build --identity alice
@@ -166,7 +166,7 @@ teardown() {
     assert_match "WARN: The default identity is not stored securely." "$stderr"
     assert_command "${BATS_TEST_DIRNAME}/../assets/expect_scripts/init_alice_with_pw.exp"
     assert_command "${BATS_TEST_DIRNAME}/../assets/expect_scripts/get_ledger_balance.exp"
-    dfx identity new bob --disable-encryption
+    dfx identity new bob --storage-mode plaintext
     assert_command dfx ledger balance --network ic --identity bob
     assert_match "WARN: The bob identity is not stored securely." "$stderr"
 }

--- a/e2e/tests-dfx/identity_command.bash
+++ b/e2e/tests-dfx/identity_command.bash
@@ -142,7 +142,7 @@ frank'
 }
 
 @test "identity new: key is compatible with openssl" {
-    assert_command dfx identity new --disable-encryption bob
+    assert_command dfx identity new --storage-mode plaintext bob
     assert_command openssl ec -in "$DFX_CONFIG_ROOT/.config/dfx/identity/bob/identity.pem"
 }
 
@@ -558,7 +558,7 @@ EOF
     [[ $stderr =~ $reg ]]
     echo "${BASH_REMATCH[1]}" >seed.txt
     principal=$(dfx identity get-principal --identity alice)
-    assert_command dfx identity import alice2 --seed-file seed.txt --disable-encryption
+    assert_command dfx identity import alice2 --seed-file seed.txt --storage-mode plaintext
     assert_command dfx identity get-principal --identity alice2
     assert_eq "$principal"
     dfx identity export alice2 > export.pem
@@ -568,7 +568,7 @@ EOF
 
 @test "identity: consistently imports a known seed phrase" {
     echo "display dawn estate night naive stomach receive lock expose boring square boy deposit mistake volume soldier coil rocket match diamond repair opinion action paddle">seed.txt
-    assert_command dfx identity import alice --seed-file seed.txt --disable-encryption
+    assert_command dfx identity import alice --seed-file seed.txt --storage-mode plaintext
     assert_command dfx identity get-principal --identity alice
     assert_eq "qimd7-lqrvx-kdvsm-7zeqn-bgoix-ukjfi-hgmfg-ur2he-odgb2-joms4-nae"
 }

--- a/e2e/tests-dfx/ledger.bash
+++ b/e2e/tests-dfx/ledger.bash
@@ -9,8 +9,8 @@ setup() {
     install_asset ledger
     install_shared_asset subnet_type/shared_network_settings/system
 
-    dfx identity import --disable-encryption alice alice.pem
-    dfx identity import --disable-encryption bob bob.pem
+    dfx identity import --storage-mode plaintext alice alice.pem
+    dfx identity import --storage-mode plaintext bob bob.pem
 
     dfx_start_for_nns_install
 

--- a/e2e/tests-dfx/network.bash
+++ b/e2e/tests-dfx/network.bash
@@ -5,7 +5,7 @@ load ../utils/_
 setup() {
     standard_setup
 
-    dfx identity new --disable-encryption test_id
+    dfx identity new --storage-mode plaintext test_id
     dfx identity use test_id
     dfx_new
 }

--- a/e2e/tests-dfx/nns.bash
+++ b/e2e/tests-dfx/nns.bash
@@ -142,7 +142,7 @@ assert_nns_canister_id_matches() {
 
     echo "    The secp256k1 account can be controlled from the command line"
     install_asset nns
-    dfx identity import --force --disable-encryption ident-1 ident-1/identity.pem
+    dfx identity import --force --storage-mode plaintext ident-1 ident-1/identity.pem
     assert_command dfx ledger account-id --identity ident-1
     assert_eq "$SECP256K1_ACCOUNT_ID"
 

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -19,7 +19,7 @@ teardown() {
     dfx_start
     setup_actuallylocal_shared_network
 
-    dfx identity new --disable-encryption alice
+    dfx identity new --storage-mode plaintext alice
 
     assert_command dfx deploy --network actuallylocal --identity alice
     assert_command dfx canister call remote write '("initial data in the remote canister")' --identity alice --network actuallylocal
@@ -98,7 +98,7 @@ teardown() {
     dfx_start
     setup_actuallylocal_shared_network
 
-    dfx identity new --disable-encryption alice
+    dfx identity new --storage-mode plaintext alice
 
     assert_command dfx deploy --network actuallylocal --identity alice
 
@@ -120,7 +120,7 @@ teardown() {
     dfx_start
     setup_actuallylocal_shared_network
 
-    dfx identity new --disable-encryption alice
+    dfx identity new --storage-mode plaintext alice
 
     assert_command dfx deploy --network actuallylocal --identity alice
 
@@ -146,7 +146,7 @@ teardown() {
     # Set up the "remote" canister, with a different controller in order to
     # demonstrate that we don't try to install/upgrade it as a remote canister.
     #
-    dfx identity new --disable-encryption alice
+    dfx identity new --storage-mode plaintext alice
 
     assert_command dfx deploy --network actuallylocal --identity alice
     assert_command dfx canister call remote write '("this is data in the remote canister")' --identity alice --network actuallylocal
@@ -215,7 +215,7 @@ teardown() {
     # Set up the "remote" canister, with a different controller in order to
     # demonstrate that we don't try to install/upgrade it as a remote canister.
     #
-    dfx identity new --disable-encryption alice
+    dfx identity new --storage-mode plaintext alice
 
     assert_command dfx deploy --network actuallylocal --identity alice
 
@@ -251,7 +251,7 @@ teardown() {
     # Set up the "remote" canister, with a different controller in order to
     # demonstrate that we don't try to install/upgrade it as a remote canister.
     #
-    dfx identity new --disable-encryption alice
+    dfx identity new --storage-mode plaintext alice
 
     assert_command dfx deploy --network actuallylocal --identity alice
     assert_command dfx canister call remote write '("this is data in the remote canister")' --network actuallylocal --identity alice

--- a/e2e/tests-dfx/shared_local_network.bash
+++ b/e2e/tests-dfx/shared_local_network.bash
@@ -131,7 +131,7 @@ teardown() {
 @test "dfx identity rename renames wallet for shared local network" {
      dfx_start
 
-     dfx identity new  alice --disable-encryption
+     dfx identity new  alice --storage-mode plaintext
      ALICE_WALLET="$(dfx identity get-wallet --identity alice)"
 
      dfx identity rename alice bob

--- a/e2e/tests-dfx/subcommands.bash
+++ b/e2e/tests-dfx/subcommands.bash
@@ -18,7 +18,7 @@ teardown() {
     install_asset whoami
     dfx_start
     dfx deploy
-    dfx identity new alice --disable-encryption
+    dfx identity new alice --storage-mode plaintext
     assert_command dfx --identity alice canister --network local call whoami whoami
     assert_match "$(dfx --identity alice identity get-principal)"
     assert_match "$(dfx identity get-principal --identity alice)"

--- a/e2e/tests-dfx/update_settings.bash
+++ b/e2e/tests-dfx/update_settings.bash
@@ -33,8 +33,8 @@ teardown() {
 
 @test "set controller" {
     # Create two identities
-    assert_command dfx identity new --disable-encryption alice
-    assert_command dfx identity new --disable-encryption bob
+    assert_command dfx identity new --storage-mode plaintext alice
+    assert_command dfx identity new --storage-mode plaintext bob
 
     assert_command dfx identity use alice
     
@@ -81,8 +81,8 @@ teardown() {
 
 @test "set controller with wallet" {
     # Create two identities
-    assert_command dfx identity new --disable-encryption alice
-    assert_command dfx identity new --disable-encryption bob
+    assert_command dfx identity new --storage-mode plaintext alice
+    assert_command dfx identity new --storage-mode plaintext bob
 
     assert_command dfx identity use alice
 
@@ -131,8 +131,8 @@ teardown() {
     use_wallet_wasm 0.7.2
 
     # Create two identities
-    assert_command dfx identity new --disable-encryption alice
-    assert_command dfx identity new --disable-encryption bob
+    assert_command dfx identity new --storage-mode plaintext alice
+    assert_command dfx identity new --storage-mode plaintext bob
 
     assert_command dfx identity use alice
 
@@ -180,8 +180,8 @@ teardown() {
 @test "set controller without wallet but using wallet 0.7.2" {
     use_wallet_wasm 0.7.2
     # Create two identities
-    assert_command dfx identity new --disable-encryption alice
-    assert_command dfx identity new --disable-encryption bob
+    assert_command dfx identity new --storage-mode plaintext alice
+    assert_command dfx identity new --storage-mode plaintext bob
 
     assert_command dfx identity use alice
     
@@ -230,8 +230,8 @@ teardown() {
 
 @test "set multiple controllers" {
     # Create two identities
-    assert_command dfx identity new --disable-encryption alice
-    assert_command dfx identity new --disable-encryption bob
+    assert_command dfx identity new --storage-mode plaintext alice
+    assert_command dfx identity new --storage-mode plaintext bob
 
     assert_command dfx identity use alice
 
@@ -259,8 +259,8 @@ teardown() {
 }
 
 @test "set multiple controllers with wallet" {
-    assert_command dfx identity new --disable-encryption alice
-    assert_command dfx identity new --disable-encryption bob
+    assert_command dfx identity new --storage-mode plaintext alice
+    assert_command dfx identity new --storage-mode plaintext bob
 
     assert_command dfx identity use alice
 
@@ -290,8 +290,8 @@ teardown() {
 @test "set multiple controllers even with wallet 0.7.2" {
     use_wallet_wasm 0.7.2
     # Create two identities
-    assert_command dfx identity new --disable-encryption alice
-    assert_command dfx identity new --disable-encryption bob
+    assert_command dfx identity new --storage-mode plaintext alice
+    assert_command dfx identity new --storage-mode plaintext bob
 
     assert_command dfx identity use alice
 
@@ -321,8 +321,8 @@ teardown() {
 @test "set multiple controllers without wallet but using wallet 0.7.2" {
     use_wallet_wasm 0.7.2
     # Create two identities
-    assert_command dfx identity new --disable-encryption alice
-    assert_command dfx identity new --disable-encryption bob
+    assert_command dfx identity new --storage-mode plaintext alice
+    assert_command dfx identity new --storage-mode plaintext bob
 
     assert_command dfx identity use alice
 
@@ -351,9 +351,9 @@ teardown() {
 }
 
 @test "add controller to existing canister" {
-    assert_command dfx identity new --disable-encryption alice
-    assert_command dfx identity new --disable-encryption bob
-    assert_command dfx identity new --disable-encryption charlie
+    assert_command dfx identity new --storage-mode plaintext alice
+    assert_command dfx identity new --storage-mode plaintext bob
+    assert_command dfx identity new --storage-mode plaintext charlie
 
     dfx identity use alice
     dfx_start
@@ -377,9 +377,9 @@ teardown() {
 }
 
 @test "add controller to all canisters" {
-    assert_command dfx identity new --disable-encryption alice
-    assert_command dfx identity new --disable-encryption bob 
-    assert_command dfx identity new --disable-encryption charlie
+    assert_command dfx identity new --storage-mode plaintext alice
+    assert_command dfx identity new --storage-mode plaintext bob 
+    assert_command dfx identity new --storage-mode plaintext charlie
 
     dfx identity use alice
     dfx_start

--- a/e2e/tests-dfx/usage_env.bash
+++ b/e2e/tests-dfx/usage_env.bash
@@ -14,7 +14,7 @@ teardown() {
     use_test_specific_cache_root   # Because this test depends on a clean cache state
 
     #identity
-    dfx identity new --disable-encryption alice
+    dfx identity new --storage-mode plaintext alice
     assert_command head "$DFX_CONFIG_ROOT/.config/dfx/identity/alice/identity.pem"
     assert_command head "$DFX_CONFIG_ROOT/.config/dfx/identity/default/identity.pem"
 
@@ -35,7 +35,7 @@ teardown() {
         unset DFX_CACHE_ROOT
         unset DFX_CONFIG_ROOT
 
-        dfx identity new --disable-encryption bob
+        dfx identity new --storage-mode plaintext bob
         assert_command head "$HOME/.config/dfx/identity/bob/identity.pem"
         assert_command head "$HOME/.config/dfx/identity/default/identity.pem"
 

--- a/e2e/tests-dfx/wallet.bash
+++ b/e2e/tests-dfx/wallet.bash
@@ -16,8 +16,8 @@ teardown() {
     dfx_new hello
     dfx_start
 
-    dfx identity new --disable-encryption alice
-    dfx identity new --disable-encryption bob
+    dfx identity new --storage-mode plaintext alice
+    dfx identity new --storage-mode plaintext bob
 
     use_wallet_wasm 0.7.0
     assert_command dfx identity get-wallet --identity alice
@@ -158,7 +158,7 @@ teardown() {
     assert_command dfx wallet balance
     assert_command dfx deploy --wallet "$WALLET"
     assert_command dfx canister call hello_backend greet '("")' --with-cycles 1 --wallet "$WALLET"
-    dfx identity new alice --disable-encryption
+    dfx identity new alice --storage-mode plaintext
     ALICE_WALLET=$(dfx identity get-wallet --identity alice)
     dfx wallet send "$ALICE_WALLET" 1
 }
@@ -166,7 +166,7 @@ teardown() {
 @test "dfx canister deposit-cycles succeeds on a canister the caller does not own" {
     dfx_new hello
     dfx_start
-    dfx identity new alice --disable-encryption
+    dfx identity new alice --storage-mode plaintext
     dfx deploy --no-wallet hello_backend --identity alice
     assert_command dfx canister deposit-cycles 1 hello_backend --wallet "$(dfx identity get-wallet)"
 }
@@ -191,7 +191,7 @@ teardown() {
     dfx deploy
     dfx ledger fabricate-cycles --canister faucet --t 1000
 
-    dfx identity new --disable-encryption faucet_testing
+    dfx identity new --storage-mode plaintext faucet_testing
     dfx identity use faucet_testing
 
     # prepare wallet to hand out


### PR DESCRIPTION
# Description

The `--disable-encryption` flag has been deprecated for a while in favour of `--storage-mode plaintext`. This updates e2e tests to use the new recommended way of creating plaintext identities

# How Has This Been Tested?

e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] ~I have edited the CHANGELOG accordingly.~
- [ ] ~I have made corresponding changes to the documentation.~
