### PR TITLE
fix(ci): checkout repo to get the hash of `rust-toolchain.toml` file

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,6 +138,8 @@ jobs:
       matrix:
         name: [ 'x86_64-darwin', 'x86_64-linux' ]
     steps:
+      - uses: actions/checkout@v3
+
       - name: Setup environment variables
         run: echo "VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV
 


### PR DESCRIPTION
# Description

[`publish.yml`](https://github.com/smallstepman/sdk/actions/runs/5868565396/job/15912542986#logs) workflow currently fails with err msg:
```
Run actions/download-artifact@v3
Starting download for dfx-artifacts--x[8](https://github.com/smallstepman/sdk/actions/runs/5868565396/job/15912542986#step:3:9)6_64-darwin
Error: Unable to find an artifact with the name: dfx-artifacts--x86_64-darwin
```

This should fix it.

continuation of #3286

# How Has This Been Tested?

waiting for https://github.com/smallstepman/sdk/actions/runs/5869023168 to see the results

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] ~I have edited the CHANGELOG accordingly.~
- [ ] ~I have made corresponding changes to the documentation.~
