### PR TITLE
fix(extensions): ensure dfx extensions locate dfx cache accurately 

### DIFF
--- a/src/dfx/src/commands/extension/run.rs
+++ b/src/dfx/src/commands/extension/run.rs
@@ -27,7 +27,7 @@ impl From<Vec<OsString>> for RunOpts {
 pub fn exec(env: &dyn Environment, opts: RunOpts) -> DfxResult<()> {
     let mgr = env.new_extension_manager()?;
     let dfx_version = &env.get_version().to_string();
-    let path_to_dfx_cache = get_bin_cache(&dfx_version)?;
+    let path_to_dfx_cache = get_bin_cache(dfx_version)?;
     mgr.run_extension(&path_to_dfx_cache, opts.name, opts.params)?;
     Ok(())
 }

--- a/src/dfx/src/commands/extension/run.rs
+++ b/src/dfx/src/commands/extension/run.rs
@@ -4,16 +4,18 @@ use crate::lib::error::DfxResult;
 use clap::Parser;
 use dfx_core::config::cache::get_bin_cache;
 
+use std::ffi::OsString;
+
 #[derive(Parser, Debug)]
 pub struct RunOpts {
     /// Specifies the name of the extension to run.
-    name: String,
+    name: OsString,
     /// Specifies the parameters to pass to the extension.
-    params: Vec<String>,
+    params: Vec<OsString>,
 }
 
-impl From<Vec<String>> for RunOpts {
-    fn from(value: Vec<String>) -> Self {
+impl From<Vec<OsString>> for RunOpts {
+    fn from(value: Vec<OsString>) -> Self {
         let (extension_name, params) = value.split_first().unwrap();
         RunOpts {
             name: extension_name.clone(),
@@ -26,6 +28,6 @@ pub fn exec(env: &dyn Environment, opts: RunOpts) -> DfxResult<()> {
     let mgr = env.new_extension_manager()?;
     let dfx_version = &env.get_version().to_string();
     let path_to_dfx_cache = get_bin_cache(dfx_version)?;
-    mgr.run_extension(&path_to_dfx_cache, opts.name, opts.params)?;
+    mgr.run_extension(path_to_dfx_cache, opts.name, opts.params)?;
     Ok(())
 }

--- a/src/dfx/src/commands/extension/run.rs
+++ b/src/dfx/src/commands/extension/run.rs
@@ -2,6 +2,7 @@ use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 
 use clap::Parser;
+use dfx_core::config::cache::get_bin_cache;
 
 use std::ffi::OsString;
 
@@ -25,6 +26,12 @@ impl From<Vec<OsString>> for RunOpts {
 
 pub fn exec(env: &dyn Environment, opts: RunOpts) -> DfxResult<()> {
     let mgr = env.new_extension_manager()?;
-    mgr.run_extension(env.get_version(), opts.name, opts.params)?;
+    let dfx_version = &env.get_version().to_string();
+    let path_to_dfx_cache = get_bin_cache(&dfx_version).unwrap();
+    mgr.run_extension(
+        &*path_to_dfx_cache.to_string_lossy(),
+        opts.name,
+        opts.params,
+    )?;
     Ok(())
 }

--- a/src/dfx/src/commands/extension/run.rs
+++ b/src/dfx/src/commands/extension/run.rs
@@ -25,6 +25,6 @@ impl From<Vec<OsString>> for RunOpts {
 
 pub fn exec(env: &dyn Environment, opts: RunOpts) -> DfxResult<()> {
     let mgr = env.new_extension_manager()?;
-    mgr.run_extension(opts.name, opts.params)?;
+    mgr.run_extension(env.get_version(), opts.name, opts.params)?;
     Ok(())
 }

--- a/src/dfx/src/commands/extension/run.rs
+++ b/src/dfx/src/commands/extension/run.rs
@@ -4,18 +4,16 @@ use crate::lib::error::DfxResult;
 use clap::Parser;
 use dfx_core::config::cache::get_bin_cache;
 
-use std::ffi::OsString;
-
 #[derive(Parser, Debug)]
 pub struct RunOpts {
     /// Specifies the name of the extension to run.
-    name: OsString,
+    name: String,
     /// Specifies the parameters to pass to the extension.
-    params: Vec<OsString>,
+    params: Vec<String>,
 }
 
-impl From<Vec<OsString>> for RunOpts {
-    fn from(value: Vec<OsString>) -> Self {
+impl From<Vec<String>> for RunOpts {
+    fn from(value: Vec<String>) -> Self {
         let (extension_name, params) = value.split_first().unwrap();
         RunOpts {
             name: extension_name.clone(),

--- a/src/dfx/src/commands/extension/run.rs
+++ b/src/dfx/src/commands/extension/run.rs
@@ -27,11 +27,7 @@ impl From<Vec<OsString>> for RunOpts {
 pub fn exec(env: &dyn Environment, opts: RunOpts) -> DfxResult<()> {
     let mgr = env.new_extension_manager()?;
     let dfx_version = &env.get_version().to_string();
-    let path_to_dfx_cache = get_bin_cache(&dfx_version).unwrap();
-    mgr.run_extension(
-        &*path_to_dfx_cache.to_string_lossy(),
-        opts.name,
-        opts.params,
-    )?;
+    let path_to_dfx_cache = get_bin_cache(&dfx_version)?;
+    mgr.run_extension(&path_to_dfx_cache, opts.name, opts.params)?;
     Ok(())
 }

--- a/src/dfx/src/commands/mod.rs
+++ b/src/dfx/src/commands/mod.rs
@@ -49,7 +49,7 @@ pub enum Command {
     // Extension(extension::ExtensionOpts),
     // Executes an extension
     // #[clap(external_subcommand)]
-    // ExtensionRun(Vec<String>),
+    // ExtensionRun(Vec<OsString>),
     Generate(generate::GenerateOpts),
     Identity(identity::IdentityOpts),
     Info(info::InfoOpts),

--- a/src/dfx/src/commands/mod.rs
+++ b/src/dfx/src/commands/mod.rs
@@ -47,9 +47,9 @@ pub enum Command {
     Diagnose(diagnose::DiagnoseOpts),
     Fix(fix::FixOpts),
     // Extension(extension::ExtensionOpts),
-    // // Executes an extension
-    // #[arg(external_subcommand)]
-    // ExtensionRun(Vec<OsString>),
+    // Executes an extension
+    // #[clap(external_subcommand)]
+    // ExtensionRun(Vec<String>),
     Generate(generate::GenerateOpts),
     Identity(identity::IdentityOpts),
     Info(info::InfoOpts),

--- a/src/dfx/src/lib/extension/manager/execute.rs
+++ b/src/dfx/src/lib/extension/manager/execute.rs
@@ -1,21 +1,20 @@
 use super::ExtensionManager;
 use crate::lib::error::ExtensionError;
-use std::{ffi::OsString, path::Path};
+use std::path::Path;
 
 impl ExtensionManager {
     pub fn run_extension(
         &self,
         dfx_cache: &Path,
-        extension_name: OsString,
-        mut params: Vec<OsString>,
+        extension_name: String,
+        mut params: Vec<String>,
     ) -> Result<(), ExtensionError> {
-        let extension_name = extension_name
-            .into_string()
-            .map_err(ExtensionError::InvalidExtensionName)?;
-
         let mut extension_binary = self.get_extension_binary(&extension_name)?;
 
-        params.extend(["--dfx-cache-path", &dfx_cache.display().to_string()].map(OsString::from));
+        params.extend([
+            "--dfx-cache-path".into(),
+            dfx_cache.to_string_lossy().into(),
+        ]);
 
         let mut child = extension_binary
             .args(&params)

--- a/src/dfx/src/lib/extension/manager/execute.rs
+++ b/src/dfx/src/lib/extension/manager/execute.rs
@@ -1,20 +1,21 @@
 use super::ExtensionManager;
 use crate::lib::error::ExtensionError;
-use std::path::Path;
+use std::{ffi::OsString, path::PathBuf};
 
 impl ExtensionManager {
     pub fn run_extension(
         &self,
-        dfx_cache: &Path,
-        extension_name: String,
-        mut params: Vec<String>,
+        dfx_cache: PathBuf,
+        extension_name: OsString,
+        mut params: Vec<OsString>,
     ) -> Result<(), ExtensionError> {
+        let extension_name = extension_name
+            .into_string()
+            .map_err(ExtensionError::InvalidExtensionName)?;
+
         let mut extension_binary = self.get_extension_binary(&extension_name)?;
 
-        params.extend([
-            "--dfx-cache-path".into(),
-            dfx_cache.to_string_lossy().into(),
-        ]);
+        params.extend(["--dfx-cache-path".into(), dfx_cache.into_os_string()]);
 
         let mut child = extension_binary
             .args(&params)

--- a/src/dfx/src/lib/extension/manager/execute.rs
+++ b/src/dfx/src/lib/extension/manager/execute.rs
@@ -1,3 +1,6 @@
+use dfx_core::config::cache::get_bin_cache;
+use semver::Version;
+
 use super::ExtensionManager;
 use crate::lib::error::ExtensionError;
 use std::ffi::OsString;
@@ -5,14 +8,26 @@ use std::ffi::OsString;
 impl ExtensionManager {
     pub fn run_extension(
         &self,
+        dfx_version: &Version,
         extension_name: OsString,
-        params: Vec<OsString>,
+        mut params: Vec<OsString>,
     ) -> Result<(), ExtensionError> {
         let extension_name = extension_name
             .into_string()
             .map_err(ExtensionError::InvalidExtensionName)?;
 
         let mut extension_binary = self.get_extension_binary(&extension_name)?;
+
+        params.extend(
+            [
+                "--dfx-cache-path",
+                get_bin_cache(&dfx_version.to_string())
+                    .unwrap()
+                    .to_str()
+                    .unwrap(),
+            ]
+            .map(OsString::from),
+        );
 
         let mut child = extension_binary
             .args(&params)

--- a/src/dfx/src/lib/extension/manager/execute.rs
+++ b/src/dfx/src/lib/extension/manager/execute.rs
@@ -8,7 +8,7 @@ use std::ffi::OsString;
 impl ExtensionManager {
     pub fn run_extension(
         &self,
-        dfx_version: &Version,
+        path_to_dfx_cache: &str,
         extension_name: OsString,
         mut params: Vec<OsString>,
     ) -> Result<(), ExtensionError> {
@@ -18,16 +18,7 @@ impl ExtensionManager {
 
         let mut extension_binary = self.get_extension_binary(&extension_name)?;
 
-        params.extend(
-            [
-                "--dfx-cache-path",
-                get_bin_cache(&dfx_version.to_string())
-                    .unwrap()
-                    .to_str()
-                    .unwrap(),
-            ]
-            .map(OsString::from),
-        );
+        params.extend(["--dfx-cache-path", path_to_dfx_cache].map(OsString::from));
 
         let mut child = extension_binary
             .args(&params)

--- a/src/dfx/src/lib/extension/manager/execute.rs
+++ b/src/dfx/src/lib/extension/manager/execute.rs
@@ -1,14 +1,11 @@
-use dfx_core::config::cache::get_bin_cache;
-use semver::Version;
-
 use super::ExtensionManager;
 use crate::lib::error::ExtensionError;
-use std::ffi::OsString;
+use std::{ffi::OsString, path::Path};
 
 impl ExtensionManager {
     pub fn run_extension(
         &self,
-        path_to_dfx_cache: &str,
+        dfx_cache: &Path,
         extension_name: OsString,
         mut params: Vec<OsString>,
     ) -> Result<(), ExtensionError> {
@@ -18,7 +15,7 @@ impl ExtensionManager {
 
         let mut extension_binary = self.get_extension_binary(&extension_name)?;
 
-        params.extend(["--dfx-cache-path", path_to_dfx_cache].map(OsString::from));
+        params.extend(["--dfx-cache-path", &dfx_cache.display().to_string()].map(OsString::from));
 
         let mut child = extension_binary
             .args(&params)


### PR DESCRIPTION
# Description

Some `dfx` extensions depend on binaries from `dfx`'s cache. Previously, extensions depended on the first `dfx` in `$PATH` to locate its cache, which is error-prone for projects that declare a custom `dfx` version in their `dfx.json`. 

Fixes: https://dfinity.atlassian.net/browse/SDK-1107
Depends on: https://github.com/dfinity/dfx-extensions/pull/21

# How Has This Been Tested?

manually, by installing sns and nns extensions and executing commands which depend on binaries from cache  

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
