### PR TITLE
refactor: use query/update rather than query_/update_

### DIFF
--- a/src/canisters/frontend/ic-asset/src/canister_api/methods/api_version.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/methods/api_version.rs
@@ -4,7 +4,7 @@ use ic_utils::Canister;
 
 pub(crate) async fn api_version(canister: &Canister<'_>) -> u16 {
     canister
-        .query_(API_VERSION)
+        .query(API_VERSION)
         .build()
         .call()
         .await

--- a/src/canisters/frontend/ic-asset/src/canister_api/methods/asset_properties.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/methods/asset_properties.rs
@@ -49,7 +49,7 @@ pub(crate) async fn get_asset_properties(
     asset_id: &str,
 ) -> Result<AssetProperties, AgentError> {
     let (asset_properties,): (AssetProperties,) = canister
-        .query_(GET_ASSET_PROPERTIES)
+        .query(GET_ASSET_PROPERTIES)
         .with_arg(GetAssetPropertiesArgument(asset_id.to_string()))
         .build()
         .call()

--- a/src/canisters/frontend/ic-asset/src/canister_api/methods/batch.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/methods/batch.rs
@@ -24,7 +24,7 @@ pub(crate) async fn create_batch(canister: &Canister<'_>) -> Result<Nat, AgentEr
     let result = loop {
         let create_batch_args = CreateBatchRequest {};
         let response = canister
-            .update_(CREATE_BATCH)
+            .update(CREATE_BATCH)
             .with_arg(&create_batch_args)
             .build()
             .map(|result: (CreateBatchResponse,)| (result.0.batch_id,))
@@ -58,7 +58,7 @@ pub(crate) async fn submit_commit_batch<T: CandidType + Sync>(
 
     loop {
         match canister
-            .update_(method_name)
+            .update(method_name)
             .with_arg(&arg)
             .build()
             .call_and_wait()
@@ -103,7 +103,7 @@ pub(crate) async fn compute_evidence(
 
     loop {
         match canister
-            .update_(COMPUTE_EVIDENCE)
+            .update(COMPUTE_EVIDENCE)
             .with_arg(arg)
             .build()
             .map(|result: (Option<ByteBuf>,)| (result.0,))

--- a/src/canisters/frontend/ic-asset/src/canister_api/methods/chunk.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/methods/chunk.rs
@@ -26,7 +26,7 @@ pub(crate) async fn create_chunk(
         .build();
 
     loop {
-        let builder = canister.update_(CREATE_CHUNK);
+        let builder = canister.update(CREATE_CHUNK);
         let builder = builder.with_arg(&args);
         let request_id_result = {
             let _releaser = semaphores.create_chunk_call.acquire(1).await;

--- a/src/canisters/frontend/ic-asset/src/canister_api/methods/list.rs
+++ b/src/canisters/frontend/ic-asset/src/canister_api/methods/list.rs
@@ -9,7 +9,7 @@ pub(crate) async fn list_assets(
     canister: &Canister<'_>,
 ) -> Result<HashMap<String, AssetDetails>, AgentError> {
     let (entries,): (Vec<AssetDetails>,) = canister
-        .query_(LIST)
+        .query(LIST)
         .with_arg(ListAssetsRequest {})
         .build()
         .call()

--- a/src/canisters/frontend/icx-asset/src/commands/list.rs
+++ b/src/canisters/frontend/icx-asset/src/commands/list.rs
@@ -26,7 +26,7 @@ pub async fn list(canister: &Canister<'_>, logger: &Logger) -> anyhow::Result<()
     struct EmptyRecord {}
 
     let (entries,): (Vec<ListEntry>,) = canister
-        .query_("list")
+        .query("list")
         .with_arg(EmptyRecord {})
         .build()
         .call()

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -94,7 +94,7 @@ struct CallIn<TCycles = u128> {
 async fn do_wallet_call(wallet: &WalletCanister<'_>, args: &CallIn) -> DfxResult<Vec<u8>> {
     // todo change to wallet.call when IDLValue implements ArgumentDecoder
     let builder = if wallet.version_supports_u128_cycles() {
-        wallet.update_("wallet_call128").with_arg(args)
+        wallet.update("wallet_call128").with_arg(args)
     } else {
         let CallIn {
             canister,
@@ -108,7 +108,7 @@ async fn do_wallet_call(wallet: &WalletCanister<'_>, args: &CallIn) -> DfxResult
             args,
             cycles: cycles as u64,
         };
-        wallet.update_("wallet_call").with_arg(args64)
+        wallet.update("wallet_call").with_arg(args64)
     };
     let (result,): (Result<CallResult, String>,) = builder
         .build()

--- a/src/dfx/src/commands/wallet/mod.rs
+++ b/src/dfx/src/commands/wallet/mod.rs
@@ -92,7 +92,7 @@ where
     let wallet = get_or_create_wallet_canister(env, network, &identity_name).await?;
 
     let out: O = wallet
-        .query_(method)
+        .query(method)
         .with_arg(arg)
         .build()
         .call()
@@ -109,7 +109,7 @@ where
 {
     let wallet = get_wallet(env).await?;
     let out: O = wallet
-        .update_(method)
+        .update(method)
         .with_arg(arg)
         .build()
         .call_and_wait()

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -49,7 +49,7 @@ where
         CallSender::SelectedId => {
             let mgr = ManagementCanister::create(agent);
 
-            mgr.update_(method)
+            mgr.update(method)
                 .with_arg(arg)
                 .with_effective_canister_id(destination_canister)
                 .build()

--- a/src/dfx/src/lib/operations/ledger.rs
+++ b/src/dfx/src/lib/operations/ledger.rs
@@ -36,7 +36,7 @@ pub async fn balance(
         .with_canister_id(canister_id)
         .build()?;
     let (result,) = canister
-        .query_(ACCOUNT_BALANCE_METHOD)
+        .query(ACCOUNT_BALANCE_METHOD)
         .with_arg(AccountBalanceArgs {
             account: acct.to_string(),
         })
@@ -53,7 +53,7 @@ pub async fn xdr_permyriad_per_icp(agent: &Agent) -> DfxResult<u64> {
         .with_canister_id(MAINNET_CYCLE_MINTER_CANISTER_ID)
         .build()?;
     let (certified_rate,): (IcpXdrConversionRateCertifiedResponse,) = canister
-        .query_("get_icp_xdr_conversion_rate")
+        .query("get_icp_xdr_conversion_rate")
         .build()
         .call()
         .await?;


### PR DESCRIPTION
# Description

Use `Canister.update()` and `Canister.query()` rather than `Canister.update_()` and `Canister.query_()`.

# How Has This Been Tested?

Existing tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
