### PR TITLE
refactor: split up DfxConfigError into method-specific error types

### DIFF
--- a/src/dfx-core/src/error/canister_id_store.rs
+++ b/src/dfx-core/src/error/canister_id_store.rs
@@ -1,5 +1,5 @@
 use crate::error::{
-    dfx_config::DfxConfigError, fs::FsError, structured_file::StructuredFileError,
+    dfx_config::GetPullCanistersError, fs::FsError, structured_file::StructuredFileError,
     unified_io::UnifiedIoError,
 };
 use thiserror::Error;
@@ -37,7 +37,7 @@ pub enum CanisterIdStoreError {
     },
 
     #[error(transparent)]
-    DfxConfigError(#[from] DfxConfigError),
+    GetPullCanistersFailed(#[from] GetPullCanistersError),
 }
 
 impl From<FsError> for CanisterIdStoreError {

--- a/src/dfx-core/src/error/dfx_config.rs
+++ b/src/dfx-core/src/error/dfx_config.rs
@@ -2,31 +2,58 @@ use candid::Principal;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum DfxConfigError {
+pub enum AddDependenciesError {
     #[error("Circular canister dependencies: {}", _0.join(" -> "))]
     CanisterCircularDependency(Vec<String>),
 
     #[error("Canister '{0}' not found in dfx.json.")]
     CanisterNotFound(String),
+}
 
+#[derive(Error, Debug)]
+pub enum GetCanisterConfigError {
     #[error("No canisters in the configuration file.")]
     CanistersFieldDoesNotExist(),
 
-    #[error("Failed to get canisters with their dependencies (for {}): {1}", _0.as_deref().unwrap_or("all canisters"))]
-    GetCanistersWithDependenciesFailed(Option<String>, Box<DfxConfigError>),
+    #[error("Canister '{0}' not found in dfx.json.")]
+    CanisterNotFound(String),
+}
 
+#[derive(Error, Debug)]
+pub enum GetCanisterNamesWithDependenciesError {
+    #[error("No canisters in the configuration file.")]
+    CanistersFieldDoesNotExist(),
+
+    #[error("Failed to add dependencies for canister '{0}': {1}")]
+    AddDependenciesFailed(String, AddDependenciesError),
+}
+
+#[derive(Error, Debug)]
+pub enum GetComputeAllocationError {
     #[error("Failed to get compute allocation for canister '{0}': {1}")]
-    GetComputeAllocationFailed(String, Box<DfxConfigError>),
+    GetComputeAllocationFailed(String, GetCanisterConfigError),
+}
 
+#[derive(Error, Debug)]
+pub enum GetFreezingThresholdError {
     #[error("Failed to get freezing threshold for canister '{0}': {1}")]
-    GetFreezingThresholdFailed(String, Box<DfxConfigError>),
+    GetFreezingThresholdFailed(String, GetCanisterConfigError),
+}
 
+#[derive(Error, Debug)]
+pub enum GetMemoryAllocationError {
     #[error("Failed to get memory allocation for canister '{0}': {1}")]
-    GetMemoryAllocationFailed(String, Box<DfxConfigError>),
+    GetMemoryAllocationFailed(String, GetCanisterConfigError),
+}
 
-    #[error("Failed to figure out if canister '{0}' has a remote id on network '{1}': {2}")]
-    GetRemoteCanisterIdFailed(Box<String>, Box<String>, Box<DfxConfigError>),
-
+#[derive(Error, Debug)]
+pub enum GetPullCanistersError {
     #[error("Pull dependencies '{0}' and '{1}' have the same canister ID: {2}")]
     PullCanistersSameId(String, String, Principal),
+}
+
+#[derive(Error, Debug)]
+pub enum GetRemoteCanisterIdError {
+    #[error("Failed to figure out if canister '{0}' has a remote id on network '{1}': {2}")]
+    GetRemoteCanisterIdFailed(Box<String>, Box<String>, GetCanisterConfigError),
 }


### PR DESCRIPTION
# Description

Eliminates some boxing and makes it more clear what errors are possible for any given method.

# How Has This Been Tested?

Covered by CI