### PR TITLE
feat: Read install arg from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # UNRELEASED
 
+=== feat: Read dfx canister install argument from a file
+
+Enables passing large arguments that cannot be passed directly in the command line using the `--argument-file` flag. For example `dfx canister install --argument-file ./my/argument/file.txt my_canister_name`.
+
+
 ### feat: change `list_permitted` and `list_authorized` to an update call.
 
 This requires the `list_authorized` and `list_permitted` methods to be called as an update and disables the ability to

--- a/docs/cli-reference/dfx-canister.md
+++ b/docs/cli-reference/dfx-canister.md
@@ -438,6 +438,7 @@ You can use the following optional flags with the `dfx canister install` command
 
 | Flag                  | Description                                                                                                                                                             |
 |-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--argument-file`     | Specifies the file from which to read the argument to pass to the init method.  Stdin may be referred to as `-`.                                                        |
 | `--async-call`        | Enables you to continue without waiting for the result of the installation to be returned by polling the Internet Computer or the local canister execution environment. |
 | `--upgrade-unchanged` | Upgrade the canister even if the .wasm did not change.                                                                                                                  |
 

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -198,6 +198,15 @@ teardown() {
   assert_command dfx canister install e2e_project_backend --argument-file "$TMPFILE"
 }
 
+@test "installing with an argument on stdin succeeds" {
+  dfx_start
+  assert_command dfx canister create e2e_project_backend
+  assert_command dfx build e2e_project_backend
+  TMPFILE="$(mktemp)"
+  echo '()' >"$TMPFILE"
+  assert_command dfx canister install e2e_project_backend --argument-file - <"$TMPFILE"
+}
+
 @test "installing multiple canisters with arguments fails" {
   assert_command_fail dfx canister install --all --argument '()'
   assert_contains "error: the argument '--all' cannot be used with '--argument <ARGUMENT>'"

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -183,12 +183,18 @@ teardown() {
 }
 
 @test "installing one canister with an argument succeeds" {
+  dfx_start
+  use_asset_wasm 0.12.1
+  assert_command dfx canister create e2e_project_backend
   assert_command dfx canister install e2e_project_backend --argument '()'
 }
 
 @test "installing with an argument in a file succeeds" {
+  dfx_start
+  use_asset_wasm 0.12.1
   TMPFILE="$(mktemp)"
   echo '()' >"$TMPFILE"
+  assert_command dfx canister create e2e_project_backend
   assert_command dfx canister install e2e_project_backend --argument-file "$TMPFILE"
 }
 

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -184,14 +184,14 @@ teardown() {
 
 @test "installing one canister with an argument succeeds" {
   dfx_start
-  use_asset_wasm 0.12.1
+  assert_command dfx build e2e_project_backend
   assert_command dfx canister create e2e_project_backend
   assert_command dfx canister install e2e_project_backend --argument '()'
 }
 
 @test "installing with an argument in a file succeeds" {
   dfx_start
-  use_asset_wasm 0.12.1
+  assert_command dfx build e2e_project_backend
   TMPFILE="$(mktemp)"
   echo '()' >"$TMPFILE"
   assert_command dfx canister create e2e_project_backend

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -184,17 +184,17 @@ teardown() {
 
 @test "installing one canister with an argument succeeds" {
   dfx_start
-  assert_command dfx build e2e_project_backend
   assert_command dfx canister create e2e_project_backend
+  assert_command dfx build e2e_project_backend
   assert_command dfx canister install e2e_project_backend --argument '()'
 }
 
 @test "installing with an argument in a file succeeds" {
   dfx_start
+  assert_command dfx canister create e2e_project_backend
   assert_command dfx build e2e_project_backend
   TMPFILE="$(mktemp)"
   echo '()' >"$TMPFILE"
-  assert_command dfx canister create e2e_project_backend
   assert_command dfx canister install e2e_project_backend --argument-file "$TMPFILE"
 }
 

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -182,7 +182,17 @@ teardown() {
   assert_contains db07e7e24f6f8ddf53c33a610713259a7c1eb71c270b819ebd311e2d223267f0
 }
 
+@test "installing one canister with an argument succeeds" {
+  assert_command dfx canister install e2e_project_backend --argument '()'
+}
+
+@test "installing with an argument in a file succeeds" {
+  TMPFILE="$(mktemp)"
+  echo '()' >"$TMPFILE"
+  assert_command dfx canister install e2e_project_backend --argument-file "$TMPFILE"
+}
+
 @test "installing multiple canisters with arguments fails" {
-  assert_command_fail dfx canister install --all --argument hello
+  assert_command_fail dfx canister install --all --argument '()'
   assert_contains "error: the argument '--all' cannot be used with '--argument <ARGUMENT>'"
 }

--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -3,8 +3,12 @@ use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::operations::canister::install_canister::install_canister;
 use crate::lib::root_key::fetch_root_key_if_needed;
+use crate::util::clap::parsers::file_or_stdin_parser;
 use crate::util::get_candid_init_type;
-use crate::{lib::canister_info::CanisterInfo, util::blob_from_arguments};
+use crate::{
+    lib::canister_info::CanisterInfo,
+    util::{arguments_from_file, blob_from_arguments},
+};
 use dfx_core::identity::CallSender;
 
 use anyhow::{anyhow, bail, Context};


### PR DESCRIPTION
# Description
This PR adds support for providing install arguments from a file.

This is motivated by these issues:

* It is impossible to pass a large canister init arg as the length of shell arguments is limited by the terminal (which in turn may be limited by the operating system).
* For shorter arguments, it is more convenient to write `--argument-file somefile.hex` than `--argument "$(cat somefile.hex)"`.
* The `dfx canister call` method supports `--argument-file` for similar reasons.  It would be nice to be consistent.

# How Has This Been Tested?

e2e tests are included in the PR.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
