### PR TITLE
chore: build/test with macos-12

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,9 +24,9 @@ jobs:
         rust: [ '1.65.0' ]
         # We build a dynamic-linked linux binary because otherwise HSM support fails with:
         #   Error: IO: Dynamic loading not supported
-        os: [ macos-11, ubuntu-20.04, ubuntu-22.04 ]
+        os: [ macos-12, ubuntu-20.04, ubuntu-22.04 ]
         include:
-          - os: macos-11
+          - os: macos-12
             target: x86_64-apple-darwin
             binary_path: target/x86_64-apple-darwin/release
           - os: ubuntu-20.04
@@ -92,7 +92,7 @@ jobs:
         # ubuntu-18.04 not supported due to:
         #     /home/runner/.cache/dfinity/versions/0.8.3-34-g36e39809/ic-starter:
         #     /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found
-        os: [macos-11, ubuntu-20.04, ubuntu-22.04]
+        os: [macos-12, ubuntu-20.04, ubuntu-22.04]
         rust: ["1.65.0"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
         #   Error: IO: Dynamic loading not supported
         target: [ x86_64-apple-darwin, x86_64-unknown-linux-gnu ]
         include:
-          - os: macos-latest
+          - os: macos-12
             target: x86_64-apple-darwin
             binary_path: target/x86_64-apple-darwin/release
             name: x86_64-darwin

--- a/scripts/workflows/e2e-matrix.py
+++ b/scripts/workflows/e2e-matrix.py
@@ -16,7 +16,7 @@ test = sorted(test_scripts("dfx") + test_scripts("replica") + test_scripts("icx-
 matrix = {
     "test": test,
     "backend": ["ic-ref", "replica"],
-    "os": ["macos-11", "ubuntu-20.04"],
+    "os": ["macos-12", "ubuntu-20.04"],
     "rust": ["1.65.0"],
     "exclude": [
         {"backend": "ic-ref", "test": "dfx/bitcoin"},


### PR DESCRIPTION
# Description

Currently, `macos-latest` corresponds to `macos-12`.  This PR updates our publish workflow to build using `macos-12` directly, rather than `macos-latest`.

It also updates our e2e workflows to build with `macos-12` to match.

# How Has This Been Tested?

Covered by existing workflows

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

