### PR TITLE
test: re-enable canister http query test

### DIFF
--- a/e2e/assets/canister_http/main.mo
+++ b/e2e/assets/canister_http/main.mo
@@ -6,8 +6,8 @@ import Blob "mo:base/Blob";
 import Nat "mo:base/Nat";
 
 shared actor class HttpQuery() = this {
-    let MAX_RESPONSE_BYTES : Nat64 = 12000;
-    let CYCLES_TO_PAY : Nat = 2_000_000_000;
+    let MAX_RESPONSE_BYTES : Nat64 = 800000; // last seen ~90k
+    let CYCLES_TO_PAY : Nat = 16_000_000_000;
 
     public func get_url(host : Text, url : Text) : async Text {
         let request_headers = [

--- a/e2e/tests-dfx/canister_http.bash
+++ b/e2e/tests-dfx/canister_http.bash
@@ -330,8 +330,6 @@ set_shared_local_network_canister_http_empty() {
 }
 
 @test "can query a website" {
-    skip "Canister http functionality is broken.  See https://dfinity.atlassian.net/browse/SDK-1129"
-
     dfx_start
 
     dfx_new
@@ -339,8 +337,7 @@ set_shared_local_network_canister_http_empty() {
 
     dfx deploy
 
-    assert_command dfx canister call e2e_project_backend get_url '("smartcontracts.org:443","https://smartcontracts.org:443")'
-    assert_contains "Internet Computer"
-    assert_contains "smart contracts"
-    assert_contains "dapps"
+    assert_command dfx canister call e2e_project_backend get_url '("www.githubstatus.com:443","https://www.githubstatus.com:443")'
+    assert_contains "Git Operations"
+    assert_contains "API Requests"
 }


### PR DESCRIPTION
# Description

This test started failing last month.  It seems that for some reason, canister http outcalls to smartcontracts.org or internetcomputer.org fail with `Could not find a canister id to forward to.`.  While this is interesting, it's not the purpose of this test.  

Use `www.githubstatus.com` instead: within the context of a CI run, one query here seems ok.

Addresses https://dfinity.atlassian.net/browse/SDK-1129

