### PR TITLE
chore: Update to new ic-agent version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -97,6 +97,10 @@ jobs:
           path: /usr/local/bin
       - name: Setup dfx binary
         run: chmod +x /usr/local/bin/dfx
+      - name: Disable query verification in ic-ref
+        if: ${{ matrix.backend == 'ic-ref' }}
+        run: |
+          echo DFX_DISABLE_QUERY_VERIFICATION=1 >> $GITHUB_ENV
       - name: start and deploy
         run: |
           pwd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +730,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cached"
+version = "0.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c8c50262271cdf5abc979a5f76515c234e764fa025d1ba4862c0f0bcda0e95"
+dependencies = [
+ "ahash 0.8.6",
+ "hashbrown 0.14.2",
+ "instant",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
 name = "candid"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1211,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
 name = "cvt"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,7 +1420,7 @@ dependencies = [
  "ic-asset",
  "ic-cdk",
  "ic-identity-hsm",
- "ic-utils 0.29.0",
+ "ic-utils 0.30.1",
  "ic-wasm",
  "icrc-ledger-types",
  "indicatif",
@@ -1458,7 +1490,7 @@ dependencies = [
  "humantime-serde",
  "ic-agent",
  "ic-identity-hsm",
- "ic-utils 0.29.0",
+ "ic-utils 0.30.1",
  "k256 0.11.6",
  "keyring",
  "lazy_static",
@@ -1627,6 +1659,21 @@ dependencies = [
  "rfc6979 0.4.0",
  "signature 2.1.0",
  "spki 0.7.2",
+]
+
+[[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core",
+ "serde",
+ "sha2 0.9.9",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -2201,6 +2248,10 @@ name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+dependencies = [
+ "ahash 0.8.6",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -2408,11 +2459,13 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.29.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=b91b85b7b6ba6bfaf9dfd616b7c7c8f966bf8f68#b91b85b7b6ba6bfaf9dfd616b7c7c8f966bf8f68"
+version = "0.30.1"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9#5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
 dependencies = [
  "backoff",
+ "cached 0.46.1",
  "candid 0.9.11",
+ "ed25519-consensus",
  "futures-util",
  "hex",
  "http",
@@ -2425,6 +2478,7 @@ dependencies = [
  "pem 2.0.1",
  "pkcs8 0.10.2",
  "rand",
+ "rangemap",
  "reqwest",
  "ring 0.16.20",
  "rustls-webpki",
@@ -2455,7 +2509,7 @@ dependencies = [
  "globset",
  "hex",
  "ic-agent",
- "ic-utils 0.29.0",
+ "ic-utils 0.30.1",
  "itertools 0.10.5",
  "json5",
  "mime",
@@ -2657,7 +2711,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=a533346f63f4091eb64692891de0
 dependencies = [
  "arrayvec 0.5.2",
  "base64 0.11.0",
- "cached",
+ "cached 0.41.0",
  "hex",
  "ic-crypto-internal-bls12-381-type",
  "ic-crypto-internal-seed",
@@ -2774,8 +2828,8 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.29.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=b91b85b7b6ba6bfaf9dfd616b7c7c8f966bf8f68#b91b85b7b6ba6bfaf9dfd616b7c7c8f966bf8f68"
+version = "0.30.1"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9#5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
 dependencies = [
  "hex",
  "ic-agent",
@@ -2870,8 +2924,8 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.29.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=b91b85b7b6ba6bfaf9dfd616b7c7c8f966bf8f68#b91b85b7b6ba6bfaf9dfd616b7c7c8f966bf8f68"
+version = "0.30.1"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9#5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
 dependencies = [
  "candid 0.9.11",
  "hex",
@@ -2945,8 +2999,8 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.29.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=b91b85b7b6ba6bfaf9dfd616b7c7c8f966bf8f68#b91b85b7b6ba6bfaf9dfd616b7c7c8f966bf8f68"
+version = "0.30.1"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9#5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
 dependencies = [
  "async-trait",
  "candid 0.9.11",
@@ -3039,7 +3093,7 @@ dependencies = [
  "humantime",
  "ic-agent",
  "ic-asset",
- "ic-utils 0.29.0",
+ "ic-utils 0.30.1",
  "libflate",
  "num-traits",
  "pem 1.1.1",
@@ -4485,6 +4539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rangemap"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977b1e897f9d764566891689e642653e5ed90c6895106acd005eb4c1d0203991"
+
+[[package]]
 name = "rayon"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5453,6 +5513,12 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "supports-color"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
  "ic-asset",
  "ic-cdk",
  "ic-identity-hsm",
- "ic-utils 0.30.1",
+ "ic-utils 0.30.2",
  "ic-wasm",
  "icrc-ledger-types",
  "indicatif",
@@ -1490,7 +1490,7 @@ dependencies = [
  "humantime-serde",
  "ic-agent",
  "ic-identity-hsm",
- "ic-utils 0.30.1",
+ "ic-utils 0.30.2",
  "k256 0.11.6",
  "keyring",
  "lazy_static",
@@ -2459,8 +2459,8 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.30.1"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9#5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
+version = "0.30.2"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=ed0862a45d5973ff123cbabc4ac40a89821b18c6#ed0862a45d5973ff123cbabc4ac40a89821b18c6"
 dependencies = [
  "backoff",
  "cached 0.46.1",
@@ -2509,7 +2509,7 @@ dependencies = [
  "globset",
  "hex",
  "ic-agent",
- "ic-utils 0.30.1",
+ "ic-utils 0.30.2",
  "itertools 0.10.5",
  "json5",
  "mime",
@@ -2828,8 +2828,8 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.30.1"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9#5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
+version = "0.30.2"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=ed0862a45d5973ff123cbabc4ac40a89821b18c6#ed0862a45d5973ff123cbabc4ac40a89821b18c6"
 dependencies = [
  "hex",
  "ic-agent",
@@ -2924,8 +2924,8 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.30.1"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9#5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
+version = "0.30.2"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=ed0862a45d5973ff123cbabc4ac40a89821b18c6#ed0862a45d5973ff123cbabc4ac40a89821b18c6"
 dependencies = [
  "candid 0.9.11",
  "hex",
@@ -2999,8 +2999,8 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.30.1"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9#5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
+version = "0.30.2"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=ed0862a45d5973ff123cbabc4ac40a89821b18c6#ed0862a45d5973ff123cbabc4ac40a89821b18c6"
 dependencies = [
  "async-trait",
  "candid 0.9.11",
@@ -3093,7 +3093,7 @@ dependencies = [
  "humantime",
  "ic-agent",
  "ic-asset",
- "ic-utils 0.30.1",
+ "ic-utils 0.30.2",
  "libflate",
  "num-traits",
  "pem 1.1.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 candid = { version = "0.9.0", features = ["parser"] }
-ic-agent = "0.30.1"
+ic-agent = "0.30.2"
 ic-asset = { path = "src/canisters/frontend/ic-asset" }
 ic-cdk = "0.10.0"
-ic-identity-hsm = "0.30.1"
-ic-utils = "0.30.1"
+ic-identity-hsm = "0.30.2"
+ic-utils = "0.30.2"
 
 aes-gcm = "0.9.4"
 anyhow = "1.0.56"
@@ -69,19 +69,19 @@ url = "2.1.0"
 walkdir = "2.3.2"
 
 [patch.crates-io.ic-agent]
-version = "0.30.1"
+version = "0.30.2"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
+rev = "ed0862a45d5973ff123cbabc4ac40a89821b18c6"
 
 [patch.crates-io.ic-identity-hsm]
-version = "0.30.1"
+version = "0.30.2"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
+rev = "ed0862a45d5973ff123cbabc4ac40a89821b18c6"
 
 [patch.crates-io.ic-utils]
-version = "0.30.1"
+version = "0.30.2"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
+rev = "ed0862a45d5973ff123cbabc4ac40a89821b18c6"
 
 [profile.release]
 panic = 'abort'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,18 @@ rust-version = "1.71.1"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-candid = { version = "0.9.0", features = [ "parser" ] }
-ic-agent = "0.29.0"
+candid = { version = "0.9.0", features = ["parser"] }
+ic-agent = "0.30.1"
 ic-asset = { path = "src/canisters/frontend/ic-asset" }
 ic-cdk = "0.10.0"
-ic-identity-hsm = "0.29.0"
-ic-utils = "0.29.0"
+ic-identity-hsm = "0.30.1"
+ic-utils = "0.30.1"
 
 aes-gcm = "0.9.4"
 anyhow = "1.0.56"
 anstyle = "1.0.0"
 argon2 = "0.4.0"
-backoff = { version = "0.4.0", features = [ "futures", "tokio" ] }
+backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 base64 = "0.13.0"
 byte-unit = "4.0.14"
 bytes = "1.2.1"
@@ -69,19 +69,19 @@ url = "2.1.0"
 walkdir = "2.3.2"
 
 [patch.crates-io.ic-agent]
-version = "0.29.0"
+version = "0.30.1"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "b91b85b7b6ba6bfaf9dfd616b7c7c8f966bf8f68"
+rev = "5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
 
 [patch.crates-io.ic-identity-hsm]
-version = "0.29.0"
+version = "0.30.1"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "b91b85b7b6ba6bfaf9dfd616b7c7c8f966bf8f68"
+rev = "5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
 
 [patch.crates-io.ic-utils]
-version = "0.29.0"
+version = "0.30.1"
 git = "https://github.com/dfinity/agent-rs.git"
-rev = "b91b85b7b6ba6bfaf9dfd616b7c7c8f966bf8f68"
+rev = "5aa3ba7d8c38d44910900af7ed7d8a25402fa9d9"
 
 [profile.release]
 panic = 'abort'

--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -13,6 +13,7 @@ setup() {
   dfx deploy
 
   BACKEND="127.0.0.1:$(get_webserver_port)"
+  declare -x DFX_DISABLE_QUERY_VERIFICATION=1
 
   # In github workflows, at the time of this writing, we get:
   #     macos-latest: mitmproxy 7.0.4

--- a/e2e/tests-dfx/certificate.bash
+++ b/e2e/tests-dfx/certificate.bash
@@ -13,7 +13,6 @@ setup() {
   dfx deploy
 
   BACKEND="127.0.0.1:$(get_webserver_port)"
-  declare -x DFX_DISABLE_QUERY_VERIFICATION=1
 
   # In github workflows, at the time of this writing, we get:
   #     macos-latest: mitmproxy 7.0.4
@@ -74,6 +73,7 @@ teardown() {
   # The wallet does not have a query call forward method (currently calls forward from wallet's update method)
   # So call with users Identity as sender here
   # There may need to be a query version of wallet_call
+  declare -x DFX_DISABLE_QUERY_VERIFICATION=1
   assert_command dfx canister call certificate_backend hello_query '("Buckaroo")'
   assert_eq '("Hullo, Buckaroo!")'
 }

--- a/src/canisters/frontend/ic-asset/src/lib.rs
+++ b/src/canisters/frontend/ic-asset/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use ic_agent::agent::{Agent, http_transport::ReqwestHttpReplicaV2Transport};
+//! use ic_agent::agent::{Agent, http_transport::ReqwestTransport};
 //! use ic_agent::identity::BasicIdentity;
 //! use ic_utils::Canister;
 //! use std::time::Duration;
@@ -12,7 +12,7 @@
 //! # let pemfile = "";
 //! # let canister_id = "";
 //! let agent = Agent::builder()
-//!     .with_transport(ReqwestHttpReplicaV2Transport::create(replica_url)?)
+//!     .with_transport(ReqwestTransport::create(replica_url)?)
 //!     .with_identity(BasicIdentity::from_pem_file(pemfile)?)
 //!     .build()?;
 //! let canister = Canister::builder()

--- a/src/canisters/frontend/icx-asset/src/main.rs
+++ b/src/canisters/frontend/icx-asset/src/main.rs
@@ -110,9 +110,9 @@ async fn main() -> anyhow::Result<()> {
     let logger = support::new_logger();
 
     let agent = Agent::builder()
-        .with_transport(
-            agent::http_transport::ReqwestHttpReplicaV2Transport::create(opts.replica.clone())?,
-        )
+        .with_transport(agent::http_transport::ReqwestTransport::create(
+            opts.replica.clone(),
+        )?)
         .with_boxed_identity(create_identity(opts.pem))
         .build()?;
 

--- a/src/dfx-core/src/util/mod.rs
+++ b/src/dfx-core/src/util/mod.rs
@@ -6,5 +6,6 @@ pub fn network_to_pathcompat(network_name: &str) -> String {
 
 pub fn expiry_duration() -> Duration {
     // 5 minutes is max ingress timeout
-    Duration::from_secs(60 * 5)
+    // 4 minutes accounts for possible replica drift
+    Duration::from_secs(60 * 4)
 }

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -77,7 +77,7 @@ mime.workspace = true
 mime_guess.workspace = true
 net2 = "0.2.34"
 num-traits.workspace = true
-os_str_bytes = "6.3.0"
+os_str_bytes = { version = "6.3.0", features = ["conversions"] }
 patch = "0.7.0"
 pem.workspace = true
 petgraph = "0.6.0"

--- a/src/dfx/src/commands/canister/deposit_cycles.rs
+++ b/src/dfx/src/commands/canister/deposit_cycles.rs
@@ -60,6 +60,8 @@ pub async fn exec(
     opts: DepositCyclesOpts,
     mut call_sender: &CallSender,
 ) -> DfxResult {
+    fetch_root_key_if_needed(env).await?;
+
     let proxy_sender;
 
     // choose default wallet if no wallet is specified
@@ -78,8 +80,6 @@ pub async fn exec(
     let cycles = opts.cycles;
 
     let config = env.get_config_or_anyhow()?;
-
-    fetch_root_key_if_needed(env).await?;
 
     if let Some(canister) = opts.canister.as_deref() {
         deposit_cycles(env, canister, call_sender, cycles).await

--- a/src/dfx/src/commands/canister/send.rs
+++ b/src/dfx/src/commands/canister/send.rs
@@ -6,7 +6,7 @@ use candid::Principal;
 use clap::Parser;
 use dfx_core::identity::CallSender;
 use ic_agent::agent::Transport;
-use ic_agent::{agent::http_transport::ReqwestHttpReplicaV2Transport, RequestId};
+use ic_agent::{agent::http_transport::ReqwestTransport, RequestId};
 use std::{fs::File, path::Path};
 use std::{io::Read, str::FromStr};
 
@@ -40,8 +40,8 @@ pub async fn exec(
     message.validate()?;
 
     let network = message.network.clone();
-    let transport = ReqwestHttpReplicaV2Transport::create(network)
-        .context("Failed to create transport object.")?;
+    let transport =
+        ReqwestTransport::create(network).context("Failed to create transport object.")?;
     let content = hex::decode(&message.content).context("Failed to decode message content.")?;
     let canister_id = Principal::from_text(message.canister_id.clone())
         .with_context(|| format!("Failed to parse canister id {:?}.", message.canister_id))?;

--- a/src/dfx/src/commands/cycles/balance.rs
+++ b/src/dfx/src/commands/cycles/balance.rs
@@ -2,6 +2,7 @@ use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::nns_types::account_identifier::Subaccount;
 use crate::lib::operations::cycles_ledger;
+use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::util::{format_as_trillions, pretty_thousand_separators};
 use candid::Principal;
 use clap::Parser;
@@ -29,6 +30,8 @@ pub struct CyclesBalanceOpts {
 }
 
 pub async fn exec(env: &dyn Environment, opts: CyclesBalanceOpts) -> DfxResult {
+    fetch_root_key_if_needed(env).await?;
+
     let agent = env.get_agent();
 
     let owner = opts.owner.unwrap_or_else(|| {

--- a/src/dfx/src/commands/ledger/balance.rs
+++ b/src/dfx/src/commands/ledger/balance.rs
@@ -2,6 +2,7 @@ use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::nns_types::account_identifier::{AccountIdentifier, Subaccount};
 use crate::lib::operations::ledger;
+use crate::lib::root_key::fetch_root_key_if_needed;
 use anyhow::anyhow;
 use candid::Principal;
 use clap::Parser;
@@ -23,6 +24,7 @@ pub struct BalanceOpts {
 }
 
 pub async fn exec(env: &dyn Environment, opts: BalanceOpts) -> DfxResult {
+    fetch_root_key_if_needed(env).await?;
     let sender = env
         .get_selected_identity_principal()
         .expect("Selected identity not instantiated.");

--- a/src/dfx/src/commands/ledger/mod.rs
+++ b/src/dfx/src/commands/ledger/mod.rs
@@ -3,6 +3,7 @@ use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::network::network_opt::NetworkOpt;
 use crate::lib::nns_types::icpts::ICPTs;
+use crate::lib::root_key::fetch_root_key_if_needed;
 use anyhow::anyhow;
 use clap::Parser;
 use fn_error_context::context;
@@ -44,6 +45,7 @@ pub fn exec(env: &dyn Environment, opts: LedgerOpts) -> DfxResult {
     let agent_env = create_agent_environment(env, opts.network.to_network_name())?;
     let runtime = Runtime::new().expect("Unable to create a runtime");
     runtime.block_on(async {
+        fetch_root_key_if_needed(&agent_env).await?;
         match opts.subcmd {
             SubCommand::AccountId(v) => account_id::exec(&agent_env, v).await,
             SubCommand::Balance(v) => balance::exec(&agent_env, v).await,

--- a/src/dfx/src/commands/ledger/mod.rs
+++ b/src/dfx/src/commands/ledger/mod.rs
@@ -3,7 +3,6 @@ use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::network::network_opt::NetworkOpt;
 use crate::lib::nns_types::icpts::ICPTs;
-use crate::lib::root_key::fetch_root_key_if_needed;
 use anyhow::anyhow;
 use clap::Parser;
 use fn_error_context::context;
@@ -45,7 +44,6 @@ pub fn exec(env: &dyn Environment, opts: LedgerOpts) -> DfxResult {
     let agent_env = create_agent_environment(env, opts.network.to_network_name())?;
     let runtime = Runtime::new().expect("Unable to create a runtime");
     runtime.block_on(async {
-        fetch_root_key_if_needed(&agent_env).await?;
         match opts.subcmd {
             SubCommand::AccountId(v) => account_id::exec(&agent_env, v).await,
             SubCommand::Balance(v) => balance::exec(&agent_env, v).await,

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -383,11 +383,14 @@ pub fn create_agent(
     identity: Box<dyn Identity + Send + Sync>,
     timeout: Duration,
 ) -> DfxResult<Agent> {
+    let disable_query_verification =
+        std::env::var("DFX_DISABLE_QUERY_VERIFICATION").is_ok_and(|x| !x.trim().is_empty());
     let agent = Agent::builder()
         .with_transport(ic_agent::agent::http_transport::ReqwestTransport::create(
             url,
         )?)
         .with_boxed_identity(identity)
+        .with_verify_query_signatures(!disable_query_verification)
         .with_ingress_expiry(Some(timeout))
         .build()?;
     Ok(agent)

--- a/src/dfx/src/lib/replica/status.rs
+++ b/src/dfx/src/lib/replica/status.rs
@@ -1,13 +1,13 @@
 use crate::lib::error::DfxResult;
 use anyhow::{bail, Context};
-use ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport;
+use ic_agent::agent::http_transport::ReqwestTransport;
 use ic_agent::Agent;
 use std::time::Duration;
 
 pub async fn ping_and_wait(url: &str) -> DfxResult {
     let agent = Agent::builder()
         .with_transport(
-            ReqwestHttpReplicaV2Transport::create(url)
+            ReqwestTransport::create(url)
                 .with_context(|| format!("Failed to create replica transport from url {url}.",))?,
         )
         .build()

--- a/src/dfx/src/lib/sign/sign_transport.rs
+++ b/src/dfx/src/lib/sign/sign_transport.rs
@@ -65,6 +65,19 @@ impl Transport for SignTransport {
         Box::pin(run(self, envelope))
     }
 
+    fn read_subnet_state(
+        &self,
+        _: Principal,
+        _: Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, AgentError>> + Send + '_>> {
+        async fn run() -> Result<Vec<u8>, AgentError> {
+            Err(AgentError::MessageError(
+                "read_subnet_state calls not supported".to_string(),
+            ))
+        }
+        Box::pin(run())
+    }
+
     fn call<'a>(
         &'a self,
         _effective_canister_id: Principal,

--- a/src/dfx/src/util/currency_conversion.rs
+++ b/src/dfx/src/util/currency_conversion.rs
@@ -4,7 +4,7 @@ use crate::lib::{
 use anyhow::Context;
 use dfx_core::config::model::dfinity::DEFAULT_IC_GATEWAY;
 use fn_error_context::context;
-use ic_agent::{agent::http_transport::ReqwestHttpReplicaV2Transport, Agent};
+use ic_agent::{agent::http_transport::ReqwestTransport, Agent};
 use rust_decimal::Decimal;
 
 /// How many cycles you get per XDR when converting ICP to cycles
@@ -16,7 +16,7 @@ const CYCLES_PER_XDR: u128 = 1_000_000_000_000;
 pub async fn as_cycles_with_current_exchange_rate(icpts: &ICPTs) -> DfxResult<u128> {
     let agent = Agent::builder()
         .with_transport(
-            ReqwestHttpReplicaV2Transport::create(DEFAULT_IC_GATEWAY)
+            ReqwestTransport::create(DEFAULT_IC_GATEWAY)
                 .context("Failed to create transport object to default ic gateway.")?,
         )
         .build()


### PR DESCRIPTION
This updates to ic-agent 0.30.1, notably *not* including the large wasms feature.