### PR TITLE
refactor: flatten notify_create, notify_top_up error types

### DIFF
--- a/src/dfx/src/commands/ledger/create_canister.rs
+++ b/src/dfx/src/commands/ledger/create_canister.rs
@@ -1,7 +1,9 @@
 use crate::commands::ledger::get_icpts_from_args;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::ledger_types::{Memo, NotifyError};
+use crate::lib::error::NotifyCreateCanisterError::Notify;
+use crate::lib::ledger_types::Memo;
+use crate::lib::ledger_types::NotifyError::Refunded;
 use crate::lib::nns_types::account_identifier::Subaccount;
 use crate::lib::nns_types::icpts::{ICPTs, TRANSACTION_FEE};
 use crate::lib::operations::cmc::{notify_create, transfer_cmc};
@@ -87,16 +89,16 @@ pub async fn exec(env: &dyn Environment, opts: CreateCanisterOpts) -> DfxResult 
     .await?;
     println!("Using transfer at block height {height}");
 
-    let result = notify_create(agent, controller, height, opts.subnet_type).await?;
+    let result = notify_create(agent, controller, height, opts.subnet_type).await;
 
     match result {
         Ok(principal) => {
             println!("Canister created with id: {:?}", principal.to_text());
         }
-        Err(NotifyError::Refunded {
+        Err(Notify(Refunded {
             reason,
             block_index,
-        }) => {
+        })) => {
             match block_index {
                 Some(height) => {
                     println!("Refunded at block height {height} with message: {reason}")

--- a/src/dfx/src/commands/ledger/notify/create_canister.rs
+++ b/src/dfx/src/commands/ledger/notify/create_canister.rs
@@ -1,4 +1,5 @@
-use crate::lib::ledger_types::NotifyError;
+use crate::lib::error::NotifyCreateCanisterError::Notify;
+use crate::lib::ledger_types::NotifyError::Refunded;
 use crate::lib::operations::cmc::notify_create;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::lib::{environment::Environment, error::DfxResult};
@@ -32,16 +33,16 @@ pub async fn exec(env: &dyn Environment, opts: NotifyCreateOpts) -> DfxResult {
 
     fetch_root_key_if_needed(env).await?;
 
-    let result = notify_create(agent, controller, block_height, opts.subnet_type).await?;
+    let result = notify_create(agent, controller, block_height, opts.subnet_type).await;
 
     match result {
         Ok(principal) => {
             println!("Canister created with id: {:?}", principal.to_text());
         }
-        Err(NotifyError::Refunded {
+        Err(Notify(Refunded {
             reason,
             block_index,
-        }) => {
+        })) => {
             match block_index {
                 Some(height) => {
                     println!("Refunded at block height {height} with message: {reason}")

--- a/src/dfx/src/commands/ledger/notify/top_up.rs
+++ b/src/dfx/src/commands/ledger/notify/top_up.rs
@@ -1,4 +1,5 @@
-use crate::lib::ledger_types::NotifyError;
+use crate::lib::error::NotifyTopUpError::Notify;
+use crate::lib::ledger_types::NotifyError::Refunded;
 use crate::lib::operations::cmc::notify_top_up;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::lib::{environment::Environment, error::DfxResult};
@@ -26,16 +27,16 @@ pub async fn exec(env: &dyn Environment, opts: NotifyTopUpOpts) -> DfxResult {
 
     fetch_root_key_if_needed(env).await?;
 
-    let result = notify_top_up(agent, canister, block_height).await?;
+    let result = notify_top_up(agent, canister, block_height).await;
 
     match result {
         Ok(cycles) => {
             println!("Canister {canister} topped up with {cycles} cycles");
         }
-        Err(NotifyError::Refunded {
+        Err(Notify(Refunded {
             reason,
             block_index,
-        }) => match block_index {
+        })) => match block_index {
             Some(height) => {
                 println!("Refunded at block height {height} with message: {reason}");
             }

--- a/src/dfx/src/commands/ledger/top_up.rs
+++ b/src/dfx/src/commands/ledger/top_up.rs
@@ -1,7 +1,8 @@
 use crate::commands::ledger::get_icpts_from_args;
 use crate::lib::environment::Environment;
-use crate::lib::error::DfxResult;
-use crate::lib::ledger_types::{Memo, NotifyError};
+use crate::lib::error::{DfxResult, NotifyTopUpError::Notify};
+use crate::lib::ledger_types::Memo;
+use crate::lib::ledger_types::NotifyError::Refunded;
 use crate::lib::nns_types::account_identifier::Subaccount;
 use crate::lib::nns_types::icpts::{ICPTs, TRANSACTION_FEE};
 use crate::lib::operations::cmc::{notify_top_up, transfer_cmc};
@@ -81,16 +82,16 @@ pub async fn exec(env: &dyn Environment, opts: TopUpOpts) -> DfxResult {
     )
     .await?;
     println!("Using transfer at block height {height}");
-    let result = notify_top_up(agent, to, height).await?;
+    let result = notify_top_up(agent, to, height).await;
 
     match result {
         Ok(cycles) => {
             println!("Canister was topped up with {cycles} cycles!");
         }
-        Err(NotifyError::Refunded {
+        Err(Notify(Refunded {
             reason,
             block_index,
-        }) => match block_index {
+        })) => match block_index {
             Some(height) => {
                 println!("Refunded at block height {height} with message: {reason}")
             }

--- a/src/dfx/src/lib/error/mod.rs
+++ b/src/dfx/src/lib/error/mod.rs
@@ -1,6 +1,6 @@
 pub mod build;
-mod notify_create_canister;
-mod notify_top_up;
+pub mod notify_create_canister;
+pub mod notify_top_up;
 pub mod project;
 
 pub use build::BuildError;

--- a/src/dfx/src/lib/error/mod.rs
+++ b/src/dfx/src/lib/error/mod.rs
@@ -1,9 +1,13 @@
 pub mod build;
+mod notify_create_canister;
+mod notify_top_up;
 pub mod project;
 
 pub use build::BuildError;
 pub use dfx_core::error::extension::ExtensionError;
 pub use dfx_core::error::identity::IdentityError;
+pub use notify_create_canister::NotifyCreateCanisterError;
+pub use notify_top_up::NotifyTopUpError;
 pub use project::ProjectError;
 
 /// The type to represent DFX results.

--- a/src/dfx/src/lib/error/notify_create_canister.rs
+++ b/src/dfx/src/lib/error/notify_create_canister.rs
@@ -1,0 +1,18 @@
+use crate::lib::ledger_types::NotifyError;
+use ic_agent::AgentError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum NotifyCreateCanisterError {
+    #[error("Failed when calling notify_create_canister: {0:#}")]
+    Call(AgentError),
+
+    #[error("Failed to decode notify_create_canister response: {0:#}")]
+    DecodeResponse(candid::Error),
+
+    #[error("Failed to encode notify_create_canister arguments: {0:#}")]
+    EncodeArguments(candid::Error),
+
+    #[error("Failure reported by notify_create_canister: {0:?}")]
+    Notify(NotifyError),
+}

--- a/src/dfx/src/lib/error/notify_top_up.rs
+++ b/src/dfx/src/lib/error/notify_top_up.rs
@@ -1,0 +1,18 @@
+use crate::lib::ledger_types::NotifyError;
+use ic_agent::AgentError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum NotifyTopUpError {
+    #[error("Failed when calling notify_top_up: {0:#}")]
+    Call(AgentError),
+
+    #[error("Failed to decode notify_top_up response: {0:#}")]
+    DecodeResponse(candid::Error),
+
+    #[error("Failed to encode notify_top_up arguments: {0:#}")]
+    EncodeArguments(candid::Error),
+
+    #[error("Failure reported by notify_top_up: {0:?}")]
+    Notify(NotifyError),
+}


### PR DESCRIPTION
# Description

 Both `notify_create()` and `notify_top_up()` return `Result<Result<T, NotifyError>, DfxError>`.  This PR flattens each result into a single `Result<T, Concrete Error Type>` for the method.

This avoids in-effect matching for things like `Ok(Ok(principal))` or `Ok(Err(Refunded))`.

# How Has This Been Tested?

Covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
