### PR TITLE
test: no longer run smoke matrix with --emulator

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,7 +82,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        backend: ["ic-ref", "replica"]
         # macos-latest is currently macos-11, ubuntu-latest is currently ubuntu-20.04
         # ubuntu-18.04 not supported due to:
         #     /home/runner/.cache/dfinity/versions/0.8.3-34-g36e39809/ic-starter:
@@ -103,11 +102,7 @@ jobs:
           time dfx cache install
           time dfx new smoke
           cd smoke
-          if [ "${{ matrix.backend}}" = "ic-ref" ]; then
-              time dfx start --emulator --background
-          else
-              time dfx start --background
-          fi
+          time dfx start --background
           time dfx deploy
           time dfx canister call smoke_backend greet '("fire")'
           time curl --fail http://localhost:"$(dfx info webserver-port)"/sample-asset.txt?canisterId=$(dfx canister id smoke_frontend)


### PR DESCRIPTION
We don't need to run any CI vs the ic-ref anymore.

See https://dfinity.atlassian.net/browse/SDK-1321 for followup to remove the --emulator mode itself
