### PR TITLE
fix(extension): when executing ext, allow params with hyphens

### DIFF
--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -115,3 +115,37 @@ echo testoutput' > "$CACHE_DIR"/extensions/test_extension/test_extension
     assert_match 'No extensions installed'
 }
 
+
+@test "run with hyphened parameters" {
+    CACHE_DIR=$(dfx cache show)
+    mkdir -p "$CACHE_DIR"/extensions/test_extension
+    echo '#!/usr/bin/env bash
+
+if [ "$2" == "--the-param" ]; then
+    echo "$3"
+fi' > "$CACHE_DIR"/extensions/test_extension/test_extension
+    chmod +x "$CACHE_DIR"/extensions/test_extension/test_extension
+    echo '{
+  "name": "test_extension",
+  "version": "0.1.0",
+  "homepage": "https://github.com/dfinity/dfx-extensions",
+  "authors": "DFINITY",
+  "summary": "Test extension for e2e purposes.",
+  "categories": [],
+  "keywords": [],
+  "subcommands": {
+    "abc": {
+      "about": "something something",
+      "args": {
+        "the_param": {
+          "about": "this is the param",
+          "long": "the-param"
+        }
+      }
+    }
+  }
+}' > "$CACHE_DIR"/extensions/test_extension/extension.json
+
+    assert_command dfx test_extension abc --the-param 123
+    assert_match "123"
+}

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -119,6 +119,8 @@ echo testoutput' > "$CACHE_DIR"/extensions/test_extension/test_extension
 @test "run with hyphened parameters" {
     CACHE_DIR=$(dfx cache show)
     mkdir -p "$CACHE_DIR"/extensions/test_extension
+
+    # shellcheck disable=SC2016
     echo '#!/usr/bin/env bash
 
 if [ "$2" == "--the-param" ]; then

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -154,5 +154,5 @@ EOF
 EOF
 
     assert_command dfx test_extension abc --the-param 123
-    assert_contains "the param is 123"
+    assert_eq "the param is 123"
 }

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -120,14 +120,18 @@ echo testoutput' > "$CACHE_DIR"/extensions/test_extension/test_extension
     CACHE_DIR=$(dfx cache show)
     mkdir -p "$CACHE_DIR"/extensions/test_extension
 
-    # shellcheck disable=SC2016
-    echo '#!/usr/bin/env bash
+    cat > "$CACHE_DIR"/extensions/test_extension/test_extension << "EOF"
+#!/usr/bin/env bash
 
 if [ "$2" == "--the-param" ]; then
-    echo "$3"
-fi' > "$CACHE_DIR"/extensions/test_extension/test_extension
+    echo "the param is $3"
+fi
+EOF
+
     chmod +x "$CACHE_DIR"/extensions/test_extension/test_extension
-    echo '{
+
+    cat > "$CACHE_DIR"/extensions/test_extension/extension.json <<EOF
+{
   "name": "test_extension",
   "version": "0.1.0",
   "homepage": "https://github.com/dfinity/dfx-extensions",
@@ -146,8 +150,9 @@ fi' > "$CACHE_DIR"/extensions/test_extension/test_extension
       }
     }
   }
-}' > "$CACHE_DIR"/extensions/test_extension/extension.json
+}
+EOF
 
     assert_command dfx test_extension abc --the-param 123
-    assert_match "123"
+    assert_contains "the param is 123"
 }

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -124,7 +124,7 @@ echo testoutput' > "$CACHE_DIR"/extensions/test_extension/test_extension
 #!/usr/bin/env bash
 
 if [ "$2" == "--the-param" ]; then
-    echo "the param is $3"
+    echo "pamparam the param is $3"
 fi
 EOF
 
@@ -154,5 +154,5 @@ EOF
 EOF
 
     assert_command dfx test_extension abc --the-param 123
-    assert_eq "the param is 123"
+    assert_eq "pamparam the param is 123"
 }

--- a/src/dfx/src/commands/extension/run.rs
+++ b/src/dfx/src/commands/extension/run.rs
@@ -10,6 +10,7 @@ pub struct RunOpts {
     /// Specifies the name of the extension to run.
     name: OsString,
     /// Specifies the parameters to pass to the extension.
+    #[arg(allow_hyphen_values = true)]
     params: Vec<OsString>,
 }
 


### PR DESCRIPTION
Mitigates the anomaly experienced when executing an extension with hyphenated parameters

#### previously
```console
❯ dfx nns install --ledger-accounts fefe 

error: unexpected argument '--ledger-accounts' found

  tip: to pass '--ledger-accounts' as a value, use '-- --ledger-accounts'

Usage: dfx extension run <NAME|PARAMS>

For more information, try '--help'.
```
 
(same for `dfx extension run nns install...`)

#### now
```console
❯ dfx nns install --ledger-accounts fefe 

Error: No config file found. Please run `dfx config create` first.
Error: Extension exited with non-zero status code '1'.
```

# How Has This Been Tested?

manually

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] ~I have edited the CHANGELOG accordingly.~
- [ ] ~I have made corresponding changes to the documentation.~