### PR TITLE
fix: Wait for new module hash when installing wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## DFX
 
+### fix: Wait for new module hash when installing wallet
+
+A previous change made dfx wait after installing a canister until the replica updated its reported module hash, but this change did not affect wallets. Now dfx waits for wallets too, to eliminate a class of wallet installation errors.
+
 ### fix: Ctrl-C right after dfx start will hang for minutes and panics
 
 Early break out from actors starting procedure.


### PR DESCRIPTION
#2407 neglected the `install_wallet` function, which does not use `install_canister` and thus did not benefit from the module hash waiting. This extracts it to shared logic between the two functions.