### PR TITLE
chore: update Motoko to 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ Note that this can be combined to also disable the dfx version check warning:
 export DFX_WARNING="-version_check,-mainnet_plaintext_identity"
 ```
 
+## Dependencies
+
+### Motoko
+
+Updated Motoko to [0.9.5](https://github.com/dfinity/motoko/releases/tag/0.9.5)
+
 # 0.14.2
 
 ## DFX

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -173,7 +173,7 @@
         "sha256": "085kvs6q7nrdlnxzxb28vw36g022a4ckg3idh85b9v2azixfqx1w",
         "type": "file",
         "url": "https://github.com/dfinity/motoko/releases/download/0.9.3/motoko-macos-0.9.3.tar.gz",
-        "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-macos-<version>.tar.gz",
+        "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-Darwin-x86_64-<version>.tar.gz",
         "version": "0.9.3"
     },
     "motoko-x86_64-linux": {
@@ -181,7 +181,7 @@
         "sha256": "0p0flwbrl3z23imx590865s7jyx9py110hvm7jcclw6zmkxp0xv4",
         "type": "file",
         "url": "https://github.com/dfinity/motoko/releases/download/0.9.3/motoko-linux64-0.9.3.tar.gz",
-        "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-linux64-<version>.tar.gz",
+        "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-Linux-x86_64-<version>.tar.gz",
         "version": "0.9.3"
     },
     "replica-x86_64-darwin": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -162,27 +162,27 @@
         "builtin": false,
         "description": "The Motoko base library",
         "owner": "dfinity",
-        "sha256": "1bq6cwwib4z3siykp851987h136wfap0cw4a9gq4nakr39qzj872",
+        "sha256": "04awra5kjj9fwf3pcjr5r821ki5ajjn70ggw4in26psdi7czsziv",
         "type": "tarball",
-        "url": "https://github.com/dfinity/motoko/releases/download/0.9.3/motoko-base-library.tar.gz",
+        "url": "https://github.com/dfinity/motoko/releases/download/0.9.5/motoko-base-library.tar.gz",
         "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-base-library.tar.gz",
-        "version": "0.9.3"
+        "version": "0.9.5"
     },
     "motoko-x86_64-darwin": {
         "builtin": false,
-        "sha256": "085kvs6q7nrdlnxzxb28vw36g022a4ckg3idh85b9v2azixfqx1w",
+        "sha256": "05jp02hwmhk7i6zp729b5wi3446ds7ns3ni2jaa6k7199qc8q0sh",
         "type": "file",
-        "url": "https://github.com/dfinity/motoko/releases/download/0.9.3/motoko-macos-0.9.3.tar.gz",
+        "url": "https://github.com/dfinity/motoko/releases/download/0.9.5/motoko-Darwin-x86_64-0.9.5.tar.gz",
         "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-Darwin-x86_64-<version>.tar.gz",
-        "version": "0.9.3"
+        "version": "0.9.5"
     },
     "motoko-x86_64-linux": {
         "builtin": false,
-        "sha256": "0p0flwbrl3z23imx590865s7jyx9py110hvm7jcclw6zmkxp0xv4",
+        "sha256": "1afjyfpg42irwmanyhincdgsgvsph2zj19y7fbnh9hgpvhdwc3z4",
         "type": "file",
-        "url": "https://github.com/dfinity/motoko/releases/download/0.9.3/motoko-linux64-0.9.3.tar.gz",
+        "url": "https://github.com/dfinity/motoko/releases/download/0.9.5/motoko-Linux-x86_64-0.9.5.tar.gz",
         "url_template": "https://github.com/dfinity/motoko/releases/download/<version>/motoko-Linux-x86_64-<version>.tar.gz",
-        "version": "0.9.3"
+        "version": "0.9.5"
     },
     "replica-x86_64-darwin": {
         "builtin": false,

--- a/src/dfx/assets/dfx-asset-sources.toml
+++ b/src/dfx/assets/dfx-asset-sources.toml
@@ -30,8 +30,8 @@ url = 'https://download.dfinity.systems/ic/ef8ca68771baa20a14af650ab89c9b31b1dc9
 sha256 = 'a8816fdd4531b4ce468c6e382b76545736f92d176e5b7d6b7a2d2eb811b2d840'
 
 [x86_64-darwin.motoko]
-url = 'https://github.com/dfinity/motoko/releases/download/0.9.3/motoko-macos-0.9.3.tar.gz'
-sha256 = '3c74ec7afc4aecb40a822d8e37195142806706df48acfebba52ddb838ddeb320'
+url = 'https://github.com/dfinity/motoko/releases/download/0.9.5/motoko-Darwin-x86_64-0.9.5.tar.gz'
+sha256 = '50038c184e299c69949222daa1edd1cd1032222f2b8973bf8967c2caa1005716'
 # The replica and canister_sandbox binaries must have the same revision.
 
 [x86_64-darwin.replica]
@@ -52,8 +52,8 @@ url = 'https://download.dfinity.systems/ic/ef8ca68771baa20a14af650ab89c9b31b1dc9
 sha256 = '7c8fc272696722bd56813d9f94906203b253cbf244825f1f6f929bc79e0601b1'
 
 [x86_64-darwin.motoko-base]
-url = 'https://github.com/dfinity/motoko/releases/download/0.9.3/motoko-base-library.tar.gz'
-sha256 = 'c22da317d5f3a0493f0e754221401eb5f21d85468db33e50b971bc49fa0b24bb'
+url = 'https://github.com/dfinity/motoko/releases/download/0.9.5/motoko-base-library.tar.gz'
+sha256 = '50235695c1fa1f33ac672949182362947b9c472629dfda531642f394dab6616c'
 
 [x86_64-darwin.ic-btc-canister]
 url = 'https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2023-03-31/ic-btc-canister.wasm.gz'
@@ -88,8 +88,8 @@ url = 'https://download.dfinity.systems/ic/ef8ca68771baa20a14af650ab89c9b31b1dc9
 sha256 = 'c620a5e2c7a731c8a2332b793e523a25ad5190163578c7e4c887ed6c53f0166e'
 
 [x86_64-linux.motoko]
-url = 'https://github.com/dfinity/motoko/releases/download/0.9.3/motoko-linux64-0.9.3.tar.gz'
-sha256 = '647770fbacdf70ca983c75431082bfa97b79743108a4d26b1ce20f9a17a70e5c'
+url = 'https://github.com/dfinity/motoko/releases/download/0.9.5/motoko-Linux-x86_64-0.9.5.tar.gz'
+sha256 = 'e40fc61bdcf7c104ed72c7a720bf8057efa75f6336426f55e5390af2aef3d2a9'
 # The replica and canister_sandbox binaries must have the same revision.
 
 [x86_64-linux.replica]
@@ -110,8 +110,8 @@ url = 'https://download.dfinity.systems/ic/ef8ca68771baa20a14af650ab89c9b31b1dc9
 sha256 = 'e3410ecd63b6e35a68ab8e5c12d7b543ab0cdae8c3382fac26f5cb84c4fd73c3'
 
 [x86_64-linux.motoko-base]
-url = 'https://github.com/dfinity/motoko/releases/download/0.9.3/motoko-base-library.tar.gz'
-sha256 = 'c22da317d5f3a0493f0e754221401eb5f21d85468db33e50b971bc49fa0b24bb'
+url = 'https://github.com/dfinity/motoko/releases/download/0.9.5/motoko-base-library.tar.gz'
+sha256 = '50235695c1fa1f33ac672949182362947b9c472629dfda531642f394dab6616c'
 
 [x86_64-linux.ic-btc-canister]
 url = 'https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2023-03-31/ic-btc-canister.wasm.gz'


### PR DESCRIPTION
# Description

Also updated the URL templates for the new build artifact paths.

Fixes https://dfinity.atlassian.net/browse/SDK-1158

# How Has This Been Tested?

Covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
