### PR TITLE
feat: added --ic as shorthand for --network ic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ When the timer runs out the canister(s) will be uninstalled and are returned to 
 Any commands that allow choosing a target network (e.g. `dfx canister call`) require `--playground` or `--network playground` in order to target the borrowed canister(s).
 Use `dfx deploy --playground` to deploy simple projects to a canister borrowed from the Motoko Playground.
 
+### feat: `--ic` is shorthand for `--network ic`
+
+For example, `dfx deploy --ic` rather than `dfx deploy --network ic`.
+
 # 0.15.0
 
 ## DFX

--- a/docs/cli-reference/dfx-deploy.md
+++ b/docs/cli-reference/dfx-deploy.md
@@ -24,6 +24,7 @@ You can use the following options with the `dfx deploy` command.
 |------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--network <network>`              | Overrides the environment to connect to. By default, the local canister execution environment is used.                                                                      |
 | `--playground       `              | Alias for `--network playground`. By default, canisters on this network are borrowed from the Motoko Playground.                                                            |
+| `--ic               `              | Alias for `--network ic`.                                                                                                                                                   |
 | `--argument <argument>`            | Specifies an argument using Candid syntax to pass to the canister during deployment. Note that this option requires you to define an actor class in the Motoko program. |
 | `--with-cycles <number-of-cycles>` | Enables you to specify the initial number of cycles for a canister in a project.                                                                                            |
 | `--specified-id <PRINCIPAL>`       | Attempts to create the canister with this Canister ID                                                                                 |

--- a/e2e/tests-dfx/fabricate_cycles.bash
+++ b/e2e/tests-dfx/fabricate_cycles.bash
@@ -41,6 +41,8 @@ teardown() {
     install_asset greet
     assert_command_fail dfx ledger fabricate-cycles --all --network ic
     assert_match "Cannot run this on the real IC."
+    assert_command_fail dfx ledger fabricate-cycles --all --ic
+    assert_match "Cannot run this on the real IC."
 }
 
 @test "ledger fabricate-cycles fails with wrong option combinations" {

--- a/e2e/tests-dfx/network.bash
+++ b/e2e/tests-dfx/network.bash
@@ -92,3 +92,21 @@ teardown() {
     assert_command_fail dfx canister id hello_backend --network playground
     assert_contains "Cannot find canister id"
 }
+
+@test "equivalent: --network ic and --ic" {
+    dfx identity get-wallet
+
+    assert_command_fail dfx diagnose --network ic
+    assert_contains "The test_id identity is not stored securely."
+    assert_contains "use it in mainnet-facing commands"
+    assert_contains "No wallet found; nothing to do"
+
+    assert_command_fail dfx diagnose --ic
+    assert_contains "The test_id identity is not stored securely."
+    assert_contains "use it in mainnet-facing commands"
+    assert_contains "No wallet found; nothing to do"
+
+    assert_command dfx diagnose
+    assert_not_contains "identity is not stored securely"
+    assert_eq "No problems found"
+}

--- a/e2e/tests-dfx/network.bash
+++ b/e2e/tests-dfx/network.bash
@@ -94,6 +94,7 @@ teardown() {
 }
 
 @test "equivalent: --network ic and --ic" {
+    dfx_start
     dfx identity get-wallet
 
     assert_command_fail dfx diagnose --network ic

--- a/src/dfx/src/lib/network/network_opt.rs
+++ b/src/dfx/src/lib/network/network_opt.rs
@@ -1,4 +1,4 @@
-use clap::{Args, ArgGroup};
+use clap::{ArgGroup, Args};
 
 #[derive(Args, Clone, Debug, Default)]
 #[clap(

--- a/src/dfx/src/lib/network/network_opt.rs
+++ b/src/dfx/src/lib/network/network_opt.rs
@@ -1,24 +1,33 @@
-use clap::Args;
+use clap::{Args, ArgGroup};
 
 #[derive(Args, Clone, Debug, Default)]
+#[clap(
+group(ArgGroup::new("network-select").multiple(false)),
+)]
 pub struct NetworkOpt {
     /// Override the compute network to connect to. By default, the local network is used.
     /// A valid URL (starting with `http:` or `https:`) can be used here, and a special
     /// ephemeral network will be created specifically for this request. E.g.
     /// "http://localhost:12345/" is a valid network name.
-    #[arg(long, global = true, conflicts_with("playground"))]
+    #[arg(long, global = true, group = "network-select")]
     network: Option<String>,
 
     /// Shorthand for --network=playground.
     /// Borrows short-lived canisters on the real IC network instead of creating normal canisters.
-    #[clap(long, global(true), conflicts_with("network"))]
+    #[clap(long, global(true), group = "network-select")]
     playground: bool,
+
+    /// Shorthand for --network=ic.
+    #[clap(long, global(true), group = "network-select")]
+    ic: bool,
 }
 
 impl NetworkOpt {
     pub fn to_network_name(&self) -> Option<String> {
         if self.playground {
             Some("playground".to_string())
+        } else if self.ic {
+            Some("ic".to_string())
         } else {
             self.network.clone()
         }

--- a/src/dfx/src/lib/network/network_opt.rs
+++ b/src/dfx/src/lib/network/network_opt.rs
@@ -9,7 +9,7 @@ pub struct NetworkOpt {
     /// A valid URL (starting with `http:` or `https:`) can be used here, and a special
     /// ephemeral network will be created specifically for this request. E.g.
     /// "http://localhost:12345/" is a valid network name.
-    #[arg(long, global = true, group = "network-select")]
+    #[arg(long, global(true), group = "network-select")]
     network: Option<String>,
 
     /// Shorthand for --network=playground.


### PR DESCRIPTION
# Description

Accept `--ic` in place of `--network ic`

> For most of dfx commands I type --network=ic. Can we create a shorthand to reduce the number of letters and make the command easier to read?

Fixes https://dfinity.atlassian.net/browse/SDK-439

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
