### PR TITLE
refactor: rename get_config_dfx_dir_path() -> get_user_dfx_config_dir()

### DIFF
--- a/src/dfx-core/src/config/directories.rs
+++ b/src/dfx-core/src/config/directories.rs
@@ -23,7 +23,7 @@ pub fn get_shared_network_data_directory(network: &str) -> Result<PathBuf, Confi
     Ok(project_dirs.data_local_dir().join("network").join(network))
 }
 
-pub fn get_config_dfx_dir_path() -> Result<PathBuf, ConfigError> {
+pub fn get_user_dfx_config_dir() -> Result<PathBuf, ConfigError> {
     let config_root = std::env::var_os("DFX_CONFIG_ROOT");
     // dirs-next is not used for *nix to preserve existing paths
     #[cfg(not(windows))]

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 #![allow(clippy::should_implement_trait)] // for from_str.  why now?
-use crate::config::directories::get_config_dfx_dir_path;
+use crate::config::directories::get_user_dfx_config_dir;
 use crate::config::model::bitcoin_adapter::BitcoinAdapterLogLevel;
 use crate::config::model::canister_http_adapter::HttpAdapterLogLevel;
 use crate::error::dfx_config::AddDependenciesError::CanisterCircularDependency;
@@ -1079,7 +1079,7 @@ impl NetworksConfig {
     }
 
     pub fn new() -> Result<NetworksConfig, LoadNetworksConfigError> {
-        let dir = get_config_dfx_dir_path().map_err(GetConfigPathFailed)?;
+        let dir = get_user_dfx_config_dir().map_err(GetConfigPathFailed)?;
 
         let path = dir.join("networks.json");
         if path.exists() {

--- a/src/dfx-core/src/identity/identity_manager.rs
+++ b/src/dfx-core/src/identity/identity_manager.rs
@@ -1,6 +1,6 @@
 use super::pem_utils::validate_pem_file;
 use super::{keyring_mock, WALLET_CONFIG_FILENAME};
-use crate::config::directories::get_config_dfx_dir_path;
+use crate::config::directories::get_user_dfx_config_dir;
 use crate::error::encryption::EncryptionError;
 use crate::error::encryption::EncryptionError::{NonceGenerationFailed, SaltGenerationFailed};
 use crate::error::fs::FsError;
@@ -208,7 +208,7 @@ impl IdentityManager {
         identity_override: &Option<String>,
     ) -> Result<Self, NewIdentityManagerError> {
         let config_dfx_dir_path =
-            get_config_dfx_dir_path().map_err(NewIdentityManagerError::GetConfigDirectoryFailed)?;
+            get_user_dfx_config_dir().map_err(NewIdentityManagerError::GetConfigDirectoryFailed)?;
         let identity_root_path = config_dfx_dir_path.join("identity");
         let identity_json_path = config_dfx_dir_path.join("identity.json");
 

--- a/src/dfx-core/src/identity/mod.rs
+++ b/src/dfx-core/src/identity/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Wallets are a map of network-identity, but don't have their own types or manager
 //! type.
-use crate::config::directories::{get_config_dfx_dir_path, get_shared_network_data_directory};
+use crate::config::directories::{get_shared_network_data_directory, get_user_dfx_config_dir};
 use crate::error::identity::call_sender_from_wallet::CallSenderFromWalletError;
 use crate::error::identity::call_sender_from_wallet::CallSenderFromWalletError::ParsePrincipalFromIdFailed;
 use crate::error::identity::load_pem_identity::LoadPemIdentityError;
@@ -225,7 +225,7 @@ impl Identity {
         original_identity: &str,
         renamed_identity: &str,
     ) -> Result<(), MapWalletsToRenamedIdentityError> {
-        let persistent_wallet_path = get_config_dfx_dir_path()
+        let persistent_wallet_path = get_user_dfx_config_dir()
             .map_err(MapWalletsToRenamedIdentityError::GetConfigDirectoryFailed)?
             .join("identity")
             .join(original_identity)

--- a/src/dfx/src/lib/identity/wallet.rs
+++ b/src/dfx/src/lib/identity/wallet.rs
@@ -6,7 +6,7 @@ use crate::Environment;
 use anyhow::{anyhow, bail, Context};
 use candid::Principal;
 use dfx_core::canister::build_wallet_canister;
-use dfx_core::config::directories::get_config_dfx_dir_path;
+use dfx_core::config::directories::get_user_dfx_config_dir;
 use dfx_core::config::model::network_descriptor::{NetworkDescriptor, NetworkTypeDescriptor};
 use dfx_core::error::wallet_config::WalletConfigError;
 use dfx_core::error::wallet_config::WalletConfigError::{
@@ -59,7 +59,7 @@ pub fn get_wallet_config_path(
     Ok(match &network.r#type {
         NetworkTypeDescriptor::Persistent | NetworkTypeDescriptor::Playground { .. } => {
             // Using the global
-            get_config_dfx_dir_path()
+            get_user_dfx_config_dir()
                 .map_err(|e| {
                     GetWalletConfigPathFailed(
                         Box::new(name.to_string()),


### PR DESCRIPTION
# Description

This method is about  `$HOME/.config/dfx/` (on linux/osx.  It will be different on Windows)

Meaning: "get the .config/dfx directory path" -> "get the user's dfx config directory",

Motivation for the change: about to add an error type for this method

# How Has This Been Tested?

Covered by CI