### PR TITLE
fix: dfx deploy urls printed for asset canisters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+### fix: dfx deploy urls printed for asset canisters
+
 ### chore: --emulator parameter is deprecated and will be discontinued soon
 
 Added warning that the `--emulator` is deprecated and will be discontinued soon.

--- a/e2e/tests-dfx/deploy.bash
+++ b/e2e/tests-dfx/deploy.bash
@@ -119,3 +119,18 @@ teardown() {
     ONCHAIN_HASH="$(dfx canister info hello_backend | tail -n 1 | cut -d " " -f 3)"
     assert_eq "$BUILD_HASH" "$ONCHAIN_HASH"
 }
+
+@test "prints the frontend url after deploy" {
+    dfx_new_frontend hello
+    dfx_start
+    assert_command dfx deploy
+    assert_contains "hello_frontend: http://127.0.0.1"
+}
+
+@test "prints the frontend url if 'frontend' section is not present in dfx.json" {
+    dfx_new_frontend hello
+    jq 'del(.canisters.e2e_project_frontend.frontend)' dfx.json | sponge dfx.json
+    dfx_start
+    assert_command dfx deploy
+    assert_contains "hello_frontend: http://127.0.0.1"
+}

--- a/e2e/tests-dfx/deploy.bash
+++ b/e2e/tests-dfx/deploy.bash
@@ -134,3 +134,13 @@ teardown() {
     assert_command dfx deploy
     assert_contains "hello_frontend: http://127.0.0.1"
 }
+
+@test "prints the frontend url if the frontend section has been removed after initial deployment" {
+    dfx_new_frontend hello
+    dfx_start
+    assert_command dfx deploy
+    assert_contains "hello_frontend: http://127.0.0.1"
+    jq 'del(.canisters.hello_frontend.frontend)' dfx.json | sponge dfx.json
+    assert_command dfx deploy
+    assert_contains "hello_frontend: http://127.0.0.1"
+}

--- a/e2e/tests-dfx/deploy.bash
+++ b/e2e/tests-dfx/deploy.bash
@@ -129,7 +129,7 @@ teardown() {
 
 @test "prints the frontend url if 'frontend' section is not present in dfx.json" {
     dfx_new_frontend hello
-    jq 'del(.canisters.e2e_project_frontend.frontend)' dfx.json | sponge dfx.json
+    jq 'del(.canisters.hello_frontend.frontend)' dfx.json | sponge dfx.json
     dfx_start
     assert_command dfx deploy
     assert_contains "hello_frontend: http://127.0.0.1"

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -209,7 +209,10 @@ fn display_urls(env: &dyn Environment) -> DfxResult {
             if let Some(canister_id) = canister_id {
                 let canister_info = CanisterInfo::load(&config, canister_name, Some(canister_id))?;
 
-                if canister_config.frontend.is_some() {
+                // If the canister is an assets canister or has a frontend section, we can display a frontend url.
+                let is_assets = canister_info.is_assets() || canister_config.frontend.is_some();
+                
+                if is_assets {
                     let url = construct_frontend_url(network, &canister_id)?;
                     frontend_urls.insert(canister_name, url);
                 }

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -211,7 +211,7 @@ fn display_urls(env: &dyn Environment) -> DfxResult {
 
                 // If the canister is an assets canister or has a frontend section, we can display a frontend url.
                 let is_assets = canister_info.is_assets() || canister_config.frontend.is_some();
-                
+
                 if is_assets {
                     let url = construct_frontend_url(network, &canister_id)?;
                     frontend_urls.insert(canister_name, url);


### PR DESCRIPTION
# Description

Currently, we're not printing frontend urls for most asset canisters, and it's inconvenient. Given a dfx config with no "frontend" block such as 

```json
"hello_frontend": {
      "dependencies": [
        "hello_backend"
      ],
      "source": [
        "src/hello_frontend/assets",
        "dist/hello_frontend/"
      ],
      "type": "assets"
    }
```

we get

![image](https://github.com/dfinity/sdk/assets/16298804/064b7793-3152-4cd4-8822-2bb3ed7af92a)


After this change, we get 

![Screenshot 2023-08-29 at 10 39 31 AM](https://github.com/dfinity/sdk/assets/16298804/c7398298-f13e-4730-9747-69b82d4c0ca7)


# How Has This Been Tested?

Tested manually on a dfx new starter

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
