### PR TITLE
feat: Add `use-old-metering` flag to the `dfx` (#3292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@
 
 ### fix: added https://icp-api.io to the default Content-Security-Policy header
 
+### chore: add `--use-old-metering` flag
+
+The `use-old-metering` flag enables old metering in replica. The new metering is enabled in the `starter` by default, so this flag is to compare the default new metering with the old one.
+
+The flag is temporary and will be removed in a few months.
+
+### feat!: Removed dfx nns and dfx sns commands
+
+Both have now been turned into the dfx extensions. In order to obtain them, please run `dfx extension install nns` and `dfx extension install sns` respectively. After the installation, you can use them as you did before: `dfx nns ...`, and `dfx sns ...`.
+
+### feat!: Removed dfx replica and dfx bootstrap commands
+
+Use `dfx start` instead.  If you have a good reason why we should keep these commands, please contribute to the discussion at https://github.com/dfinity/sdk/discussions/3163
+
 Existing projects will need to change this value in .ic-assets.json or .ic-assets.json5 to include https://icp-api.io
 
 All projects will need to redeploy.

--- a/docs/cli-reference/dfx-start.md
+++ b/docs/cli-reference/dfx-start.md
@@ -21,6 +21,7 @@ You can use the following optional flags with the `dfx start` command.
 | `--emulator`      | Starts the [IC reference emulator](https://github.com/dfinity/ic-hs) rather than the replica.                                                                                                                                                |
 | `--enable-bitcoin` | Enables bitcoin integration.                                                                                                                                                                                                                 |
 | `--enable-canister-http` | Enables canister HTTP requests. (deprecated: now enabled by default)                                                                                                                                                                         |
+| `--use-old-metering` | Enables the old metering in the local canister execution environment. Please see the forum thread for more details or to report any issues: [forum.dfinity.org/t/new-wasm-instrumentation/](https://forum.dfinity.org/t/new-wasm-instrumentation/22080) |
 
 ## Options
 

--- a/src/dfx/src/actors/mod.rs
+++ b/src/dfx/src/actors/mod.rs
@@ -122,7 +122,7 @@ fn setup_replica_env(
     let replica_configuration_dir = local_server_descriptor.replica_configuration_dir();
     fs::create_dir_all(&replica_configuration_dir).with_context(|| {
         format!(
-            "Failed to create replica config direcory {}.",
+            "Failed to create replica config directory {}.",
             replica_configuration_dir.to_string_lossy()
         )
     })?;

--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -344,11 +344,15 @@ fn replica_start_thread(
         }
         cmd.args([
             "--initial-notary-delay-millis",
-            // The intial notary delay is set to 2500ms in the replica's
+            // The initial notary delay is set to 2500ms in the replica's
             // default subnet configuration to help running tests.
             // For our production network, we actually set them to 600ms.
             &format!("{artificial_delay}"),
         ]);
+
+        if config.use_old_metering {
+            cmd.args(["--use-old-metering"]);
+        }
 
         // This should agree with the value at
         // at https://gitlab.com/dfinity-lab/core/ic/-/blob/master/ic-os/guestos/rootfs/etc/systemd/system/ic-replica.service

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -77,6 +77,10 @@ pub struct StartOpts {
     /// Start even if the network config was modified.
     #[arg(long)]
     force: bool,
+
+    /// Use old metering.
+    #[arg(long)]
+    use_old_metering: bool,
 }
 
 // The frontend webserver is brought up by the bg process; thus, the fg process
@@ -142,6 +146,7 @@ pub fn exec(
         enable_bitcoin,
         enable_canister_http,
         artificial_delay,
+        use_old_metering,
     }: StartOpts,
 ) -> DfxResult {
     if !background {
@@ -288,8 +293,13 @@ pub fn exec(
         .unwrap_or_default();
 
     let replica_config = {
-        let replica_config =
-            ReplicaConfig::new(&state_root, subnet_type, log_level, artificial_delay);
+        let replica_config = ReplicaConfig::new(
+            &state_root,
+            subnet_type,
+            log_level,
+            artificial_delay,
+            use_old_metering,
+        );
         let mut replica_config = if let Some(port) = local_server_descriptor.replica.port {
             replica_config.with_port(port)
         } else {

--- a/src/dfx/src/lib/replica_config.rs
+++ b/src/dfx/src/lib/replica_config.rs
@@ -54,6 +54,7 @@ pub struct ReplicaConfig {
     pub canister_http_adapter: CanisterHttpAdapterConfig,
     pub log_level: ReplicaLogLevel,
     pub artificial_delay: u32,
+    pub use_old_metering: bool,
 }
 
 impl ReplicaConfig {
@@ -62,6 +63,7 @@ impl ReplicaConfig {
         subnet_type: ReplicaSubnetType,
         log_level: ReplicaLogLevel,
         artificial_delay: u32,
+        use_old_metering: bool,
     ) -> Self {
         ReplicaConfig {
             http_handler: HttpHandlerConfig {
@@ -88,6 +90,7 @@ impl ReplicaConfig {
             },
             log_level,
             artificial_delay,
+            use_old_metering,
         }
     }
 


### PR DESCRIPTION
The `use-old-metering` flag enables old metering in replica. The new metering is enabled in the `starter` by default, so this flag is to compare the default new metering with the old one.

The flag is temporary and will be removed in a few months.

Forum post with details: https://forum.dfinity.org/t/new-wasm-instrumentation/22080

Note, the flag requires replica version [rc--2023-08-23_23-01](https://github.com/dfinity/ic/tree/rc--2023-08-23_23-01) (64016bcd15a39bb494591f949b289d5a92128365)

Fixes RUN-682
