### PR TITLE
fix: dfx start will restart replica if it does not report healthy after launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ Removing oneself (or the wallet one uses) can result in the loss of control over
 Therefore `dfx canister update-settings` now asks for extra confirmation when removing the currently used principal/wallet from the list of controllers.
 To skip this check in CI, use either the `--yes`/`-y` argument or use `echo "yes" | dfx canister update-settings <...>`.
 
+### fix: dfx start will restart replica if it does not report healthy after launch
+
+If the replica does not report healthy at least once after launch,
+dfx will terminate and restart it.
+
 ## Asset Canister Synchronization
 
 Added more detailed logging to `ic-asset`. Now, when running `dfx deploy -v` (or `-vv`), the following information will be printed:


### PR DESCRIPTION
# Description

This was almost a refactor, but it can change the behavior in a subtle way.

Previously, if the replica never reported healthy, `dfx start` would display a `panic!`, and not display the Dashboard URL, but would otherwise continue.

Now, if the replica doesn't report healthy within one minute of starting, dfx will terminate the replica process and try again.  Ctrl-C can still abort this process (cause dfx to exit).  I don't expect that this will result in a healthy replica, but who knows?

The motivation for this change: I want to add more "initialization" type steps that happen after launching the replica, such as installing the bitcoin canister.  This will consist of calling one or more `async fn`.  This provides a place to do it.

Further context: I have some work-in-progress that reworks the replica actor to no longer use a separate thread to manage the replica process.  I think it will eventually be nicer (and more correct) than what we have now, but I don't want to hold up the work of updating the replica.

# How Has This Been Tested?

Manually, though there are also some CI tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
