### PR TITLE
test: pin mops to version that only writes package parameters to stdout

### DIFF
--- a/e2e/tests-dfx/playground.bash
+++ b/e2e/tests-dfx/playground.bash
@@ -16,7 +16,7 @@ teardown() {
 setup_playground() {
   if ! command -v ic-mops &> /dev/null
   then
-    npm i -g ic-mops
+    npm i -g ic-mops@0.27.1
   fi
   dfx_new hello
   create_networks_json


### PR DESCRIPTION
# Description

mops 0.27.2 logs extra information to stdout, alongside the expected `--package <path>` output.  This causes our calls to `moc` to fail, and blocks any PR from passing CI.

This PR pins mops to 0.27.1 pending a fix.  Once a reversion of this PR passes CI, that reversion can be merged.

# How Has This Been Tested?

See https://github.com/dfinity/sdk/pull/3394 for a demonstration. 

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
