### PR TITLE
feat: publish dfxvm install script from feature branch

### DIFF
--- a/.github/workflows/publish-dfxvm-install-script.yml
+++ b/.github/workflows/publish-dfxvm-install-script.yml
@@ -1,0 +1,44 @@
+name: Publish dfxvm install script
+
+on:
+  push:
+    branches:
+      - sdk-1278-dfxvm-install-script
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # When getting Rust dependencies, retry on network error:
+  CARGO_NET_RETRY: 10
+  # Use the local .curlrc
+  CURL_HOME: .
+
+jobs:
+  publish-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shfmt
+        run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
+      - name: Generate
+        run: |
+          shellcheck --shell=sh public/install/*.sh --exclude SC2154,SC2034,SC3003,SC3014,SC3043
+          ~/go/bin/shfmt -d -p -i 4 -ci -bn -s public/install/*.sh
+          sed -i "s/@revision@/${GITHUB_SHA}/" public/install/999_footer.sh
+          mkdir _out
+          cat public/install/*.sh > _out/install.sh
+          sed -i "
+            /#!.*/p
+            /##.*/p
+            /^ *$/d
+            /^ *#/d
+            s/ *#.*//
+          " _out/install.sh
+      - name: Upload Artifacts
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          single_commit: yes
+          branch: dfxvm-install-script
+          folder: _out/


### PR DESCRIPTION
# Description

Background: On any merge to master, the [publish-manifest workflow](https://github.com/dfinity/sdk/blob/master/.github/workflows/publish-manifest.yml) updates the install script and manifest.json on the [public-manifest branch](https://github.com/dfinity/sdk/tree/public-manifest).  That branch contains only those two files.  These are ultimately the files accessed by `sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"`.

This PR introduces a new workflow and the following two branches:
- [dfxvm-install-script](https://github.com/dfinity/sdk/tree/dfxvm-install-script), which contains only install.sh
- [sdk-1278-dfxvm-install-script](https://github.com/dfinity/sdk/tree/sdk-1278-dfxvm-install-script), a feature branch to hold the changes to install.sh that will make it install dfxvm rather than dfx.

The workflow in this PR, to be merged to master, will update the install.sh script on the [dfxvm-install-script](https://github.com/dfinity/sdk/tree/dfxvm-install-script) branch whenever a change is pushed to the [sdk-1278-dfxvm-install-script](https://github.com/dfinity/sdk/tree/sdk-1278-dfxvm-install-script) feature branch.

Populating the dfxvm-install-script branch will allow testing the new install script with something like `sh -ci "$(curl -fsSL https://raw.githubusercontent.com/dfinity/sdk/dfxvm-install-script/install.sh)"`, before merging those changes to master.

# How Has This Been Tested?

I have not tested this workflow due to the difficulties in running a new workflow that has not yet been merged to master.  I have run the following to verify the ways in which the two workflows differ.

```
$ diff .github/workflows/publish-manifest.yml .github/workflows/publish-dfxvm-install-script.yml
1c1
< name: Publish manifest
---
> name: Publish dfxvm install script
6c6
<       - master
---
>       - sdk-1278-dfxvm-install-script
22c22
<       - uses: actions/checkout@v3
---
>       - uses: actions/checkout@v4
39d38
<           cp public/manifest.json _out/manifest.json
44c43
<           branch: public-manifest
---
>           branch: dfxvm-install-script

```
