### PR TITLE
test: revert: pin mops to version that only writes package parameters to stdout

### DIFF
--- a/e2e/tests-dfx/playground.bash
+++ b/e2e/tests-dfx/playground.bash
@@ -16,7 +16,7 @@ teardown() {
 setup_playground() {
   if ! command -v ic-mops &> /dev/null
   then
-    npm i -g ic-mops@0.27.1
+    npm i -g ic-mops
   fi
   dfx_new hello
   create_networks_json


### PR DESCRIPTION

# Description

This reverts commit d2404ec7c60fa9a37cc70eb489a14509e8eee992 now that the extra output has been removed.

# How Has This Been Tested?

CI wouldn't pass without the fix to mops

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
