### PR TITLE
fix: on PRs, run shellcheck for install scripts

### DIFF
--- a/.github/workflows/publish-dfxvm-install-script.yml
+++ b/.github/workflows/publish-dfxvm-install-script.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - sdk-1278-dfxvm-install-script
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,6 +18,7 @@ env:
 
 jobs:
   publish-manifest:
+    name: dfxvm-install-script-shellcheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +39,7 @@ jobs:
             s/ *#.*//
           " _out/install.sh
       - name: Upload Artifacts
+        if: github.event_name == 'push'
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           single_commit: yes

--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,6 +18,7 @@ env:
 
 jobs:
   publish-manifest:
+    name: install-script-shellcheck:required
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -38,6 +40,7 @@ jobs:
           " _out/install.sh
           cp public/manifest.json _out/manifest.json
       - name: Upload Artifacts
+        if: github.event_name == 'push'
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           single_commit: yes


### PR DESCRIPTION
# Description

Runs the shellcheck workflow for the install script on PRs as well as merge to master, skipping the upload step for PRs.
For the publish-manifest workflow, sets the name to `install-script-shellcheck:required` for later inclusion as a required status.
Does not do this for the dfxvm-install-script-shellcheck, since we'd only remove it again soon, but it will still be reported as a status.

# How Has This Been Tested?

Here are the two workflow runs for this PR, which as expected, generated the script (running shellcheck in the process) but did not upload it:
- [install-script-shellcheck:required](https://github.com/dfinity/sdk/actions/runs/7108474788/job/19351821415?pr=3469)
- [dfxvm-install-script-shellcheck](https://github.com/dfinity/sdk/actions/runs/7108474790/job/19351821304?pr=3469)

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
