### PR TITLE
feat: dfx start for shared network warns if ignoring defaults in dfx.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ For example, `dfx deploy --ic` rather than `dfx deploy --network ic`.
 
 ### fix: Motoko base library files in cache are no longer executable
 
+### feat: `dfx start` for shared network warns if ignoring 'defaults' in dfx.json
+
+Background: In order to determine whether to start a project-specific network or the shared network, `dfx start` looks for the `local` network in dfx.json.
+   - If found, `dfx start` starts the project-specific local network, applying any `defaults` from dfx.json.
+   - If there is no dfx.json, or if dfx.json does not define a `local` network, `dfx start` starts the shared network.  Because the shared network is not specific to any project, `dfx start` ignores any other settings from dfx.json, including `defaults`.
+
+If `dfx start` is starting the shared network from within a dfx project, and that dfx.json contains settings in the `defaults` key for `bitcoin`, `replica`, or `canister_http`, then `dfx start` will warn that it is ignoring those settings.  It will also describe how to define equivalent settings in networks.json.
+
 ## Dependencies
 
 ### Frontend canister


### PR DESCRIPTION
# Description

If you run `dfx start` from a dfx project directory,
and dfx.json does not define a `local` network
then `dfx start` will start the shared network.

If dfx.json defines `bitcoin`, `replica`, or `canister_http` settings in `defaults`,
`dfx start` will ignore them,
because the shared network by definition doesn't use any project settings.

In case it's surprising that `dfx start` ignores project settings in dfx.json when starting the shared network,
`dfx start` now warns about any such ignored project settings.

Fixes https://dfinity.atlassian.net/browse/SDK-1001

# How Has This Been Tested?

Added an e2e test and tested manually.

Example output:
```
$ dfx-wip start
Running dfx start for version 0.15.0-beta.1+rev20.dirty-b335dd995
Using shared network 'local' defined in /Users/ericswanson/.config/dfx/networks.json
WARN: Ignoring the 'defaults' field in dfx.json because project settings never apply to the shared network.
To apply these settings to the shared network, define them in /Users/ericswanson/.config/dfx/networks.json like so:
{
  "local": {
    "bitcoin": {
      "enabled": true,
      "log_level": "info",
      "nodes": [
        "127.0.0.1:18444"
      ]
    },
    "replica": {
      "subnet_type": "system"
    }
  }
}
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
