### PR TITLE
chore: skip reserving 8GB of memory when deleting a canister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Previously, `dfx ledger top-up` only accepted canister principals. Now it accept
 A change to `curl --help` output made it so the install script did not detect
 that the `--proto` and `--tlsv1.2` options are available.
 
+### chore: skip reserving 8GB of memory when deleting a canister
+
+When dfx deletes a canister, it first withdraws as many cycles as possible from the canister.
+While doing so, dfx previously set the memory allocation of the canister to 8GB in order to not run into any memory problems while withdrawing.
+This, however, lead to problems with dynamic memory pricing in subnets with a lot of data because then it becomes very expensive to reserve that much data.
+dfx now no longer sets a memory allocation. We anticipate fewer problems this way.
+
 ### feat: Added support for icx-proxy `--domain` parameter
 
 In order to access a local replica through a domain name or domain names,

--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -35,7 +35,6 @@ const DANK_PRINCIPAL: Principal =
 
 // "Couldn't send message" when deleting a canister: increase WITHDRAWAL_COST
 const WITHDRAWAL_COST: u128 = 10_606_030_000; // 5% higher than a value observed ok locally
-const MAX_MEMORY_ALLOCATION: u64 = 8589934592;
 const DEFAULT_RESERVED_CYCLES_LIMIT: u128 = 5_000_000_000_000;
 
 /// Deletes a currently stopped canister.
@@ -163,7 +162,7 @@ async fn delete_canister(
             let settings = CanisterSettings {
                 controllers: Some(vec![principal]),
                 compute_allocation: Some(ComputeAllocation::try_from(0u8).unwrap()),
-                memory_allocation: Some(MemoryAllocation::try_from(MAX_MEMORY_ALLOCATION).unwrap()),
+                memory_allocation: Some(MemoryAllocation::try_from(0u8).unwrap()),
                 freezing_threshold: Some(FreezingThreshold::try_from(0u8).unwrap()),
                 reserved_cycles_limit: Some(
                     ReservedCyclesLimit::try_from(DEFAULT_RESERVED_CYCLES_LIMIT).unwrap(),


### PR DESCRIPTION
# Description

When dfx deletes a canister, it first withdraws as many cycles as possible from the canister. While doing so, dfx previously set the memory allocation of the canister to 8GB in order to not run into any memory problems while withdrawing. This, however, lead to problems with dynamic memory pricing in subnets with a lot of data because then it becomes very expensive to reserve that much data.
This PR removes the 8GB allocation.

Fixes issues such as [this one](https://forum.dfinity.org/t/how-can-i-delete-my-canister-after-i-create-it/25546/3)

# How Has This Been Tested?

Covered by existing e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
