### PR TITLE
fix: remove duplicate .with_arg in wallet call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ Background: In order to determine whether to start a project-specific network or
 
 If `dfx start` is starting the shared network from within a dfx project, and that dfx.json contains settings in the `defaults` key for `bitcoin`, `replica`, or `canister_http`, then `dfx start` will warn that it is ignoring those settings.  It will also describe how to define equivalent settings in networks.json.
 
+### fix: dfx canister call --wallet no longer passes the parameter twice
+
+Removed the duplicate parameter.
+
 ## Dependencies
 
 ### Frontend canister

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -111,7 +111,6 @@ async fn do_wallet_call(wallet: &WalletCanister<'_>, args: &CallIn) -> DfxResult
         wallet.update_("wallet_call").with_arg(args64)
     };
     let (result,): (Result<CallResult, String>,) = builder
-        .with_arg(args)
         .build()
         .call_and_wait()
         .await


### PR DESCRIPTION
# Description

When making a call with the wallet, we had two calls to `builder.with_arg()`.  With the current agent this (probably) just adds a parameter that will be ignored, but with the 0.27.0 rust agent this causes a `argument is being set more than once` panic.

This will fix the e2e failures on https://github.com/dfinity/sdk/pull/3370

# How Has This Been Tested?

Existing e2e tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] (no need) I have made corresponding changes to the documentation.
