### PR TITLE
fix(extension-run): allow params with multiple values

### DIFF
--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -155,6 +155,8 @@ EOF
 
     assert_command dfx test_extension abc --the-param 123
     assert_eq "pamparam the param is 123"
+    assert_command dfx extension run test_extension abc --the-param 123
+    assert_eq "pamparam the param is 123"
 }
 
 @test "run with multiple values for the same parameter" {
@@ -199,7 +201,11 @@ EOF
 EOF
 
     assert_command dfx test_extension abc --the-param 123 456 789 --the-another-param 464646
-    assert_match "abc --the-param 123 456 789 --the-another-param 464646"
+    assert_eq "abc --the-param 123 456 789 --the-another-param 464646 --dfx-cache-path $CACHE_DIR"
     assert_command dfx test_extension abc --the-another-param 464646 --the-param 123 456 789
-    assert_match "abc --the-another-param 464646 --the-param 123 456 789"
+    assert_eq "abc --the-another-param 464646 --the-param 123 456 789 --dfx-cache-path $CACHE_DIR"
+    assert_command dfx extension run test_extension abc --the-param 123 456 789 --the-another-param 464646
+    assert_eq "abc --the-param 123 456 789 --the-another-param 464646 --dfx-cache-path $CACHE_DIR"
+    assert_command dfx extension run test_extension abc --the-another-param 464646 --the-param 123 456 789
+    assert_eq "abc --the-another-param 464646 --the-param 123 456 789 --dfx-cache-path $CACHE_DIR"
 }

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -156,3 +156,50 @@ EOF
     assert_command dfx test_extension abc --the-param 123
     assert_eq "pamparam the param is 123"
 }
+
+@test "run with multiple values for the same parameter" {
+    CACHE_DIR=$(dfx cache show)
+    mkdir -p "$CACHE_DIR"/extensions/test_extension
+
+    cat > "$CACHE_DIR"/extensions/test_extension/test_extension << "EOF"
+#!/usr/bin/env bash
+
+echo $@
+EOF
+
+    chmod +x "$CACHE_DIR"/extensions/test_extension/test_extension
+
+    cat > "$CACHE_DIR"/extensions/test_extension/extension.json <<EOF
+{
+  "name": "test_extension",
+  "version": "0.1.0",
+  "homepage": "https://github.com/dfinity/dfx-extensions",
+  "authors": "DFINITY",
+  "summary": "Test extension for e2e purposes.",
+  "categories": [],
+  "keywords": [],
+  "subcommands": {
+    "abc": {
+      "about": "something something",
+      "args": {
+        "the_param": {
+          "about": "this is the param",
+          "long": "the-param",
+          "multiple": true
+        },
+        "another_param": {
+          "about": "this is the param",
+          "long": "the-another-param",
+          "multiple": true
+        }
+      }
+    }
+  }
+}
+EOF
+
+    assert_command dfx test_extension abc --the-param 123 456 789 --the-another-param 464646
+    assert_match "abc --the-param 123 456 789 --the-another-param 464646"
+    assert_command dfx test_extension abc --the-another-param 464646 --the-param 123 456 789
+    assert_match "abc --the-another-param 464646 --the-param 123 456 789"
+}

--- a/src/dfx/src/lib/extension/manifest/extension.rs
+++ b/src/dfx/src/lib/extension/manifest/extension.rs
@@ -60,7 +60,8 @@ pub struct ExtensionSubcommandArgOpts {
     pub about: Option<String>,
     pub long: Option<String>,
     pub short: Option<char>,
-    pub multiple: Option<bool>,
+    #[serde(default)]
+    pub multiple: bool,
 }
 
 impl ExtensionSubcommandArgOpts {
@@ -79,8 +80,8 @@ impl ExtensionSubcommandArgOpts {
         if let Some(s) = self.short {
             arg = arg.short(s);
         }
-        if matches!(self.multiple, Some(true)) {
-            arg = arg.num_args(0..)
+        if self.multiple {
+            arg = arg.num_args(0..);
         }
         Ok(arg
             // let's not enforce any restrictions
@@ -199,6 +200,13 @@ fn parse_test_file() {
                     Some(&"value".to_string()),
                     matches.get_one::<String>("ic_commit")
                 );
+                let matches = s.clone().try_get_matches_from(vec![
+                    "download",
+                    "--ic-commit",
+                    "value",
+                    "value2",
+                ]);
+                assert!(matches.is_err());
             }
             "install" => {
                 let matches = s.clone().get_matches_from(vec![

--- a/src/dfx/src/lib/extension/manifest/extension.rs
+++ b/src/dfx/src/lib/extension/manifest/extension.rs
@@ -79,9 +79,8 @@ impl ExtensionSubcommandArgOpts {
         if let Some(s) = self.short {
             arg = arg.short(s);
         }
-        match self.multiple {
-            Some(m) if m => arg = arg.num_args(0..),
-            _ => {}
+        if matches!(self.multiple, Some(true)) {
+            arg = arg.num_args(0..)
         }
         Ok(arg
             // let's not enforce any restrictions


### PR DESCRIPTION
-------

# Description

Adds a configuration flag for `extension.json`: `.subcommands.<CMD>.args.<ARG>.multiple`, which allows passing multiple values for one param, e.g.:
```console
dfx extension install nns
dfx nns install --ledger-accounts fefe efef eeff
```


# How Has This Been Tested?

e2e + unit

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.