### PR TITLE
fix: no longer enable the bitcoin_regtest feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ This is required for future replica versions.
 
 Adds a new field `canister_init_arg` to the bitcoin configuration in dfx.json and networks.json.  Its default is documented in the JSON schema and is appropriate for the canister wasm bundled with dfx.
 
+### fix: no longer enable the bitcoin_regtest feature
+
 ## Asset Canister Synchronization
 
 Added more detailed logging to `ic-asset`. Now, when running `dfx deploy -v` (or `-vv`), the following information will be printed:

--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -318,7 +318,6 @@ fn replica_start_thread(
         // change is rolled out without any issues.
         cmd.args(["--subnet-features", "canister_sandboxing"]);
         if config.btc_adapter.enabled {
-            cmd.args(["--subnet-features", "bitcoin_regtest"]);
             if let Some(socket_path) = config.btc_adapter.socket_path {
                 cmd.args([
                     "--bitcoin-testnet-uds-path",


### PR DESCRIPTION
# Description

With the newest replica which uses a separate bitcoin canister, there is no longer a need to enable the bitcoin_regtest feature.

Fixes https://dfinity.atlassian.net/browse/SDK-1123

# How Has This Been Tested?

Covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
