### PR TITLE
chore: update changelog with dfx 0.14.2 cutoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # UNRELEASED
 
-Note: Canister http functionality is broken.  Do not release dfx until this is corrected.  See https://dfinity.atlassian.net/browse/SDK-1129
+# 0.14.2
 
 ## DFX
 


### PR DESCRIPTION
Also removed the note about canister http support being broken.  It's still broken, even as far back as dfx 0.13.1, and worked in 0.13.1, 0.14.0, and 0.14.1 at time of their release.