### PR TITLE
refactor(ic-asset): Use concrete types rather than anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,10 +1959,10 @@ dependencies = [
 name = "ic-asset"
 version = "0.20.0"
 dependencies = [
- "anyhow",
  "backoff",
  "candid 0.8.4",
  "derivative",
+ "dfx-core",
  "flate2",
  "futures",
  "futures-intrusive",
@@ -1982,6 +1982,7 @@ dependencies = [
  "sha2 0.10.6",
  "slog",
  "tempfile",
+ "thiserror",
  "tokio",
  "walkdir",
 ]

--- a/src/canisters/frontend/ic-asset/Cargo.toml
+++ b/src/canisters/frontend/ic-asset/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["api-bindings", "data-structures"]
 keywords = ["internet-computer", "assets", "icp", "dfinity"]
 
 [dependencies]
-anyhow.workspace = true
 backoff.workspace = true
 candid = { workspace = true }
 derivative = "2.2.0"
+dfx-core = { path = "../../../dfx-core" }
 flate2.workspace = true
 futures.workspace = true
 futures-intrusive = "0.4.0"
@@ -32,6 +32,7 @@ serde_bytes.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 slog = { workspace = true, features = ["max_level_trace"] }
+thiserror.workspace = true
 tokio.workspace = true
 walkdir.workspace = true
 

--- a/src/canisters/frontend/ic-asset/src/asset/content.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/content.rs
@@ -1,4 +1,5 @@
 use crate::asset::content_encoder::ContentEncoder;
+use dfx_core::error::fs::FsError;
 
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -13,8 +14,8 @@ pub(crate) struct Content {
 }
 
 impl Content {
-    pub fn load(path: &Path) -> anyhow::Result<Content> {
-        let data = std::fs::read(path)?;
+    pub fn load(path: &Path) -> Result<Content, FsError> {
+        let data = dfx_core::fs::read(path)?;
 
         // todo: check contents if mime_guess fails https://github.com/dfinity/sdk/issues/1594
         let media_type = mime_guess::from_path(path)
@@ -24,13 +25,13 @@ impl Content {
         Ok(Content { data, media_type })
     }
 
-    pub fn encode(&self, encoder: &ContentEncoder) -> anyhow::Result<Content> {
+    pub fn encode(&self, encoder: &ContentEncoder) -> Result<Content, std::io::Error> {
         match encoder {
             ContentEncoder::Gzip => self.to_gzip(),
         }
     }
 
-    pub fn to_gzip(&self) -> anyhow::Result<Content> {
+    pub fn to_gzip(&self) -> Result<Content, std::io::Error> {
         let mut e = GzEncoder::new(Vec::new(), Compression::default());
         e.write_all(&self.data)?;
         let data = e.finish()?;

--- a/src/canisters/frontend/ic-asset/src/asset/content_encoder.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/content_encoder.rs
@@ -1,3 +1,4 @@
+#[derive(Clone, Debug)]
 pub enum ContentEncoder {
     Gzip,
 }

--- a/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
+++ b/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
@@ -4,6 +4,10 @@ use crate::asset::content_encoder::ContentEncoder;
 use crate::batch_upload::semaphores::Semaphores;
 use crate::canister_api::methods::chunk::create_chunk;
 use crate::canister_api::types::asset::AssetDetails;
+use crate::error::create_chunk::CreateChunkError;
+use crate::error::create_encoding::CreateEncodingError;
+use crate::error::create_encoding::CreateEncodingError::EncodeContentFailed;
+use crate::error::create_project_asset::CreateProjectAssetError;
 
 use candid::Nat;
 use futures::future::try_join_all;
@@ -63,7 +67,7 @@ impl<'agent> ChunkUploader<'agent> {
         &self,
         contents: &[u8],
         semaphores: &Semaphores,
-    ) -> anyhow::Result<Nat> {
+    ) -> Result<Nat, CreateChunkError> {
         self.chunks.fetch_add(1, Ordering::SeqCst);
         self.bytes.fetch_add(contents.len(), Ordering::SeqCst);
         create_chunk(&self.canister, &self.batch_id, contents, semaphores).await
@@ -86,7 +90,7 @@ async fn make_project_asset_encoding(
     content_encoding: &str,
     semaphores: &Semaphores,
     logger: &Logger,
-) -> anyhow::Result<ProjectAssetEncoding> {
+) -> Result<ProjectAssetEncoding, CreateChunkError> {
     let sha256 = content.sha256();
 
     let already_in_place = if let Some(canister_asset) = canister_assets.get(&asset_descriptor.key)
@@ -156,7 +160,7 @@ async fn make_encoding(
     encoder: &Option<ContentEncoder>,
     semaphores: &Semaphores,
     logger: &Logger,
-) -> anyhow::Result<Option<(String, ProjectAssetEncoding)>> {
+) -> Result<Option<(String, ProjectAssetEncoding)>, CreateEncodingError> {
     match encoder {
         None => {
             let identity_asset_encoding = make_project_asset_encoding(
@@ -168,14 +172,17 @@ async fn make_encoding(
                 semaphores,
                 logger,
             )
-            .await?;
+            .await
+            .map_err(CreateEncodingError::CreateChunkFailed)?;
             Ok(Some((
                 CONTENT_ENCODING_IDENTITY.to_string(),
                 identity_asset_encoding,
             )))
         }
         Some(encoder) => {
-            let encoded = content.encode(encoder)?;
+            let encoded = content.encode(encoder).map_err(|e| {
+                EncodeContentFailed(asset_descriptor.key.clone(), encoder.clone(), e)
+            })?;
             if encoded.data.len() < content.data.len() {
                 let content_encoding = format!("{}", encoder);
                 let project_asset_encoding = make_project_asset_encoding(
@@ -187,7 +194,8 @@ async fn make_encoding(
                     semaphores,
                     logger,
                 )
-                .await?;
+                .await
+                .map_err(CreateEncodingError::CreateChunkFailed)?;
                 Ok(Some((content_encoding, project_asset_encoding)))
             } else {
                 Ok(None)
@@ -203,7 +211,7 @@ async fn make_encodings(
     content: &Content,
     semaphores: &Semaphores,
     logger: &Logger,
-) -> anyhow::Result<HashMap<String, ProjectAssetEncoding>> {
+) -> Result<HashMap<String, ProjectAssetEncoding>, CreateEncodingError> {
     let mut encoders = vec![None];
     for encoder in applicable_encoders(&content.media_type) {
         encoders.push(Some(encoder));
@@ -240,8 +248,10 @@ async fn make_project_asset(
     canister_assets: &HashMap<String, AssetDetails>,
     semaphores: &Semaphores,
     logger: &Logger,
-) -> anyhow::Result<ProjectAsset> {
-    let file_size = std::fs::metadata(&asset_descriptor.source)?.len();
+) -> Result<ProjectAsset, CreateProjectAssetError> {
+    let file_size = dfx_core::fs::metadata(&asset_descriptor.source)
+        .map_err(CreateProjectAssetError::DetermineAssetSizeFailed)?
+        .len();
     let permits = std::cmp::max(
         1,
         std::cmp::min(
@@ -250,7 +260,8 @@ async fn make_project_asset(
         ),
     );
     let _releaser = semaphores.file.acquire(permits).await;
-    let content = Content::load(&asset_descriptor.source)?;
+    let content = Content::load(&asset_descriptor.source)
+        .map_err(CreateProjectAssetError::LoadContentFailed)?;
 
     let encodings = make_encodings(
         chunk_upload_target,
@@ -274,7 +285,7 @@ pub(crate) async fn make_project_assets(
     asset_descriptors: Vec<AssetDescriptor>,
     canister_assets: &HashMap<String, AssetDetails>,
     logger: &Logger,
-) -> anyhow::Result<HashMap<String, ProjectAsset>> {
+) -> Result<HashMap<String, ProjectAsset>, CreateProjectAssetError> {
     let semaphores = Semaphores::new();
 
     let project_asset_futures: Vec<_> = asset_descriptors
@@ -306,7 +317,7 @@ async fn upload_content_chunks(
     content_encoding: &str,
     semaphores: &Semaphores,
     logger: &Logger,
-) -> anyhow::Result<Vec<Nat>> {
+) -> Result<Vec<Nat>, CreateChunkError> {
     if content.data.is_empty() {
         let empty = vec![];
         let chunk_id = chunk_uploader.create_chunk(&empty, semaphores).await?;

--- a/src/canisters/frontend/ic-asset/src/canister_api/methods/asset_properties.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/methods/asset_properties.rs
@@ -8,11 +8,13 @@ use crate::canister_api::{
     methods::method_names::GET_ASSET_PROPERTIES,
     types::asset::{AssetDetails, AssetProperties, GetAssetPropertiesArgument},
 };
+use crate::error::get_asset_properties::GetAssetPropertiesError;
+use crate::error::get_asset_properties::GetAssetPropertiesError::GetAssetPropertiesFailed;
 
 pub(crate) async fn get_assets_properties(
     canister: &Canister<'_>,
     canister_assets: &HashMap<String, AssetDetails>,
-) -> anyhow::Result<HashMap<String, AssetProperties>> {
+) -> Result<HashMap<String, AssetProperties>, GetAssetPropertiesError> {
     let mut all_assets_properties = HashMap::new();
     for asset_id in canister_assets.keys() {
         match get_asset_properties(canister, asset_id).await {
@@ -32,7 +34,7 @@ pub(crate) async fn get_assets_properties(
                 break;
             }
             Err(e) => {
-                return Err(anyhow::anyhow!("Failed to get asset properties: {e}"));
+                return Err(GetAssetPropertiesFailed(asset_id.clone(), e));
             }
         }
     }

--- a/src/canisters/frontend/ic-asset/src/canister_api/methods/batch.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/methods/batch.rs
@@ -6,15 +6,15 @@ use crate::canister_api::types::batch_upload::common::{
     ComputeEvidenceArguments, CreateBatchRequest, CreateBatchResponse,
 };
 
-use anyhow::bail;
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoffBuilder;
 use candid::{CandidType, Nat};
+use ic_agent::AgentError;
 use ic_utils::Canister;
 use serde_bytes::ByteBuf;
 use std::time::Duration;
 
-pub(crate) async fn create_batch(canister: &Canister<'_>) -> anyhow::Result<Nat> {
+pub(crate) async fn create_batch(canister: &Canister<'_>) -> Result<Nat, AgentError> {
     let mut retry_policy = ExponentialBackoffBuilder::new()
         .with_initial_interval(Duration::from_secs(1))
         .with_max_interval(Duration::from_secs(16))
@@ -49,7 +49,7 @@ pub(crate) async fn submit_commit_batch<T: CandidType + Sync>(
     canister: &Canister<'_>,
     method_name: &str,
     arg: T, // CommitBatchArguments_{v0,v1,etc}
-) -> anyhow::Result<()> {
+) -> Result<(), AgentError> {
     let mut retry_policy = ExponentialBackoffBuilder::new()
         .with_initial_interval(Duration::from_secs(1))
         .with_max_interval(Duration::from_secs(16))
@@ -67,11 +67,11 @@ pub(crate) async fn submit_commit_batch<T: CandidType + Sync>(
         {
             Ok(()) => return Ok(()),
             Err(agent_err) if !retryable(&agent_err) => {
-                bail!(agent_err);
+                return Err(agent_err);
             }
             Err(agent_err) => match retry_policy.next_backoff() {
                 Some(duration) => tokio::time::sleep(duration).await,
-                None => bail!(agent_err),
+                None => return Err(agent_err),
             },
         }
     }
@@ -80,21 +80,21 @@ pub(crate) async fn submit_commit_batch<T: CandidType + Sync>(
 pub(crate) async fn commit_batch<T: CandidType + Sync>(
     canister: &Canister<'_>,
     arg: T, // CommitBatchArguments_{v0,v1,etc}
-) -> anyhow::Result<()> {
+) -> Result<(), AgentError> {
     submit_commit_batch(canister, COMMIT_BATCH, arg).await
 }
 
 pub(crate) async fn propose_commit_batch<T: CandidType + Sync>(
     canister: &Canister<'_>,
     arg: T, // CommitBatchArguments_{v0,v1,etc}
-) -> anyhow::Result<()> {
+) -> Result<(), AgentError> {
     submit_commit_batch(canister, PROPOSE_COMMIT_BATCH, arg).await
 }
 
 pub(crate) async fn compute_evidence(
     canister: &Canister<'_>,
     arg: &ComputeEvidenceArguments,
-) -> anyhow::Result<Option<ByteBuf>> {
+) -> Result<Option<ByteBuf>, AgentError> {
     let mut retry_policy = ExponentialBackoffBuilder::new()
         .with_initial_interval(Duration::from_secs(1))
         .with_max_interval(Duration::from_secs(16))
@@ -113,11 +113,11 @@ pub(crate) async fn compute_evidence(
         {
             Ok(x) => return Ok(x.0),
             Err(agent_err) if !retryable(&agent_err) => {
-                bail!(agent_err);
+                return Err(agent_err);
             }
             Err(agent_err) => match retry_policy.next_backoff() {
                 Some(duration) => tokio::time::sleep(duration).await,
-                None => bail!(agent_err),
+                None => return Err(agent_err),
             },
         }
     }

--- a/src/canisters/frontend/ic-asset/src/canister_api/methods/chunk.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/methods/chunk.rs
@@ -4,7 +4,8 @@ use crate::batch_upload::retryable::retryable;
 use crate::batch_upload::semaphores::Semaphores;
 use crate::canister_api::methods::method_names::CREATE_CHUNK;
 use crate::canister_api::types::batch_upload::common::{CreateChunkRequest, CreateChunkResponse};
-use anyhow::bail;
+use crate::error::create_chunk::CreateChunkError;
+
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoffBuilder;
 use candid::{Decode, Nat};
@@ -15,7 +16,7 @@ pub(crate) async fn create_chunk(
     batch_id: &Nat,
     content: &[u8],
     semaphores: &Semaphores,
-) -> anyhow::Result<Nat> {
+) -> Result<Nat, CreateChunkError> {
     let _chunk_releaser = semaphores.create_chunk.acquire(1).await;
     let batch_id = batch_id.clone();
     let args = CreateChunkRequest { batch_id, content };
@@ -49,14 +50,16 @@ pub(crate) async fn create_chunk(
         match wait_result {
             Ok(response) => {
                 // failure to decode the response is not retryable
-                return Ok(Decode!(&response, CreateChunkResponse)?.chunk_id);
+                let response = Decode!(&response, CreateChunkResponse)
+                    .map_err(CreateChunkError::DecodeCreateChunkResponseFailed)?;
+                return Ok(response.chunk_id);
             }
             Err(agent_err) if !retryable(&agent_err) => {
-                bail!(agent_err);
+                return Err(CreateChunkError::Agent(agent_err));
             }
             Err(agent_err) => match retry_policy.next_backoff() {
                 Some(duration) => tokio::time::sleep(duration).await,
-                None => bail!(agent_err),
+                None => return Err(CreateChunkError::Agent(agent_err)),
             },
         }
     }

--- a/src/canisters/frontend/ic-asset/src/canister_api/methods/list.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/methods/list.rs
@@ -4,11 +4,12 @@ use crate::canister_api::types::{asset::AssetDetails, list::ListAssetsRequest};
 use ic_utils::call::SyncCall;
 use ic_utils::Canister;
 
+use ic_agent::AgentError;
 use std::collections::HashMap;
 
 pub(crate) async fn list_assets(
     canister: &Canister<'_>,
-) -> anyhow::Result<HashMap<String, AssetDetails>> {
+) -> Result<HashMap<String, AssetDetails>, AgentError> {
     let (entries,): (Vec<AssetDetails>,) = canister
         .query_(LIST)
         .with_arg(ListAssetsRequest {})

--- a/src/canisters/frontend/ic-asset/src/canister_api/types/batch_upload/v0.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/types/batch_upload/v0.rs
@@ -1,4 +1,7 @@
 use super::common::*;
+use crate::error::downgrade_commit_batch_arguments::DowngradeCommitBatchArgumentsV1ToV0Error;
+use crate::error::downgrade_commit_batch_arguments::DowngradeCommitBatchArgumentsV1ToV0Error::V0SetAssetPropertiesNotSupported;
+
 use candid::{CandidType, Nat};
 
 /// Batch operations that can be applied atomically.
@@ -33,7 +36,7 @@ pub struct CommitBatchArguments {
 
 // impl try_from for v0::BatchOperationKind from v1::BatchOperationKind
 impl TryFrom<super::v1::CommitBatchArguments> for CommitBatchArguments {
-    type Error = String;
+    type Error = DowngradeCommitBatchArgumentsV1ToV0Error;
 
     fn try_from(value: super::v1::CommitBatchArguments) -> Result<Self, Self::Error> {
         let mut operations = vec![];
@@ -53,7 +56,7 @@ impl TryFrom<super::v1::CommitBatchArguments> for CommitBatchArguments {
                 }
                 super::v1::BatchOperationKind::Clear(args) => BatchOperationKind::Clear(args),
                 super::v1::BatchOperationKind::SetAssetProperties(_) => {
-                    return Err("SetAssetProperties is not supported".to_string())
+                    return Err(V0SetAssetPropertiesNotSupported)
                 }
             };
             operations.push(operation);

--- a/src/canisters/frontend/ic-asset/src/error/compatibility.rs
+++ b/src/canisters/frontend/ic-asset/src/error/compatibility.rs
@@ -1,0 +1,9 @@
+use crate::error::downgrade_commit_batch_arguments::DowngradeCommitBatchArgumentsV1ToV0Error;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CompatibilityError {
+    #[error("Failed to downgrade from v1::CommitBatchArguments to v0::CommitBatchArguments: {0}. Please upgrade your asset canister, or use older tooling (dfx<=v-0.13.1 or icx-asset<=0.20.0)")]
+    DowngradeV1TOV0Failed(DowngradeCommitBatchArgumentsV1ToV0Error),
+}

--- a/src/canisters/frontend/ic-asset/src/error/compute_evidence.rs
+++ b/src/canisters/frontend/ic-asset/src/error/compute_evidence.rs
@@ -1,0 +1,25 @@
+use crate::error::create_project_asset::CreateProjectAssetError;
+use crate::error::gather_asset_descriptors::GatherAssetDescriptorsError;
+use crate::error::get_asset_properties::GetAssetPropertiesError;
+use crate::error::hash_content::HashContentError;
+
+use ic_agent::AgentError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ComputeEvidenceError {
+    #[error(transparent)]
+    ProcessProjectAsset(#[from] CreateProjectAssetError),
+
+    #[error(transparent)]
+    GatherAssetDescriptors(#[from] GatherAssetDescriptorsError),
+
+    #[error(transparent)]
+    GetAssetProperties(#[from] GetAssetPropertiesError),
+
+    #[error(transparent)]
+    HashContent(#[from] HashContentError),
+
+    #[error("Failed to list assets: {0}")]
+    ListAssets(AgentError),
+}

--- a/src/canisters/frontend/ic-asset/src/error/create_chunk.rs
+++ b/src/canisters/frontend/ic-asset/src/error/create_chunk.rs
@@ -1,0 +1,11 @@
+use ic_agent::AgentError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CreateChunkError {
+    #[error(transparent)]
+    Agent(#[from] AgentError),
+
+    #[error("Failed to decode create chunk response: {0}")]
+    DecodeCreateChunkResponseFailed(candid::Error),
+}

--- a/src/canisters/frontend/ic-asset/src/error/create_encoding.rs
+++ b/src/canisters/frontend/ic-asset/src/error/create_encoding.rs
@@ -1,0 +1,13 @@
+use crate::asset::content_encoder::ContentEncoder;
+use crate::error::create_chunk::CreateChunkError;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CreateEncodingError {
+    #[error("Failed to create chunk: {0}")]
+    CreateChunkFailed(CreateChunkError),
+
+    #[error("Failed to encode content of '{0}' with {1} encoding: {2}")]
+    EncodeContentFailed(String, ContentEncoder, std::io::Error),
+}

--- a/src/canisters/frontend/ic-asset/src/error/create_project_asset.rs
+++ b/src/canisters/frontend/ic-asset/src/error/create_project_asset.rs
@@ -1,0 +1,16 @@
+use crate::error::create_encoding::CreateEncodingError;
+use dfx_core::error::fs::FsError;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CreateProjectAssetError {
+    #[error("Failed to create encoding: {0}")]
+    CreateEncodingError(#[from] CreateEncodingError),
+
+    #[error("Failed to determine asset size: {0}")]
+    DetermineAssetSizeFailed(FsError),
+
+    #[error("Failed to load asset content: {0}")]
+    LoadContentFailed(FsError),
+}

--- a/src/canisters/frontend/ic-asset/src/error/downgrade_commit_batch_arguments.rs
+++ b/src/canisters/frontend/ic-asset/src/error/downgrade_commit_batch_arguments.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DowngradeCommitBatchArgumentsV1ToV0Error {
+    #[error("SetAssetProperties is not supported")]
+    V0SetAssetPropertiesNotSupported,
+}

--- a/src/canisters/frontend/ic-asset/src/error/gather_asset_descriptors.rs
+++ b/src/canisters/frontend/ic-asset/src/error/gather_asset_descriptors.rs
@@ -1,0 +1,24 @@
+use crate::error::get_asset_config::GetAssetConfigError;
+use crate::error::load_config::AssetLoadConfigError;
+
+use dfx_core::error::fs::FsError;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GatherAssetDescriptorsError {
+    #[error("Asset with key '{0}' defined at {1} and {2}")]
+    DuplicateAssetKey(String, Box<PathBuf>, Box<PathBuf>),
+
+    #[error("Failed to get asset configuration: {0}")]
+    GetAssetConfigFailed(#[from] GetAssetConfigError),
+
+    #[error("Invalid directory entry: {0}")]
+    InvalidDirectoryEntry(FsError),
+
+    #[error("Invalid source directory: {0}")]
+    InvalidSourceDirectory(FsError),
+
+    #[error("Failed to load asset configuration: {0}")]
+    LoadConfigFailed(AssetLoadConfigError),
+}

--- a/src/canisters/frontend/ic-asset/src/error/get_asset_config.rs
+++ b/src/canisters/frontend/ic-asset/src/error/get_asset_config.rs
@@ -1,0 +1,12 @@
+use dfx_core::error::fs::FsError;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GetAssetConfigError {
+    #[error("No configuration found for asset '{0}'")]
+    AssetConfigNotFound(PathBuf),
+
+    #[error("Invalid asset path: {0}")]
+    InvalidPath(FsError),
+}

--- a/src/canisters/frontend/ic-asset/src/error/get_asset_properties.rs
+++ b/src/canisters/frontend/ic-asset/src/error/get_asset_properties.rs
@@ -1,0 +1,8 @@
+use ic_agent::AgentError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GetAssetPropertiesError {
+    #[error("Failed to get asset properties for {0}: {1}")]
+    GetAssetPropertiesFailed(String, AgentError),
+}

--- a/src/canisters/frontend/ic-asset/src/error/hash_content.rs
+++ b/src/canisters/frontend/ic-asset/src/error/hash_content.rs
@@ -1,0 +1,13 @@
+use crate::asset::content_encoder::ContentEncoder;
+
+use dfx_core::error::fs::FsError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum HashContentError {
+    #[error("Failed to encode content of '{0}' with {1} encoding: {2}")]
+    EncodeContentFailed(String, ContentEncoder, std::io::Error),
+
+    #[error("Failed to load content: {0}")]
+    LoadContentFailed(FsError),
+}

--- a/src/canisters/frontend/ic-asset/src/error/load_config.rs
+++ b/src/canisters/frontend/ic-asset/src/error/load_config.rs
@@ -1,0 +1,26 @@
+use crate::error::load_rule::LoadRuleError;
+
+use dfx_core::error::fs::FsError;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AssetLoadConfigError {
+    #[error(transparent)]
+    FsError(#[from] FsError),
+
+    #[error("root_dir '{0}' is expected to be a canonical path")]
+    InvalidRootDir(PathBuf),
+
+    #[error("Failed to load rule in {0}: {1}")]
+    LoadRuleFailed(PathBuf, LoadRuleError),
+
+    #[error("Malformed JSON asset config file '{0}': {1}")]
+    MalformedAssetConfigFile(PathBuf, json5::Error),
+
+    #[error("both {} and {} files exist in the same directory (dir = {:?})",
+    crate::asset::config::ASSETS_CONFIG_FILENAME_JSON,
+    crate::asset::config::ASSETS_CONFIG_FILENAME_JSON5,
+    .0.display())]
+    MultipleConfigurationFiles(PathBuf),
+}

--- a/src/canisters/frontend/ic-asset/src/error/load_rule.rs
+++ b/src/canisters/frontend/ic-asset/src/error/load_rule.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LoadRuleError {
+    #[error("Failed to combine {0} and {1} into a string (to be later used as a glob pattern)")]
+    FormGlobPatternFailed(PathBuf, String),
+
+    #[error("{0} is not a valid glob pattern: {1}")]
+    InvalidGlobPattern(String, globset::Error),
+}

--- a/src/canisters/frontend/ic-asset/src/error/mod.rs
+++ b/src/canisters/frontend/ic-asset/src/error/mod.rs
@@ -1,0 +1,16 @@
+pub mod compatibility;
+pub mod compute_evidence;
+pub mod create_chunk;
+pub mod create_encoding;
+pub mod create_project_asset;
+pub mod downgrade_commit_batch_arguments;
+pub mod gather_asset_descriptors;
+pub mod get_asset_config;
+pub mod get_asset_properties;
+pub mod hash_content;
+pub mod load_config;
+pub mod load_rule;
+pub mod prepare_sync_for_proposal;
+pub mod sync;
+pub mod upload;
+pub mod upload_content;

--- a/src/canisters/frontend/ic-asset/src/error/prepare_sync_for_proposal.rs
+++ b/src/canisters/frontend/ic-asset/src/error/prepare_sync_for_proposal.rs
@@ -1,0 +1,16 @@
+use crate::error::upload_content::UploadContentError;
+
+use ic_agent::AgentError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum PrepareSyncForProposalError {
+    #[error("Failed to compute evidence: {0}")]
+    ComputeEvidence(AgentError),
+
+    #[error("Failed to propose batch to commit: {0}")]
+    ProposeCommitBatch(AgentError),
+
+    #[error(transparent)]
+    UploadContent(#[from] UploadContentError),
+}

--- a/src/canisters/frontend/ic-asset/src/error/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/error/sync.rs
@@ -1,0 +1,17 @@
+use crate::error::compatibility::CompatibilityError;
+use crate::error::upload_content::UploadContentError;
+
+use ic_agent::AgentError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SyncError {
+    #[error("Failed to commit batch: {0}")]
+    CommitBatchFailed(AgentError),
+
+    #[error(transparent)]
+    Compatibility(#[from] CompatibilityError),
+
+    #[error(transparent)]
+    UploadContentFailed(#[from] UploadContentError),
+}

--- a/src/canisters/frontend/ic-asset/src/error/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/error/upload.rs
@@ -1,0 +1,23 @@
+use crate::error::compatibility::CompatibilityError;
+use crate::error::create_project_asset::CreateProjectAssetError;
+
+use ic_agent::AgentError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum UploadError {
+    #[error("Commit batch failed: {0}")]
+    CommitBatchFailed(AgentError),
+
+    #[error(transparent)]
+    Compatibility(#[from] CompatibilityError),
+
+    #[error("Create batch failed: {0}")]
+    CreateBatchFailed(AgentError),
+
+    #[error("Failed to create project asset: {0}")]
+    CreateProjectAssetFailed(#[from] CreateProjectAssetError),
+
+    #[error("List assets failed: {0}")]
+    ListAssetsFailed(AgentError),
+}

--- a/src/canisters/frontend/ic-asset/src/error/upload_content.rs
+++ b/src/canisters/frontend/ic-asset/src/error/upload_content.rs
@@ -1,0 +1,24 @@
+use crate::error::create_project_asset::CreateProjectAssetError;
+use crate::error::gather_asset_descriptors::GatherAssetDescriptorsError;
+use crate::error::get_asset_properties::GetAssetPropertiesError;
+
+use ic_agent::AgentError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum UploadContentError {
+    #[error("Failed to create batch: {0}")]
+    CreateBatchFailed(AgentError),
+
+    #[error("Failed to create project asset: {0}")]
+    CreateProjectAssetError(#[from] CreateProjectAssetError),
+
+    #[error("Failed to gather asset descriptors: {0}")]
+    GatherAssetDescriptorsFailed(#[from] GatherAssetDescriptorsError),
+
+    #[error(transparent)]
+    GetAssetPropertiesFailed(#[from] GetAssetPropertiesError),
+
+    #[error("Failed to list assets: {0}")]
+    ListAssetsFailed(AgentError),
+}

--- a/src/canisters/frontend/ic-asset/src/evidence/mod.rs
+++ b/src/canisters/frontend/ic-asset/src/evidence/mod.rs
@@ -11,6 +11,9 @@ use crate::canister_api::types::batch_upload::common::{
     UnsetAssetContentArguments,
 };
 use crate::canister_api::types::batch_upload::v1::BatchOperationKind;
+use crate::error::compute_evidence::ComputeEvidenceError;
+use crate::error::hash_content::HashContentError;
+use crate::error::hash_content::HashContentError::{EncodeContentFailed, LoadContentFailed};
 use crate::sync::gather_asset_descriptors;
 use ic_utils::Canister;
 use sha2::{Digest, Sha256};
@@ -36,10 +39,12 @@ pub async fn compute_evidence(
     canister: &Canister<'_>,
     dirs: &[&Path],
     logger: &Logger,
-) -> anyhow::Result<String> {
+) -> Result<String, ComputeEvidenceError> {
     let asset_descriptors = gather_asset_descriptors(dirs, logger)?;
 
-    let canister_assets = list_assets(canister).await?;
+    let canister_assets = list_assets(canister)
+        .await
+        .map_err(ComputeEvidenceError::ListAssets)?;
     info!(
         logger,
         "Fetching properties for all assets in the canister."
@@ -74,7 +79,7 @@ fn hash_operation(
     hasher: &mut Sha256,
     op: &BatchOperationKind,
     project_assets: &HashMap<String, ProjectAsset>,
-) -> anyhow::Result<()> {
+) -> Result<(), HashContentError> {
     match op {
         BatchOperationKind::CreateAsset(args) => hash_create_asset(hasher, args),
         BatchOperationKind::SetAssetContent(args) => {
@@ -107,7 +112,7 @@ fn hash_set_asset_content(
     hasher: &mut Sha256,
     args: &SetAssetContentArguments,
     project_assets: &HashMap<String, ProjectAsset>,
-) -> anyhow::Result<()> {
+) -> Result<(), HashContentError> {
     hasher.update(TAG_SET_ASSET_CONTENT);
     hasher.update(&args.key);
     hasher.update(&args.content_encoding);
@@ -117,11 +122,13 @@ fn hash_set_asset_content(
     let ad = &project_asset.asset_descriptor;
 
     let content = {
-        let identity = Content::load(&ad.source)?;
+        let identity = Content::load(&ad.source).map_err(LoadContentFailed)?;
         if args.content_encoding == "identity" {
             identity
         } else if args.content_encoding == "gzip" {
-            identity.encode(&Gzip)?
+            identity
+                .encode(&Gzip)
+                .map_err(|e| EncodeContentFailed(ad.key.clone(), Gzip, e))?
         } else {
             unreachable!("unhandled content encoder");
         }

--- a/src/canisters/frontend/ic-asset/src/lib.rs
+++ b/src/canisters/frontend/ic-asset/src/lib.rs
@@ -34,6 +34,7 @@
 mod asset;
 mod batch_upload;
 mod canister_api;
+mod error;
 mod evidence;
 mod sync;
 mod upload;

--- a/src/canisters/frontend/ic-asset/src/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/sync.rs
@@ -16,13 +16,23 @@ use crate::canister_api::methods::{
     list::list_assets,
 };
 use crate::canister_api::types::batch_upload::v0;
+use crate::canister_api::types::batch_upload::v1::BatchOperationKind;
 use crate::canister_api::types::batch_upload::{
     common::ComputeEvidenceArguments, v1::CommitBatchArguments,
 };
+use crate::error::compatibility::CompatibilityError::DowngradeV1TOV0Failed;
+use crate::error::gather_asset_descriptors::GatherAssetDescriptorsError;
+use crate::error::gather_asset_descriptors::GatherAssetDescriptorsError::{
+    DuplicateAssetKey, InvalidDirectoryEntry, InvalidSourceDirectory, LoadConfigFailed,
+};
+use crate::error::prepare_sync_for_proposal::PrepareSyncForProposalError;
+use crate::error::sync::SyncError;
+use crate::error::sync::SyncError::CommitBatchFailed;
+use crate::error::upload_content::UploadContentError;
+use crate::error::upload_content::UploadContentError::{CreateBatchFailed, ListAssetsFailed};
 
-use crate::canister_api::types::batch_upload::v1::BatchOperationKind;
-use anyhow::{anyhow, bail, Context};
 use candid::Nat;
+use ic_agent::AgentError;
 use ic_utils::Canister;
 use slog::{debug, info, trace, warn, Logger};
 use std::collections::HashMap;
@@ -34,10 +44,10 @@ pub async fn upload_content_and_assemble_sync_operations(
     canister: &Canister<'_>,
     dirs: &[&Path],
     logger: &Logger,
-) -> anyhow::Result<CommitBatchArguments> {
+) -> Result<CommitBatchArguments, UploadContentError> {
     let asset_descriptors = gather_asset_descriptors(dirs, logger)?;
 
-    let canister_assets = list_assets(canister).await?;
+    let canister_assets = list_assets(canister).await.map_err(ListAssetsFailed)?;
     info!(
         logger,
         "Fetching properties for all assets in the canister."
@@ -46,7 +56,7 @@ pub async fn upload_content_and_assemble_sync_operations(
 
     info!(logger, "Starting batch.");
 
-    let batch_id = create_batch(canister).await?;
+    let batch_id = create_batch(canister).await.map_err(CreateBatchFailed)?;
 
     info!(
         logger,
@@ -91,31 +101,31 @@ pub async fn upload_content_and_assemble_sync_operations(
 }
 
 /// Sets the contents of the asset canister to the contents of a directory, including deleting old assets.
-pub async fn sync(canister: &Canister<'_>, dirs: &[&Path], logger: &Logger) -> anyhow::Result<()> {
+pub async fn sync(
+    canister: &Canister<'_>,
+    dirs: &[&Path],
+    logger: &Logger,
+) -> Result<(), SyncError> {
     let commit_batch_args =
         upload_content_and_assemble_sync_operations(canister, dirs, logger).await?;
     let canister_api_version = api_version(canister).await;
     debug!(logger, "Canister API version: {canister_api_version}. ic-asset API version: {BATCH_UPLOAD_API_VERSION}");
     info!(logger, "Committing batch.");
-    let response = match canister_api_version {
+    match canister_api_version {
         0 => {
-            let commit_batch_args_v0 = v0::CommitBatchArguments::try_from(commit_batch_args)
-                .map_err(|e| anyhow!("Failed to downgrade from v1::CommitBatchArguments to v0::CommitBatchArguments: {}. Please upgrade your asset canister, or use older tooling (dfx<=v-0.13.1 or icx-asset<=0.20.0)", e))?;
+            let commit_batch_args_v0 = v0::CommitBatchArguments::try_from(commit_batch_args).map_err(DowngradeV1TOV0Failed)?;
             warn!(logger, "The asset canister is running an old version of the API. It will not be able to set assets properties.");
             commit_batch(canister, commit_batch_args_v0).await
         }
         BATCH_UPLOAD_API_VERSION.. => commit_in_stages(canister, commit_batch_args, logger).await,
-    };
-    response.context("Failed to synchronize frontend canister with project assets.")?;
-
-    Ok(())
+    }.map_err(CommitBatchFailed)
 }
 
 async fn commit_in_stages(
     canister: &Canister<'_>,
     commit_batch_args: CommitBatchArguments,
     logger: &Logger,
-) -> anyhow::Result<()> {
+) -> Result<(), AgentError> {
     // Note that SetAssetProperties operations are only generated for assets that
     // already exist, since CreateAsset operations set all properties.
     let (set_properties_operations, other_operations): (Vec<_>, Vec<_>) = commit_batch_args
@@ -170,13 +180,15 @@ pub async fn prepare_sync_for_proposal(
     canister: &Canister<'_>,
     dirs: &[&Path],
     logger: &Logger,
-) -> anyhow::Result<()> {
+) -> Result<(), PrepareSyncForProposalError> {
     let arg = upload_content_and_assemble_sync_operations(canister, dirs, logger).await?;
     let arg = sort_batch_operations(arg);
     let batch_id = arg.batch_id.clone();
 
     info!(logger, "Preparing batch {}.", batch_id);
-    propose_commit_batch(canister, arg).await?;
+    propose_commit_batch(canister, arg)
+        .await
+        .map_err(PrepareSyncForProposalError::ProposeCommitBatch)?;
 
     let compute_evidence_arg = ComputeEvidenceArguments {
         batch_id: batch_id.clone(),
@@ -184,7 +196,10 @@ pub async fn prepare_sync_for_proposal(
     };
     info!(logger, "Computing evidence.");
     let evidence = loop {
-        if let Some(evidence) = compute_evidence(canister, &compute_evidence_arg).await? {
+        if let Some(evidence) = compute_evidence(canister, &compute_evidence_arg)
+            .await
+            .map_err(PrepareSyncForProposalError::ComputeEvidence)?
+        {
             break evidence;
         }
     };
@@ -215,16 +230,12 @@ fn include_entry(entry: &walkdir::DirEntry, config: &AssetConfig) -> bool {
 pub(crate) fn gather_asset_descriptors(
     dirs: &[&Path],
     logger: &Logger,
-) -> anyhow::Result<Vec<AssetDescriptor>> {
+) -> Result<Vec<AssetDescriptor>, GatherAssetDescriptorsError> {
     let mut asset_descriptors: HashMap<String, AssetDescriptor> = HashMap::new();
     for dir in dirs {
-        let dir = dir.canonicalize().with_context(|| {
-            format!(
-                "unable to canonicalize the following path: {}",
-                dir.display()
-            )
-        })?;
-        let mut configuration = AssetSourceDirectoryConfiguration::load(&dir)?;
+        let dir = dfx_core::fs::canonicalize(dir).map_err(InvalidSourceDirectory)?;
+        let mut configuration =
+            AssetSourceDirectoryConfiguration::load(&dir).map_err(LoadConfigFailed)?;
         let mut asset_descriptors_interim = vec![];
         let entries = WalkDir::new(&dir)
             .into_iter()
@@ -245,18 +256,10 @@ pub(crate) fn gather_asset_descriptors(
             .collect::<Vec<_>>();
 
         for e in entries {
-            let source = e.path().canonicalize().with_context(|| {
-                format!(
-                    "unable to canonicalize the path when gathering asset descriptors: {}",
-                    dir.display()
-                )
-            })?;
+            let source = dfx_core::fs::canonicalize(e.path()).map_err(InvalidDirectoryEntry)?;
             let relative = source.strip_prefix(&dir).expect("cannot strip prefix");
             let key = String::from("/") + relative.to_string_lossy().as_ref();
-            let config = configuration.get_asset_config(&source).context(format!(
-                "failed to get config for asset: {}",
-                source.display()
-            ))?;
+            let config = configuration.get_asset_config(&source)?;
 
             asset_descriptors_interim.push(AssetDescriptor {
                 source,
@@ -267,12 +270,11 @@ pub(crate) fn gather_asset_descriptors(
 
         for asset_descriptor in asset_descriptors_interim {
             if let Some(already_seen) = asset_descriptors.get(&asset_descriptor.key) {
-                bail!(
-                    "Asset with key '{}' defined at {} and {}",
-                    &asset_descriptor.key,
-                    asset_descriptor.source.display(),
-                    already_seen.source.display()
-                )
+                return Err(DuplicateAssetKey(
+                    asset_descriptor.key.clone(),
+                    Box::new(asset_descriptor.source.clone()),
+                    Box::new(already_seen.source.clone()),
+                ));
             }
             asset_descriptors.insert(asset_descriptor.key.clone(), asset_descriptor);
         }

--- a/src/canisters/frontend/ic-asset/src/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/upload.rs
@@ -11,8 +11,10 @@ use crate::canister_api::methods::{
     list::list_assets,
 };
 use crate::canister_api::types::batch_upload::v0;
+use crate::error::compatibility::CompatibilityError::DowngradeV1TOV0Failed;
+use crate::error::upload::UploadError;
+use crate::error::upload::UploadError::{CommitBatchFailed, CreateBatchFailed, ListAssetsFailed};
 
-use anyhow::anyhow;
 use ic_utils::Canister;
 use slog::{info, Logger};
 use std::collections::HashMap;
@@ -23,7 +25,7 @@ pub async fn upload(
     canister: &Canister<'_>,
     files: HashMap<String, PathBuf>,
     logger: &Logger,
-) -> anyhow::Result<()> {
+) -> Result<(), UploadError> {
     let asset_descriptors: Vec<AssetDescriptor> = files
         .iter()
         .map(|x| AssetDescriptor {
@@ -33,11 +35,11 @@ pub async fn upload(
         })
         .collect();
 
-    let canister_assets = list_assets(canister).await?;
+    let canister_assets = list_assets(canister).await.map_err(ListAssetsFailed)?;
 
     info!(logger, "Starting batch.");
 
-    let batch_id = create_batch(canister).await?;
+    let batch_id = create_batch(canister).await.map_err(CreateBatchFailed)?;
 
     info!(logger, "Staging contents of new and changed assets:");
 
@@ -61,15 +63,13 @@ pub async fn upload(
 
     let canister_api_version = api_version(canister).await;
     info!(logger, "Committing batch.");
-    let response = match canister_api_version {
+    match canister_api_version {
         0 => {
             let commit_batch_args_v0 = v0::CommitBatchArguments::try_from(commit_batch_args)
-                .map_err(|e| anyhow!("Failed to downgrade from v1::CommitBatchArguments to v0::CommitBatchArguments: {}. Please upgrade your asset canister, or use older tooling (dfx<=v-0.13.1 or icx-asset<=0.20.0)", e))?;
+                .map_err(DowngradeV1TOV0Failed)?;
             commit_batch(canister, commit_batch_args_v0).await
         }
         BATCH_UPLOAD_API_VERSION.. => commit_batch(canister, commit_batch_args).await,
-    };
-    response.map_err(|e| anyhow!("Failed to upload project assets to frontend canister: {e}"))?;
-
-    Ok(())
+    }
+    .map_err(CommitBatchFailed)
 }

--- a/src/dfx-core/src/error/fs.rs
+++ b/src/dfx-core/src/error/fs.rs
@@ -24,6 +24,9 @@ pub enum FsErrorKind {
     #[error("Failed to read {0}: {1}")]
     ReadFileFailed(PathBuf, std::io::Error),
 
+    #[error("Failed to read metadata of {0}: {1}")]
+    ReadMetadataFailed(PathBuf, std::io::Error),
+
     #[error("Failed to read permissions of {0}: {1}")]
     ReadPermissionsFailed(PathBuf, std::io::Error),
 

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -4,12 +4,12 @@ use crate::error::archive::ArchiveError;
 use crate::error::fs::FsError;
 use crate::error::fs::FsErrorKind::{
     CanonicalizePathFailed, CopyFileFailed, CreateDirectoryFailed, NoParent, ReadDirFailed,
-    ReadFileFailed, ReadPermissionsFailed, ReadToStringFailed, RemoveDirectoryAndContentsFailed,
-    RemoveDirectoryFailed, RemoveFileFailed, RenameFailed, UnpackingArchiveFailed, WriteFileFailed,
-    WritePermissionsFailed,
+    ReadFileFailed, ReadMetadataFailed, ReadPermissionsFailed, ReadToStringFailed,
+    RemoveDirectoryAndContentsFailed, RemoveDirectoryFailed, RemoveFileFailed, RenameFailed,
+    UnpackingArchiveFailed, WriteFileFailed, WritePermissionsFailed,
 };
 
-use std::fs::{Permissions, ReadDir};
+use std::fs::{Metadata, Permissions, ReadDir};
 use std::path::{Path, PathBuf};
 
 pub fn canonicalize(path: &Path) -> Result<PathBuf, FsError> {
@@ -39,6 +39,10 @@ pub fn get_archive_path(
         .path()
         .map_err(ArchiveError::ArchiveFileInvalidPath)?;
     Ok(path.to_path_buf())
+}
+
+pub fn metadata(path: &Path) -> Result<Metadata, FsError> {
+    std::fs::metadata(path).map_err(|err| FsError::new(ReadMetadataFailed(path.to_path_buf(), err)))
 }
 
 pub fn parent(path: &Path) -> Result<PathBuf, FsError> {


### PR DESCRIPTION
# Description

Replace use of `anyhow` in the `ic-asset` crate with concrete error types.

Fixes https://dfinity.atlassian.net/browse/SDK-869


Regarding this note from  https://mmapped.blog/posts/12-rust-error-handling.html, I gave it a shot. So far I think it turned out better than I expected.
> Feel free to introduce distinct error types for each function you implement. I am still looking for Rust code that went overboard with distinct error types.

# How Has This Been Tested?

Covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
