### PR TITLE
fix: deleting project canister by id will clean up canister id store.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # UNRELEASED
 
+=== fix: `dfx canister delete <canister id>` removes the related entry from the canister id store
+
+Previously, deleting a canister in the project by id rather than by name
+would leave the canister id in the canister id store. This would cause
+`dfx deploy` to fail.
+
 === fix: dfx extension install can no longer create a corrupt cache directory
 
 Running `dfx cache delete && dfx extension install nns` would previously

--- a/e2e/tests-dfx/delete.bash
+++ b/e2e/tests-dfx/delete.bash
@@ -14,6 +14,19 @@ teardown() {
   standard_teardown
 }
 
+@test "delete by canister id cleans up canister id store" {
+  dfx_start
+  dfx deploy e2e_project_backend
+  id=$(dfx canister id e2e_project_backend)
+  dfx canister stop e2e_project_backend
+  assert_command dfx canister delete "$id"
+  assert_command_fail dfx canister info e2e_project_backend
+  assert_contains "Cannot find canister id. Please issue 'dfx canister create e2e_project_backend'."
+  assert_command_fail dfx canister status "$id"
+  assert_contains "Canister $id not found"
+  assert_command dfx deploy
+}
+
 @test "delete can be used to delete a canister" {
   dfx_start
   dfx deploy e2e_project_backend

--- a/src/dfx-core/src/config/model/canister_id_store.rs
+++ b/src/dfx-core/src/config/model/canister_id_store.rs
@@ -188,8 +188,12 @@ impl CanisterIdStore {
         self.remote_ids
             .as_ref()
             .and_then(|remote_ids| self.get_name_in(canister_id, remote_ids))
-            .or_else(|| self.get_name_in(canister_id, &self.ids))
+            .or_else(|| self.get_name_in_project(canister_id))
             .or_else(|| self.get_name_in_pull_ids(canister_id))
+    }
+
+    pub fn get_name_in_project(&self, canister_id: &str) -> Option<&String> {
+        self.get_name_in(canister_id, &self.ids)
     }
 
     pub fn get_name_in<'a>(


### PR DESCRIPTION
# Description

`dfx canister delete <by id>` would leave entries (canister name -> canister id) in the canister id store.  A subsequent `dfx deploy` would then fail because it would try to install to the deleted canister rather than creating a new one.

Fixes https://dfinity.atlassian.net/browse/SDK-1143

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
