### PR TITLE
fix: removes  from default Content-Security-Policy header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+### fix: removes `upgrade-insecure-requests` from default Content-Security-Policy header
+
+This was causing requests in safari to localhost to fail. We will re-add this header in a future PR without breaking local development.
+
 ### feat: `dfx ledger top-up` also accepts canister names
 
 Previously, `dfx ledger top-up` only accepted canister principals. Now it accepts both principals and canister names.

--- a/src/dfx/assets/new_project_node_files/src/__project_name___frontend/assets/.ic-assets.json5
+++ b/src/dfx/assets/new_project_node_files/src/__project_name___frontend/assets/.ic-assets.json5
@@ -24,7 +24,7 @@
             //   See: https://github.com/WebAssembly/content-security-policy/blob/main/proposals/CSP.md.
             // - We added img-src data: because data: images are used often.
             // - frame-ancestors: none mitigates clickjacking attacks. See https://owasp.org/www-community/attacks/Clickjacking.
-            "Content-Security-Policy": "default-src 'self';script-src 'self' 'unsafe-eval';connect-src 'self' https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';style-src-elem * 'unsafe-inline';font-src *;object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;",
+            "Content-Security-Policy": "default-src 'self';script-src 'self' 'unsafe-eval';connect-src 'self' https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';style-src-elem * 'unsafe-inline';font-src *;object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';",
 
             // Security: The permissions policy disables all features for security reasons. If your site needs such permissions, activate them.
             // To configure permissions go here https://www.permissionspolicy.com/


### PR DESCRIPTION
# Description

This was causing requests in safari to localhost to fail. We will re-add this header in a future PR without breaking local development.

![image](https://github.com/dfinity/sdk/assets/16298804/f5f45c48-3393-44c1-a133-7f739d787355)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
