### PR TITLE
fix: for CI failures in playground e2e test

### DIFF
--- a/e2e/assets/playground_backend/mops-sources
+++ b/e2e/assets/playground_backend/mops-sources
@@ -15,5 +15,4 @@ for i in 0 2 4 8 16 32; do
   fi
   echo "failed with output: $output" 1>&2
 done
-
 exit 1

--- a/e2e/assets/playground_backend/mops-sources
+++ b/e2e/assets/playground_backend/mops-sources
@@ -14,4 +14,5 @@ for i in 0 2 4 8 16 32; do
   fi
   echo "failed with output: $output" 1>&2
 done
+
 exit 1

--- a/e2e/assets/playground_backend/mops-sources
+++ b/e2e/assets/playground_backend/mops-sources
@@ -8,7 +8,7 @@ for i in 0 2 4 8 16 32; do
     sleep $i
   fi
 
-  if output=$(mops sources); then
+  if output=$(mops sources | grep -v "reducing threads"); then
     echo "$output"
     exit 0
   fi

--- a/e2e/assets/playground_backend/mops-sources
+++ b/e2e/assets/playground_backend/mops-sources
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 for i in 0 2 4 8 16 32; do
   if [ $i -gt 0 ]; then


### PR DESCRIPTION
# Description

A [recent change to mops](https://github.com/ZenVoich/mops/commit/d0e4d3815b93b77eadb1bc78b11546e34d3f341f) has added some logging output in CI.  This makes its way to the `moc` command-line, which then fails.

```
		if (process.env.GITHUB_ENV) {
			console.log('Running in GitHub Actions, reducing threads to 4');
			threads = 4;
		}
```

See the first commit in this PR, which doesn't change anything that would matter, but fails due to passing this message along to `moc`:

```
"Running" "in" "GitHub" "Actions," "reducing" "threads" "to" "4" "--package" "base" ".mops/base@0.9.1/src" "--package" "splay" ".mops/splay@0.1.0/src"' failed with exit status 'exit status: 1'.
```

The second commit in this PR filters the output of `mops sources` using grep, which demonstrates that the console.log() message is going to stdout.

# How Has This Been Tested?

See above.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
