### PR TITLE
feat: install bitcoin canister when bitcoin support is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ To skip this check in CI, use either the `--yes`/`-y` argument or use `echo "yes
 If the replica does not report healthy at least once after launch,
 dfx will terminate and restart it.
 
+### fix: dfx start now installs the bitcoin canister when bitcoin support is enabled
+
+This is required for future replica versions.
+
+Adds a new field `canister_init_arg` to the bitcoin configuration in dfx.json and networks.json.  Its default is documented in the JSON schema and is appropriate for the canister wasm bundled with dfx.
+
 ## Asset Canister Synchronization
 
 Added more detailed logging to `ic-asset`. Now, when running `dfx deploy -v` (or `-vv`), the following information will be printed:

--- a/docs/dfx-json-schema.json
+++ b/docs/dfx-json-schema.json
@@ -532,6 +532,12 @@
       "title": "Bitcoin Adapter Configuration",
       "type": "object",
       "properties": {
+        "canister_init_arg": {
+          "title": "Initialization Argument",
+          "description": "The initialization argument for the bitcoin canister.",
+          "default": "(record { stability_threshold = 0 : nat; network = variant { regtest }; blocks_source = principal \"aaaaa-aa\"; fees = record { get_utxos_base = 0 : nat; get_utxos_cycles_per_ten_instructions = 0 : nat; get_utxos_maximum = 0 : nat; get_balance = 0 : nat; get_balance_maximum = 0 : nat; get_current_fee_percentiles = 0 : nat; get_current_fee_percentiles_maximum = 0 : nat;  send_transaction_base = 0 : nat; send_transaction_per_byte = 0 : nat; }; syncing = variant { enabled }; api_access = variant { enabled }; disable_api_if_not_fully_synced = variant { enabled }})",
+          "type": "string"
+        },
         "enabled": {
           "title": "Enable Bitcoin Adapter",
           "default": false,

--- a/docs/networks-json-schema.json
+++ b/docs/networks-json-schema.json
@@ -22,6 +22,12 @@
       "title": "Bitcoin Adapter Configuration",
       "type": "object",
       "properties": {
+        "canister_init_arg": {
+          "title": "Initialization Argument",
+          "description": "The initialization argument for the bitcoin canister.",
+          "default": "(record { stability_threshold = 0 : nat; network = variant { regtest }; blocks_source = principal \"aaaaa-aa\"; fees = record { get_utxos_base = 0 : nat; get_utxos_cycles_per_ten_instructions = 0 : nat; get_utxos_maximum = 0 : nat; get_balance = 0 : nat; get_balance_maximum = 0 : nat; get_current_fee_percentiles = 0 : nat; get_current_fee_percentiles_maximum = 0 : nat;  send_transaction_base = 0 : nat; send_transaction_per_byte = 0 : nat; }; syncing = variant { enabled }; api_access = variant { enabled }; disable_api_if_not_fully_synced = variant { enabled }})",
+          "type": "string"
+        },
         "enabled": {
           "title": "Enable Bitcoin Adapter",
           "default": false,

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -4,6 +4,8 @@ load ../utils/_
 
 # All tests in this file are skipped for ic-ref.  See scripts/workflows/e2e-matrix.py
 
+BITCOIN_CANISTER_ID="g4xu7-jiaaa-aaaan-aaaaq-cai"
+
 setup() {
     standard_setup
 
@@ -157,6 +159,16 @@ set_local_network_bitcoin_enabled() {
     dfx_start --enable-bitcoin
 
     assert_file_not_empty "$E2E_SHARED_LOCAL_NETWORK_DATA_DIRECTORY/ic-btc-adapter-pid"
+}
+
+@test "dfx start --enable-bitcoin --background waits until bitcoin canister is installed" {
+    dfx_new hello
+
+    dfx_start --enable-bitcoin
+
+    assert_command dfx canister info "$BITCOIN_CANISTER_ID"
+    assert_contains "Controllers: 2vxsx-fae"
+    assert_contains "Module hash: 0x"
 }
 
 @test "dfx replica --enable-bitcoin with no other configuration succeeds" {

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -384,8 +384,21 @@ pub struct ConfigDefaultsBitcoin {
 
     /// # Logging Level
     /// The logging level of the adapter.
-    #[serde(default)]
+    #[serde(default = "default_bitcoin_log_level")]
     pub log_level: BitcoinAdapterLogLevel,
+
+    /// # Initialization Argument
+    /// The initialization argument for the bitcoin canister.
+    #[serde(default = "default_bitcoin_canister_init_arg")]
+    pub canister_init_arg: String,
+}
+
+pub fn default_bitcoin_log_level() -> BitcoinAdapterLogLevel {
+    BitcoinAdapterLogLevel::Info
+}
+
+pub fn default_bitcoin_canister_init_arg() -> String {
+    "(record { stability_threshold = 0 : nat; network = variant { regtest }; blocks_source = principal \"aaaaa-aa\"; fees = record { get_utxos_base = 0 : nat; get_utxos_cycles_per_ten_instructions = 0 : nat; get_utxos_maximum = 0 : nat; get_balance = 0 : nat; get_balance_maximum = 0 : nat; get_current_fee_percentiles = 0 : nat; get_current_fee_percentiles_maximum = 0 : nat;  send_transaction_base = 0 : nat; send_transaction_per_byte = 0 : nat; }; syncing = variant { enabled }; api_access = variant { enabled }; disable_api_if_not_fully_synced = variant { enabled }})".to_string()
 }
 
 impl Default for ConfigDefaultsBitcoin {
@@ -393,7 +406,8 @@ impl Default for ConfigDefaultsBitcoin {
         ConfigDefaultsBitcoin {
             enabled: false,
             nodes: None,
-            log_level: BitcoinAdapterLogLevel::Info,
+            log_level: default_bitcoin_log_level(),
+            canister_init_arg: default_bitcoin_canister_init_arg(),
         }
     }
 }

--- a/src/dfx-core/src/network/provider.rs
+++ b/src/dfx-core/src/network/provider.rs
@@ -690,7 +690,8 @@ mod tests {
             &ConfigDefaultsBitcoin {
                 enabled: true,
                 nodes: Some(vec![SocketAddr::from_str("127.0.0.1:18444").unwrap()]),
-                log_level: BitcoinAdapterLogLevel::Info
+                log_level: BitcoinAdapterLogLevel::Info,
+                ..ConfigDefaultsBitcoin::default()
             }
         );
     }
@@ -732,7 +733,8 @@ mod tests {
             &ConfigDefaultsBitcoin {
                 enabled: true,
                 nodes: Some(vec![SocketAddr::from_str("127.0.0.1:18444").unwrap()]),
-                log_level: BitcoinAdapterLogLevel::Info // A default log level of "info" is assumed
+                log_level: BitcoinAdapterLogLevel::Info, // A default log level of "info" is assumed
+                ..ConfigDefaultsBitcoin::default()
             }
         );
     }
@@ -773,8 +775,8 @@ mod tests {
             bitcoin_config,
             &ConfigDefaultsBitcoin {
                 enabled: true,
-                nodes: None,
-                log_level: BitcoinAdapterLogLevel::Debug
+                log_level: BitcoinAdapterLogLevel::Debug,
+                ..ConfigDefaultsBitcoin::default()
             }
         );
     }
@@ -815,7 +817,8 @@ mod tests {
             &ConfigDefaultsBitcoin {
                 enabled: true,
                 nodes: Some(vec![SocketAddr::from_str("127.0.0.1:18444").unwrap()]),
-                log_level: BitcoinAdapterLogLevel::Info
+                log_level: BitcoinAdapterLogLevel::Info,
+                ..ConfigDefaultsBitcoin::default()
             }
         );
     }

--- a/src/dfx/src/actors/mod.rs
+++ b/src/dfx/src/actors/mod.rs
@@ -6,7 +6,7 @@ use crate::actors::canister_http_adapter::CanisterHttpAdapter;
 use crate::actors::emulator::Emulator;
 use crate::actors::icx_proxy::signals::PortReadySubscribe;
 use crate::actors::icx_proxy::{IcxProxy, IcxProxyConfig};
-use crate::actors::replica::Replica;
+use crate::actors::replica::{BitcoinIntegrationConfig, Replica};
 use crate::actors::shutdown_controller::ShutdownController;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
@@ -166,9 +166,17 @@ pub fn start_replica_actor(
     setup_replica_env(local_server_descriptor, &replica_config)?;
     let replica_pid_path = local_server_descriptor.replica_pid_path();
 
+    let bitcoin_integration_config = if local_server_descriptor.bitcoin.enabled {
+        let canister_init_arg = local_server_descriptor.bitcoin.canister_init_arg.clone();
+        Some(BitcoinIntegrationConfig { canister_init_arg })
+    } else {
+        None
+    };
+
     let actor_config = replica::Config {
         ic_starter_path,
         replica_config,
+        bitcoin_integration_config,
         replica_path,
         shutdown_controller,
         logger: Some(env.get_logger().clone()),

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -243,8 +243,8 @@ pub fn exec(
                 fg_ping_and_wait(
                     &webserver_port_path,
                     &frontend_url,
-                    &env.get_logger(),
-                    &local_server_descriptor,
+                    env.get_logger(),
+                    local_server_descriptor,
                 )
                 .await
             });

--- a/src/dfx/src/lib/integrations/bitcoin.rs
+++ b/src/dfx/src/lib/integrations/bitcoin.rs
@@ -1,0 +1,41 @@
+use crate::actors::replica::BitcoinIntegrationConfig;
+use crate::lib::error::DfxResult;
+use crate::lib::integrations::initialize_integration_canister;
+use crate::util::assets::bitcoin_wasm;
+
+use candid::Principal;
+use fn_error_context::context;
+use ic_agent::Agent;
+use slog::{debug, Logger};
+
+pub const MAINNET_BITCOIN_CANISTER_ID: Principal =
+    Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x01, 0xA0, 0x00, 0x01, 0x01, 0x01]);
+
+#[context("Failed to initialize bitcoin canister")]
+pub async fn initialize_bitcoin_canister(
+    agent: &Agent,
+    logger: &Logger,
+    bitcoin_integration_config: BitcoinIntegrationConfig,
+) -> DfxResult {
+    debug!(logger, "Initializing bitcoin canister");
+
+    let name = "bitcoin integration";
+    let canister_id = MAINNET_BITCOIN_CANISTER_ID;
+    let wasm = bitcoin_wasm(logger)?;
+    let init_arg = &bitcoin_integration_config.canister_init_arg;
+
+    initialize_integration_canister(agent, logger, name, canister_id, &wasm, init_arg).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bitcoin_canister_id() {
+        assert_eq!(
+            MAINNET_BITCOIN_CANISTER_ID,
+            Principal::from_text("g4xu7-jiaaa-aaaan-aaaaq-cai").unwrap()
+        );
+    }
+}

--- a/src/dfx/src/lib/integrations/mod.rs
+++ b/src/dfx/src/lib/integrations/mod.rs
@@ -1,0 +1,103 @@
+use crate::lib::deps::deploy::try_create_canister;
+use crate::lib::deps::PulledCanister;
+use crate::lib::environment::create_agent;
+use crate::lib::error::DfxResult;
+use crate::lib::state_tree::canister_info::read_state_tree_canister_module_hash;
+use crate::util::{blob_from_arguments, expiry_duration};
+use dfx_core::error::root_key::FetchRootKeyError;
+use dfx_core::identity::Identity;
+
+use anyhow::bail;
+use candid::Principal;
+use fn_error_context::context;
+use ic_agent::Agent;
+use ic_utils::interfaces::management_canister::builders::InstallMode;
+use ic_utils::interfaces::ManagementCanister;
+use sha2::Digest;
+use slog::{debug, info, Logger};
+use std::time::Duration;
+
+pub mod bitcoin;
+pub mod status;
+
+pub async fn create_integrations_agent(url: &str, logger: &Logger) -> DfxResult<Agent> {
+    let timeout = expiry_duration();
+    let identity = Box::new(Identity::anonymous());
+    let agent = create_agent(logger.clone(), &url, identity, timeout).unwrap();
+    agent
+        .fetch_root_key()
+        .await
+        .map_err(FetchRootKeyError::AgentError)?;
+    Ok(agent)
+}
+#[context("Failed to install {name} integration canister {canister_id}")]
+pub async fn initialize_integration_canister(
+    agent: &Agent,
+    logger: &Logger,
+    name: &str,
+    canister_id: Principal,
+    wasm: &[u8],
+    init_arg: &str,
+) -> DfxResult {
+    if already_installed(agent, &canister_id, wasm).await? {
+        debug!(logger, "Canister {canister_id} already installed");
+        return Ok(());
+    }
+
+    let pulled_canister = PulledCanister {
+        name: Some(name.to_string()),
+        ..Default::default()
+    };
+    try_create_canister(agent, logger, &canister_id, &pulled_canister).await?;
+
+    let install_arg = blob_from_arguments(Some(init_arg), None, None, &None)?;
+    install_canister(agent, logger, &canister_id, wasm, install_arg, name).await
+}
+
+#[context("Failed to install canister {canister_id}")]
+async fn install_canister(
+    agent: &Agent,
+    logger: &Logger,
+    canister_id: &Principal,
+    wasm: &[u8],
+    install_args: Vec<u8>,
+    name: &str,
+) -> DfxResult {
+    info!(logger, "Installing canister: {name}");
+    ManagementCanister::create(agent)
+        .install_code(canister_id, wasm)
+        // always reinstall pulled canister
+        .with_mode(InstallMode::Reinstall)
+        .with_raw_arg(install_args)
+        .call_and_wait()
+        .await?;
+    Ok(())
+}
+
+#[context("Failed to determine if canister {canister_id} is already installed")]
+async fn already_installed(agent: &Agent, canister_id: &Principal, wasm: &[u8]) -> DfxResult<bool> {
+    let installed_module_hash = read_state_tree_canister_module_hash(agent, *canister_id).await?;
+    let expected_module_hash: [u8; 32] = sha2::Sha256::digest(wasm).into();
+    let result = matches!(installed_module_hash, Some(hash) if hash == expected_module_hash);
+
+    Ok(result)
+}
+
+#[context("Failed to wait until canister {canister_id} is installed")]
+pub async fn wait_for_canister_installed(agent: &Agent, canister_id: &Principal) -> DfxResult {
+    let mut retries = 0;
+    loop {
+        if read_state_tree_canister_module_hash(agent, *canister_id)
+            .await?
+            .is_some()
+        {
+            break;
+        }
+        if retries >= 60 {
+            bail!("Canister {canister_id} was never installed");
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        retries += 1;
+    }
+    Ok(())
+}

--- a/src/dfx/src/lib/integrations/mod.rs
+++ b/src/dfx/src/lib/integrations/mod.rs
@@ -23,7 +23,7 @@ pub mod status;
 pub async fn create_integrations_agent(url: &str, logger: &Logger) -> DfxResult<Agent> {
     let timeout = expiry_duration();
     let identity = Box::new(Identity::anonymous());
-    let agent = create_agent(logger.clone(), &url, identity, timeout).unwrap();
+    let agent = create_agent(logger.clone(), url, identity, timeout).unwrap();
     agent
         .fetch_root_key()
         .await

--- a/src/dfx/src/lib/integrations/status.rs
+++ b/src/dfx/src/lib/integrations/status.rs
@@ -1,0 +1,24 @@
+use crate::lib::error::DfxResult;
+use crate::lib::integrations::bitcoin::MAINNET_BITCOIN_CANISTER_ID;
+use crate::lib::integrations::{create_integrations_agent, wait_for_canister_installed};
+use dfx_core::config::model::local_server_descriptor::LocalServerDescriptor;
+
+use slog::Logger;
+
+pub async fn wait_for_integrations_initialized(
+    agent_url: &str,
+    logger: &Logger,
+    local_server_descriptor: &LocalServerDescriptor,
+) -> DfxResult {
+    if !local_server_descriptor.bitcoin.enabled {
+        return Ok(());
+    }
+
+    let agent = create_integrations_agent(agent_url, logger).await?;
+
+    if local_server_descriptor.bitcoin.enabled {
+        wait_for_canister_installed(&agent, &MAINNET_BITCOIN_CANISTER_ID).await?;
+    }
+
+    Ok(())
+}

--- a/src/dfx/src/lib/mod.rs
+++ b/src/dfx/src/lib/mod.rs
@@ -12,6 +12,7 @@ pub mod ic_attributes;
 pub mod identity;
 pub mod info;
 pub mod installers;
+pub mod integrations;
 pub mod ledger_types;
 pub mod logger;
 pub mod manifest;


### PR DESCRIPTION
# Description

When bitcoin support is enabled, `dfx start` now deploys the bitcoin canister.

This PR doesn't update the replica version or `remove code from ic-starter that enables the bitcoin feature` as mentioned in the ticket.  However, once merged, it should make both of those tasks possible, for example in  https://github.com/dfinity/sdk/pull/3074 or a similar PR.

Part of https://dfinity.atlassian.net/browse/SDK-1037

# How Has This Been Tested?

Added an e2e test and tested manually with `dfx-wip -v -v start --clean --enable-bitcoin` and `dfx-wip -v -v start --clean --enable-bitcoin --background`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
