### PR TITLE
fix(ci): bump `cachix/install-nix-action` from `v18` to `v21`

### DIFF
--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -44,7 +44,7 @@ jobs:
         grep -s "REPLICA_VERSION" $GITHUB_ENV
    
     - name: install Nix
-      uses: cachix/install-nix-action@v18
+      uses: cachix/install-nix-action@v21
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 

--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -50,9 +50,8 @@ jobs:
 
     - name: install niv (dependency manager for Nix projects)
       run: |
-        nix-env -iA niv -f https://github.com/nmattia/niv/tarball/master \
-          --substituters https://niv.cachix.org \
-          --trusted-public-keys niv.cachix.org-1:X32PCg2e/zAm3/uD1ScqW2z/K0LtDyNV7RdaxIuLgQM=
+        nix-env -i niv -f '<nixpkgs>'
+        printenv PATH
 
     - name: intall packages from nix/sources.json
       run: niv update

--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -51,7 +51,6 @@ jobs:
     - name: install niv (dependency manager for Nix projects)
       run: |
         nix-env -i niv -f '<nixpkgs>'
-        printenv PATH
 
     - name: intall packages from nix/sources.json
       run: niv update

--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -49,7 +49,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: install niv (dependency manager for Nix projects)
-      run: nix-env -i niv -f '<nixpkgs>'
+      run: nix-env -iA nixpkgs.niv
 
     - name: intall packages from nix/sources.json
       run: niv update

--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -49,8 +49,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: install niv (dependency manager for Nix projects)
-      run: |
-        nix-env -i niv -f '<nixpkgs>'
+      run: nix-env -i niv -f '<nixpkgs>'
 
     - name: intall packages from nix/sources.json
       run: niv update

--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -44,7 +44,7 @@ jobs:
         grep -s "REPLICA_VERSION" $GITHUB_ENV
    
     - name: install Nix
-      uses: cachix/install-nix-action@v21
+      uses: cachix/install-nix-action@v18
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 

--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -49,7 +49,7 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: install niv (dependency manager for Nix projects)
-      run: nix-env -iA nixpkgs.niv
+      run: NIX_PATH=nixpkgs=$NIX_PATH/nixpkgs nix-env -iA nixpkgs.niv
 
     - name: intall packages from nix/sources.json
       run: niv update

--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -49,7 +49,10 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
 
     - name: install niv (dependency manager for Nix projects)
-      run: NIX_PATH=nixpkgs=$NIX_PATH/nixpkgs nix-env -iA nixpkgs.niv
+      run: |
+        nix-env -iA niv -f https://github.com/nmattia/niv/tarball/master \
+          --substituters https://niv.cachix.org \
+          --trusted-public-keys niv.cachix.org-1:X32PCg2e/zAm3/uD1ScqW2z/K0LtDyNV7RdaxIuLgQM=
 
     - name: intall packages from nix/sources.json
       run: niv update


### PR DESCRIPTION
# Description

For some reason, this fixes the workflow which would otherwise crash due to `niv command not found` error 
![image](https://github.com/dfinity/sdk/assets/21069150/0e953a1e-c38e-4afa-8d53-86012940c668)

# How Has This Been Tested?

manually, by running CI on my fork 

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
