### PR TITLE
fix(extension): change permission mode from 0777 to 0500

### DIFF
--- a/src/dfx-core/src/extension/manager/install.rs
+++ b/src/dfx-core/src/extension/manager/install.rs
@@ -113,7 +113,7 @@ impl ExtensionManager {
         #[cfg(unix)]
         {
             let bin = effective_extension_dir.join(effective_extension_name);
-            crate::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o777))?;
+            crate::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o500))?;
         }
         Ok(())
     }


### PR DESCRIPTION
-------

# Description

Currently dfx (extension command) will execute a binary that is writable by any other user on the system, which is bad from security standpoint. This PR changes the permissions, such that the extension binary is executable and readable only by the owner.

Fixes https://dfinity.atlassian.net/browse/SDK-1199

# How Has This Been Tested?

covered by e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] ~I have edited the CHANGELOG accordingly.~
- [ ] ~I have made corresponding changes to the documentation.~