### PR TITLE
feat: dynamic wasm_url and wasm_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 # UNRELEASED
 
+### feat: dynamic wasm_url and wasm_hash
+
+`wasm_url` and `wasm_hash` might need to be calculated dynamically during canister build.
+
+#### wasm_url
+
+Beyond setting `wasm_url` directly, you can generate it into a file with configuration in `dfx.json` like:
+
+```json
+{
+  "pullable" : {
+    "dynamic_wasm_url" : {
+      "generate" : "<commands to generate wasm_url file>",
+      "path" : "<path/to/wasm_url_file>"
+    }
+  }
+}
+```
+
+You can only set one of `wasm_url` and `dynamic_wasm_url`.
+
+#### wasm_hash
+
+Service providers may want consumers to download a different wasm module than the on-chain canister.
+
+In such case, providers need to include a `wasm_hash` field in the `dfx/pullable` metadata of the on-chain pullable canister.
+
+There are three ways to specify `wasm_hash` in `dfx.json`. You can choose the most suitable one for your use.
+
+1. Set `wasm_hash` statically:
+
+```json
+{
+  "pullable" : {
+    "wasm_hash" : "<hex-encoded SHA256 hash of the wasm module to be downloaded>"
+  }
+}
+```
+
+1. Set `wasm_hash_file`, then `dfx` read its content to set `wasm_hash`:
+
+```json
+{
+  "pullable" : {
+    "wasm_hash_file" : "<path/to/wasm_hash_file>"
+  }
+}
+```
+
+3. Set `custom_wasm` which run `generate` commands and use the custom wasm module to calculate `wasm_hash`:
+
+```json
+{
+  "pullable" : {
+    "custom_wasm" : {
+      "generate" : "<commands to generate custom wasm file>",
+      "path" : "<path/to/custom_wasm_file>"
+    }
+  }
+}
+```
+
+`dfx` will do the same post-processing (optimize, metadata, gzip) to the custom wasm as to the canister to be deployed on-chain. `wasm_hash` will be calculated from the post-processed wasm.
+
 ### chore: --emulator parameter is deprecated and will be discontinued soon
 
 Added warning that the `--emulator` is deprecated and will be discontinued soon.

--- a/docs/dfx-json-schema.json
+++ b/docs/dfx-json-schema.json
@@ -426,7 +426,7 @@
           "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/Pullable"
+              "$ref": "#/definitions/PullableConfig"
             },
             {
               "type": "null"
@@ -799,6 +799,56 @@
         }
       }
     },
+    "CustomWasm": {
+      "title": "Custom WASM configuration",
+      "description": "Configs how to generate a custom WASM for pullable and where is the custom WASM file.",
+      "type": "object",
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "generate": {
+          "title": "Generate Commands",
+          "description": "Commands that are executed in order to generate a custom wasm of this pullable canister. Expected to produce the wasm file in the path specified by the 'path' field.",
+          "default": [],
+          "allOf": [
+            {
+              "$ref": "#/definitions/SerdeVec_for_String"
+            }
+          ]
+        },
+        "path": {
+          "title": "Custom WASM Path",
+          "description": "Path to the custom wasm file from the \"generate\" commands. The file should be a valid canister WASM .",
+          "type": "string"
+        }
+      }
+    },
+    "DynamicWasmUrl": {
+      "title": "Dynamic wasm_url configuration",
+      "description": "Configs how to generate wasm_url dynamically and where is the file contains wasm_url.",
+      "type": "object",
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "generate": {
+          "title": "Generate Commands",
+          "description": "Commands that are executed in order to generate this pullable canister's wasm_url dynamically. Expected to produce the wasm_url file in the path specified by the 'path' field.",
+          "default": [],
+          "allOf": [
+            {
+              "$ref": "#/definitions/SerdeVec_for_String"
+            }
+          ]
+        },
+        "path": {
+          "title": "wasm_url Path",
+          "description": "Path to the wasm_url file from the \"generate\" commands. The file should contains a valid URL.",
+          "type": "string"
+        }
+      }
+    },
     "HttpAdapterLogLevel": {
       "description": "Represents the log level of the HTTP adapter.",
       "type": "string",
@@ -909,14 +959,27 @@
         "Release"
       ]
     },
