### PR TITLE
chore: update Motoko to 0.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ The HttpResponse type now explicitly mentions the `upgrade : Option<bool>` field
 - https://github.com/dfinity/sdk/pull/3120
 - https://github.com/dfinity/sdk/pull/3112
 
+### Motoko
+
+Updated Motoko to 0.8.8
+
 # 0.14.0
 
 ## DFX

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -164,25 +164,25 @@
         "owner": "dfinity",
         "sha256": "039j55x0hknlhgy7x812f76nz6qsi2ld4svap5hw6kvx5pj43ksp",
         "type": "tarball",
-        "url": "https://github.com/dfinity/motoko/releases/download/0.8.7/motoko-base-library.tar.gz",
+        "url": "https://github.com/dfinity/motoko/releases/download/0.8.8/motoko-base-library.tar.gz",
         "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-base-library.tar.gz",
-        "version": "0.8.7"
+        "version": "0.8.8"
     },
     "motoko-x86_64-darwin": {
         "builtin": false,
-        "sha256": "1pv85b9c7xgmnb9vzvh36wlhghbh15aa3qn5sk5zp4laykgalvd2",
+        "sha256": "003mp2a4llzpq22fq64ivpjqynijyvcmjy9m0fxnpbk08jv2yjik",
         "type": "file",
-        "url": "https://github.com/dfinity/motoko/releases/download/0.8.7/motoko-macos-0.8.7.tar.gz",
+        "url": "https://github.com/dfinity/motoko/releases/download/0.8.8/motoko-macos-0.8.8.tar.gz",
         "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-macos-<version>.tar.gz",
-        "version": "0.8.7"
+        "version": "0.8.8"
     },
     "motoko-x86_64-linux": {
         "builtin": false,
-        "sha256": "1si1mr0xckhgvaqyzly9w3ys8r89bbhy1i1jnyk3bsp7frjjp670",
+        "sha256": "05826d775yjiqvi5bam9qfw4xygafyqzf6wfdcyqj6wbm7a6lgdk",
         "type": "file",
-        "url": "https://github.com/dfinity/motoko/releases/download/0.8.7/motoko-linux64-0.8.7.tar.gz",
+        "url": "https://github.com/dfinity/motoko/releases/download/0.8.8/motoko-linux64-0.8.8.tar.gz",
         "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-linux64-<version>.tar.gz",
-        "version": "0.8.7"
+        "version": "0.8.8"
     },
     "replica-x86_64-darwin": {
         "builtin": false,

--- a/src/dfx/assets/dfx-asset-sources.toml
+++ b/src/dfx/assets/dfx-asset-sources.toml
@@ -30,8 +30,8 @@ url = 'https://download.dfinity.systems/ic/21aa2ba29bf97115aa3cdedecf0655d0cfa64
 sha256 = 'ba4f6a2a54902196f7e729fd03c79f7a5930942f6c66575095f78a02cfbc1c31'
 
 [x86_64-darwin.motoko]
-url = 'https://github.com/dfinity/motoko/releases/download/0.8.7/motoko-macos-0.8.7.tar.gz'
-sha256 = 'a26daadef48a92fbcbd4c5e2a1540970c107293703eebfd3b2f5f5c3d22a68df'
+url = 'https://github.com/dfinity/motoko/releases/download/0.8.8/motoko-macos-0.8.8.tar.gz'
+sha256 = '334a2fb64460ae6bbb03357959d9f6325a8fe5dd9118ec84c0f7534a94b87500'
 # The replica and canister_sandbox binaries must have the same revision.
 
 [x86_64-darwin.replica]
@@ -52,8 +52,8 @@ url = 'https://download.dfinity.systems/ic/21aa2ba29bf97115aa3cdedecf0655d0cfa64
 sha256 = 'ea61ce090e644fba6e488686e59c78dfdfcce12cf57eb17cbbb458d32bac99d8'
 
 [x86_64-darwin.motoko-base]
-url = 'https://github.com/dfinity/motoko/releases/download/0.8.7/motoko-base-library.tar.gz'
-sha256 = '5c5dfb1ab1a7edddcb6276c9652d418b5ef4210a7635db2ee6dde3a8ab68902e'
+url = 'https://github.com/dfinity/motoko/releases/download/0.8.8/motoko-base-library.tar.gz'
+sha256 = '8985f6c876d2afb88a8f3b73a1a97427a9023356da4a0fd8860a29eebe792164'
 
 [x86_64-darwin.ic-btc-canister]
 url = 'https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2023-03-31/ic-btc-canister.wasm.gz'
@@ -88,8 +88,8 @@ url = 'https://download.dfinity.systems/ic/21aa2ba29bf97115aa3cdedecf0655d0cfa64
 sha256 = 'fd9873f2e90b3ee04d9f7fffb0f8d3a9a041aa987b075daa3ef4d4091734ed19'
 
 [x86_64-linux.motoko]
-url = 'https://github.com/dfinity/motoko/releases/download/0.8.7/motoko-linux64-0.8.7.tar.gz'
-sha256 = 'e0982b6576e7ea35a6b732c4e0e15a0965a4fde0c9d3efb1da0f4ed641ae21ea'
+url = 'https://github.com/dfinity/motoko/releases/download/0.8.8/motoko-linux64-0.8.8.tar.gz'
+sha256 = 'b33d6ad4a98b1b893d6b8e1bf7b177eaf94eb8c3a9aa55e2c651fa724e330215'
 # The replica and canister_sandbox binaries must have the same revision.
 
 [x86_64-linux.replica]
@@ -110,8 +110,8 @@ url = 'https://download.dfinity.systems/ic/21aa2ba29bf97115aa3cdedecf0655d0cfa64
 sha256 = '4ad5cf14d220a1036ed0abc3bf28eeb48c1bb146eef58a7ed00aa71f5e90bd6f'
 
 [x86_64-linux.motoko-base]
-url = 'https://github.com/dfinity/motoko/releases/download/0.8.7/motoko-base-library.tar.gz'
-sha256 = '5c5dfb1ab1a7edddcb6276c9652d418b5ef4210a7635db2ee6dde3a8ab68902e'
+url = 'https://github.com/dfinity/motoko/releases/download/0.8.8/motoko-base-library.tar.gz'
+sha256 = '8985f6c876d2afb88a8f3b73a1a97427a9023356da4a0fd8860a29eebe792164'
 
 [x86_64-linux.ic-btc-canister]
 url = 'https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2023-03-31/ic-btc-canister.wasm.gz'


### PR DESCRIPTION
# Description

Motoko 0.8.8 is ready for inclusion in dfx.

# How Has This Been Tested?

e2e
# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
