### PR TITLE
chore: allow dashes in new project names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Use `dfx deploy --playground` to deploy simple projects to a canister borrowed f
 
 For example, `dfx deploy --ic` rather than `dfx deploy --network ic`.
 
+### chore: Allow `-` in `dfx new` project name except for the first letter
+
 ### fix: Motoko base library files in cache are no longer executable
 
 ## Dependencies

--- a/e2e/tests-dfx/new.bash
+++ b/e2e/tests-dfx/new.bash
@@ -20,6 +20,7 @@ teardown() {
     dfx new --no-frontend a_1
     dfx new --no-frontend a1
     dfx new --no-frontend a1a
+    dfx new --no-frontend a-b-c
 }
 
 @test "dfx new - bad names" {
@@ -31,7 +32,6 @@ teardown() {
     assert_command_fail dfx new 1_
     assert_command_fail dfx new -
     assert_command_fail dfx new _
-    assert_command_fail dfx new a-b-c
     assert_command_fail dfx new '🕹'
     assert_command_fail dfx new '不好'
     assert_command_fail dfx new 'a:b'

--- a/src/dfx/src/util/clap/parsers.rs
+++ b/src/dfx/src/util/clap/parsers.rs
@@ -96,7 +96,7 @@ pub fn project_name_parser(name: &str) -> Result<String, String> {
             // Reverses the search here; if there is a character that is not compatible
             // it is found and an error is returned.
             let m: Vec<&str> = name
-                .matches(|x: char| !x.is_ascii_alphanumeric() && x != '_')
+                .matches(|x: char| !x.is_ascii_alphanumeric() && x != '_' && x != '-')
                 .collect();
 
             if m.is_empty() {


### PR DESCRIPTION
# Description

Dashes are not allowed in new project names, but underscores are. This PR adds dashes to the list of allowed characters.

# How Has This Been Tested?

e2e adapted

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
