### PR TITLE
feat: allow update-replica-version workflow to update a non-master branch

### DIFF
--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -15,10 +15,6 @@ on:
       sdkBranch:
         description: 'Open PR against this sdk branch'
         default: "master"
-      updateNnsCanisters:
-        description: 'Update the NNS canisters for e2e tests'
-        type: boolean
-        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -12,6 +12,9 @@ on:
       customReplicaVersion:
         description: 'dfinity/ic commit SHA - get the latest Elect Replica Version from https://dashboard.internetcomputer.org/releases'     
         default: "required if custom"
+      sdkBranch:
+        description: 'Open PR against this sdk branch'
+        default: "master"
       updateNnsCanisters:
         description: 'Update the NNS canisters for e2e tests'
         type: boolean
@@ -33,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3.0.2
+      with:
+        ref: ${{ github.event.inputs.sdkBranch }}
 
     - name: determine replica commit sha
       run: |
@@ -51,7 +56,7 @@ jobs:
     - name: install niv (dependency manager for Nix projects)
       run: nix-env -i niv -f '<nixpkgs>'
 
-    - name: intall packages from nix/sources.json
+    - name: install packages from nix/sources.json
       run: niv update
 
     - name: update replica
@@ -113,7 +118,7 @@ jobs:
             owner,
             repo,
             head: 'chore-update-replica-${{ env.REPLICA_VERSION }}',
-            base: 'master',
+            base: '${{ github.event.inputs.sdkBranch }}',
             body: [
               `## Suggested [CHANGELOG.md](https://github.com/${owner}/${repo}/edit/chore-update-replica-${{ env.REPLICA_VERSION }}/CHANGELOG.md) changes`,
               '```',


### PR DESCRIPTION
# Description

Using this to make a dfx 0.14.3 beta that is dfx 0.14.2 + an RC replica

# How Has This Been Tested?

See workflow https://github.com/dfinity/sdk/actions/runs/5545890280/jobs/10125497277 and generated [PR #3237](https://github.com/dfinity/sdk/pull/3237)

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
