### PR TITLE
fix: revert e2e runner from ubuntu-22.04 back to -20.04

### DIFF
--- a/scripts/workflows/e2e-matrix.py
+++ b/scripts/workflows/e2e-matrix.py
@@ -16,7 +16,7 @@ test = sorted(test_scripts("dfx") + test_scripts("replica") + test_scripts("icx-
 matrix = {
     "test": test,
     "backend": ["replica"],
-    "os": ["macos-12", "ubuntu-22.04"],
+    "os": ["macos-12", "ubuntu-20.04"],
     "exclude": [
         {"backend": "ic-ref", "test": "dfx/bitcoin"},
         {"backend": "ic-ref", "test": "dfx/canister_http"},


### PR DESCRIPTION
# Description

partially reverts #3307 
ref: https://github.com/dfinity/sdk/pull/3307#issuecomment-1697681904

# How Has This Been Tested?

covered by CI
