### PR TITLE
refactor: move remaining IdentityError types to method-specific errors

### DIFF
--- a/src/dfx-core/src/error/identity/call_sender_from_wallet.rs
+++ b/src/dfx-core/src/error/identity/call_sender_from_wallet.rs
@@ -1,0 +1,8 @@
+use candid::types::principal::PrincipalError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CallSenderFromWalletError {
+    #[error("Failed to read principal from id '{0}': {1}")]
+    ParsePrincipalFromIdFailed(String, PrincipalError),
+}

--- a/src/dfx-core/src/error/identity/create_new_identity.rs
+++ b/src/dfx-core/src/error/identity/create_new_identity.rs
@@ -6,6 +6,7 @@ use crate::error::identity::load_pem_from_file::LoadPemFromFileError;
 use crate::error::identity::remove_identity::RemoveIdentityError;
 use crate::error::identity::save_identity_configuration::SaveIdentityConfigurationError;
 use crate::error::identity::save_pem::SavePemError;
+use crate::error::identity::use_identity_by_name::UseIdentityByNameError;
 use crate::error::identity::validate_pem_file::ValidatePemFileError;
 use crate::error::identity::IdentityError;
 use thiserror::Error;
@@ -55,10 +56,10 @@ pub enum CreateNewIdentityError {
     SavePemFailed(SavePemError),
 
     #[error("Failed to switch back over to the identity you're replacing: {0}")]
-    SwitchBackToIdentityFailed(IdentityError),
+    SwitchBackToIdentityFailed(UseIdentityByNameError),
 
     #[error("Failed to temporarily switch over to anonymous identity: {0}")]
-    SwitchToAnonymousIdentityFailed(IdentityError),
+    SwitchToAnonymousIdentityFailed(UseIdentityByNameError),
 
     #[error("Failed to validate pem file: {0}")]
     ValidatePemFileFailed(ValidatePemFileError),

--- a/src/dfx-core/src/error/identity/create_new_identity.rs
+++ b/src/dfx-core/src/error/identity/create_new_identity.rs
@@ -8,7 +8,6 @@ use crate::error::identity::save_identity_configuration::SaveIdentityConfigurati
 use crate::error::identity::save_pem::SavePemError;
 use crate::error::identity::use_identity_by_name::UseIdentityByNameError;
 use crate::error::identity::validate_pem_file::ValidatePemFileError;
-use crate::error::identity::IdentityError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/dfx-core/src/error/identity/export_identity.rs
+++ b/src/dfx-core/src/error/identity/export_identity.rs
@@ -1,7 +1,7 @@
 use crate::error::identity::get_identity_config_or_default::GetIdentityConfigOrDefaultError;
 use crate::error::identity::load_pem::LoadPemError;
+use crate::error::identity::require_identity_exists::RequireIdentityExistsError;
 use crate::error::identity::validate_pem_file::ValidatePemFileError;
-use crate::error::identity::IdentityError;
 use std::string::FromUtf8Error;
 use thiserror::Error;
 
@@ -11,7 +11,7 @@ pub enum ExportIdentityError {
     GetIdentityConfigFailed(GetIdentityConfigOrDefaultError),
 
     #[error("The specified identity does not exist: {0}")]
-    IdentityDoesNotExist(IdentityError),
+    IdentityDoesNotExist(RequireIdentityExistsError),
 
     #[error("Failed to load pem file: {0}")]
     LoadPemFailed(LoadPemError),

--- a/src/dfx-core/src/error/identity/instantiate_identity_from_name.rs
+++ b/src/dfx-core/src/error/identity/instantiate_identity_from_name.rs
@@ -1,5 +1,5 @@
 use crate::error::identity::load_identity::LoadIdentityError;
-use crate::error::identity::IdentityError;
+use crate::error::identity::require_identity_exists::RequireIdentityExistsError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -11,5 +11,5 @@ pub enum InstantiateIdentityFromNameError {
     LoadIdentityFailed(LoadIdentityError),
 
     #[error("Identity must exist: {0}")]
-    RequireIdentityExistsFailed(IdentityError),
+    RequireIdentityExistsFailed(RequireIdentityExistsError),
 }

--- a/src/dfx-core/src/error/identity/mod.rs
+++ b/src/dfx-core/src/error/identity/mod.rs
@@ -22,9 +22,9 @@ pub mod save_identity_configuration;
 pub mod save_pem;
 pub mod use_identity_by_name;
 pub mod validate_pem_file;
+pub mod write_default_identity;
 pub mod write_pem_to_file;
 
-use crate::error::structured_file::StructuredFileError;
 use ic_agent::export::PrincipalError;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -39,7 +39,4 @@ pub enum IdentityError {
 
     #[error("An Identity named {0} cannot be created as it is reserved for internal use.")]
     ReservedIdentityName(String),
-
-    #[error("Failed to save identity manager configuration: {0}")]
-    SaveIdentityManagerConfigurationFailed(StructuredFileError),
 }

--- a/src/dfx-core/src/error/identity/mod.rs
+++ b/src/dfx-core/src/error/identity/mod.rs
@@ -1,3 +1,4 @@
+pub mod call_sender_from_wallet;
 pub mod convert_mnemonic_to_key;
 pub mod create_identity_config;
 pub mod create_new_identity;
@@ -25,7 +26,6 @@ pub mod validate_pem_file;
 pub mod write_default_identity;
 pub mod write_pem_to_file;
 
-use ic_agent::export::PrincipalError;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -33,9 +33,6 @@ use thiserror::Error;
 pub enum IdentityError {
     #[error("Identity {0} does not exist at '{1}'.")]
     IdentityDoesNotExist(String, PathBuf),
-
-    #[error("Failed to read principal from id '{0}': {1}")]
-    ParsePrincipalFromIdFailed(String, PrincipalError),
 
     #[error("An Identity named {0} cannot be created as it is reserved for internal use.")]
     ReservedIdentityName(String),

--- a/src/dfx-core/src/error/identity/mod.rs
+++ b/src/dfx-core/src/error/identity/mod.rs
@@ -20,6 +20,7 @@ pub mod rename_identity;
 pub mod rename_wallet_global_config_key;
 pub mod save_identity_configuration;
 pub mod save_pem;
+pub mod use_identity_by_name;
 pub mod validate_pem_file;
 pub mod write_pem_to_file;
 

--- a/src/dfx-core/src/error/identity/mod.rs
+++ b/src/dfx-core/src/error/identity/mod.rs
@@ -19,21 +19,10 @@ pub mod new_identity_manager;
 pub mod remove_identity;
 pub mod rename_identity;
 pub mod rename_wallet_global_config_key;
+pub mod require_identity_exists;
 pub mod save_identity_configuration;
 pub mod save_pem;
 pub mod use_identity_by_name;
 pub mod validate_pem_file;
 pub mod write_default_identity;
 pub mod write_pem_to_file;
-
-use std::path::PathBuf;
-use thiserror::Error;
-
-#[derive(Error, Debug)]
-pub enum IdentityError {
-    #[error("Identity {0} does not exist at '{1}'.")]
-    IdentityDoesNotExist(String, PathBuf),
-
-    #[error("An Identity named {0} cannot be created as it is reserved for internal use.")]
-    ReservedIdentityName(String),
-}

--- a/src/dfx-core/src/error/identity/new_identity_manager.rs
+++ b/src/dfx-core/src/error/identity/new_identity_manager.rs
@@ -1,6 +1,6 @@
 use crate::error::config::ConfigError;
 use crate::error::identity::initialize_identity_manager::InitializeIdentityManagerError;
-use crate::error::identity::IdentityError;
+use crate::error::identity::require_identity_exists::RequireIdentityExistsError;
 use crate::error::structured_file::StructuredFileError;
 use thiserror::Error;
 
@@ -16,5 +16,5 @@ pub enum NewIdentityManagerError {
     InitializeFailed(InitializeIdentityManagerError),
 
     #[error("The specified identity must exist: {0}")]
-    OverrideIdentityMustExist(IdentityError),
+    OverrideIdentityMustExist(RequireIdentityExistsError),
 }

--- a/src/dfx-core/src/error/identity/remove_identity.rs
+++ b/src/dfx-core/src/error/identity/remove_identity.rs
@@ -1,5 +1,5 @@
 use crate::error::fs::FsError;
-use crate::error::identity::IdentityError;
+use crate::error::identity::require_identity_exists::RequireIdentityExistsError;
 use crate::error::keyring::KeyringError;
 use crate::error::wallet_config::WalletConfigError;
 use thiserror::Error;
@@ -28,5 +28,5 @@ pub enum RemoveIdentityError {
     RemoveIdentityFromKeyringFailed(KeyringError),
 
     #[error("Identity must exist: {0}")]
-    RequireIdentityExistsFailed(IdentityError),
+    RequireIdentityExistsFailed(RequireIdentityExistsError),
 }

--- a/src/dfx-core/src/error/identity/rename_identity.rs
+++ b/src/dfx-core/src/error/identity/rename_identity.rs
@@ -2,10 +2,10 @@ use crate::error::fs::FsError;
 use crate::error::identity::get_identity_config_or_default::GetIdentityConfigOrDefaultError;
 use crate::error::identity::load_pem::LoadPemError;
 use crate::error::identity::map_wallets_to_renamed_identity::MapWalletsToRenamedIdentityError;
+use crate::error::identity::require_identity_exists::RequireIdentityExistsError;
 use crate::error::identity::save_identity_configuration::SaveIdentityConfigurationError;
 use crate::error::identity::save_pem::SavePemError;
 use crate::error::identity::write_default_identity::WriteDefaultIdentityError;
-use crate::error::identity::IdentityError;
 use crate::error::keyring::KeyringError;
 use thiserror::Error;
 
@@ -21,7 +21,7 @@ pub enum RenameIdentityError {
     IdentityAlreadyExists(),
 
     #[error("Identity does not exist: {0}")]
-    IdentityDoesNotExist(IdentityError),
+    IdentityDoesNotExist(RequireIdentityExistsError),
 
     #[error("Failed to load pem: {0}")]
     LoadPemFailed(LoadPemError),

--- a/src/dfx-core/src/error/identity/rename_identity.rs
+++ b/src/dfx-core/src/error/identity/rename_identity.rs
@@ -4,6 +4,7 @@ use crate::error::identity::load_pem::LoadPemError;
 use crate::error::identity::map_wallets_to_renamed_identity::MapWalletsToRenamedIdentityError;
 use crate::error::identity::save_identity_configuration::SaveIdentityConfigurationError;
 use crate::error::identity::save_pem::SavePemError;
+use crate::error::identity::write_default_identity::WriteDefaultIdentityError;
 use crate::error::identity::IdentityError;
 use crate::error::keyring::KeyringError;
 use thiserror::Error;
@@ -41,5 +42,5 @@ pub enum RenameIdentityError {
     SavePemFailed(SavePemError),
 
     #[error("Failed to switch over default identity settings: {0}")]
-    SwitchDefaultIdentitySettingsFailed(IdentityError),
+    SwitchDefaultIdentitySettingsFailed(WriteDefaultIdentityError),
 }

--- a/src/dfx-core/src/error/identity/require_identity_exists.rs
+++ b/src/dfx-core/src/error/identity/require_identity_exists.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum RequireIdentityExistsError {
+    #[error("Identity {0} does not exist at '{1}'.")]
+    IdentityDoesNotExist(String, PathBuf),
+
+    #[error("An Identity named {0} cannot be created as it is reserved for internal use.")]
+    ReservedIdentityName(String),
+}

--- a/src/dfx-core/src/error/identity/use_identity_by_name.rs
+++ b/src/dfx-core/src/error/identity/use_identity_by_name.rs
@@ -1,3 +1,4 @@
+use crate::error::identity::write_default_identity::WriteDefaultIdentityError;
 use crate::error::identity::IdentityError;
 use thiserror::Error;
 
@@ -7,5 +8,5 @@ pub enum UseIdentityByNameError {
     RequireIdentityExistsFailed(IdentityError),
 
     #[error("Failed to write default identity: {0}")]
-    WriteDefaultIdentityFailed(IdentityError),
+    WriteDefaultIdentityFailed(WriteDefaultIdentityError),
 }

--- a/src/dfx-core/src/error/identity/use_identity_by_name.rs
+++ b/src/dfx-core/src/error/identity/use_identity_by_name.rs
@@ -1,0 +1,11 @@
+use crate::error::identity::IdentityError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum UseIdentityByNameError {
+    #[error("Identity must exist: {0}")]
+    RequireIdentityExistsFailed(IdentityError),
+
+    #[error("Failed to write default identity: {0}")]
+    WriteDefaultIdentityFailed(IdentityError),
+}

--- a/src/dfx-core/src/error/identity/use_identity_by_name.rs
+++ b/src/dfx-core/src/error/identity/use_identity_by_name.rs
@@ -1,11 +1,11 @@
+use crate::error::identity::require_identity_exists::RequireIdentityExistsError;
 use crate::error::identity::write_default_identity::WriteDefaultIdentityError;
-use crate::error::identity::IdentityError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum UseIdentityByNameError {
     #[error("Identity must exist: {0}")]
-    RequireIdentityExistsFailed(IdentityError),
+    RequireIdentityExistsFailed(RequireIdentityExistsError),
 
     #[error("Failed to write default identity: {0}")]
     WriteDefaultIdentityFailed(WriteDefaultIdentityError),

--- a/src/dfx-core/src/error/identity/write_default_identity.rs
+++ b/src/dfx-core/src/error/identity/write_default_identity.rs
@@ -1,0 +1,8 @@
+use crate::error::structured_file::StructuredFileError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum WriteDefaultIdentityError {
+    #[error("Failed to save identity manager configuration: {0}")]
+    SaveIdentityManagerConfigurationFailed(StructuredFileError),
+}

--- a/src/dfx-core/src/identity/identity_manager.rs
+++ b/src/dfx-core/src/identity/identity_manager.rs
@@ -49,6 +49,8 @@ use crate::error::identity::save_identity_configuration::SaveIdentityConfigurati
 use crate::error::identity::save_identity_configuration::SaveIdentityConfigurationError::EnsureIdentityConfigurationDirExistsFailed;
 use crate::error::identity::use_identity_by_name::UseIdentityByNameError;
 use crate::error::identity::use_identity_by_name::UseIdentityByNameError::WriteDefaultIdentityFailed;
+use crate::error::identity::write_default_identity::WriteDefaultIdentityError;
+use crate::error::identity::write_default_identity::WriteDefaultIdentityError::SaveIdentityManagerConfigurationFailed;
 use crate::error::identity::IdentityError;
 use crate::error::structured_file::StructuredFileError;
 use crate::foundation::get_user_home;
@@ -610,12 +612,12 @@ impl IdentityManager {
         Ok(())
     }
 
-    fn write_default_identity(&self, name: &str) -> Result<(), IdentityError> {
+    fn write_default_identity(&self, name: &str) -> Result<(), WriteDefaultIdentityError> {
         let config = Configuration {
             default: String::from(name),
         };
         save_configuration(&self.identity_json_path, &config)
-            .map_err(IdentityError::SaveIdentityManagerConfigurationFailed)?;
+            .map_err(SaveIdentityManagerConfigurationFailed)?;
         Ok(())
     }
 

--- a/src/dfx-core/src/identity/identity_manager.rs
+++ b/src/dfx-core/src/identity/identity_manager.rs
@@ -47,6 +47,8 @@ use crate::error::identity::rename_identity::RenameIdentityError::{
 };
 use crate::error::identity::save_identity_configuration::SaveIdentityConfigurationError;
 use crate::error::identity::save_identity_configuration::SaveIdentityConfigurationError::EnsureIdentityConfigurationDirExistsFailed;
+use crate::error::identity::use_identity_by_name::UseIdentityByNameError;
+use crate::error::identity::use_identity_by_name::UseIdentityByNameError::WriteDefaultIdentityFailed;
 use crate::error::identity::IdentityError;
 use crate::error::structured_file::StructuredFileError;
 use crate::foundation::get_user_home;
@@ -595,9 +597,15 @@ impl IdentityManager {
     }
 
     /// Select an identity by name to use by default
-    pub fn use_identity_named(&mut self, log: &Logger, name: &str) -> Result<(), IdentityError> {
-        self.require_identity_exists(log, name)?;
-        self.write_default_identity(name)?;
+    pub fn use_identity_named(
+        &mut self,
+        log: &Logger,
+        name: &str,
+    ) -> Result<(), UseIdentityByNameError> {
+        self.require_identity_exists(log, name)
+            .map_err(UseIdentityByNameError::RequireIdentityExistsFailed)?;
+        self.write_default_identity(name)
+            .map_err(WriteDefaultIdentityFailed)?;
         self.configuration.default = name.to_string();
         Ok(())
     }

--- a/src/dfx-core/src/identity/mod.rs
+++ b/src/dfx-core/src/identity/mod.rs
@@ -3,6 +3,8 @@
 //! Wallets are a map of network-identity, but don't have their own types or manager
 //! type.
 use crate::config::directories::{get_config_dfx_dir_path, get_shared_network_data_directory};
+use crate::error::identity::call_sender_from_wallet::CallSenderFromWalletError;
+use crate::error::identity::call_sender_from_wallet::CallSenderFromWalletError::ParsePrincipalFromIdFailed;
 use crate::error::identity::load_pem_identity::LoadPemIdentityError;
 use crate::error::identity::load_pem_identity::LoadPemIdentityError::ReadIdentityFileFailed;
 use crate::error::identity::map_wallets_to_renamed_identity::MapWalletsToRenamedIdentityError;
@@ -12,7 +14,6 @@ use crate::error::identity::new_hardware_identity::NewHardwareIdentityError::Ins
 use crate::error::identity::new_identity::NewIdentityError;
 use crate::error::identity::rename_wallet_global_config_key::RenameWalletGlobalConfigKeyError;
 use crate::error::identity::rename_wallet_global_config_key::RenameWalletGlobalConfigKeyError::RenameWalletFailed;
-use crate::error::identity::IdentityError;
 use crate::error::wallet_config::WalletConfigError;
 use crate::error::wallet_config::WalletConfigError::{
     EnsureWalletConfigDirFailed, LoadWalletConfigFailed, SaveWalletConfigFailed,
@@ -304,11 +305,10 @@ pub enum CallSender {
 // Determine whether the selected Identity
 // or the provided wallet canister ID should be the Sender of the call.
 impl CallSender {
-    pub fn from(wallet: &Option<String>) -> Result<Self, IdentityError> {
+    pub fn from(wallet: &Option<String>) -> Result<Self, CallSenderFromWalletError> {
         let sender = if let Some(id) = wallet {
             CallSender::Wallet(
-                Principal::from_text(id)
-                    .map_err(|e| IdentityError::ParsePrincipalFromIdFailed(id.clone(), e))?,
+                Principal::from_text(id).map_err(|e| ParsePrincipalFromIdFailed(id.clone(), e))?,
             )
         } else {
             CallSender::SelectedId

--- a/src/dfx/src/lib/error/mod.rs
+++ b/src/dfx/src/lib/error/mod.rs
@@ -5,7 +5,6 @@ pub mod project;
 
 pub use build::BuildError;
 pub use dfx_core::error::extension::ExtensionError;
-pub use dfx_core::error::identity::IdentityError;
 pub use notify_create_canister::NotifyCreateCanisterError;
 pub use notify_top_up::NotifyTopUpError;
 pub use project::ProjectError;


### PR DESCRIPTION
# Description

Move the remaining enumerated types in IdentityError to method-specific error types, and remove IdentityError.

New types:
- CallSenderFromWalletError
- RequireIdentityExistsError
- UseIdentityByNameError
- WriteDefaultIdentityError

# How Has This Been Tested?

Covered by CI