### PR TITLE
chore: use default tls config

### DIFF
--- a/src/dfx/src/lib/project/import.rs
+++ b/src/dfx/src/lib/project/import.rs
@@ -239,16 +239,10 @@ impl Loader {
 
     fn client(&mut self) -> Result<&Client, ProjectError> {
         if self.client.is_none() {
-            let tls_config = rustls::ClientConfig::builder()
-                .with_safe_defaults()
-                .with_webpki_roots()
-                .with_no_client_auth();
-
             // Advertise support for HTTP/2
             //tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-
             let client = reqwest::Client::builder()
-                .use_preconfigured_tls(tls_config)
+                .use_rustls_tls()
                 .build()
                 .map_err(ProjectError::CouldNotCreateHttpClient)?;
             self.client = Some(client);

--- a/src/dfx/src/util/mod.rs
+++ b/src/dfx/src/util/mod.rs
@@ -334,13 +334,10 @@ pub async fn download_file_to_path(from: &Url, to: &Path) -> DfxResult {
 
 #[context("Failed to download from url: {}.", from)]
 pub async fn download_file(from: &Url) -> DfxResult<Vec<u8>> {
-    let tls_config = rustls::ClientConfig::builder()
-        .with_safe_defaults()
-        .with_webpki_roots()
-        .with_no_client_auth();
-
+    // Advertise support for HTTP/2
+    //tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
     let client = reqwest::Client::builder()
-        .use_preconfigured_tls(tls_config)
+        .use_rustls_tls()
         .build()
         .context("Could not create HTTP client.")?;
 


### PR DESCRIPTION
-------

# Description

When working on #3221, some e2e failed:

```console
             Could not create HTTP client.
               builder error: Unknown TLS backend passed to `use_preconfigured_tls`
                 Unknown TLS backend passed to `use_preconfigured_tls`
```

This fixes the issue. The approach is lifted from https://github.com/dfinity/agent-rs/pull/441

# How Has This Been Tested?

covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.