### PR TITLE
feat: add DFX_WARNING mainnet_plaintext_identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 # UNRELEASED
 
+## DFX
+
+### feat: can disable the warnings about using an unencrypted identity on mainnet
+
+It's now possible to suppress warnings of this form:
+
+```
+WARN: The <identity> identity is not stored securely. Do not use it to control a lot of cycles/ICP. Create a new identity with `dfx identity new` and use it in mainnet-facing commands with the `--identity` flag
+```
+
+To do so, export the environment variable `DFX_WARNING` with the value `-mainnet_plaintext_identity`.
+```bash
+export DFX_WARNING="-mainnet_plaintext_identity"
+```
+
+Note that this can be combined to also disable the dfx version check warning:
+```bash
+export DFX_WARNING="-version_check,-mainnet_plaintext_identity"
+```
+
 # 0.14.2
 
 ## DFX

--- a/docs/cli-reference/dfx-envars.md
+++ b/docs/cli-reference/dfx-envars.md
@@ -43,3 +43,22 @@ Use the `DFX_VERSION` environment variable to identify a specific version of the
 ## DFX_MOC_PATH
 
 Use the `DFX_MOC_PATH` environment variable to use a different version of the Motoko compiler than the one bundled with a given dfx version.
+
+## DFX_WARNING
+
+Use the `DFX_WARNING` environment variable to disable one or more warnings that dfx may display. The value is a comma-separated list of warning names, each prefixed with a "-" to disable. The following warning names are currently supported:
+
+- `version_check`: Disables the warning message that is displayed when you use an older version of the SDK.
+- `mainnet_plaintext_identity`: Disables the warning message that is displayed when you use an insecure identity on the Internet Computer mainnet.
+
+```bash
+export DFX_WARNING="-version_check"
+DFX_VERSION=0.13.1 dfx deploy --network ic
+
+export DFX_WARNING="-mainnet_plaintext_identity"
+dfx deploy --network ic
+
+# disable multiple warnings, though dfx 0.13.1 does not know about the mainnet_plaintext_identity warning
+export DFX_WARNING="-version_check,-mainnet_plaintext_identity"
+DFX_VERSION=0.13.1 dfx deploy --network ic
+```

--- a/e2e/tests-dfx/identity.bash
+++ b/e2e/tests-dfx/identity.bash
@@ -169,4 +169,9 @@ teardown() {
     dfx identity new bob --storage-mode plaintext
     assert_command dfx ledger balance --network ic --identity bob
     assert_match "WARN: The bob identity is not stored securely." "$stderr"
+
+    export DFX_WARNING=-mainnet_plaintext_identity
+    assert_command dfx ledger balance --network ic --identity bob
+    assert_not_contains "not stored securely" "$stderr"
+
 }

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -4,6 +4,7 @@ use crate::lib::error::extension::ExtensionError;
 use crate::lib::error::DfxResult;
 use crate::lib::extension::manager::ExtensionManager;
 use crate::lib::progress_bar::ProgressBar;
+use crate::lib::warning::{is_warning_disabled, DfxWarning::MainnetPlainTextIdentity};
 use dfx_core::config::cache::Cache;
 use dfx_core::config::model::canister_id_store::CanisterIdStore;
 use dfx_core::config::model::dfinity::{Config, NetworksConfig};
@@ -11,7 +12,6 @@ use dfx_core::config::model::network_descriptor::NetworkDescriptor;
 use dfx_core::error::canister_id_store::CanisterIdStoreError;
 use dfx_core::error::identity::IdentityError;
 use dfx_core::identity::identity_manager::IdentityManager;
-use crate::lib::warning::{is_warning_disabled, DfxWarning::MainnetPlainTextIdentity};
 
 use anyhow::{anyhow, Context};
 use candid::Principal;

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -11,6 +11,7 @@ use dfx_core::config::model::network_descriptor::NetworkDescriptor;
 use dfx_core::error::canister_id_store::CanisterIdStoreError;
 use dfx_core::error::identity::IdentityError;
 use dfx_core::identity::identity_manager::IdentityManager;
