### PR TITLE
chore: update to agent-rs 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,7 +1351,7 @@ dependencies = [
  "ic-agent",
  "ic-asset",
  "ic-identity-hsm",
- "ic-utils 0.25.0",
+ "ic-utils 0.26.0",
  "ic-wasm",
  "indicatif",
  "itertools 0.10.5",
@@ -1420,7 +1420,7 @@ dependencies = [
  "humantime-serde",
  "ic-agent",
  "ic-identity-hsm",
- "ic-utils 0.25.0",
+ "ic-utils 0.26.0",
  "k256 0.11.6",
  "keyring",
  "lazy_static",
@@ -2363,8 +2363,8 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.25.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=6d923cbc918852ef5bfaeb08e63c86580aa80ffe#6d923cbc918852ef5bfaeb08e63c86580aa80ffe"
+version = "0.26.0"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=bf4bc8e6f4b71d18ffea009fa3a7179ce6dd7afd#bf4bc8e6f4b71d18ffea009fa3a7179ce6dd7afd"
 dependencies = [
  "backoff",
  "candid 0.9.1",
@@ -2372,7 +2372,7 @@ dependencies = [
  "hex",
  "http",
  "http-body",
- "ic-certification 0.25.0",
+ "ic-certification 0.26.0",
  "ic-verify-bls-signature",
  "k256 0.13.1",
  "leb128",
@@ -2409,7 +2409,7 @@ dependencies = [
  "globset",
  "hex",
  "ic-agent",
- "ic-utils 0.25.0",
+ "ic-utils 0.26.0",
  "itertools 0.10.5",
  "json5",
  "mime",
@@ -2508,8 +2508,8 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "0.25.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=6d923cbc918852ef5bfaeb08e63c86580aa80ffe#6d923cbc918852ef5bfaeb08e63c86580aa80ffe"
+version = "0.26.0"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=bf4bc8e6f4b71d18ffea009fa3a7179ce6dd7afd#bf4bc8e6f4b71d18ffea009fa3a7179ce6dd7afd"
 dependencies = [
  "hex",
  "serde",
@@ -2727,8 +2727,8 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.25.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=6d923cbc918852ef5bfaeb08e63c86580aa80ffe#6d923cbc918852ef5bfaeb08e63c86580aa80ffe"
+version = "0.26.0"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=bf4bc8e6f4b71d18ffea009fa3a7179ce6dd7afd#bf4bc8e6f4b71d18ffea009fa3a7179ce6dd7afd"
 dependencies = [
  "hex",
  "ic-agent",
@@ -2882,8 +2882,8 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.25.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=6d923cbc918852ef5bfaeb08e63c86580aa80ffe#6d923cbc918852ef5bfaeb08e63c86580aa80ffe"
+version = "0.26.0"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=bf4bc8e6f4b71d18ffea009fa3a7179ce6dd7afd#bf4bc8e6f4b71d18ffea009fa3a7179ce6dd7afd"
 dependencies = [
  "async-trait",
  "candid 0.9.1",
@@ -2959,7 +2959,7 @@ dependencies = [
  "humantime",
  "ic-agent",
  "ic-asset",
- "ic-utils 0.25.0",
+ "ic-utils 0.26.0",
  "libflate",
  "num-traits",
  "pem 1.1.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 candid = "0.9.0"
-ic-agent = "0.25.0"
+ic-agent = "0.26.0"
 ic-asset = { path = "src/canisters/frontend/ic-asset" }
 ic-cdk = "0.10.0"
-ic-identity-hsm = "0.25.0"
-ic-utils = "0.25.0"
+ic-identity-hsm = "0.26.0"
+ic-utils = "0.26.0"
 
 aes-gcm = "0.9.4"
 anyhow = "1.0.56"
@@ -69,19 +69,19 @@ url = "2.1.0"
 walkdir = "2.3.2"
 
 [patch.crates-io.ic-agent]
-version = "0.25.0"
+version = "0.26.0"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "6d923cbc918852ef5bfaeb08e63c86580aa80ffe"
+rev = "bf4bc8e6f4b71d18ffea009fa3a7179ce6dd7afd"
 
 [patch.crates-io.ic-identity-hsm]
-version = "0.25.0"
+version = "0.26.0"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "6d923cbc918852ef5bfaeb08e63c86580aa80ffe"
+rev = "bf4bc8e6f4b71d18ffea009fa3a7179ce6dd7afd"
 
 [patch.crates-io.ic-utils]
-version = "0.25.0"
+version = "0.26.0"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "6d923cbc918852ef5bfaeb08e63c86580aa80ffe"
+rev = "bf4bc8e6f4b71d18ffea009fa3a7179ce6dd7afd"
 
 [profile.release]
 panic = 'abort'

--- a/src/dfx-core/src/error/identity/initialize_identity_manager.rs
+++ b/src/dfx-core/src/error/identity/initialize_identity_manager.rs
@@ -2,7 +2,6 @@ use crate::error::fs::FsError;
 use crate::error::identity::generate_key::GenerateKeyError;
 use crate::error::identity::get_legacy_credentials_pem_path::GetLegacyCredentialsPemPathError;
 use crate::error::identity::write_pem_to_file::WritePemToFileError;
-use crate::error::identity::IdentityError;
 use crate::error::structured_file::StructuredFileError;
 use thiserror::Error;
 

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -17,8 +17,6 @@ use std::ffi::OsStr;
 use std::fmt::Write;
 use std::fs;
 use std::io::Read;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;


### PR DESCRIPTION
Also removes two unused imports, which were easier to notice without the other warnings.