### PR TITLE
test: e2e test for cycles ledger

### DIFF
--- a/e2e/assets/cycles-ledger/dfx.json
+++ b/e2e/assets/cycles-ledger/dfx.json
@@ -1,0 +1,14 @@
+{
+  "canisters": {
+    "cycles-ledger": {
+      "type": "custom",
+      "wasm": "cycles-ledger.wasm.gz",
+      "candid": "cycles-ledger.did"
+    },
+    "cycles-depositor": {
+      "type": "custom",
+      "wasm": "cycles-depositor.wasm.gz",
+      "candid": "cycles-depositor.did"
+    }
+  }
+}

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+
+load ../utils/_
+load ../utils/cycles-ledger
+
+setup() {
+    standard_setup
+    install_asset cycles-ledger
+    install_shared_asset subnet_type/shared_network_settings/system
+    install_cycles_ledger_canisters
+
+    dfx identity new --storage-mode plaintext cycle-giver
+    dfx identity new --storage-mode plaintext alice
+    dfx identity new --storage-mode plaintext bob
+
+    dfx_start_for_nns_install
+
+    dfx extension install nns --version 0.2.1 || true
+    dfx nns install --ledger-accounts "$(dfx ledger account-id --identity cycle-giver)"
+}
+
+teardown() {
+    dfx_stop
+
+    standard_teardown
+}
+
+@test "cycles ledger howto" {
+    # This is the equivalent of https://www.notion.so/dfinityorg/How-to-install-and-test-the-cycles-ledger-521c9f3c410f4a438514a03e35464299
+    ALICE=$(dfx identity get-principal --identity alice)
+    BOB=$(dfx identity get-principal --identity bob)
+
+    assert_command dfx deploy cycles-ledger
+    assert_command dfx deploy cycles-depositor --argument "(record {ledger_id = principal \"$(dfx canister id cycles-ledger)\"})" --with-cycles 10000000000000
+
+    assert_command dfx ledger balance --identity cycle-giver
+    assert_eq "1000000000.00000000 ICP"
+
+    assert_command dfx canister status cycles-depositor
+    assert_contains "Balance: 10_000_000_000_000 Cycles"
+
+    dfx canister status cycles-depositor
+
+    assert_command dfx canister call cycles-ledger icrc1_balance_of "(record {owner = principal \"$ALICE\"})"
+    assert_eq "(0 : nat)"
+
+    assert_command dfx canister call cycles-ledger icrc1_balance_of "(record {owner = principal \"$BOB\"})"
+    assert_eq "(0 : nat)"
+
+    assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$ALICE\";};cycles = 500_000_000;})" --identity cycle-giver
+    assert_eq "(record { balance = 500_000_000 : nat; txid = 0 : nat })"
+
+    assert_command dfx canister status cycles-depositor
+    assert_contains "Balance: 9_999_500_000_000 Cycles"
+
+    assert_command dfx canister call cycles-ledger icrc1_balance_of "(record {owner = principal \"$ALICE\"})"
+    assert_eq "(500_000_000 : nat)"
+
+    assert_command dfx canister call cycles-ledger icrc1_transfer "(record {to = record{owner = principal \"$BOB\"}; amount = 100_000;})" --identity alice
+    assert_eq "(variant { Ok = 1 : nat })"
+
+    assert_command dfx canister call cycles-ledger icrc1_balance_of "(record {owner = principal \"$ALICE\"})"
+    assert_eq "(399_900_000 : nat)"
+
+    assert_command dfx canister call cycles-ledger icrc1_balance_of "(record {owner = principal \"$BOB\"})"
+    assert_eq "(100_000 : nat)"
+
+    assert_command dfx canister call cycles-ledger send "(record {amount = 100_000;to = principal \"$(dfx canister id cycles-depositor)\"})" --identity alice
+    assert_eq "(variant { Ok = 2 : nat })"
+
+    assert_command dfx canister call cycles-ledger icrc1_balance_of "(record {owner = principal \"$ALICE\"})"
+    assert_eq "(299_800_000 : nat)"
+
+    assert_command dfx canister status cycles-depositor
+    assert_contains "Balance: 9_999_500_100_000 Cycles"
+}

--- a/e2e/utils/cycles-ledger.bash
+++ b/e2e/utils/cycles-ledger.bash
@@ -1,0 +1,36 @@
+CYCLES_LEDGER_VERSION="0.2.1"
+
+build_artifact_url() {
+    echo "https://raw.githubusercontent.com/dfinity/sdk/cycles-ledger-prerelease/cycles-ledger-v$CYCLES_LEDGER_VERSION/${1}"
+}
+
+downloaded_cycles_ledger_canisters_dir() {
+    echo "$DFX_CACHE_ROOT/canisters/cycles-ledger/$CYCLES_LEDGER_VERSION"
+}
+
+download_cycles_ledger_canisters() {
+    DOWNLOAD_DIR="$DFX_CACHE_ROOT/.download"
+    DEST_DIR="$(downloaded_cycles_ledger_canisters_dir)"
+
+    if test -d "$DEST_DIR"; then
+        return
+    fi
+
+    rm -rf "$DOWNLOAD_DIR"
+    mkdir -p "$DOWNLOAD_DIR" "$(dirname "$DEST_DIR")"
+
+    for name in cycles-ledger cycles-depositor; do
+        for ext in wasm.gz wasm.gz.sha256 did; do
+            URL=$(build_artifact_url "${name}.${ext}")
+            curl -v --fail -o "$DOWNLOAD_DIR/${name}.${ext}" "$URL"
+        done
+    done
+
+    ( cd "$DOWNLOAD_DIR" && shasum -c cycles-ledger.wasm.gz.sha256 && shasum -c cycles-depositor.wasm.gz.sha256 )
+    mv "$DOWNLOAD_DIR" "$DEST_DIR"
+}
+
+install_cycles_ledger_canisters() {
+    download_cycles_ledger_canisters
+    cp "$(downloaded_cycles_ledger_canisters_dir)"/* .
+}


### PR DESCRIPTION


# Description

Adds an e2e test for the cycles ledger, using `dfx canister call`.  Followup PRs that add new `dfx cycles` subcommands will replace some of those `dfx canister call` commands with those new commands, as well as add new tests that focus on those subcommands.

Since the cycles-ledger repo is not yet public, this PR downloads its build artifacts from a temporary branch in this repo: https://github.com/dfinity/sdk/tree/cycles-ledger-prerelease

Fixes https://dfinity.atlassian.net/browse/SDK-1170

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
