### PR TITLE
feat: SDK-1163 dfx cycles transfer (top up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 
 This won't work on mainnet yet, but can work locally after installing the cycles ledger.
 
-Added the following subcommands:
+Added the following subcommands and variants:
  - `dfx cycles balance`
  - `dfx cycles transfer --to-owner <principal>` (transfer from one account to another account)
+ - `dfx cycles transfer --top-up <principal>` (transfer from an account to a canister)
 
 ## Dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,7 @@ dependencies = [
  "hyper-rustls",
  "ic-agent",
  "ic-asset",
+ "ic-cdk",
  "ic-identity-hsm",
  "ic-utils 0.29.0",
  "ic-wasm",

--- a/docs/cli-reference/dfx-cycles.md
+++ b/docs/cli-reference/dfx-cycles.md
@@ -68,7 +68,7 @@ dfx cycles balance --owner raxcz-bidhr-evrzj-qyivt-nht5a-eltcc-24qfc-o6cvi-hfw7j
 
 ## dfx cycles transfer
 
-Use the `dfx cycles transfer` command to transfer cycles from your account to another account.
+Use the `dfx cycles transfer` command to transfer cycles from your account to another account.  This can be to the account of another owner's principal, or to a canister.
 
 ### Basic usage
 
@@ -90,6 +90,7 @@ You can specify the following options for the `dfx cycles transfer` command.
 
 | Option                           | Description                                                        |
 |----------------------------------|--------------------------------------------------------------------|
+| `--top-up <principal>`           | The canister to which you want to transfer cycles.                 |
 | `--to-owner <principal>`         | The principal of the account to which you want to transfer cycles. |
 | `--to-subaccount <subaccount>`   | The subaccount to which you want to transfer cycles.               |
 | `--from-subaccount <subaccount>` | The subaccount from which you want to transfer cycles.             |
@@ -111,3 +112,8 @@ Transfer from a subaccount:
 dfx cycles transfer 1000000000 --from-subaccount 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f --to-owner raxcz-bidhr-evrzj-qyivt-nht5a-eltcc-24qfc-o6cvi-hfw7j-dcecz-kae --network ic
 ```
 
+Transfer to (top up) a canister:
+
+``` bash
+dfx cycles transfer 1000000000 --top-up bkyz2-fmaaa-aaaaa-qaaaq-cai --network ic
+```

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -25,6 +25,10 @@ teardown() {
     standard_teardown
 }
 
+add_cycles_ledger_canisters_to_project() {
+    jq -s '.[0] * .[1]' ../dfx.json dfx.json | sponge dfx.json
+}
+
 current_time_nanoseconds() {
   echo "$(date +%s)"000000000
 }
@@ -103,7 +107,7 @@ current_time_nanoseconds() {
     assert_eq "2.900 TC (trillion cycles)."
 }
 
-@test "transfer" {
+@test "transfer to owner" {
     ALICE=$(dfx identity get-principal --identity alice)
     ALICE_SUBACCT1="000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
     ALICE_SUBACCT1_CANDID="\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
@@ -240,6 +244,135 @@ current_time_nanoseconds() {
     assert_eq "300000 cycles."
 }
 
+@test "transfer top up canister principal check" {
+    BOB=$(dfx identity get-principal --identity bob)
+
+    assert_command dfx deploy cycles-ledger
+
+    assert_command_fail dfx cycles transfer --top-up "$BOB" 600000 --identity alice --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+    assert_contains "Invalid receiver: $BOB.  Make sure the receiver is a canister."
+}
+
+@test "transfer top up canister basic" {
+    dfx_new
+    add_cycles_ledger_canisters_to_project
+    install_cycles_ledger_canisters
+
+    BOB=$(dfx identity get-principal --identity bob)
+    BOB_SUBACCT1="7C7B7A030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+    BOB_SUBACCT1_CANDID="\7C\7B\7A\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
+    BOB_SUBACCT2="6C6B6A030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+    BOB_SUBACCT2_CANDID="\6C\6B\6A\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
+
+    assert_command dfx deploy cycles-ledger
+    assert_command dfx deploy cycles-depositor --argument "(record {ledger_id = principal \"$(dfx canister id cycles-ledger)\"})" --with-cycles 10000000000000
+
+    assert_command dfx deploy
+
+    assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$BOB\";};cycles = 2_400_000_000_000;})" --identity cycle-giver
+    assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$BOB\"; subaccount = opt blob \"$BOB_SUBACCT1_CANDID\"};cycles = 2_600_000_000_000;})" --identity cycle-giver
+    assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$BOB\"; subaccount = opt blob \"$BOB_SUBACCT2_CANDID\"};cycles = 2_700_000_000_000;})" --identity cycle-giver
+
+    # account to canister
+    assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+    assert_eq "2400000000000 cycles."
+    assert_command dfx canister status e2e_project_backend
+    assert_contains "Balance: 3_100_000_000_000 Cycles"
+
+    assert_command dfx cycles transfer --top-up "$(dfx canister id e2e_project_backend)" 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+
+    assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+    assert_eq "2399899900000 cycles."
+    assert_command dfx canister status e2e_project_backend
+    assert_contains "Balance: 3_100_000_100_000 Cycles"
+
+    # subaccount to canister
+    assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob --subaccount "$BOB_SUBACCT1"
+    assert_eq "2600000000000 cycles."
+    assert_command dfx canister status e2e_project_backend
+    assert_contains "Balance: 3_100_000_100_000 Cycles"
+
+    assert_command dfx cycles transfer --top-up "$(dfx canister id e2e_project_backend)" 300000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob  --from-subaccount "$BOB_SUBACCT1"
+
+    assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob  --subaccount "$BOB_SUBACCT1"
+    assert_eq "2599899700000 cycles."
+    assert_command dfx canister status e2e_project_backend
+    assert_contains "Balance: 3_100_000_400_000 Cycles"
+
+    # subaccount to canister - by canister name
+    assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob --subaccount "$BOB_SUBACCT2"
+    assert_eq "2700000000000 cycles."
+    assert_command dfx canister status e2e_project_backend
+    assert_contains "Balance: 3_100_000_400_000 Cycles"
+
+    assert_command dfx cycles transfer --top-up e2e_project_backend 600000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob  --from-subaccount "$BOB_SUBACCT2"
+
+    assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob  --subaccount "$BOB_SUBACCT2"
+    assert_eq "2699899400000 cycles."
+    assert_command dfx canister status e2e_project_backend
+    assert_contains "Balance: 3_100_001_000_000 Cycles"
+}
+
+@test "transfer top up canister deduplication" {
+    dfx_new
+    add_cycles_ledger_canisters_to_project
+    install_cycles_ledger_canisters
+
+    BOB=$(dfx identity get-principal --identity bob)
+    BOB_SUBACCT1="7C7B7A030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+    BOB_SUBACCT1_CANDID="\7C\7B\7A\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
+    BOB_SUBACCT2="6C6B6A030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+    BOB_SUBACCT2_CANDID="\6C\6B\6A\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
+
+    assert_command dfx deploy cycles-ledger
+    assert_command dfx deploy cycles-depositor --argument "(record {ledger_id = principal \"$(dfx canister id cycles-ledger)\"})" --with-cycles 10000000000000
+
+    assert_command dfx deploy
+
+    assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$BOB\";};cycles = 2_400_000_000_000;})" --identity cycle-giver
+    assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$BOB\"; subaccount = opt blob \"$BOB_SUBACCT1_CANDID\"};cycles = 2_600_000_000_000;})" --identity cycle-giver
+    assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$BOB\"; subaccount = opt blob \"$BOB_SUBACCT2_CANDID\"};cycles = 2_700_000_000_000;})" --identity cycle-giver
+
+    # account to canister
+    assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+    assert_eq "2400000000000 cycles."
+    assert_command dfx canister status e2e_project_backend
+    assert_contains "Balance: 3_100_000_000_000 Cycles"
+
+    t=$(current_time_nanoseconds)
+    assert_command dfx cycles transfer --top-up "$(dfx canister id e2e_project_backend)" --memo 1 --created-at-time "$t" 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+    assert_eq "Transfer sent at block index 3"
+
+    assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+    assert_eq "2399899900000 cycles."
+    assert_command dfx canister status e2e_project_backend
+    assert_contains "Balance: 3_100_000_100_000 Cycles"
+
+    # same memo and created-at-time: dupe
+    assert_command dfx cycles transfer --top-up "$(dfx canister id e2e_project_backend)" --memo 1 --created-at-time "$t" 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+    assert_contains "transaction is a duplicate of another transaction in block 3"
+    assert_contains "Transfer sent at block index 3"
+    assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+    assert_eq "2399899900000 cycles."
+
+    # same memo, different created-at-time: not dupe
+    assert_command dfx cycles transfer --top-up "$(dfx canister id e2e_project_backend)" --memo 1 --created-at-time $((t+1)) 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+    assert_eq "Transfer sent at block index 4"
+    assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+    assert_eq "2399799800000 cycles."
+
+    # different memo, same created-at-time: not dupe
+    assert_command dfx cycles transfer --top-up "$(dfx canister id e2e_project_backend)" --memo 2 --created-at-time "$t" 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+    # actual result:
+    assert_contains "transaction is a duplicate of another transaction in block 3"
+    assert_contains "Transfer sent at block index 3"
+    # expected result:
+    # assert_eq "Transfer sent at block index 5"
+    assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+    assert_eq "2399799800000 cycles." # expect something else
+
+}
+
 @test "howto" {
     # This is the equivalent of https://www.notion.so/dfinityorg/How-to-install-and-test-the-cycles-ledger-521c9f3c410f4a438514a03e35464299
     ALICE=$(dfx identity get-principal --identity alice)
@@ -281,8 +414,8 @@ current_time_nanoseconds() {
     assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob --precise
     assert_eq "100000 cycles."
 
-    assert_command dfx canister call cycles-ledger send "(record {amount = 100_000;to = principal \"$(dfx canister id cycles-depositor)\"})" --identity alice
-    assert_eq "(variant { Ok = 2 : nat })"
+    assert_command dfx cycles transfer 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice --top-up "$(dfx canister id cycles-depositor)"
+    assert_eq "Transfer sent at block index 2"
 
     assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice --precise
     assert_eq "299800000 cycles."

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -363,13 +363,19 @@ current_time_nanoseconds() {
 
     # different memo, same created-at-time: not dupe
     assert_command dfx cycles transfer --top-up "$(dfx canister id e2e_project_backend)" --memo 2 --created-at-time "$t" 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+    # This is expected to be reported as a duplicate, but is not.
+    # See https://dfinity.atlassian.net/browse/SDK-1289
+    # If this part of the test is failing, it probably means the functionality has been fixed in the cycles ledger canister.
+
+    # expected result:
+    # assert_eq "Transfer sent at block index 5"
+
     # actual result:
     assert_contains "transaction is a duplicate of another transaction in block 3"
     assert_contains "Transfer sent at block index 3"
-    # expected result:
-    # assert_eq "Transfer sent at block index 5"
+
     assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
-    assert_eq "2399799800000 cycles." # expect something else
+    assert_eq "2399799800000 cycles." # expect this to be a different value than above, but it's not
 
 }
 

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -63,6 +63,7 @@ humantime.workspace = true
 hyper-rustls = { version = "0.24.1", features = ["webpki-roots", "http2"] }
 ic-agent = { workspace = true, features = ["reqwest"] }
 ic-asset.workspace = true
+ic-cdk.workspace = true
 ic-identity-hsm = { workspace = true }
 ic-utils = { workspace = true }
 ic-wasm = "0.4.0"

--- a/src/dfx/src/lib/cycles_ledger_types/mod.rs
+++ b/src/dfx/src/lib/cycles_ledger_types/mod.rs
@@ -1,0 +1,1 @@
+pub mod send;

--- a/src/dfx/src/lib/cycles_ledger_types/send.rs
+++ b/src/dfx/src/lib/cycles_ledger_types/send.rs
@@ -1,0 +1,50 @@
+// Copied from https://github.com/dfinity/cycles-ledger/blob/main/cycles-ledger/src/endpoints.rs
+use candid::{CandidType, Nat, Principal};
+use ic_cdk::api::call::RejectionCode;
+use icrc_ledger_types::icrc1::account::Subaccount;
+use icrc_ledger_types::icrc1::transfer::{BlockIndex, Memo};
+use serde::Deserialize;
+
+pub type NumCycles = Nat;
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct SendArgs {
+    #[serde(default)]
+    pub from_subaccount: Option<Subaccount>,
+    pub to: Principal,
+    #[serde(default)]
+    pub created_at_time: Option<u64>,
+    #[serde(default)]
+    pub memo: Option<Memo>,
+    pub amount: NumCycles,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum SendError {
+    BadFee {
+        expected_fee: NumCycles,
+    },
+    InsufficientFunds {
+        balance: NumCycles,
+    },
+    TooOld,
+    CreatedInFuture {
+        ledger_time: u64,
+    },
+    TemporarilyUnavailable,
+    Duplicate {
+        duplicate_of: BlockIndex,
+    },
+    FailedToSend {
+        fee_block: Option<Nat>,
+        rejection_code: RejectionCode,
+        rejection_reason: String,
+    },
+    GenericError {
+        error_code: Nat,
+        message: String,
+    },
+    InvalidReceiver {
+        receiver: Principal,
+    },
+}

--- a/src/dfx/src/lib/mod.rs
+++ b/src/dfx/src/lib/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod builders;
 pub mod canister_info;
+pub mod cycles_ledger_types;
 pub mod deps;
 pub mod diagnosis;
 pub mod dist;


### PR DESCRIPTION
# Description

Added `dfx cycles transfer --top-up <canister name or principal>` for transferring cycles from your account to a canister.

Fixes https://dfinity.atlassian.net/browse/SDK-1163

There is one test that checks for a different result than it should.  This is due to what appears to be the cycles ledger not taking the memo field into consideration when looking for dupes.  See https://dfinity.atlassian.net/browse/SDK-1289.

# How Has This Been Tested?

Updated and added e2e tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
