### PR TITLE
chore: Clean up use of set_permissions_readwrite

### DIFF
--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -100,6 +100,12 @@ pub fn set_permissions(path: &Path, permissions: Permissions) -> Result<(), FsEr
         .map_err(|err| FsError::new(WritePermissionsFailed(path.to_path_buf(), err)))
 }
 
+pub fn set_permissions_readwrite(path: &Path) -> Result<(), FsError> {
+    let mut permissions = read_permissions(path)?;
+    permissions.set_readonly(false);
+    set_permissions(path, permissions)
+}
+
 pub fn tar_unpack_in<P: AsRef<Path>>(
     path: P,
     tar: &mut tar::Entry<flate2::read::GzDecoder<&'static [u8]>>,

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -105,7 +105,7 @@ pub fn set_permissions_readwrite(path: &Path) -> Result<(), FsError> {
     {
         use std::os::unix::fs::PermissionsExt;
         let mut permissions = read_permissions(path)?;
-        permissions.set_mode(permissions.mode() | 0o200);
+        permissions.set_mode(permissions.mode() | 0o600);
         set_permissions(path, permissions)?;
     }
     Ok(())

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -103,8 +103,9 @@ pub fn set_permissions(path: &Path, permissions: Permissions) -> Result<(), FsEr
 pub fn set_permissions_readwrite(path: &Path) -> Result<(), FsError> {
     #[cfg(unix)]
     {
+        use std::os::unix::fs::PermissionsExt;
         let mut permissions = read_permissions(path)?;
-        permissions.set_readonly(false);
+        permissions.set_mode(permissions.mode() | 0o200);
         set_permissions(path, permissions)?;
     }
     Ok(())

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -101,9 +101,13 @@ pub fn set_permissions(path: &Path, permissions: Permissions) -> Result<(), FsEr
 }
 
 pub fn set_permissions_readwrite(path: &Path) -> Result<(), FsError> {
-    let mut permissions = read_permissions(path)?;
-    permissions.set_readonly(false);
-    set_permissions(path, permissions)
+    #[cfg(unix)]
+    {
+        let mut permissions = read_permissions(path)?;
+        permissions.set_readonly(false);
+        set_permissions(path, permissions)?;
+    }
+    Ok(())
 }
 
 pub fn tar_unpack_in<P: AsRef<Path>>(

--- a/src/dfx/src/commands/deps/pull.rs
+++ b/src/dfx/src/commands/deps/pull.rs
@@ -314,6 +314,7 @@ pub fn copy_service_candid_to_project(
     let path_in_project = get_candid_path_in_project(project_root, canister_id);
     ensure_parent_dir_exists(&path_in_project)?;
     dfx_core::fs::copy(&service_candid_path, &path_in_project)?;
+    dfx_core::fs::set_permissions_readwrite(&path_in_project)?;
     Ok(())
 }
 

--- a/src/dfx/src/lib/builders/assets.rs
+++ b/src/dfx/src/lib/builders/assets.rs
@@ -1,5 +1,5 @@
 use crate::lib::builders::{
-    set_perms_readwrite, BuildConfig, BuildOutput, CanisterBuilder, IdlBuildOutput, WasmBuildOutput,
+    BuildConfig, BuildOutput, CanisterBuilder, IdlBuildOutput, WasmBuildOutput,
 };
 use crate::lib::canister_info::assets::AssetsCanisterInfo;
 use crate::lib::canister_info::CanisterInfo;
@@ -153,7 +153,7 @@ impl CanisterBuilder for AssetsBuilder {
         if idl_path.exists() {
             std::fs::rename(&idl_path, &idl_path_rename)
                 .with_context(|| format!("Failed to rename {}.", idl_path.to_string_lossy()))?;
-            set_perms_readwrite(&idl_path_rename)?;
+            dfx_core::fs::set_permissions_readwrite(&idl_path_rename)?;
         }
 
         Ok(idl_path_rename)

--- a/src/dfx/src/lib/builders/custom.rs
+++ b/src/dfx/src/lib/builders/custom.rs
@@ -170,13 +170,8 @@ impl CanisterBuilder for CustomBuilder {
         // get the path to candid file
         let CustomBuilderExtra { candid, .. } = CustomBuilderExtra::try_from(info, pool)?;
 
-        std::fs::copy(&candid, &output_idl_path).with_context(|| {
-            format!(
-                "Failed to copy canidid from {} to {}.",
-                candid.to_string_lossy(),
-                output_idl_path.to_string_lossy()
-            )
-        })?;
+        dfx_core::fs::copy(&candid, &output_idl_path)?;
+        dfx_core::fs::set_permissions_readwrite(&output_idl_path)?;
 
         Ok(output_idl_path)
     }

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -351,32 +351,6 @@ pub fn run_command(args: Vec<String>, vars: &[Env<'_>], cwd: &Path) -> DfxResult
     }
 }
 
-<<<<<<< Updated upstream
-/// Set the permission of the given file to be writeable.
-pub fn set_perms_readwrite(_file_path: &Path) -> DfxResult<()> {
-    #[cfg(unix)]
-    {
-        let mut perms = std::fs::metadata(_file_path)
-            .with_context(|| {
-                format!(
-                    "Failed to read metadata for file {}.",
-                    _file_path.to_string_lossy()
-                )
-            })?
-            .permissions();
-        perms.set_mode(perms.mode() | 0o600);
-        std::fs::set_permissions(_file_path, perms).with_context(|| {
-            format!(
-                "Failed to set permissions for file {}.",
-                _file_path.to_string_lossy()
-            )
-        })?;
-    }
-    Ok(())
-}
-
-=======
->>>>>>> Stashed changes
 type Env<'a> = (Cow<'static, str>, Cow<'a, OsStr>);
 
 pub fn get_and_write_environment_variables<'a>(

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -351,6 +351,7 @@ pub fn run_command(args: Vec<String>, vars: &[Env<'_>], cwd: &Path) -> DfxResult
     }
 }
 
+<<<<<<< Updated upstream
 /// Set the permission of the given file to be writeable.
 pub fn set_perms_readwrite(_file_path: &Path) -> DfxResult<()> {
     #[cfg(unix)]
@@ -374,6 +375,8 @@ pub fn set_perms_readwrite(_file_path: &Path) -> DfxResult<()> {
     Ok(())
 }
 
+=======
+>>>>>>> Stashed changes
 type Env<'a> = (Cow<'static, str>, Cow<'a, OsStr>);
 
 pub fn get_and_write_environment_variables<'a>(

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -207,13 +207,8 @@ impl CanisterBuilder for MotokoBuilder {
         let motoko_info = info.as_info::<MotokoCanisterInfo>()?;
         let idl_from_build = motoko_info.get_output_idl_path().to_path_buf();
 
-        std::fs::copy(&idl_from_build, &output_idl_path).with_context(|| {
-            format!(
-                "Failed to copy {} to {}.",
-                idl_from_build.to_string_lossy(),
-                output_idl_path.to_string_lossy()
-            )
-        })?;
+        dfx_core::fs::copy(&idl_from_build, &output_idl_path)?;
+        dfx_core::fs::set_permissions_readwrite(&output_idl_path)?;
 
         Ok(output_idl_path)
     }

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -1,5 +1,5 @@
 use crate::lib::builders::{
-    custom_download, set_perms_readwrite, BuildConfig, BuildOutput, BuilderPool, CanisterBuilder,
+    custom_download, BuildConfig, BuildOutput, BuilderPool, CanisterBuilder,
     IdlBuildOutput, WasmBuildOutput,
 };
 use crate::lib::canister_info::CanisterInfo;
@@ -268,7 +268,7 @@ impl Canister {
         let constructor_idl_path = self.info.get_constructor_idl_path();
         dfx_core::fs::composite::ensure_parent_dir_exists(&constructor_idl_path)?;
         dfx_core::fs::copy(build_idl_path, &constructor_idl_path)?;
-        set_perms_readwrite(&constructor_idl_path)?;
+        dfx_core::fs::set_permissions_readwrite(&constructor_idl_path)?;
 
         // 2. Separate into service.did and init_args
         let (service_did, init_args) = separate_candid(build_idl_path)?;
@@ -299,14 +299,19 @@ impl Canister {
             }
             dfx_core::fs::composite::ensure_parent_dir_exists(&target)?;
             dfx_core::fs::write(&target, &service_did)?;
-            set_perms_readwrite(&target)?;
+            dfx_core::fs::set_permissions_readwrite(&target)?;
         }
 
         // 4. Save init_args into .dfx/local/canisters/NAME/init_args.txt
         let init_args_txt_path = self.info.get_init_args_txt_path();
         dfx_core::fs::composite::ensure_parent_dir_exists(&init_args_txt_path)?;
+<<<<<<< Updated upstream
         dfx_core::fs::write(&init_args_txt_path, init_args)?;
         set_perms_readwrite(&init_args_txt_path)?;
+=======
+        dfx_core::fs::write(&init_args_txt_path, &init_args)?;
+        dfx_core::fs::set_permissions_readwrite(&init_args_txt_path)?;
+>>>>>>> Stashed changes
         Ok(())
     }
 }
@@ -514,6 +519,7 @@ impl CanisterPool {
                     );
                     dfx_core::fs::composite::ensure_parent_dir_exists(&to)?;
                     dfx_core::fs::copy(from, &to)?;
+                    dfx_core::fs::set_permissions_readwrite(&to)?;
                 } else {
                     warn!(
                         log,

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -1,6 +1,6 @@
 use crate::lib::builders::{
-    custom_download, BuildConfig, BuildOutput, BuilderPool, CanisterBuilder,
-    IdlBuildOutput, WasmBuildOutput,
+    custom_download, BuildConfig, BuildOutput, BuilderPool, CanisterBuilder, IdlBuildOutput,
+    WasmBuildOutput,
 };
 use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -305,13 +305,8 @@ impl Canister {
         // 4. Save init_args into .dfx/local/canisters/NAME/init_args.txt
         let init_args_txt_path = self.info.get_init_args_txt_path();
         dfx_core::fs::composite::ensure_parent_dir_exists(&init_args_txt_path)?;
-<<<<<<< Updated upstream
         dfx_core::fs::write(&init_args_txt_path, init_args)?;
-        set_perms_readwrite(&init_args_txt_path)?;
-=======
-        dfx_core::fs::write(&init_args_txt_path, &init_args)?;
         dfx_core::fs::set_permissions_readwrite(&init_args_txt_path)?;
->>>>>>> Stashed changes
         Ok(())
     }
 }


### PR DESCRIPTION
# Description

Rename set_perms_readwrite to set_permissions_readwrite, move it to dfx_core crate, and use it in places after we copy files.

This is because the source file may not be writable (e.g., installed from system package, or by another user), and we want to make sure the destination file is writable to prevent future writing failures.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
