### PR TITLE
fix(extension): update tarball filename format

### DIFF
--- a/scripts/workflows/e2e-matrix.py
+++ b/scripts/workflows/e2e-matrix.py
@@ -16,7 +16,7 @@ test = sorted(test_scripts("dfx") + test_scripts("replica") + test_scripts("icx-
 matrix = {
     "test": test,
     "backend": ["replica"],
-    "os": ["macos-12", "ubuntu-20.04"],
+    "os": ["macos-12", "ubuntu-22.04"],
     "exclude": [
         {"backend": "ic-ref", "test": "dfx/bitcoin"},
         {"backend": "ic-ref", "test": "dfx/canister_http"},

--- a/src/dfx-core/src/extension/manager/install.rs
+++ b/src/dfx-core/src/extension/manager/install.rs
@@ -31,7 +31,7 @@ impl ExtensionManager {
 
         let extension_version = self.get_extension_compatible_version(extension_name)?;
         let github_release_tag = get_git_release_tag(extension_name, &extension_version);
-        let extension_archive = get_extension_archive_name(extension_name, &extension_version)?;
+        let extension_archive = get_extension_archive_name(extension_name)?;
         let url = get_extension_download_url(&github_release_tag, &extension_archive)?;
 
         let temp_dir = self.download_and_unpack_extension_to_tempdir(url)?;
@@ -132,12 +132,9 @@ fn get_git_release_tag(extension_name: &str, extension_verion: &Version) -> Stri
     format!("{extension_name}-v{extension_verion}",)
 }
 
-fn get_extension_archive_name(
-    extension_name: &str,
-    extension_version: &Version,
-) -> Result<String, ExtensionError> {
+fn get_extension_archive_name(extension_name: &str) -> Result<String, ExtensionError> {
     Ok(format!(
-        "{extension_name}-v{extension_version}-{arch}-{platform}",
+        "{extension_name}-{arch}-{platform}",
         platform = match std::env::consts::OS {
             "linux" => "unknown-linux-gnu",
             "macos" => "apple-darwin",


### PR DESCRIPTION
# Description

https://github.com/dfinity/dfx-extensions/pull/48 changed how the filename of tarball and the name of the dir directly inside it; they no longer contain the version of the extension (meaning, we're going from `{package}-v{version}-{platform}.{ext}` to `{package}-{platform}.{ext}`)

Awaits merging of https://github.com/dfinity/dfx-extensions/pull/51 and https://github.com/dfinity/dfx-extensions/pull/50

# How Has This Been Tested?

covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] ~I have edited the CHANGELOG accordingly.~
- [ ] ~I have made corresponding changes to the documentation.~
