### PR TITLE
refactor: remove unused imports

### DIFF
--- a/src/dfx-core/src/network/provider.rs
+++ b/src/dfx-core/src/network/provider.rs
@@ -474,7 +474,7 @@ mod tests {
         ReplicaLogLevel,
     };
     use std::fs;
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::net::SocketAddr;
     use std::str::FromStr;
 
     #[test]


### PR DESCRIPTION
Remove two unused imports reported by clippy