### PR TITLE
refactor: method-specific errors for generating keys and saving pem files

### DIFF
--- a/src/dfx-core/src/error/identity/convert_mnemonic_to_key.rs
+++ b/src/dfx-core/src/error/identity/convert_mnemonic_to_key.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ConvertMnemonicToKeyError {
+    #[error("Failed to derive extended secret key from path: {0}")]
+    DeriveExtendedKeyFromPathFailed(bip32::Error),
+}

--- a/src/dfx-core/src/error/identity/create_new_identity.rs
+++ b/src/dfx-core/src/error/identity/create_new_identity.rs
@@ -1,6 +1,7 @@
 use crate::error::fs::FsError;
 use crate::error::identity::convert_mnemonic_to_key::ConvertMnemonicToKeyError;
 use crate::error::identity::generate_key::GenerateKeyError;
+use crate::error::identity::save_pem::SavePemError;
 use crate::error::identity::IdentityError;
 use thiserror::Error;
 
@@ -46,7 +47,7 @@ pub enum CreateNewIdentityError {
     SaveIdentityConfigurationFailed(IdentityError),
 
     #[error("Failed to save pem: {0}")]
-    SavePemFailed(IdentityError),
+    SavePemFailed(SavePemError),
 
     #[error("Failed to switch back over to the identity you're replacing: {0}")]
     SwitchBackToIdentityFailed(IdentityError),

--- a/src/dfx-core/src/error/identity/create_new_identity.rs
+++ b/src/dfx-core/src/error/identity/create_new_identity.rs
@@ -1,4 +1,6 @@
 use crate::error::fs::FsError;
+use crate::error::identity::convert_mnemonic_to_key::ConvertMnemonicToKeyError;
+use crate::error::identity::generate_key::GenerateKeyError;
 use crate::error::identity::IdentityError;
 use thiserror::Error;
 
@@ -11,7 +13,7 @@ pub enum CreateNewIdentityError {
     CleanupPreviousCreationAttemptsFailed(FsError),
 
     #[error("Failed to create identity config: {0}")]
-    ConvertMnemonicToKeyFailed(IdentityError),
+    ConvertMnemonicToKeyFailed(ConvertMnemonicToKeyError),
 
     #[error("Convert secret key to sec1 Pem failed: {0}")]
     ConvertSecretKeyToSec1PemFailed(Box<sec1::Error>),
@@ -26,7 +28,7 @@ pub enum CreateNewIdentityError {
     CreateTemporaryIdentityDirectoryFailed(FsError),
 
     #[error("Failed to generate key: {0}")]
-    GenerateKeyFailed(IdentityError),
+    GenerateKeyFailed(GenerateKeyError),
 
     #[error("Identity already exists.")]
     IdentityAlreadyExists(),

--- a/src/dfx-core/src/error/identity/generate_key.rs
+++ b/src/dfx-core/src/error/identity/generate_key.rs
@@ -1,0 +1,11 @@
+use crate::error::identity::convert_mnemonic_to_key::ConvertMnemonicToKeyError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GenerateKeyError {
+    #[error("Failed to convert mnemonic to key: {0}")]
+    ConvertMnemonicToKeyFailed(ConvertMnemonicToKeyError),
+
+    #[error("Failed to generate a fresh secp256k1 key: {0}")]
+    GenerateFreshSecp256k1KeyFailed(Box<sec1::Error>),
+}

--- a/src/dfx-core/src/error/identity/initialize_identity_manager.rs
+++ b/src/dfx-core/src/error/identity/initialize_identity_manager.rs
@@ -1,4 +1,5 @@
 use crate::error::fs::FsError;
+use crate::error::identity::generate_key::GenerateKeyError;
 use crate::error::identity::get_legacy_credentials_pem_path::GetLegacyCredentialsPemPathError;
 use crate::error::identity::IdentityError;
 use crate::error::structured_file::StructuredFileError;
@@ -10,7 +11,7 @@ pub enum InitializeIdentityManagerError {
     CreateIdentityDirectoryFailed(FsError),
 
     #[error("Failed to generate key: {0}")]
-    GenerateKeyFailed(IdentityError),
+    GenerateKeyFailed(GenerateKeyError),
 
     #[error(transparent)]
     GetLegacyCredentialsPemPathFailed(#[from] GetLegacyCredentialsPemPathError),

--- a/src/dfx-core/src/error/identity/initialize_identity_manager.rs
+++ b/src/dfx-core/src/error/identity/initialize_identity_manager.rs
@@ -1,6 +1,7 @@
 use crate::error::fs::FsError;
 use crate::error::identity::generate_key::GenerateKeyError;
 use crate::error::identity::get_legacy_credentials_pem_path::GetLegacyCredentialsPemPathError;
+use crate::error::identity::write_pem_to_file::WritePemToFileError;
 use crate::error::identity::IdentityError;
 use crate::error::structured_file::StructuredFileError;
 use thiserror::Error;
@@ -23,5 +24,5 @@ pub enum InitializeIdentityManagerError {
     SaveConfigurationFailed(StructuredFileError),
 
     #[error("Failed to write pem to file: {0}")]
-    WritePemToFileFailed(IdentityError),
+    WritePemToFileFailed(WritePemToFileError),
 }

--- a/src/dfx-core/src/error/identity/mod.rs
+++ b/src/dfx-core/src/error/identity/mod.rs
@@ -6,6 +6,8 @@ pub mod get_legacy_credentials_pem_path;
 pub mod initialize_identity_manager;
 pub mod new_identity_manager;
 pub mod rename_identity;
+pub mod save_pem;
+pub mod write_pem_to_file;
 
 use crate::error::config::ConfigError;
 use crate::error::encryption::EncryptionError;
@@ -27,9 +29,6 @@ pub enum IdentityError {
     #[error("Cannot delete the anonymous identity.")]
     CannotDeleteAnonymousIdentity(),
 
-    #[error("Cannot save PEM content for an HSM.")]
-    CannotSavePemContentForHsm(),
-
     #[error("Failed to decrypt PEM file: {0}")]
     DecryptPemFileFailed(PathBuf, EncryptionError),
 
@@ -38,9 +37,6 @@ pub enum IdentityError {
 
     #[error("If you want to remove an identity with configured wallets, please use the --drop-wallets flag.")]
     DropWalletsFlagRequiredToRemoveIdentityWithWallets(),
-
-    #[error("Cannot encrypt PEM file: {0}")]
-    EncryptPemFileFailed(PathBuf, EncryptionError),
 
     #[error("Failed to ensure identity configuration directory exists: {0}")]
     EnsureIdentityConfigurationDirExistsFailed(FsError),
@@ -106,10 +102,4 @@ pub enum IdentityError {
 
     #[error("Failed to validate PEM content: {0}")]
     ValidatePemContentFailed(Box<PemError>),
-
-    #[error("Cannot write PEM file: {0}")]
-    WritePemFileFailed(FsError),
-
-    #[error("Failed to write PEM to keyring: {0}")]
-    WritePemToKeyringFailed(KeyringError),
 }

--- a/src/dfx-core/src/error/identity/mod.rs
+++ b/src/dfx-core/src/error/identity/mod.rs
@@ -1,5 +1,7 @@
+pub mod convert_mnemonic_to_key;
 pub mod create_new_identity;
 pub mod export_identity;
+pub mod generate_key;
 pub mod get_legacy_credentials_pem_path;
 pub mod initialize_identity_manager;
 pub mod new_identity_manager;
@@ -31,9 +33,6 @@ pub enum IdentityError {
     #[error("Failed to decrypt PEM file: {0}")]
     DecryptPemFileFailed(PathBuf, EncryptionError),
 
-    #[error("Failed to derive extended secret key from path: {0}")]
-    DeriveExtendedKeyFromPathFailed(bip32::Error),
-
     #[error("Failed to display linked wallets: {0}")]
     DisplayLinkedWalletsFailed(WalletConfigError),
 
@@ -48,9 +47,6 @@ pub enum IdentityError {
 
     #[error("Failed to generate a fresh encryption configuration: {0}")]
     GenerateFreshEncryptionConfigurationFailed(EncryptionError),
-
-    #[error("Failed to generate a fresh secp256k1 key: {0}")]
-    GenerateFreshSecp256k1KeyFailed(Box<sec1::Error>),
 
     #[error("Failed to get config directory for identity manager: {0}")]
     GetConfigDirectoryFailed(ConfigError),

--- a/src/dfx-core/src/error/identity/rename_identity.rs
+++ b/src/dfx-core/src/error/identity/rename_identity.rs
@@ -1,4 +1,5 @@
 use crate::error::fs::FsError;
+use crate::error::identity::save_pem::SavePemError;
 use crate::error::identity::IdentityError;
 use crate::error::keyring::KeyringError;
 use thiserror::Error;
@@ -33,7 +34,7 @@ pub enum RenameIdentityError {
     SaveIdentityConfigurationFailed(IdentityError),
 
     #[error("Failed to save pem: {0}")]
-    SavePemFailed(IdentityError),
+    SavePemFailed(SavePemError),
 
     #[error("Failed to switch over default identity settings: {0}")]
     SwitchDefaultIdentitySettingsFailed(IdentityError),

--- a/src/dfx-core/src/error/identity/save_pem.rs
+++ b/src/dfx-core/src/error/identity/save_pem.rs
@@ -1,0 +1,15 @@
+use crate::error::identity::write_pem_to_file::WritePemToFileError;
+use crate::error::keyring::KeyringError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SavePemError {
+    #[error("Cannot save PEM content for an HSM.")]
+    CannotSavePemContentForHsm(),
+
+    #[error("Failed to write PEM to file: {0}")]
+    WritePemToFileFailed(WritePemToFileError),
+
+    #[error("Failed to write PEM to keyring: {0}")]
+    WritePemToKeyringFailed(KeyringError),
+}

--- a/src/dfx-core/src/error/identity/write_pem_to_file.rs
+++ b/src/dfx-core/src/error/identity/write_pem_to_file.rs
@@ -1,0 +1,13 @@
+use crate::error::encryption::EncryptionError;
+use crate::error::fs::FsError;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum WritePemToFileError {
+    #[error("Failed to encrypt PEM file: {0}")]
+    EncryptPemFileFailed(PathBuf, EncryptionError),
+
+    #[error("Failed to write to PEM file: {0}")]
+    WritePemContentFailed(FsError),
+}


### PR DESCRIPTION
# Description

- GenerateKeyError
- ConvertMnemonicToKeyError
- SavePemError
- WritePemToFileError

# How Has This Been Tested?

Covered by CI