### PR TITLE
feat: deprecate bootstrap and replica commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Note: Canister http functionality is broken.  Do not release dfx until this is c
 
 ## DFX
 
+### feat: deprecate `dfx bootstrap` and `dfx replica` commands
+
+Please use `dfx start` instead, which is a combination of the two commands.
+
+If you have a good reason why we should keep these commands, please contribute to the discussion at https://github.com/dfinity/sdk/discussions/3163
+
 ### feat: add optional custom build command for asset canisters
 
 The custom build command can be set in `dfx.json` the same way it is set for `custom` type canisters. If the command is not provided, DFX will fallback to the default `npm run build` command.

--- a/docs/cli-reference/dfx-bootstrap.md
+++ b/docs/cli-reference/dfx-bootstrap.md
@@ -1,5 +1,7 @@
 # dfx bootstrap {#_dfx_bootstrap}
 
+> **NOTE**: The bootstrap command is deprecated. Please use the [dfx start](./dfx-start.md) command instead. If you have a good reason to use the bootstrap command, please contribute to the [discussion](https://github.com/dfinity/sdk/discussions/3163).
+
 Use the `dfx bootstrap` command to start the bootstrap web server defined in the `dfx.json` configuration file or specified using command-line options.
 
 The bootstrap web server you specify is used to serve the front-end static assets for your project.

--- a/docs/cli-reference/dfx-replica.md
+++ b/docs/cli-reference/dfx-replica.md
@@ -1,5 +1,7 @@
 # dfx replica
 
+> **NOTE**: The replica command is deprecated. Please use the [dfx start](./dfx-start.md) command instead. If you have a good reason to use the replica command, please contribute to the [discussion](https://github.com/dfinity/sdk/discussions/3163).
+
 Use the `dfx replica` command to start a local canister execution environment (without a web server). This command enables you to deploy canisters locally and to test your dapps during development.
 
 By default, all local dfx projects will use a single shared local canister execution environment, and you can run `dfx replica` from any directory.  See [Local Server Configuration](#local-server-configuration) and [Project-Specific Local Networks](dfx-start.md#project-specific-local-networks) for exceptions.

--- a/src/dfx/src/commands/bootstrap.rs
+++ b/src/dfx/src/commands/bootstrap.rs
@@ -10,6 +10,7 @@ use dfx_core::network::provider::{create_network_descriptor, LocalBindDeterminat
 use anyhow::{anyhow, Context, Error};
 use clap::Parser;
 use fn_error_context::context;
+use slog::warn;
 use std::fs::create_dir_all;
 use std::net::{IpAddr, SocketAddr};
 
@@ -43,6 +44,13 @@ pub fn exec(
         timeout,
     }: BootstrapOpts,
 ) -> DfxResult {
+    warn!(
+        env.get_logger(),
+        "The bootstrap command is deprecated. \
+        Please use the start command instead. \
+        If you have a good reason to use the bootstrap command, \
+        please contribute to the discussion at https://github.com/dfinity/sdk/discussions/3163"
+    );
     let network_descriptor = create_network_descriptor(
         env.get_config(),
         env.get_networks_config(),

--- a/src/dfx/src/commands/replica.rs
+++ b/src/dfx/src/commands/replica.rs
@@ -18,6 +18,7 @@ use dfx_core::network::provider::{create_network_descriptor, LocalBindDeterminat
 use anyhow::{bail, Context};
 use clap::{ArgAction, Parser};
 use fn_error_context::context;
+use slog::warn;
 use std::default::Default;
 use std::fs;
 use std::fs::create_dir_all;
@@ -101,6 +102,13 @@ pub fn exec(
         force,
     }: ReplicaOpts,
 ) -> DfxResult {
+    warn!(
+        env.get_logger(),
+        "The replica command is deprecated. \
+        Please use the start command instead. \
+        If you have a good reason to use the replica command, \
+        please contribute to the discussion at https://github.com/dfinity/sdk/discussions/3163"
+    );
     let system = actix::System::new();
 
     let network_descriptor = create_network_descriptor(


### PR DESCRIPTION
# Description

Adds deprecation warnings for the `dfx bootstrap` and `dfx replica` commands, linking to https://github.com/dfinity/sdk/discussions/3163 to encourage discussion.

# How Has This Been Tested?

Ran the commands manually.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
