### PR TITLE
refactor: concrete error type for Identity::new

### DIFF
--- a/src/dfx-core/src/error/identity/create_new_identity.rs
+++ b/src/dfx-core/src/error/identity/create_new_identity.rs
@@ -1,6 +1,7 @@
 use crate::error::fs::FsError;
 use crate::error::identity::convert_mnemonic_to_key::ConvertMnemonicToKeyError;
 use crate::error::identity::generate_key::GenerateKeyError;
+use crate::error::identity::load_pem_from_file::LoadPemFromFileError;
 use crate::error::identity::remove_identity::RemoveIdentityError;
 use crate::error::identity::save_pem::SavePemError;
 use crate::error::identity::IdentityError;
@@ -36,7 +37,7 @@ pub enum CreateNewIdentityError {
     IdentityAlreadyExists(),
 
     #[error("Failed to load pem file: {0}")]
-    LoadPemFromFileFailed(IdentityError),
+    LoadPemFromFileFailed(LoadPemFromFileError),
 
     #[error("Failed to remove identity: {0}")]
     RemoveIdentityFailed(RemoveIdentityError),

--- a/src/dfx-core/src/error/identity/export_identity.rs
+++ b/src/dfx-core/src/error/identity/export_identity.rs
@@ -1,3 +1,5 @@
+use crate::error::identity::get_identity_config_or_default::GetIdentityConfigOrDefaultError;
+use crate::error::identity::load_pem::LoadPemError;
 use crate::error::identity::IdentityError;
 use std::string::FromUtf8Error;
 use thiserror::Error;
@@ -5,13 +7,13 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum ExportIdentityError {
     #[error("Failed to get identity config: {0}")]
-    GetIdentityConfigFailed(IdentityError),
+    GetIdentityConfigFailed(GetIdentityConfigOrDefaultError),
 
     #[error("The specified identity does not exist: {0}")]
     IdentityDoesNotExist(IdentityError),
 
     #[error("Failed to load pem file: {0}")]
-    LoadPemFailed(IdentityError),
+    LoadPemFailed(LoadPemError),
 
     #[error("Could not translate pem file to text: {0}")]
     TranslatePemContentToTextFailed(FromUtf8Error),

--- a/src/dfx-core/src/error/identity/get_identity_config_or_default.rs
+++ b/src/dfx-core/src/error/identity/get_identity_config_or_default.rs
@@ -1,0 +1,8 @@
+use crate::error::structured_file::StructuredFileError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GetIdentityConfigOrDefaultError {
+    #[error("Failed to load configuration for identity '{0}': {1}")]
+    LoadIdentityConfigurationFailed(String, StructuredFileError),
+}

--- a/src/dfx-core/src/error/identity/instantiate_identity_from_name.rs
+++ b/src/dfx-core/src/error/identity/instantiate_identity_from_name.rs
@@ -1,0 +1,15 @@
+use crate::error::identity::load_identity::LoadIdentityError;
+use crate::error::identity::IdentityError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum InstantiateIdentityFromNameError {
+    #[error("Failed to get principal of identity: {0}")]
+    GetIdentityPrincipalFailed(String),
+
+    #[error("Failed to load identity: {0}")]
+    LoadIdentityFailed(LoadIdentityError),
+
+    #[error("Identity must exist: {0}")]
+    RequireIdentityExistsFailed(IdentityError),
+}

--- a/src/dfx-core/src/error/identity/load_identity.rs
+++ b/src/dfx-core/src/error/identity/load_identity.rs
@@ -1,0 +1,12 @@
+use crate::error::identity::get_identity_config_or_default::GetIdentityConfigOrDefaultError;
+use crate::error::identity::new_identity::NewIdentityError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LoadIdentityError {
+    #[error("Failed to get identity config: {0}")]
+    GetIdentityConfigOrDefaultFailed(GetIdentityConfigOrDefaultError),
+
+    #[error("Failed to instantiate identity: {0}")]
+    NewIdentityFailed(NewIdentityError),
+}

--- a/src/dfx-core/src/error/identity/load_pem.rs
+++ b/src/dfx-core/src/error/identity/load_pem.rs
@@ -1,0 +1,12 @@
+use crate::error::identity::load_pem_from_file::LoadPemFromFileError;
+use crate::error::keyring::KeyringError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LoadPemError {
+    #[error("Failed to load PEM file from file : {0}")]
+    LoadFromFileFailed(LoadPemFromFileError),
+
+    #[error("Failed to load PEM file from keyring for identity '{0}': {1}")]
+    LoadFromKeyringFailed(Box<String>, KeyringError),
+}

--- a/src/dfx-core/src/error/identity/load_pem_from_file.rs
+++ b/src/dfx-core/src/error/identity/load_pem_from_file.rs
@@ -1,0 +1,13 @@
+use crate::error::encryption::EncryptionError;
+use crate::error::fs::FsError;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LoadPemFromFileError {
+    #[error("Failed to decrypt PEM file: {0}")]
+    DecryptPemFileFailed(PathBuf, EncryptionError),
+
+    #[error("Failed to read pem file: {0}")]
+    ReadPemFileFailed(FsError),
+}

--- a/src/dfx-core/src/error/identity/load_pem_identity.rs
+++ b/src/dfx-core/src/error/identity/load_pem_identity.rs
@@ -1,0 +1,8 @@
+use ic_agent::identity::PemError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LoadPemIdentityError {
+    #[error("Cannot read identity file '{0}': {1:#}")]
+    ReadIdentityFileFailed(String, Box<PemError>),
+}

--- a/src/dfx-core/src/error/identity/mod.rs
+++ b/src/dfx-core/src/error/identity/mod.rs
@@ -2,8 +2,16 @@ pub mod convert_mnemonic_to_key;
 pub mod create_new_identity;
 pub mod export_identity;
 pub mod generate_key;
+pub mod get_identity_config_or_default;
 pub mod get_legacy_credentials_pem_path;
 pub mod initialize_identity_manager;
+pub mod instantiate_identity_from_name;
+pub mod load_identity;
+pub mod load_pem;
+pub mod load_pem_from_file;
+pub mod load_pem_identity;
+pub mod new_hardware_identity;
+pub mod new_identity;
 pub mod new_identity_manager;
 pub mod remove_identity;
 pub mod rename_identity;
@@ -13,20 +21,15 @@ pub mod write_pem_to_file;
 use crate::error::config::ConfigError;
 use crate::error::encryption::EncryptionError;
 use crate::error::fs::FsError;
-use crate::error::keyring::KeyringError;
 use crate::error::structured_file::StructuredFileError;
 use crate::error::wallet_config::WalletConfigError;
 use ic_agent::export::PrincipalError;
 use ic_agent::identity::PemError;
-use ic_identity_hsm::HardwareIdentityError;
 use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum IdentityError {
-    #[error("Failed to decrypt PEM file: {0}")]
-    DecryptPemFileFailed(PathBuf, EncryptionError),
-
     #[error("Failed to ensure identity configuration directory exists: {0}")]
     EnsureIdentityConfigurationDirExistsFailed(FsError),
 
@@ -39,29 +42,11 @@ pub enum IdentityError {
     #[error("Failed to get shared network data directory: {0}")]
     GetSharedNetworkDataDirectoryFailed(ConfigError),
 
-    #[error("Failed to get principal of identity: {0}")]
-    GetIdentityPrincipalFailed(String),
-
     #[error("Identity {0} does not exist at '{1}'.")]
     IdentityDoesNotExist(String, PathBuf),
 
-    #[error("Failed to instantiate hardware identity for identity '{0}': {1}.")]
-    InstantiateHardwareIdentityFailed(String, Box<HardwareIdentityError>),
-
-    #[error("Failed to load configuration for identity '{0}': {1}")]
-    LoadIdentityConfigurationFailed(String, StructuredFileError),
-
-    #[error("Failed to load PEM file from keyring for identity '{0}': {1}")]
-    LoadPemFromKeyringFailed(Box<String>, KeyringError),
-
     #[error("Failed to read principal from id '{0}': {1}")]
     ParsePrincipalFromIdFailed(String, PrincipalError),
-
-    #[error("Cannot read identity file '{0}': {1:#}")]
-    ReadIdentityFileFailed(String, Box<PemError>),
-
-    #[error("Failed to read pem file: {0}")]
-    ReadPemFileFailed(FsError),
 
     #[error("Failed to rename '{0}' to '{1}' in the global wallet config: {2}")]
     RenameWalletFailed(Box<String>, Box<String>, WalletConfigError),

--- a/src/dfx-core/src/error/identity/new_hardware_identity.rs
+++ b/src/dfx-core/src/error/identity/new_hardware_identity.rs
@@ -1,0 +1,8 @@
+use ic_identity_hsm::HardwareIdentityError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum NewHardwareIdentityError {
+    #[error("Failed to instantiate hardware identity for identity '{0}': {1}.")]
+    InstantiateHardwareIdentityFailed(String, Box<HardwareIdentityError>),
+}

--- a/src/dfx-core/src/error/identity/new_identity.rs
+++ b/src/dfx-core/src/error/identity/new_identity.rs
@@ -1,0 +1,16 @@
+use crate::error::identity::load_pem::LoadPemError;
+use crate::error::identity::load_pem_identity::LoadPemIdentityError;
+use crate::error::identity::new_hardware_identity::NewHardwareIdentityError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum NewIdentityError {
+    #[error("Failed to load PEM: {0}")]
+    LoadPemFailed(LoadPemError),
+
+    #[error("Failed to load PEM identity: {0}")]
+    LoadPemIdentityFailed(LoadPemIdentityError),
+
+    #[error("Failed to instantiate hardware identity: {0}")]
+    NewHardwareIdentityFailed(NewHardwareIdentityError),
+}

--- a/src/dfx-core/src/error/identity/rename_identity.rs
+++ b/src/dfx-core/src/error/identity/rename_identity.rs
@@ -1,4 +1,6 @@
 use crate::error::fs::FsError;
+use crate::error::identity::get_identity_config_or_default::GetIdentityConfigOrDefaultError;
+use crate::error::identity::load_pem::LoadPemError;
 use crate::error::identity::save_pem::SavePemError;
 use crate::error::identity::IdentityError;
 use crate::error::keyring::KeyringError;
@@ -10,7 +12,7 @@ pub enum RenameIdentityError {
     CannotCreateAnonymousIdentity(),
 
     #[error("Failed to get identity config: {0}")]
-    GetIdentityConfigFailed(IdentityError),
+    GetIdentityConfigFailed(GetIdentityConfigOrDefaultError),
 
     #[error("Identity already exists.")]
     IdentityAlreadyExists(),
@@ -19,7 +21,7 @@ pub enum RenameIdentityError {
     IdentityDoesNotExist(IdentityError),
 
     #[error("Failed to load pem: {0}")]
-    LoadPemFailed(IdentityError),
+    LoadPemFailed(LoadPemError),
 
     #[error("Failed to map wallets to renamed identity: {0}")]
     MapWalletsToRenamedIdentityFailed(IdentityError /*MapWalletsToRenamedIdentityError*/),

--- a/src/dfx-core/src/identity/pem_safekeeping.rs
+++ b/src/dfx-core/src/identity/pem_safekeeping.rs
@@ -3,6 +3,12 @@ use super::IdentityConfiguration;
 use crate::error::encryption::EncryptionError;
 use crate::error::encryption::EncryptionError::{DecryptContentFailed, HashPasswordFailed};
 use crate::error::fs::FsError;
+use crate::error::identity::load_pem::LoadPemError;
+use crate::error::identity::load_pem::LoadPemError::LoadFromKeyringFailed;
+use crate::error::identity::load_pem_from_file::LoadPemFromFileError;
+use crate::error::identity::load_pem_from_file::LoadPemFromFileError::{
+    DecryptPemFileFailed, ReadPemFileFailed,
+};
 use crate::error::identity::save_pem::SavePemError;
 use crate::error::identity::save_pem::SavePemError::{
     CannotSavePemContentForHsm, WritePemToKeyringFailed,
@@ -10,10 +16,6 @@ use crate::error::identity::save_pem::SavePemError::{
 use crate::error::identity::write_pem_to_file::WritePemToFileError;
 use crate::error::identity::write_pem_to_file::WritePemToFileError::{
     EncryptPemFileFailed, WritePemContentFailed,
-};
-use crate::error::identity::IdentityError;
-use crate::error::identity::IdentityError::{
-    DecryptPemFileFailed, LoadPemFromKeyringFailed, ReadPemFileFailed,
 };
 use crate::identity::identity_file_locations::IdentityFileLocations;
 use crate::identity::keyring_mock;
@@ -30,7 +32,7 @@ pub(crate) fn load_pem(
     locations: &IdentityFileLocations,
     identity_name: &str,
     identity_config: &IdentityConfiguration,
-) -> Result<(Vec<u8>, bool), IdentityError> {
+) -> Result<(Vec<u8>, bool), LoadPemError> {
     if identity_config.hsm.is_some() {
         unreachable!("Cannot load pem content for an HSM identity.")
     } else if identity_config.keyring_identity_suffix.is_some() {
@@ -39,11 +41,12 @@ pub(crate) fn load_pem(
             "Found keyring identity suffix - PEM file is stored in keyring."
         );
         let pem = keyring_mock::load_pem_from_keyring(identity_name)
-            .map_err(|err| LoadPemFromKeyringFailed(Box::new(identity_name.to_string()), err))?;
+            .map_err(|err| LoadFromKeyringFailed(Box::new(identity_name.to_string()), err))?;
         Ok((pem, true))
     } else {
         let pem_path = locations.get_identity_pem_path(identity_name, identity_config);
         load_pem_from_file(&pem_path, Some(identity_config))
+            .map_err(LoadPemError::LoadFromFileFailed)
     }
 }
 
@@ -80,7 +83,7 @@ pub(crate) fn save_pem(
 pub fn load_pem_from_file(
     path: &Path,
     config: Option<&IdentityConfiguration>,
-) -> Result<(Vec<u8>, bool), IdentityError> {
+) -> Result<(Vec<u8>, bool), LoadPemFromFileError> {
     let content = crate::fs::read(path).map_err(ReadPemFileFailed)?;
 
     let (content, was_encrypted) = maybe_decrypt_pem(content.as_slice(), config)

--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -15,7 +15,7 @@ use anyhow::{bail, Context};
 use byte_unit::Byte;
 use candid::Principal as CanisterId;
 use clap::{ArgAction, Parser};
-use dfx_core::error::identity::IdentityError::GetIdentityPrincipalFailed;
+use dfx_core::error::identity::instantiate_identity_from_name::InstantiateIdentityFromNameError::GetIdentityPrincipalFailed;
 use dfx_core::identity::CallSender;
 use ic_agent::Identity as _;
 use slog::info;

--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -14,7 +14,7 @@ use byte_unit::Byte;
 use candid::Principal as CanisterId;
 use clap::{ArgAction, Parser};
 use dfx_core::cli::ask_for_consent;
-use dfx_core::error::identity::IdentityError::GetIdentityPrincipalFailed;
+use dfx_core::error::identity::instantiate_identity_from_name::InstantiateIdentityFromNameError::GetIdentityPrincipalFailed;
 use dfx_core::identity::CallSender;
 use fn_error_context::context;
 use ic_agent::identity::Identity;


### PR DESCRIPTION
# Description

Adds concrete error type `NewIdentityError` for `Identity::new()`, and require dependent error types.

# How Has This Been Tested?

Covered by CI
