### PR TITLE
fix: enable tlsv1.2 if curl supports it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 Previously, `dfx ledger top-up` only accepted canister principals. Now it accepts both principals and canister names.
 
+### fix: installer once again detects if curl supports tlsv1.2
+
+A change to `curl --help` output made it so the install script did not detect
+that the `--proto` and `--tlsv1.2` options are available.
+
 # 0.15.2
 
 ### fix: `dfx canister delete <canister id>` removes the related entry from the canister id store

--- a/public/install/200_downloader.sh
+++ b/public/install/200_downloader.sh
@@ -26,7 +26,7 @@ check_help_for() {
     fi
 
     for _arg in "$@"; do
-        if ! "$_cmd" --help | grep -q -- "$_arg"; then
+        if ! "$_cmd" --help all | grep -q -- "$_arg"; then
             _ok="n"
         fi
     done


### PR DESCRIPTION
# Description

curl 7.73 (Released Oct 13 2020, see https://github.com/curl/curl/commit/aa8777f63febca6a13f6b86e141a832232560037) changed the output of `curl --help` to display categories, rather than all of the options, unless you pass `--help all`.  Our install script only called `curl --help`, so it stopped detecting that the `--proto` and `--tlsv1.2` options are available, and called curl in a less secure mode.

This PR calls `<cmd> --help all` instead of `<cmd> --help` when checking command help.  The install script calls this for `curl` and for `wget`.

`wget --help all` works in the latest wget that I tried, and I built wget 1.5.3 (circa 2015) which also worked.

Also checked "curl --help all" with curl 7.54.0.  It shows the same output as "curl --help" and returns exit code 0.

# How Has This Been Tested?

See above, and:

before:
```bash
$ bash install.sh
install.sh: line 8: install/300_license.sh: No such file or directory
info: Executing dfx install script, commit: @revision@
warn: Not forcing TLS v1.2, this is potentially less secure
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
...
```

after:
```bash
$ bash ./install.sh
./install.sh: line 8: install/300_license.sh: No such file or directory
info: Executing dfx install script, commit: @revision@
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
