### PR TITLE
feat: installer downloads and executes dfxvm

### DIFF
--- a/public/install/200_downloader.sh
+++ b/public/install/200_downloader.sh
@@ -70,10 +70,10 @@ downloader() {
         need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
         if check_help_for curl --proto --tlsv1.2; then
-            curl --proto '=https' --tlsv1.2 --show-error --fail --connect-timeout 10 --retry 5 --location "$1" --output "$2"
+            curl --proto '=https' --tlsv1.2 --show-error --fail --connect-timeout 10 --retry 5 --location "$1" --output "$2"  --progress-bar
         elif ! [ "$flag_INSECURE" ]; then
             warn "Not forcing TLS v1.2, this is potentially less secure"
-            curl --show-error --fail --connect-timeout 10 --retry 5 --location "$1" --output "$2"
+            curl --show-error --fail --connect-timeout 10 --retry 5 --location "$1" --output "$2" --progress-bar
         else
             err "TLS 1.2 is not supported on this platform. To force using it, use the --insecure flag."
         fi


### PR DESCRIPTION
# Description

Alters the install script to install dfxvm, rather than dfx.

Note the base branch for the PR is not master.  A PR from the base branch will be submitted once we are ready to release dfxvm.

The script is a lot simpler, in part because it always downloads the latest version.  Even so, I restructured it a bit:
- make sure the temporary directory is always cleaned up
- handle errors in subshells properly
- never try to download an aarch64-unknown-linux-gnu build, which wouldn't exist

Also updates the downloader to pass `--progress-bar` to curl, which is much more streamlined.  The `--progress-bar` parameter was added in curl 5.10 in 1999.

Fixes https://dfinity.atlassian.net/browse/SDK-1278

# How Has This Been Tested?

`bash ./install.sh` , with or without DFX_VERSION, run from the public/ directory.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
