### PR TITLE
fix: dfx canister id no longer warns about plaintext passwords on mainnet

### DIFF
--- a/e2e/tests-dfx/id.bash
+++ b/e2e/tests-dfx/id.bash
@@ -23,6 +23,14 @@ teardown() {
     assert_match "$(jq -r .e2e_project_backend.local < .dfx/local/canister_ids.json)"
 }
 
+@test "id subcommand does not display warning about plaintext keys" {
+    install_asset id
+    dfx identity get-principal
+    echo "{}" | jq '.e2e_project_backend.ic = "bd3sg-teaaa-aaaaa-qaaba-cai"' >canister_ids.json
+    assert_command dfx canister id e2e_project_backend --ic
+    assert_eq "bd3sg-teaaa-aaaaa-qaaba-cai"
+}
+
 @test "id subcommand works from a subdirectory of the project - ephemeral id" {
     install_asset id
     dfx_start

--- a/src/dfx/src/commands/canister/id.rs
+++ b/src/dfx/src/commands/canister/id.rs
@@ -1,19 +1,34 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
+use crate::lib::network::network_opt::NetworkOpt;
 use candid::Principal;
 use clap::Parser;
+use dfx_core::config::model::canister_id_store::CanisterIdStore;
+use dfx_core::network::provider::{create_network_descriptor, LocalBindDetermination};
 
 /// Prints the identifier of a canister.
 #[derive(Parser)]
 pub struct CanisterIdOpts {
     /// Specifies the name of the canister.
     canister: String,
+
+    #[command(flatten)]
+    network: NetworkOpt,
 }
 
 pub async fn exec(env: &dyn Environment, opts: CanisterIdOpts) -> DfxResult {
     env.get_config_or_anyhow()?;
+    let network_descriptor = create_network_descriptor(
+        env.get_config(),
+        env.get_networks_config(),
+        opts.network.to_network_name(),
+        None,
+        LocalBindDetermination::AsConfigured,
+    )?;
+    let canister_id_store =
+        CanisterIdStore::new(env.get_logger(), &network_descriptor, env.get_config())?;
+
     let canister_name = opts.canister.as_str();
-    let canister_id_store = env.get_canister_id_store()?;
     let canister_id =
         Principal::from_text(canister_name).or_else(|_| canister_id_store.get(canister_name))?;
     println!("{}", Principal::to_text(&canister_id));

--- a/src/dfx/src/commands/canister/mod.rs
+++ b/src/dfx/src/commands/canister/mod.rs
@@ -61,31 +61,35 @@ pub enum SubCommand {
 }
 
 pub fn exec(env: &dyn Environment, opts: CanisterOpts) -> DfxResult {
-    let agent_env = create_agent_environment(env, opts.network.to_network_name())?;
+    let agent_env;
+    let env = if matches!(&opts.subcmd, SubCommand::Id(_)) {
+        env
+    } else {
+        agent_env = create_agent_environment(env, opts.network.to_network_name())?;
+        &agent_env
+    };
     let runtime = Runtime::new().expect("Unable to create a runtime");
 
     runtime.block_on(async {
         let call_sender = CallSender::from(&opts.wallet)
             .map_err(|e| anyhow!("Failed to determine call sender: {}", e))?;
         match opts.subcmd {
-            SubCommand::Call(v) => call::exec(&agent_env, v, &call_sender).await,
-            SubCommand::Create(v) => create::exec(&agent_env, v, &call_sender).await,
-            SubCommand::Delete(v) => delete::exec(&agent_env, v, &call_sender).await,
-            SubCommand::DepositCycles(v) => deposit_cycles::exec(&agent_env, v, &call_sender).await,
-            SubCommand::Id(v) => id::exec(&agent_env, v).await,
-            SubCommand::Install(v) => install::exec(&agent_env, v, &call_sender).await,
-            SubCommand::Info(v) => info::exec(&agent_env, v).await,
-            SubCommand::Metadata(v) => metadata::exec(&agent_env, v).await,
-            SubCommand::RequestStatus(v) => request_status::exec(&agent_env, v).await,
-            SubCommand::Send(v) => send::exec(&agent_env, v, &call_sender).await,
-            SubCommand::Sign(v) => sign::exec(&agent_env, v, &call_sender).await,
-            SubCommand::Start(v) => start::exec(&agent_env, v, &call_sender).await,
-            SubCommand::Status(v) => status::exec(&agent_env, v, &call_sender).await,
-            SubCommand::Stop(v) => stop::exec(&agent_env, v, &call_sender).await,
-            SubCommand::UninstallCode(v) => uninstall_code::exec(&agent_env, v, &call_sender).await,
-            SubCommand::UpdateSettings(v) => {
-                update_settings::exec(&agent_env, v, &call_sender).await
-            }
+            SubCommand::Call(v) => call::exec(env, v, &call_sender).await,
+            SubCommand::Create(v) => create::exec(env, v, &call_sender).await,
+            SubCommand::Delete(v) => delete::exec(env, v, &call_sender).await,
+            SubCommand::DepositCycles(v) => deposit_cycles::exec(env, v, &call_sender).await,
+            SubCommand::Id(v) => id::exec(env, v).await,
+            SubCommand::Install(v) => install::exec(env, v, &call_sender).await,
+            SubCommand::Info(v) => info::exec(env, v).await,
+            SubCommand::Metadata(v) => metadata::exec(env, v).await,
+            SubCommand::RequestStatus(v) => request_status::exec(env, v).await,
+            SubCommand::Send(v) => send::exec(env, v, &call_sender).await,
+            SubCommand::Sign(v) => sign::exec(env, v, &call_sender).await,
+            SubCommand::Start(v) => start::exec(env, v, &call_sender).await,
+            SubCommand::Status(v) => status::exec(env, v, &call_sender).await,
+            SubCommand::Stop(v) => stop::exec(env, v, &call_sender).await,
+            SubCommand::UninstallCode(v) => uninstall_code::exec(env, v, &call_sender).await,
+            SubCommand::UpdateSettings(v) => update_settings::exec(env, v, &call_sender).await,
         }
     })
 }


### PR DESCRIPTION
# Description

`dfx canister id` doesn't use the identity, but displays a warning if the selected identity is stored in plaintext.  

Motivation: to make it easier for a new feature, 'dfx canister url', to also not display this warning.

# How Has This Been Tested?

Added an e2e test.  There are two commits in this PR: the first adds the test, in case you want to see it fail without the code update.

before
```
$ dfx canister id frontend --ic
WARN: The default identity is not stored securely. Do not use it to control a lot of cycles/ICP. Create a new identity with `dfx identity new` and use it in mainnet-facing commands with the `--identity` flag
bd3sg-teaaa-aaaaa-qaaba-cai
```

after
```
$ dfx canister id frontend --ic
bd3sg-teaaa-aaaaa-qaaba-cai
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
