### PR TITLE
fix: Update URL for Candid UI

### DIFF
--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -273,7 +273,7 @@ fn construct_ui_canister_url(
 ) -> DfxResult<Option<Url>> {
     if network.is_ic {
         let url = format!(
-            "https://{}.raw.icp0.io/?id={}",
+            "https://{}.raw.ic0.app/?id={}",
             MAINNET_CANDID_INTERFACE_PRINCIPAL, canister_id
         );
         let url = Url::parse(&url).with_context(|| {


### PR DESCRIPTION
# Description

This fixes an issue where the candid UI should have `ic0.app`, but the SDK is telling users that Candid UI has `icp0.io` domain.
