### PR TITLE
refactor: move try_create_canister from commands/deps to lib/deps

### DIFF
--- a/src/dfx/src/lib/deps/deploy.rs
+++ b/src/dfx/src/lib/deps/deploy.rs
@@ -1,0 +1,34 @@
+use crate::lib::error::DfxResult;
+use crate::lib::state_tree::canister_info::read_state_tree_canister_controllers;
+
+use anyhow::bail;
+use candid::Principal;
+use fn_error_context::context;
+use ic_agent::Agent;
+use ic_utils::interfaces::ManagementCanister;
+use slog::{info, Logger};
+
+// not use operations::canister::create_canister because we don't want to modify canister_id_store
+#[context("Failed to create canister {}", canister_id)]
+pub async fn try_create_canister(
+    agent: &Agent,
+    logger: &Logger,
+    canister_id: &Principal,
+    canister_prompt: &str,
+) -> DfxResult {
+    match read_state_tree_canister_controllers(agent, *canister_id).await? {
+        Some(cs) if cs.len() == 1 && cs[0] == Principal::anonymous() => Ok(()),
+        Some(_) => {
+            bail!("Canister {canister_id} has been created before and its controller is not the anonymous identity. Please stop and delete it and then deploy again.");
+        }
+        None => {
+            let mgr = ManagementCanister::create(agent);
+            info!(logger, "Creating canister: {canister_prompt}");
+            mgr.create_canister()
+                .as_provisional_create_with_specified_id(*canister_id)
+                .call_and_wait()
+                .await?;
+            Ok(())
+        }
+    }
+}

--- a/src/dfx/src/lib/deps/mod.rs
+++ b/src/dfx/src/lib/deps/mod.rs
@@ -1,3 +1,5 @@
+pub mod deploy;
+
 use crate::lib::{environment::Environment, error::DfxResult};
 use dfx_core::{
     config::cache::get_cache_root,


### PR DESCRIPTION
# Description

Moving this method into lib/deps in order to call it from other code/commands

# How Has This Been Tested?

Covered by CI
