### PR TITLE
fix: remove project specific network deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ If `dfx start` is starting the shared network from within a dfx project, and tha
 
 The parameter was erroneously passed twice.  Now it is passed only once.
 
+### fix: Removed deprecation warning about project-specific networks
+
+Removed this warning: "Project-specific networks are deprecated and will be removed after February 2023." While we may remove project-specific networks in the future, it is not imminent.  One key requirement is the ability to run more than one subnet type at one time.
+
 ## Dependencies
 
 ### Frontend canister

--- a/docs/cli-reference/dfx-start.md
+++ b/docs/cli-reference/dfx-start.md
@@ -84,6 +84,4 @@ dfx stores data for the shared local network in one of the following locations, 
 
 If dfx.json defines the `local` network, then `dfx start` will use this definition and store network data files under `\<project dir\>/.dfx/network/local`. 
 
-Such project-specific networks are deprecated, and we plan to remove support for them after February 2023.  We encourage you to remove any definitions of the `local` network from your project's dfx.json file and instead use the default shared local network.
-
 Note that for projects that define the `local` network in dfx.json, you can only run the `dfx start` and `dfx stop` commands from within the project directory structure. For example, if your project name is `hello_world`, your current working directory must be the `hello_world` top-level project directory or one of its subdirectories.

--- a/src/dfx-core/src/network/provider.rs
+++ b/src/dfx-core/src/network/provider.rs
@@ -353,10 +353,6 @@ fn create_project_network_descriptor(
                 network_name,
                 config.get_path().display(),
             );
-            warn!(
-                logger,
-                "Project-specific networks are deprecated and will be removed after February 2023."
-            );
 
             let data_directory = config.get_temp_path().join("network").join(network_name);
             let legacy_pid_path = Some(config.get_temp_path().join("pid"));


### PR DESCRIPTION
# Description

When running `dfx start` with a project-specific network (dfx.json contains a `local` network definition), dfx displays the following warning:
```
WARN: Project-specific networks are deprecated and will be removed after February 2023.
```

It's mid-September, which is not a good look, but also we shouldn't remove project-specific networks until we can support multiple subnet types at the same time.

# How Has This Been Tested?

Ran `dfx start` in a directory where dfx.json defined a local network.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
