### PR TITLE
refactor: actor threads: break out of loop

### DIFF
--- a/src/dfx/src/actors/btc_adapter.rs
+++ b/src/dfx/src/actors/btc_adapter.rs
@@ -179,8 +179,7 @@ fn btc_adapter_start_thread(
         cmd.stdout(std::process::Stdio::inherit());
         cmd.stderr(std::process::Stdio::inherit());
 
-        let mut done = false;
-        while !done {
+        loop {
             if let Some(socket_path) = &config.socket_path {
                 if socket_path.exists() {
                     std::fs::remove_file(socket_path).expect("Could not remove btc-adapter socket");
@@ -208,7 +207,7 @@ fn btc_adapter_start_thread(
                     debug!(logger, "Got signal to stop. Killing btc-adapter process...");
                     let _ = child.kill();
                     let _ = child.wait();
-                    done = true;
+                    break;
                 }
                 ChildOrReceiver::Child => {
                     debug!(logger, "ic-btc-adapter process failed.");

--- a/src/dfx/src/actors/canister_http_adapter.rs
+++ b/src/dfx/src/actors/canister_http_adapter.rs
@@ -184,8 +184,7 @@ fn canister_http_adapter_start_thread(
         cmd.stdout(std::process::Stdio::inherit());
         cmd.stderr(std::process::Stdio::inherit());
 
-        let mut done = false;
-        while !done {
+        loop {
             if let Some(socket_path) = &config.socket_path {
                 if socket_path.exists() {
                     std::fs::remove_file(socket_path)
@@ -217,7 +216,7 @@ fn canister_http_adapter_start_thread(
                     );
                     let _ = child.kill();
                     let _ = child.wait();
-                    done = true;
+                    break;
                 }
                 ChildOrReceiver::Child => {
                     debug!(logger, "ic-canister-http-adapter process failed.");

--- a/src/dfx/src/actors/emulator.rs
+++ b/src/dfx/src/actors/emulator.rs
@@ -200,8 +200,7 @@ fn emulator_start_thread(
         cmd.stdout(std::process::Stdio::inherit());
         cmd.stderr(std::process::Stdio::inherit());
 
-        let mut done = false;
-        while !done {
+        loop {
             let _ = std::fs::remove_file(&config.write_port_to);
             let last_start = std::time::Instant::now();
             debug!(logger, "Starting emulator...");
@@ -217,7 +216,7 @@ fn emulator_start_thread(
                     debug!(logger, "Got signal to stop. Killing emulator process...");
                     let _ = child.kill();
                     let _ = child.wait();
-                    done = true;
+                    break;
                 }
                 ChildOrReceiver::Child => {
                     debug!(logger, "Emulator process failed.");

--- a/src/dfx/src/actors/icx_proxy.rs
+++ b/src/dfx/src/actors/icx_proxy.rs
@@ -212,8 +212,7 @@ fn icx_proxy_start_thread(
         cmd.stdout(std::process::Stdio::inherit());
         cmd.stderr(std::process::Stdio::inherit());
 
-        let mut done = false;
-        while !done {
+        loop {
             let last_start = std::time::Instant::now();
             debug!(logger, "Starting icx-proxy...");
             let mut child = cmd.spawn().expect("Could not start icx-proxy.");
@@ -230,7 +229,7 @@ fn icx_proxy_start_thread(
                     debug!(logger, "Got signal to stop. Killing icx-proxy process...");
                     let _ = child.kill();
                     let _ = child.wait();
-                    done = true;
+                    break;
                 }
                 ChildOrReceiver::Child => {
                     debug!(logger, "icx-proxy process failed.");

--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -348,8 +348,7 @@ fn replica_start_thread(
         cmd.stdout(std::process::Stdio::inherit());
         cmd.stderr(std::process::Stdio::inherit());
 
-        let mut done = false;
-        while !done {
+        loop {
             if let Some(port_path) = write_port_to.as_ref() {
                 let _ = std::fs::remove_file(port_path);
             }
@@ -388,7 +387,7 @@ fn replica_start_thread(
                     debug!(logger, "Got signal to stop. Killing replica process...");
                     let _ = child.kill();
                     let _ = child.wait();
-                    done = true;
+                    break;
                 }
                 ChildOrReceiver::Child => {
                     debug!(logger, "Replica process failed.");


### PR DESCRIPTION
# Description

No need for a `mut bool` when we can break directly out of the loop.

# How Has This Been Tested?

Manually by pressing Ctrl-C after `dfx start`

