### PR TITLE
test: remove references to ic-ref from e2e

### DIFF
--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -2,8 +2,6 @@
 
 load ../utils/_
 
-# All tests in this file are skipped for ic-ref.  See scripts/workflows/e2e-matrix.py
-
 BITCOIN_CANISTER_ID="g4xu7-jiaaa-aaaan-aaaaq-cai"
 
 setup() {

--- a/e2e/tests-dfx/canister_http.bash
+++ b/e2e/tests-dfx/canister_http.bash
@@ -2,8 +2,6 @@
 
 load ../utils/_
 
-# All tests in this file are skipped for ic-ref.  See scripts/workflows/e2e-matrix.py
-
 setup() {
     standard_setup
 }

--- a/e2e/tests-dfx/dfx_install.bash
+++ b/e2e/tests-dfx/dfx_install.bash
@@ -2,8 +2,6 @@
 
 load ../utils/_
 
-# All tests in this file are skipped for ic-ref.  See scripts/workflows/e2e-matrix.py
-
 setup() {
     standard_setup
 }

--- a/e2e/tests-dfx/leak.bash
+++ b/e2e/tests-dfx/leak.bash
@@ -2,8 +2,6 @@
 
 load ../utils/_
 
-# All tests in this file are skipped for ic-ref.  See scripts/workflows/e2e-matrix.py
-
 setup() {
     standard_setup
 

--- a/e2e/tests-dfx/ledger.bash
+++ b/e2e/tests-dfx/ledger.bash
@@ -2,9 +2,6 @@
 
 load ../utils/_
 
-# All tests in this file are skipped for ic-ref.  See scripts/workflows/e2e-matrix.py
-
-
 setup() {
     standard_setup
     install_asset ledger

--- a/e2e/tests-dfx/new.bash
+++ b/e2e/tests-dfx/new.bash
@@ -2,8 +2,6 @@
 
 load ../utils/_
 
-# All tests in this file are skipped for ic-ref.  See scripts/workflows/e2e-matrix.py
-
 setup() {
     standard_setup
 }

--- a/e2e/tests-dfx/signals.bash
+++ b/e2e/tests-dfx/signals.bash
@@ -2,9 +2,6 @@
 
 load ../utils/_
 
-# All tests in this file are skipped for ic-ref.  See scripts/workflows/e2e-matrix.py
-
-
 setup() {
     standard_setup
 

--- a/scripts/workflows/e2e-matrix.py
+++ b/scripts/workflows/e2e-matrix.py
@@ -16,17 +16,7 @@ test = sorted(test_scripts("dfx") + test_scripts("replica") + test_scripts("icx-
 matrix = {
     "test": test,
     "backend": ["replica"],
-    "os": ["macos-12", "ubuntu-20.04"],
-    "exclude": [
-        {"backend": "ic-ref", "test": "dfx/bitcoin"},
-        {"backend": "ic-ref", "test": "dfx/canister_http"},
-        {"backend": "ic-ref", "test": "dfx/dfx_install"},
-        {"backend": "ic-ref", "test": "dfx/leak"},
-        {"backend": "ic-ref", "test": "dfx/ledger"},
-        {"backend": "ic-ref", "test": "dfx/new"},
-        {"backend": "ic-ref", "test": "dfx/print"},
-        {"backend": "ic-ref", "test": "dfx/signals"},
-    ],
+    "os": ["macos-12", "ubuntu-20.04"]
 }
 
 print(json.dumps(matrix))


### PR DESCRIPTION
# Description

There's no need to specify exclusions for the ic-ref for certain tests, since we aren't running any tests vs ic-ref anymore.

# How Has This Been Tested?
Covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
