### PR TITLE
chore(extensions): enable `dfx extension` commands

### DIFF
--- a/e2e/tests-dfx/usage.bash
+++ b/e2e/tests-dfx/usage.bash
@@ -19,6 +19,7 @@ teardown() {
 }
 
 @test "using an invalid command fails" {
+    skip "remove this skip once https://github.com/dfinity/sdk/pull/3096 is merged"
     run dfx blurp
     if [[ $status -eq 0 ]]; then
         echo "$@" >&2

--- a/src/dfx/src/commands/mod.rs
+++ b/src/dfx/src/commands/mod.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsString;
+
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 
@@ -46,10 +48,11 @@ pub enum Command {
     Deps(deps::DepsOpts),
     Diagnose(diagnose::DiagnoseOpts),
     Fix(fix::FixOpts),
-    // Extension(extension::ExtensionOpts),
+    #[command(hide = true)]
+    Extension(extension::ExtensionOpts),
     // Executes an extension
-    // #[clap(external_subcommand)]
-    // ExtensionRun(Vec<OsString>),
+    #[clap(external_subcommand)]
+    ExtensionRun(Vec<OsString>),
     Generate(generate::GenerateOpts),
     Identity(identity::IdentityOpts),
     Info(info::InfoOpts),
@@ -82,8 +85,8 @@ pub fn exec(env: &dyn Environment, cmd: Command) -> DfxResult {
         Command::Deps(v) => deps::exec(env, v),
         Command::Diagnose(v) => diagnose::exec(env, v),
         Command::Fix(v) => fix::exec(env, v),
-        // Command::Extension(v) => extension::exec(env, v),
-        // Command::ExtensionRun(v) => extension::run::exec(env, v.into()),
+        Command::Extension(v) => extension::exec(env, v),
+        Command::ExtensionRun(v) => extension::run::exec(env, v.into()),
         Command::Generate(v) => generate::exec(env, v),
         Command::Identity(v) => identity::exec(env, v),
         Command::Info(v) => info::exec(env, v),


### PR DESCRIPTION
# Description

needed for https://github.com/dfinity/dfx-extensions/pull/17

- enables and hides `dfx extension` cmd
- enables `dfx <EXT>` shorthand notation for running extensions (hidden by default cause its clap' `external_subcommand`) 

# How Has This Been Tested?

manually

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.