+use crate::lib::warning::{is_warning_disabled, DfxWarning::MainnetPlainTextIdentity};
 
 use anyhow::{anyhow, Context};
 use candid::Principal;
@@ -280,7 +281,10 @@ impl<'a> AgentEnvironment<'a> {
         } else {
             identity_manager.instantiate_selected_identity(&logger)?
         };
-        if network_descriptor.is_ic && identity.insecure {
+        if network_descriptor.is_ic
+            && identity.insecure
+            && !is_warning_disabled(MainnetPlainTextIdentity)
+        {
             warn!(logger, "The {} identity is not stored securely. Do not use it to control a lot of cycles/ICP. Create a new identity with `dfx identity new` \
                 and use it in mainnet-facing commands with the `--identity` flag", identity.name());
         }

--- a/src/dfx/src/lib/mod.rs
+++ b/src/dfx/src/lib/mod.rs
@@ -35,4 +35,5 @@ pub mod sign;
 pub mod sns;
 pub mod state_tree;
 pub mod toolchain;
+pub mod warning;
 pub mod wasm;

--- a/src/dfx/src/lib/warning.rs
+++ b/src/dfx/src/lib/warning.rs
@@ -1,0 +1,17 @@
+pub enum DfxWarning {
+    VersionCheck,
+    MainnetPlainTextIdentity,
+}
+
+pub fn is_warning_disabled(warning: DfxWarning) -> bool {
+    let warning = match warning {
+        DfxWarning::VersionCheck => "version_check",
+        DfxWarning::MainnetPlainTextIdentity => "mainnet_plaintext_identity",
+    };
+    // By default, warnings are all enabled.
+    let env_warnings = std::env::var("DFX_WARNING").unwrap_or_else(|_| "".to_string());
+    env_warnings
+        .split(',')
+        .filter(|w| w.starts_with('-'))
+        .any(|w| w.chars().skip(1).collect::<String>().eq(warning))
+}

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -4,6 +4,7 @@ use crate::config::{dfx_version, dfx_version_str};
 use crate::lib::environment::{Environment, EnvironmentImpl};
 use crate::lib::logger::{create_root_logger, LoggingMode};
 
+use crate::lib::warning::{is_warning_disabled, DfxWarning::VersionCheck};
 use anyhow::Error;
 use clap::{ArgAction, Args, Parser};
 use lib::diagnosis::{diagnose, Diagnosis, NULL_DIAGNOSIS};
@@ -58,15 +59,6 @@ struct NetworkOpt {
     network: Option<String>,
 }
 
-fn is_warning_disabled(warning: &str) -> bool {
-    // By default, warnings are all enabled.
-    let env_warnings = std::env::var("DFX_WARNING").unwrap_or_else(|_| "".to_string());
-    env_warnings
-        .split(',')
-        .filter(|w| w.starts_with('-'))
-        .any(|w| w.chars().skip(1).collect::<String>().eq(warning))
-}
-
 /// In some cases, redirect the dfx execution to the proper version.
 /// This will ALWAYS return None, OR WILL TERMINATE THE PROCESS. There is no Ok()
 /// version of this (nor should there be).
@@ -78,7 +70,7 @@ fn maybe_redirect_dfx(version: &Version) -> Option<()> {
     // call to the cache.
     if dfx_version() != version {
         // Show a warning to the user.
-        if !is_warning_disabled("version_check") {
+        if !is_warning_disabled(VersionCheck) {
             eprintln!(
                 concat!(
                     "Warning: The version of DFX used ({}) is different than the version ",


### PR DESCRIPTION
# Description

Make it possible to disable this warning:
> The {} identity is not stored securely. Do not use it to control a lot of cycles/ICP. Create a new identity with `dfx identity new` and use it in mainnet-facing commands with the `--identity` flag

Also added a documentation section for the `DFX_WARNING` environment variable to dfx-envvars.md.

Fixes https://dfinity.atlassian.net/browse/SDK-962

# How Has This Been Tested?

Extended an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
