### PR TITLE
fix: dfx extension install will no longer create a corrupt cache directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # UNRELEASED
 
+=== fix: dfx extension install can no longer create a corrupt cache directory
+
+Running `dfx cache delete && dfx extension install nns` would previously
+create a cache directory containing only an `extensions` subdirectory.
+dfx only looks for the existence of a cache version subdirectory to
+determine whether it has been installed. The end result was that later
+commands would fail when the cache did not contain expected files.
+
 === feat: Read dfx canister install argument from a file
 
 Enables passing large arguments that cannot be passed directly in the command line using the `--argument-file` flag. For example `dfx canister install --argument-file ./my/argument/file.txt my_canister_name`.

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -13,6 +13,12 @@ teardown() {
   standard_teardown
 }
 
+@test "extension install with an empty cache does not create a corrupt cache" {
+  dfx cache delete
+  dfx extension install nns --version 0.2.1
+  dfx_start
+}
+
 @test "install extension from official registry" {
   assert_command_fail dfx snsx
 

--- a/src/dfx/src/commands/extension/install.rs
+++ b/src/dfx/src/commands/extension/install.rs
@@ -1,11 +1,11 @@
 use crate::commands::DfxCommand;
+use crate::config::cache::DiskBasedCache;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use clap::Parser;
 use clap::Subcommand;
 use dfx_core::error::extension::ExtensionError;
 use semver::Version;
-use crate::config::cache::DiskBasedCache;
 
 #[derive(Parser)]
 pub struct InstallOpts {

--- a/src/dfx/src/commands/extension/install.rs
+++ b/src/dfx/src/commands/extension/install.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use clap::Subcommand;
 use dfx_core::error::extension::ExtensionError;
 use semver::Version;
+use crate::config::cache::DiskBasedCache;
 
 #[derive(Parser)]
 pub struct InstallOpts {
@@ -19,6 +20,9 @@ pub struct InstallOpts {
 }
 
 pub fn exec(env: &dyn Environment, opts: InstallOpts) -> DfxResult<()> {
+    // creating an `extensions` directory in an otherwise empty cache directory would
+    // cause the cache to be considered "installed" and later commands would fail
+    DiskBasedCache::install(&env.get_cache().version_str())?;
     let spinner = env.new_spinner(format!("Installing extension: {}", opts.name).into());
     let mgr = env.new_extension_manager()?;
     let effective_extension_name = opts.install_as.clone().unwrap_or_else(|| opts.name.clone());


### PR DESCRIPTION
# Description

Running `dfx extension install <extension>` immediately after installing a new dfx version, or after `dfx cache delete`, would result in a cache directory that contained only an `extensions` subdirectory.

Later, dfx would see that the cache directory exists and therefore not install it.  Then, commands like `dfx start` or `dfx build` would fail due to missing files.

Fixes: https://dfinity.atlassian.net/browse/SDK-1240

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
