### PR TITLE
ci: add bitcoin workflow

### DIFF
--- a/.github/workflows/bitcoin-canister-update.yml
+++ b/.github/workflows/bitcoin-canister-update.yml
@@ -1,0 +1,69 @@
+name: Check Bitcoin Canister Release Update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Runs at UTC midnight every day
+
+jobs:
+  check-update:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout dfx repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Fetch Bitcoin Canister latest release tag
+      env:
+        GH_TOKEN: "${{ secrets.NIV_UPDATER_TOKEN }}"
+      run: |
+        LATEST_TAG=$(gh release view --repo dfinity/bitcoin-canister --json tagName -q .tagName)
+        echo "Latest tag is $LATEST_TAG"
+        echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+
+    - name: Check if the latest release tag has been updated
+      run: |
+        URL_ENCODED_CURRENT_TAG=$(jq -r '.["ic-btc-canister"].version' nix/sources.json)
+        CURRENT_TAG=$(python -c "import sys, urllib.parse as ul; print(ul.unquote_plus(sys.argv[1]))" "$URL_ENCODED_CURRENT_TAG")
+        echo "Current tag is $CURRENT_TAG"
+        if [[ "$CURRENT_TAG" == "$LATEST_TAG" ]]; then
+          echo "No update is required."
+          exit 1
+        else
+          echo "An update is required."
+        fi
+
+
+    - name: install Nix
+      uses: cachix/install-nix-action@v21
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - name: install niv (dependency manager for Nix projects)
+      run: nix-env -i niv -f '<nixpkgs>'
+
+    - name: install packages from nix/sources.json
+      run: niv update
+
+    - name: update sources
+      run: |
+        URL_ENCODED_LATEST_TAG=$(echo -n "$LATEST_TAG" | python -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=""))')
+        niv update ic-btc-canister -a version=$URL_ENCODED_LATEST_TAG
+        ./scripts/write-dfx-asset-sources.sh
+
+    - name: Update dfx to use the latest Bitcoin Canister version
+      env:
+        GH_TOKEN: "${{ secrets.NIV_UPDATER_TOKEN }}"
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git checkout -b bot/update-bitcoin-canister/$LATEST_TAG
+        git add .
+        git commit -m "Update Bitcoin Canister to $LATEST_TAG"
+        git push --set-upstream origin bot/update-bitcoin-canister/$LATEST_TAG
+        PR_TITLE="chore: Update Bitcoin Canister Version to $LATEST_TAG"
+        PR_BODY="This PR updates the Bitcoin Canister version to the latest tag: $LATEST_TAG"
+        gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base master --head $(git branch --show-current)
+


### PR DESCRIPTION
# Description

This PR introduces a new github workflow to update sources for bitcoin canister:
- runs periodically (daily, at midnight UTC)
- checks to see if the release tag associated with the latest tag no longer matches the release tag that dfx uses for the bitcoin canister
- If the latest tag has changed, opens a PR to update the release tag that dfx uses to match.

Closes https://dfinity.atlassian.net/browse/SDK-1039

# How Has This Been Tested?

https://github.com/smallstepman/sdk/pull/64

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] ~I have edited the CHANGELOG accordingly.~
- [ ] ~I have made corresponding changes to the documentation.~