-    "Pullable": {
+    "PullableConfig": {
+      "title": "Pullable configuration",
+      "description": "Configs the \"pullable\" metadata of the canister.",
       "type": "object",
       "required": [
         "dependencies",
-        "init_guide",
-        "wasm_url"
+        "init_guide"
       ],
       "properties": {
+        "custom_wasm": {
+          "title": "Custom WASM",
+          "description": "Build a custom WASM for pullable. wasm_hash will be calculated from this custom WASM. Conflicts with `wasm_hash` and `wasm_hash_file`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CustomWasm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "dependencies": {
           "title": "dependencies",
           "description": "Canister IDs (Principal) of direct dependencies.",
@@ -925,6 +988,18 @@
             "type": "string"
           }
         },
+        "dynamic_wasm_url": {
+          "title": "Dynamic wasm_url",
+          "description": "Generate wasm_url dynamically. Conflicts with `wasm_url`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DynamicWasmUrl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "init_guide": {
           "title": "init_guide",
           "description": "A message to guide consumers how to initialize the canister.",
@@ -932,7 +1007,15 @@
         },
         "wasm_hash": {
           "title": "wasm_hash",
-          "description": "SHA256 hash of the wasm module located at wasm_url. Only define this if the on-chain canister wasm is expected not to match the wasm at wasm_url.",
+          "description": "SHA256 hash of the wasm module located at wasm_url. Only define this if the on-chain canister wasm is expected not to match the wasm at wasm_url. Conflicts with `wasm_hash_file` and `custom_wasm`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wasm_hash_file": {
+          "title": "Path to wasm_hash",
+          "description": "Conflicts with `wasm_hash` and `custom_wasm`.",
           "type": [
             "string",
             "null"
@@ -940,8 +1023,11 @@
         },
         "wasm_url": {
           "title": "wasm_url",
-          "description": "The Url to download canister wasm.",
-          "type": "string"
+          "description": "The URL to download canister wasm. Conflicts with `dynamic_wasm_url`.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },

--- a/e2e/tests-dfx/deps.bash
+++ b/e2e/tests-dfx/deps.bash
@@ -8,8 +8,8 @@ setup() {
 
 teardown() {
     stop_webserver
-    # dfx_stop
-    # standard_teardown
+    dfx_stop
+    standard_teardown
 }
 
 CANISTER_ID_A="yofga-2qaaa-aaaaa-aabsq-cai"
@@ -132,6 +132,11 @@ setup_onchain() {
     ic-wasm .dfx/local/canisters/a/a.wasm metadata dfx > a_dfx.json
     assert_command jq -r '.pullable.wasm_hash' a_dfx.json
     assert_eq "$PROCESSED_WASM_HASH" "$output"
+
+    assert_command ic-wasm .dfx/local/canisters/a/a.wasm metadata
+    assert_contains "icp:public dfx"
+    assert_contains "icp:public candid:service"
+    assert_contains "icp:public candid:args"
 }
 
 @test "dfx deps pull can resolve dependencies from on-chain canister metadata" {
@@ -214,8 +219,6 @@ Failed to download from url: http://example.com/c.wasm."
     dfx_start
 
     setup_onchain
-
-    # TODO: test gzipped wasm can be pulled when we have "gzip" option in dfx.json (SDK-1102)
 
     # pull canisters in app project
     cd app

--- a/e2e/tests-dfx/deps.bash
+++ b/e2e/tests-dfx/deps.bash
@@ -76,10 +76,10 @@ setup_onchain() {
 
     cd onchain
     jq 'del(.canisters.a.pullable.wasm_url)' dfx.json | sponge dfx.json
-    jq '.canisters.a.pullable.dynamic_wasm_url.generate=""' dfx.json | sponge dfx.json
+    jq '.canisters.a.pullable.dynamic_wasm_url.generate="bash dynamic_wasm_url_a.sh"' dfx.json | sponge dfx.json
     jq '.canisters.a.pullable.dynamic_wasm_url.path="dynamic_wasm_url.txt"' dfx.json | sponge dfx.json
 
-    echo "http:/example.com/dynamic_wasm_url/a.wasm" > dynamic_wasm_url.txt
+    echo "echo \"http:/example.com/dynamic_wasm_url/a.wasm\" > dynamic_wasm_url.txt" > dynamic_wasm_url_a.sh
 
     assert_command dfx canister create --all
     assert_command dfx build

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -154,21 +154,37 @@ impl CanisterMetadataSection {
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
-pub struct Pullable {
+pub struct PullableConfig {
     /// # wasm_url
     /// The Url to download canister wasm.
-    pub wasm_url: String,
+    pub wasm_url: Option<String>,
+
+    /// # dynamic_wasm_url
+    /// Generate wasm_url dynamically.
+    pub dynamic_wasm_url: Option<DynamicWasmUrl>,
+
     /// # wasm_hash
     /// SHA256 hash of the wasm module located at wasm_url.
     /// Only define this if the on-chain canister wasm is expected not to match the wasm at wasm_url.
     pub wasm_hash: Option<String>,
+
     /// # dependencies
     /// Canister IDs (Principal) of direct dependencies.
     #[schemars(with = "Vec::<String>")]
     pub dependencies: Vec<Principal>,
+
     /// # init_guide
     /// A message to guide consumers how to initialize the canister.
     pub init_guide: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct DynamicWasmUrl {
+    /// TODO: use similar description of "build"
+    pub generate: String,
+
+    /// TODO: use similar description of "wasm"
+    pub path: String,
 }
 
 pub const DEFAULT_SHARED_LOCAL_BIND: &str = "127.0.0.1:4943"; // hex for "IC"
@@ -247,7 +263,7 @@ pub struct ConfigCanistersCanister {
     /// # Pullable
     /// Defines required properties so that this canister is ready for `dfx deps pull` by other projects.
     #[serde(default)]
-    pub pullable: Option<Pullable>,
+    pub pullable: Option<PullableConfig>,
 
     /// # Gzip Canister WASM
     /// Disabled by default.

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -153,6 +153,8 @@ impl CanisterMetadataSection {
     }
 }
 
+/// # Pullable configuration
+/// Configs the "pullable" metadata of the canister.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct PullableConfig {
     /// # wasm_url
@@ -191,6 +193,8 @@ pub struct PullableConfig {
     pub init_guide: String,
 }
 
+/// # Dynamic wasm_url configuration
+/// Configs how to generate wasm_url dynamically and where is the file contains wasm_url.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct DynamicWasmUrl {
     /// # Generate Commands
@@ -205,6 +209,8 @@ pub struct DynamicWasmUrl {
     pub path: String,
 }
 
+/// # Custom WASM configuration
+/// Configs how to generate a custom WASM for pullable and where is the custom WASM file.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct CustomWasm {
     /// # Generate Commands

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -180,10 +180,15 @@ pub struct PullableConfig {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct DynamicWasmUrl {
-    /// TODO: use similar description of "build"
-    pub generate: String,
+    /// # Generate Commands
+    /// Commands that are executed in order to generate this pullable canister's wasm_url dynamically.
+    /// Expected to produce the wasm_url file in the path specified by the 'path' field.
+    #[schemars(default)]
+    pub generate: SerdeVec<String>,
 
-    /// TODO: use similar description of "wasm"
+    /// # wasm_url Path
+    /// Path to the wasm_url file from the "generate" commands.
+    /// The file should contains a valid URL.
     pub path: String,
 }
 

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -157,16 +157,29 @@ impl CanisterMetadataSection {
 pub struct PullableConfig {
     /// # wasm_url
     /// The Url to download canister wasm.
+    /// Conflicts with `dynamic_wasm_url`.
     pub wasm_url: Option<String>,
 
-    /// # dynamic_wasm_url
+    /// # Dynamic wasm_url
     /// Generate wasm_url dynamically.
+    /// Conflicts with `wasm_url`.
     pub dynamic_wasm_url: Option<DynamicWasmUrl>,
 
     /// # wasm_hash
     /// SHA256 hash of the wasm module located at wasm_url.
     /// Only define this if the on-chain canister wasm is expected not to match the wasm at wasm_url.
+    /// Conflicts with `wasm_hash_file` and `custom_wasm`.
     pub wasm_hash: Option<String>,
+
+    /// # Path to wasm_hash
+    /// Conflicts with `wasm_hash` and `custom_wasm`.
+    pub wasm_hash_file: Option<String>,
+
+    /// # Custom WASM
+    /// Build a custom WASM for pullable.
+    /// wasm_hash will be calculated from this custom WASM.
+    /// Conflicts with `wasm_hash` and `wasm_hash_file`.
+    pub custom_wasm: Option<CustomWasm>,
 
     /// # dependencies
     /// Canister IDs (Principal) of direct dependencies.
@@ -189,6 +202,20 @@ pub struct DynamicWasmUrl {
     /// # wasm_url Path
     /// Path to the wasm_url file from the "generate" commands.
     /// The file should contains a valid URL.
+    pub path: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct CustomWasm {
+    /// # Generate Commands
+    /// Commands that are executed in order to generate a custom wasm of this pullable canister.
+    /// Expected to produce the wasm file in the path specified by the 'path' field.
+    #[schemars(default)]
+    pub generate: SerdeVec<String>,
+
+    /// # Custom WASM Path
+    /// Path to the custom wasm file from the "generate" commands.
+    /// The file should be a valid canister WASM .
     pub path: String,
 }
 

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -158,7 +158,7 @@ impl CanisterMetadataSection {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct PullableConfig {
     /// # wasm_url
-    /// The Url to download canister wasm.
+    /// The URL to download canister wasm.
     /// Conflicts with `dynamic_wasm_url`.
     pub wasm_url: Option<String>,
 

--- a/src/dfx/src/lib/builders/assets.rs
+++ b/src/dfx/src/lib/builders/assets.rs
@@ -7,7 +7,7 @@ use crate::lib::environment::Environment;
 use crate::lib::error::{BuildError, DfxError, DfxResult};
 use crate::lib::models::canister::CanisterPool;
 use crate::util;
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use candid::Principal as CanisterId;
 use console::style;
 use dfx_core::config::cache::Cache;
@@ -31,17 +31,7 @@ struct AssetsBuilderExtra {
 impl AssetsBuilderExtra {
     #[context("Failed to create AssetBuilderExtra for canister '{}'.", info.get_name())]
     fn try_from(info: &CanisterInfo, pool: &CanisterPool) -> DfxResult<Self> {
-        let dependencies = info.get_dependencies()
-            .iter()
-            .map(|name| {
-                pool.get_first_canister_with_name(name)
-                    .map(|c| c.canister_id())
-                    .map_or_else(
-                        || Err(anyhow!("A canister with the name '{}' was not found in the current project.", name.clone())),
-                        DfxResult::Ok,
-                    )
-            })
-            .collect::<DfxResult<Vec<CanisterId>>>().with_context( || format!("Failed to collect dependencies (canister ids) of canister {}.", info.get_name()))?;
+        let dependencies = super::collect_dependencies(info, pool)?;
         let info = info.as_info::<AssetsCanisterInfo>()?;
         let build = info.get_build_tasks().to_owned();
 

--- a/src/dfx/src/lib/builders/rust.rs
+++ b/src/dfx/src/lib/builders/rust.rs
@@ -6,7 +6,7 @@ use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::models::canister::CanisterPool;
-use anyhow::{anyhow, bail, Context};
+use anyhow::{bail, Context};
 use candid::Principal as CanisterId;
 use fn_error_context::context;
 use slog::{info, o};
@@ -36,18 +36,7 @@ impl CanisterBuilder for RustBuilder {
         pool: &CanisterPool,
         info: &CanisterInfo,
     ) -> DfxResult<Vec<CanisterId>> {
-        let dependencies = info.get_dependencies()
-            .iter()
-            .map(|name| {
-                pool.get_first_canister_with_name(name)
-                    .map(|c| c.canister_id())
-                    .map_or_else(
-                        || Err(anyhow!("A canister with the name '{}' was not found in the current project.", name.clone())),
-                        DfxResult::Ok,
-                    )
-            })
-            .collect::<DfxResult<Vec<CanisterId>>>().with_context(|| format!("Failed to collect dependencies (canister ids) for canister {}.", info.get_name()))?;
-        Ok(dependencies)
+        super::collect_dependencies(info, pool)
     }
 
     #[context("Failed to build Rust canister '{}'.", canister_info.get_name())]

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -279,7 +279,7 @@ impl CanisterInfo {
             "wasm"
         };
         self.output_root
-            .join(&format!("{}_custom", &self.name))
+            .join(format!("{}_custom", &self.name))
             .with_extension(ext)
     }
 

--- a/src/dfx/src/lib/metadata/dfx.rs
+++ b/src/dfx/src/lib/metadata/dfx.rs
@@ -13,15 +13,19 @@ pub struct DfxMetadata {
     pub pullable: Option<Pullable>,
 }
 
+/// "pullable" object of the "dfx" metadata
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Pullable {
     /// # wasm_url
     /// The Url to download canister wasm.
+    /// Must be valid URL for on-chain canisters.
+    /// Can be Empty for custom wasm module.
     pub wasm_url: String,
 
     /// # wasm_hash
     /// SHA256 hash of the wasm module located at wasm_url.
     /// Only define this if the on-chain canister wasm is expected not to match the wasm at wasm_url.
+    /// Can be None for custom wasm module.
     pub wasm_hash: Option<String>,
 
     /// # dependencies

--- a/src/dfx/src/lib/metadata/dfx.rs
+++ b/src/dfx/src/lib/metadata/dfx.rs
@@ -3,9 +3,12 @@
 //! The cli tool dfx should consolidate its usage of canister metadata into this single section
 //! It's originally for pulling dependencies. But open to extend for other usage.
 use crate::lib::error::DfxResult;
-use anyhow::bail;
-use dfx_core::config::model::dfinity::Pullable;
+use anyhow::{bail, Context};
+use candid::Principal;
+use dfx_core::config::model::dfinity::PullableConfig;
+use dfx_core::fs::read_to_string;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DfxMetadata {
@@ -13,9 +16,57 @@ pub struct DfxMetadata {
     pub pullable: Option<Pullable>,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Pullable {
+    /// # wasm_url
+    /// The Url to download canister wasm.
+    pub wasm_url: String,
+
+    /// # wasm_hash
+    /// SHA256 hash of the wasm module located at wasm_url.
+    /// Only define this if the on-chain canister wasm is expected not to match the wasm at wasm_url.
+    pub wasm_hash: Option<String>,
+
+    /// # dependencies
+    /// Canister IDs (Principal) of direct dependencies.
+    pub dependencies: Vec<Principal>,
+
+    /// # init_guide
+    /// A message to guide consumers how to initialize the canister.
+    pub init_guide: String,
+}
+
 impl DfxMetadata {
-    pub fn set_pullable(&mut self, pullable: Pullable) {
-        self.pullable = Some(pullable);
+    pub fn set_pullable(&mut self, pullable_config: PullableConfig) -> DfxResult {
+        let wasm_url_str = match (pullable_config.wasm_url, pullable_config.dynamic_wasm_url) {
+            (Some(_), Some(_)) => {
+                bail!("Cannot define `wasm_url` and `dynamic_wasm_url` at the same time.")
+            }
+            (None, None) => {
+                bail!("Pullable canister must define `wasm_url` or `dynamic_wasm_url`.")
+            }
+            (Some(s), None) => s,
+            (None, Some(dwu)) => {
+                let path = PathBuf::from(dwu.path);
+                let file_content = read_to_string(&path)?;
+                file_content
+            }
+        };
+
+        reqwest::Url::parse(&wasm_url_str).with_context(|| {
+            format!(
+                "Failed to set wasm_url: \"{}\" is not a valid URL.",
+                wasm_url_str
+            )
+        })?;
+
+        self.pullable = Some(Pullable {
+            wasm_url: wasm_url_str,
+            wasm_hash: None, // TODO: get from config
+            dependencies: pullable_config.dependencies,
+            init_guide: pullable_config.init_guide,
+        });
+        Ok(())
     }
 
     pub fn get_pullable(&self) -> DfxResult<&Pullable> {

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -51,7 +51,8 @@ impl Canister {
     }
 
     pub fn prebuild(&self, pool: &CanisterPool, build_config: &BuildConfig) -> DfxResult {
-        // TODO: run scripts for custom_wasm and dynamic_wasm_url
+        self.builder
+            .prepare_pullable(pool, &self.info, build_config)?;
         self.builder.prebuild(pool, &self.info, build_config)
     }
 

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -250,9 +250,6 @@ impl Canister {
             if section.name == CANDID_SERVICE && info.is_motoko() {
                 if let Some(specified_path) = &section.path {
                     check_valid_subtype(&info.get_service_idl_path(), specified_path)?
-                } else {
-                    // Motoko compiler handles this
-                    continue;
                 }
             }
 

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -51,6 +51,7 @@ impl Canister {
     }
 
     pub fn prebuild(&self, pool: &CanisterPool, build_config: &BuildConfig) -> DfxResult {
+        // TODO: run scripts for custom_wasm and dynamic_wasm_url
         self.builder.prebuild(pool, &self.info, build_config)
     }
 
@@ -151,9 +152,9 @@ impl Canister {
             public_candid = true;
         }
 
-        if let Some(pullable) = info.get_pullable() {
+        if let Some(pullable_config) = info.get_pullable() {
             let mut dfx_metadata = DfxMetadata::default();
-            dfx_metadata.set_pullable(pullable);
+            dfx_metadata.set_pullable(pullable_config)?;
             let content = serde_json::to_string_pretty(&dfx_metadata)
                 .with_context(|| "Failed to serialize `dfx` metadata.".to_string())?;
             metadata_sections.insert(


### PR DESCRIPTION
# Description

Implement SDK-1211

`wasm_url` and `wasm_hash` might need to be calculated dynamically during canister build.

#### wasm_url

Beyond setting `wasm_url` directly, you can generate it into a file with configuration in `dfx.json` like:

```json
{
  "pullable" : {
    "dynamic_wasm_url" : {
      "generate" : "<commands to generate wasm_url file>",
      "path" : "<path/to/wasm_url_file>"
    }
  }
}
```

You can only set one of `wasm_url` and `dynamic_wasm_url`.

#### wasm_hash

Service providers may want consumers to download a different wasm module than the on-chain canister.

In such case, providers need to include a `wasm_hash` field in the `dfx/pullable` metadata of the on-chain pullable canister.

There are three ways to specify `wasm_hash` in `dfx.json`. You can choose the most suitable one for your use.

1. Set `wasm_hash` statically:

```json
{
  "pullable" : {
    "wasm_hash" : "<hex-encoded SHA256 hash of the wasm module to be downloaded>"
  }
}
```

2. Set `wasm_hash_file`, then `dfx` read its content to set `wasm_hash`:

```json
{
  "pullable" : {
    "wasm_hash_file" : "<path/to/wasm_hash_file>"
  }
}
```

3. Set `custom_wasm` which run `generate` commands and use the custom wasm module to calculate `wasm_hash`:

```json
{
  "pullable" : {
    "custom_wasm" : {
      "generate" : "<commands to generate custom wasm file>",
      "path" : "<path/to/custom_wasm_file>"
    }
  }
}
```

`dfx` will do the same post-processing (optimize, metadata, gzip) to the custom wasm as to the canister to be deployed on-chain. `wasm_hash` will be calculated from the post-processed wasm.

# How Has This Been Tested?

e2e test in deps.bash

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
