### PR TITLE
refactor: method-specific error types for IdentityManager::new and initialize

### DIFF
--- a/src/dfx-core/src/error/identity/get_legacy_credentials_pem_path.rs
+++ b/src/dfx-core/src/error/identity/get_legacy_credentials_pem_path.rs
@@ -1,0 +1,8 @@
+use crate::error::foundation::FoundationError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GetLegacyCredentialsPemPathError {
+    #[error("Failed to get legacy pem path: {0}")]
+    GetLegacyPemPathFailed(FoundationError),
+}

--- a/src/dfx-core/src/error/identity/initialize_identity_manager.rs
+++ b/src/dfx-core/src/error/identity/initialize_identity_manager.rs
@@ -1,0 +1,26 @@
+use crate::error::fs::FsError;
+use crate::error::identity::get_legacy_credentials_pem_path::GetLegacyCredentialsPemPathError;
+use crate::error::identity::IdentityError;
+use crate::error::structured_file::StructuredFileError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum InitializeIdentityManagerError {
+    #[error("Cannot create identity directory: {0}")]
+    CreateIdentityDirectoryFailed(FsError),
+
+    #[error("Failed to generate key: {0}")]
+    GenerateKeyFailed(IdentityError),
+
+    #[error(transparent)]
+    GetLegacyCredentialsPemPathFailed(#[from] GetLegacyCredentialsPemPathError),
+
+    #[error("Failed to migrate legacy identity")]
+    MigrateLegacyIdentityFailed(FsError),
+
+    #[error("Failed to save configuration: {0}")]
+    SaveConfigurationFailed(StructuredFileError),
+
+    #[error("Failed to write pem to file: {0}")]
+    WritePemToFileFailed(IdentityError),
+}

--- a/src/dfx-core/src/error/identity/mod.rs
+++ b/src/dfx-core/src/error/identity/mod.rs
@@ -1,3 +1,5 @@
+pub mod new_identity_manager;
+
 use crate::error::config::ConfigError;
 use crate::error::encryption::EncryptionError;
 use crate::error::foundation::FoundationError;
@@ -88,9 +90,6 @@ pub enum IdentityError {
 
     #[error("Failed to load configuration for identity '{0}': {1}")]
     LoadIdentityConfigurationFailed(String, StructuredFileError),
-
-    #[error("Failed to load identity manager configuration: {0}")]
-    LoadIdentityManagerConfigurationFailed(StructuredFileError),
 
     #[error("Failed to load PEM file from keyring for identity '{0}': {1}")]
     LoadPemFromKeyringFailed(Box<String>, KeyringError),

--- a/src/dfx-core/src/error/identity/mod.rs
+++ b/src/dfx-core/src/error/identity/mod.rs
@@ -1,8 +1,9 @@
+pub mod get_legacy_credentials_pem_path;
+pub mod initialize_identity_manager;
 pub mod new_identity_manager;
 
 use crate::error::config::ConfigError;
 use crate::error::encryption::EncryptionError;
-use crate::error::foundation::FoundationError;
 use crate::error::fs::FsError;
 use crate::error::keyring::KeyringError;
 use crate::error::structured_file::StructuredFileError;
@@ -30,9 +31,6 @@ pub enum IdentityError {
 
     #[error("Convert secret key to sec1 Pem failed: {0}")]
     ConvertSecretKeyToSec1PemFailed(Box<sec1::Error>),
-
-    #[error("Cannot create identity directory: {0}")]
-    CreateIdentityDirectoryFailed(FsError),
 
     #[error("Failed to create mnemonic from phrase: {0}")]
     CreateMnemonicFromPhraseFailed(String),
@@ -76,9 +74,6 @@ pub enum IdentityError {
     #[error("Failed to get principal of identity: {0}")]
     GetIdentityPrincipalFailed(String),
 
-    #[error("Failed to get legacy pem path: {0}")]
-    GetLegacyPemPathFailed(FoundationError),
-
     #[error("Identity already exists.")]
     IdentityAlreadyExists(),
 
@@ -93,9 +88,6 @@ pub enum IdentityError {
 
     #[error("Failed to load PEM file from keyring for identity '{0}': {1}")]
     LoadPemFromKeyringFailed(Box<String>, KeyringError),
-
-    #[error("Failed to migrate legacy identity")]
-    MigrateLegacyIdentityFailed(FsError),
 
     #[error("Failed to read principal from id '{0}': {1}")]
     ParsePrincipalFromIdFailed(String, PrincipalError),

--- a/src/dfx-core/src/error/identity/new_identity_manager.rs
+++ b/src/dfx-core/src/error/identity/new_identity_manager.rs
@@ -1,0 +1,19 @@
+use crate::error::config::ConfigError;
+use crate::error::identity::IdentityError;
+use crate::error::structured_file::StructuredFileError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum NewIdentityManagerError {
+    #[error("Failed to get config directory for identity manager: {0}")]
+    GetConfigDirectoryFailed(ConfigError),
+
+    #[error("Failed to load identity manager configuration: {0}")]
+    LoadIdentityManagerConfigurationFailed(StructuredFileError),
+
+    #[error("Failed to initialize identity manager: {0}")]
+    InitializeFailed(IdentityError),
+
+    #[error("The specified identity must exist: {0}")]
+    OverrideIdentityMustExist(IdentityError),
+}

--- a/src/dfx-core/src/error/identity/new_identity_manager.rs
+++ b/src/dfx-core/src/error/identity/new_identity_manager.rs
@@ -1,4 +1,5 @@
 use crate::error::config::ConfigError;
+use crate::error::identity::initialize_identity_manager::InitializeIdentityManagerError;
 use crate::error::identity::IdentityError;
 use crate::error::structured_file::StructuredFileError;
 use thiserror::Error;
@@ -12,7 +13,7 @@ pub enum NewIdentityManagerError {
     LoadIdentityManagerConfigurationFailed(StructuredFileError),
 
     #[error("Failed to initialize identity manager: {0}")]
-    InitializeFailed(IdentityError),
+    InitializeFailed(InitializeIdentityManagerError),
 
     #[error("The specified identity must exist: {0}")]
     OverrideIdentityMustExist(IdentityError),

--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -1,6 +1,6 @@
 use crate::lib::deps::get_pull_canisters_in_config;
 use crate::lib::environment::Environment;
-use crate::lib::error::DfxResult;
+use crate::lib::error::{DfxError, DfxResult};
 use crate::lib::ic_attributes::{
     get_compute_allocation, get_freezing_threshold, get_memory_allocation, CanisterSettings,
 };
@@ -119,11 +119,12 @@ pub async fn exec(
                                     .and_then(|identity| {
                                         identity.sender().map_err(GetIdentityPrincipalFailed)
                                     })
+                                    .map_err(DfxError::new)
                             }
                         }
                     },
                 )
-                .collect::<Result<Vec<_>, IdentityError>>()
+                .collect::<Result<Vec<_>, DfxError>>()
         })
         .transpose()
         .context("Failed to determine controllers.")?;

--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -15,7 +15,6 @@ use anyhow::{bail, Context};
 use byte_unit::Byte;
 use candid::Principal as CanisterId;
 use clap::{ArgAction, Parser};
-use dfx_core::error::identity::IdentityError;
 use dfx_core::error::identity::IdentityError::GetIdentityPrincipalFailed;
 use dfx_core::identity::CallSender;
 use ic_agent::Identity as _;

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -12,7 +12,6 @@ use dfx_core::config::model::network_descriptor::NetworkDescriptor;
 use dfx_core::error::canister_id_store::CanisterIdStoreError;
 use dfx_core::error::extension::ExtensionError;
 use dfx_core::error::identity::new_identity_manager::NewIdentityManagerError;
-use dfx_core::error::identity::IdentityError;
 use dfx_core::extension::manager::ExtensionManager;
 use dfx_core::identity::identity_manager::IdentityManager;
 use fn_error_context::context;

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -11,6 +11,7 @@ use dfx_core::config::model::dfinity::{Config, NetworksConfig};
 use dfx_core::config::model::network_descriptor::NetworkDescriptor;
 use dfx_core::error::canister_id_store::CanisterIdStoreError;
 use dfx_core::error::extension::ExtensionError;
+use dfx_core::error::identity::new_identity_manager::NewIdentityManagerError;
 use dfx_core::error::identity::IdentityError;
 use dfx_core::extension::manager::ExtensionManager;
 use dfx_core::identity::identity_manager::IdentityManager;
@@ -53,7 +54,7 @@ pub trait Environment {
     fn new_spinner(&self, message: Cow<'static, str>) -> ProgressBar;
     fn new_progress(&self, message: &str) -> ProgressBar;
 
-    fn new_identity_manager(&self) -> Result<IdentityManager, IdentityError> {
+    fn new_identity_manager(&self) -> Result<IdentityManager, NewIdentityManagerError> {
         IdentityManager::new(self.get_logger(), self.get_identity_override())
     }
 


### PR DESCRIPTION
# Description

Introduces per-method error types for IdentityManager::new() and initialize().

Some of the error enums have `IdentityError` as the error cause.  This happens when a called method returns IdentityError and other methods (that still return IdentityError) call it.  These will change as more methods return their own error types.

The overall direction to look for is removal of variants from the `IdentityError` enum.

# How Has This Been Tested?

Covered by CI