### PR TITLE
fix(conventional-commits-workflow): harden against shell injection

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -37,6 +37,6 @@ jobs:
               echo pass
           else
               echo "PR title does not match conventions"
-              echo "PR title: ${{ github.event.pull_request.title }}"
+              echo "PR title: $TITLE"
               exit 1
           fi

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -31,7 +31,7 @@ jobs:
         # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
         # !: Indicates that the PR contains a breaking change.
       - run: |
-          if echo "${{ github.event.pull_request.title }}" | grep -Eq ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
+          if echo "${{ github.event.pull_request.title }}" | grep -Eq "^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\:" ; then
               echo pass
           else
               echo "PR title does not match conventions"

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -31,7 +31,7 @@ jobs:
         # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
         # !: Indicates that the PR contains a breaking change.
       - run: |
-          if echo "${{ github.event.pull_request.title }}" | grep -Eq ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
+          if [[ "${{ github.event.pull_request.title }}" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
               echo pass
           else
               echo "PR title does not match conventions"

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -33,10 +33,10 @@ jobs:
       - env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
+          echo "PR title: $TITLE"
           if [[ "$TITLE" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
               echo pass
           else
               echo "PR title does not match conventions"
-              echo "PR title: $TITLE"
               exit 1
           fi

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -30,8 +30,10 @@ jobs:
         # verb: feat, fix, ...
         # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
         # !: Indicates that the PR contains a breaking change.
-      - run: |
-          if [[ "${{ github.event.pull_request.title }}" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
+      - env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$TITLE" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
               echo pass
           else
               echo "PR title does not match conventions"

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -31,7 +31,7 @@ jobs:
         # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
         # !: Indicates that the PR contains a breaking change.
       - run: |
-          if echo "${{ github.event.pull_request.title }}" | grep -Eq "^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\:" ; then
+          if echo "${{ github.event.pull_request.title }}" | grep -Eq ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
               echo pass
           else
               echo "PR title does not match conventions"

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -31,7 +31,7 @@ jobs:
         # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
         # !: Indicates that the PR contains a breaking change.
       - run: |
-          if [[ "${{ github.event.pull_request.title }}" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
+          if echo "${{ github.event.pull_request.title }}" | grep -Eq ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
               echo pass
           else
               echo "PR title does not match conventions"


### PR DESCRIPTION
# Description

In an expression like `"${{ github.event.pull_request.title }}"` in an inline script, nothing escapes quotes, backticks, `$()`, and so forth.

In practice, this means a title like `fix(frontend-canister): Revert "fix(frontend-canister): ..."` would break this workflow at the first single-quote in the title.

Followed the advice here to remedy: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

Fixes https://dfinity.atlassian.net/browse/SDK-1002

# How Has This Been Tested?

Tested some problematic titles; you can see them in the PR history

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
