### PR TITLE
feat!: update `dfx cycles` commands with maninet `cycles-ledger` canister ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # UNRELEASED
 
-### chore: update `dfx cycles` commands with maninet `cycles-ledger` canister ID
+### chore: update `dfx cycles` commands with mainnet `cycles-ledger` canister ID
 
 ### fix: frontend code crashing when there is no canister ID
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+### chore: update `dfx cycles` commands with maninet `cycles-ledger` canister ID
+
 ### fix: frontend code crashing when there is no canister ID
 
 ### feat: `dfx ledger top-up` also accepts canister names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 # UNRELEASED
 
-### chore: update `dfx cycles` commands with mainnet `cycles-ledger` canister ID
+### feat!: update `dfx cycles` commands with mainnet `cycles-ledger` canister ID
 
+The `dfx cycles` command no longer needs nor accepts the `--cycles-ledger-canister-id <canister id>` parameter.
 ### fix: allow `http://localhost:*` as `connect-src` in the asset canister's CSP
 
 This will enable browsing the asset canister at `http://<canister-id>.localhost:<port>` in most browsers.

--- a/docs/cli-reference/dfx-cycles.md
+++ b/docs/cli-reference/dfx-cycles.md
@@ -41,11 +41,8 @@ You can specify the following arguments for the `dfx cycles balance` command.
 | `--owner <principal>`                       | Display the balance of this principal                               |
 | `--subaccount <subaccount>`                 | Display the balance of this subaccount                              |
 | `--precise`                                 | Displays the exact balance, without scaling to trillions of cycles. |
-| `--cycles-ledger-canister-id <canister id>` | Specify the ID of the cycles ledger canister.                       |
 
 ### Examples
-
-> **NOTE**: None of the examples below specify the `--cycles-ledger-canister-id` option, but it is required until the cycles ledger canister ID is known.
 
 Check the cycles balance of the selected identity.
 

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -73,23 +73,23 @@ current_time_nanoseconds() {
   assert_command dfx cycles balance --precise --identity alice
   assert_eq "1700400200150 cycles."
 
-  assert_command dfx cycles balance  --precise --identity alice --subaccount "$ALICE_SUBACCT1"
+  assert_command dfx cycles balance --precise --identity alice --subaccount "$ALICE_SUBACCT1"
   assert_eq "3750000000000 cycles."
 
-  assert_command dfx cycles balance  --precise --identity alice --subaccount "$ALICE_SUBACCT2"
+  assert_command dfx cycles balance --precise --identity alice --subaccount "$ALICE_SUBACCT2"
   assert_eq "760500000000 cycles."
 
-  assert_command dfx cycles balance  --precise --identity bob
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "2900000000000 cycles."
 
 
   assert_command dfx cycles balance --identity alice
   assert_eq "1.700 TC (trillion cycles)."
 
-  assert_command dfx cycles balance  --identity alice --subaccount "$ALICE_SUBACCT1"
+  assert_command dfx cycles balance --identity alice --subaccount "$ALICE_SUBACCT1"
   assert_eq "3.750 TC (trillion cycles)."
 
-  assert_command dfx cycles balance  --identity alice --subaccount "$ALICE_SUBACCT2"
+  assert_command dfx cycles balance --identity alice --subaccount "$ALICE_SUBACCT2"
   assert_eq "0.760 TC (trillion cycles)."
 
   assert_command dfx cycles balance --identity bob
@@ -103,7 +103,7 @@ current_time_nanoseconds() {
   assert_command dfx cycles balance --owner "$ALICE" --subaccount "$ALICE_SUBACCT1" --identity bob
   assert_eq "3.750 TC (trillion cycles)."
 
-  assert_command dfx cycles balance --owner "$BOB"  --identity anonymous
+  assert_command dfx cycles balance --owner "$BOB" --identity anonymous
   assert_eq "2.900 TC (trillion cycles)."
 }
 
@@ -195,7 +195,7 @@ current_time_nanoseconds() {
 
   assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$ALICE\";};cycles = 3_000_000_000_000;})" --identity cycle-giver
 
-  assert_command dfx cycles balance  --precise --identity alice
+  assert_command dfx cycles balance --precise --identity alice
   assert_eq "3000000000000 cycles."
 
   assert_command dfx cycles balance --precise --identity bob
@@ -294,9 +294,9 @@ current_time_nanoseconds() {
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_000_100_000 Cycles"
 
-  assert_command dfx cycles top-up e2e_project_backend 300000 --identity bob  --from-subaccount "$BOB_SUBACCT1"
+  assert_command dfx cycles top-up e2e_project_backend 300000 --identity bob --from-subaccount "$BOB_SUBACCT1"
 
-  assert_command dfx cycles balance --precise --identity bob  --subaccount "$BOB_SUBACCT1"
+  assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT1"
   assert_eq "2599899700000 cycles."
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_000_400_000 Cycles"
@@ -307,9 +307,9 @@ current_time_nanoseconds() {
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_000_400_000 Cycles"
 
-  assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" 600000 --identity bob  --from-subaccount "$BOB_SUBACCT2"
+  assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" 600000 --identity bob --from-subaccount "$BOB_SUBACCT2"
 
-  assert_command dfx cycles balance --precise --identity bob  --subaccount "$BOB_SUBACCT2"
+  assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT2"
   assert_eq "2699899400000 cycles."
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_001_000_000 Cycles"

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -29,6 +29,11 @@ add_cycles_ledger_canisters_to_project() {
   jq -s '.[0] * .[1]' ../dfx.json dfx.json | sponge dfx.json
 }
 
+deploy_cycles_ledger() {
+  assert_command dfx deploy cycles-ledger --specified-id "um5iw-rqaaa-aaaaq-qaaba-cai"
+  assert_command dfx deploy cycles-depositor --argument "(record {ledger_id = principal \"$(dfx canister id cycles-ledger)\"})" --with-cycles 10000000000000 --specified-id "ul4oc-4iaaa-aaaaq-qaabq-cai"
+}
+
 current_time_nanoseconds() {
   echo "$(date +%s)"000000000
 }
@@ -41,8 +46,7 @@ current_time_nanoseconds() {
   ALICE_SUBACCT2_CANDID="\9C\9B\9A\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
   BOB=$(dfx identity get-principal --identity bob)
 
-  assert_command dfx deploy cycles-ledger
-  assert_command dfx deploy cycles-depositor --argument "(record {ledger_id = principal \"$(dfx canister id cycles-ledger)\"})" --with-cycles 10000000000000
+  deploy_cycles_ledger
 
   assert_command dfx cycles balance --identity alice --precise
   assert_eq "0 cycles."
@@ -116,8 +120,7 @@ current_time_nanoseconds() {
   BOB=$(dfx identity get-principal --identity bob)
   BOB_SUBACCT1="7C7B7A030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
 
-  assert_command dfx deploy cycles-ledger
-  assert_command dfx deploy cycles-depositor --argument "(record {ledger_id = principal \"$(dfx canister id cycles-ledger)\"})" --with-cycles 10000000000000
+  deploy_cycles_ledger
 
   assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$ALICE\";};cycles = 3_000_000_000_000;})" --identity cycle-giver
   assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$ALICE\"; subaccount = opt blob \"$ALICE_SUBACCT1_CANDID\"};cycles = 2_000_000_000_000;})" --identity cycle-giver
@@ -190,8 +193,7 @@ current_time_nanoseconds() {
   ALICE=$(dfx identity get-principal --identity alice)
   BOB=$(dfx identity get-principal --identity bob)
 
-  assert_command dfx deploy cycles-ledger
-  assert_command dfx deploy cycles-depositor --argument "(record {ledger_id = principal \"$(dfx canister id cycles-ledger)\"})" --with-cycles 10000000000000
+  deploy_cycles_ledger
 
   assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$ALICE\";};cycles = 3_000_000_000_000;})" --identity cycle-giver
 
@@ -249,7 +251,7 @@ current_time_nanoseconds() {
 @test "top up canister principal check" {
   BOB=$(dfx identity get-principal --identity bob)
 
-  assert_command dfx deploy cycles-ledger
+  deploy_cycles_ledger
 
   assert_command_fail dfx cycles top-up "$BOB" 600000 --identity alice
   assert_contains "Invalid receiver: $BOB.  Make sure the receiver is a canister."
@@ -266,8 +268,7 @@ current_time_nanoseconds() {
   BOB_SUBACCT2="6C6B6A030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
   BOB_SUBACCT2_CANDID="\6C\6B\6A\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
 
-  assert_command dfx deploy cycles-ledger
-  assert_command dfx deploy cycles-depositor --argument "(record {ledger_id = principal \"$(dfx canister id cycles-ledger)\"})" --with-cycles 10000000000000
+  deploy_cycles_ledger
 
   assert_command dfx deploy
 
@@ -326,8 +327,7 @@ current_time_nanoseconds() {
   BOB_SUBACCT2="6C6B6A030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
   BOB_SUBACCT2_CANDID="\6C\6B\6A\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
 
-  assert_command dfx deploy cycles-ledger
-  assert_command dfx deploy cycles-depositor --argument "(record {ledger_id = principal \"$(dfx canister id cycles-ledger)\"})" --with-cycles 10000000000000
+  deploy_cycles_ledger
 
   assert_command dfx deploy
 
@@ -371,8 +371,7 @@ current_time_nanoseconds() {
   ALICE=$(dfx identity get-principal --identity alice)
   BOB=$(dfx identity get-principal --identity bob)
 
-  assert_command dfx deploy cycles-ledger
-  assert_command dfx deploy cycles-depositor --argument "(record {ledger_id = principal \"$(dfx canister id cycles-ledger)\"})" --with-cycles 10000000000000
+  deploy_cycles_ledger
 
   assert_command dfx ledger balance --identity cycle-giver
   assert_eq "1000000000.00000000 ICP"

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -44,16 +44,16 @@ current_time_nanoseconds() {
   assert_command dfx deploy cycles-ledger
   assert_command dfx deploy cycles-depositor --argument "(record {ledger_id = principal \"$(dfx canister id cycles-ledger)\"})" --with-cycles 10000000000000
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice --precise
+  assert_command dfx cycles balance --identity alice --precise
   assert_eq "0 cycles."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice
+  assert_command dfx cycles balance --identity alice
   assert_eq "0.000 TC (trillion cycles)."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob --precise
+  assert_command dfx cycles balance --identity bob --precise
   assert_eq "0 cycles."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+  assert_command dfx cycles balance --identity bob
   assert_eq "0.000 TC (trillion cycles)."
 
 
@@ -70,40 +70,40 @@ current_time_nanoseconds() {
   assert_eq "(record { balance = 2_900_000_000_000 : nat; txid = 3 : nat })"
 
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity alice
+  assert_command dfx cycles balance --precise --identity alice
   assert_eq "1700400200150 cycles."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"  --precise --identity alice --subaccount "$ALICE_SUBACCT1"
+  assert_command dfx cycles balance  --precise --identity alice --subaccount "$ALICE_SUBACCT1"
   assert_eq "3750000000000 cycles."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"  --precise --identity alice --subaccount "$ALICE_SUBACCT2"
+  assert_command dfx cycles balance  --precise --identity alice --subaccount "$ALICE_SUBACCT2"
   assert_eq "760500000000 cycles."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"  --precise --identity bob
+  assert_command dfx cycles balance  --precise --identity bob
   assert_eq "2900000000000 cycles."
 
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice
+  assert_command dfx cycles balance --identity alice
   assert_eq "1.700 TC (trillion cycles)."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"  --identity alice --subaccount "$ALICE_SUBACCT1"
+  assert_command dfx cycles balance  --identity alice --subaccount "$ALICE_SUBACCT1"
   assert_eq "3.750 TC (trillion cycles)."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"  --identity alice --subaccount "$ALICE_SUBACCT2"
+  assert_command dfx cycles balance  --identity alice --subaccount "$ALICE_SUBACCT2"
   assert_eq "0.760 TC (trillion cycles)."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+  assert_command dfx cycles balance --identity bob
   assert_eq "2.900 TC (trillion cycles)."
 
 
   # can see cycles balance of other accounts
-  assert_command dfx cycles balance --owner "$ALICE" --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+  assert_command dfx cycles balance --owner "$ALICE" --identity bob
   assert_eq "1.700 TC (trillion cycles)."
 
-  assert_command dfx cycles balance --owner "$ALICE" --subaccount "$ALICE_SUBACCT1" --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+  assert_command dfx cycles balance --owner "$ALICE" --subaccount "$ALICE_SUBACCT1" --identity bob
   assert_eq "3.750 TC (trillion cycles)."
 
-  assert_command dfx cycles balance --owner "$BOB" --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"  --identity anonymous
+  assert_command dfx cycles balance --owner "$BOB"  --identity anonymous
   assert_eq "2.900 TC (trillion cycles)."
 }
 
@@ -124,65 +124,65 @@ current_time_nanoseconds() {
   assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$ALICE\"; subaccount = opt blob \"$ALICE_SUBACCT2_CANDID\"};cycles = 1_000_000_000_000;})" --identity cycle-giver
 
   # account to account
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity alice
+  assert_command dfx cycles balance --precise --identity alice
   assert_eq "3000000000000 cycles."
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "0 cycles."
 
-  assert_command dfx cycles transfer "$BOB" 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice
+  assert_command dfx cycles transfer "$BOB" 100000 --identity alice
   assert_eq "Transfer sent at block index 3"
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity alice
+  assert_command dfx cycles balance --precise --identity alice
   assert_eq "2999899900000 cycles."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "100000 cycles."
 
   # account to subaccount
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity alice
+  assert_command dfx cycles balance --precise --identity alice
   assert_eq "2999899900000 cycles."
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob --subaccount "$BOB_SUBACCT1"
+  assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT1"
   assert_eq "0 cycles."
 
-  assert_command dfx cycles transfer "$BOB" 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice --to-subaccount "$BOB_SUBACCT1"
+  assert_command dfx cycles transfer "$BOB" 100000 --identity alice --to-subaccount "$BOB_SUBACCT1"
   assert_eq "Transfer sent at block index 4"
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity alice
+  assert_command dfx cycles balance --precise --identity alice
   assert_eq "2999799800000 cycles."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob --subaccount "$BOB_SUBACCT1"
+  assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT1"
   assert_eq "100000 cycles."
 
 
   # subaccount to account
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity alice --subaccount "$ALICE_SUBACCT2"
+  assert_command dfx cycles balance --precise --identity alice --subaccount "$ALICE_SUBACCT2"
   assert_eq "1000000000000 cycles."
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "100000 cycles."
 
-  assert_command dfx cycles transfer "$BOB" 700000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice --from-subaccount "$ALICE_SUBACCT2"
+  assert_command dfx cycles transfer "$BOB" 700000 --identity alice --from-subaccount "$ALICE_SUBACCT2"
   assert_eq "Transfer sent at block index 5"
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity alice --subaccount "$ALICE_SUBACCT2"
+  assert_command dfx cycles balance --precise --identity alice --subaccount "$ALICE_SUBACCT2"
   assert_eq "999899300000 cycles."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "800000 cycles."
 
 
   # subaccount to subaccount
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity alice --subaccount "$ALICE_SUBACCT2"
+  assert_command dfx cycles balance --precise --identity alice --subaccount "$ALICE_SUBACCT2"
   assert_eq "999899300000 cycles."
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob --subaccount "$BOB_SUBACCT1"
+  assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT1"
   assert_eq "100000 cycles."
 
-  assert_command dfx cycles transfer "$BOB" 400000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice --to-subaccount "$BOB_SUBACCT1" --from-subaccount "$ALICE_SUBACCT2"
+  assert_command dfx cycles transfer "$BOB" 400000 --identity alice --to-subaccount "$BOB_SUBACCT1" --from-subaccount "$ALICE_SUBACCT2"
   assert_eq "Transfer sent at block index 6"
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity alice --subaccount "$ALICE_SUBACCT2"
+  assert_command dfx cycles balance --precise --identity alice --subaccount "$ALICE_SUBACCT2"
   assert_eq "999798900000 cycles."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob --subaccount "$BOB_SUBACCT1"
+  assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT1"
   assert_eq "500000 cycles."
 }
 
@@ -195,54 +195,54 @@ current_time_nanoseconds() {
 
   assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$ALICE\";};cycles = 3_000_000_000_000;})" --identity cycle-giver
 
-  assert_command dfx cycles balance  --precise --identity alice --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles balance  --precise --identity alice
   assert_eq "3000000000000 cycles."
 
-  assert_command dfx cycles balance --precise --identity bob --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "0 cycles."
 
   t=$(current_time_nanoseconds)
 
-  assert_command dfx cycles transfer "$BOB" 100000 --created-at-time "$t" --memo 1 --identity alice --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles transfer "$BOB" 100000 --created-at-time "$t" --memo 1 --identity alice
   assert_eq "Transfer sent at block index 1"
 
-  assert_command dfx cycles balance --precise --identity alice --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles balance --precise --identity alice
   assert_eq "2999899900000 cycles."
 
-  assert_command dfx cycles balance --precise --identity bob --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "100000 cycles."
 
   # same memo and created-at-time: dupe
-  assert_command dfx cycles transfer "$BOB" 100000 --created-at-time "$t" --memo 1 --identity alice --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles transfer "$BOB" 100000 --created-at-time "$t" --memo 1 --identity alice
   # shellcheck disable=SC2154
   assert_contains "transaction is a duplicate of another transaction in block 1" "$stderr"
   # shellcheck disable=SC2154
   assert_eq "Transfer sent at block index 1" "$stdout"
 
-  assert_command dfx cycles balance --precise --identity alice --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles balance --precise --identity alice
   assert_eq "2999899900000 cycles."
 
-  assert_command dfx cycles balance --precise --identity bob --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "100000 cycles."
 
   # different memo and same created-at-time same: not dupe
-  assert_command dfx cycles transfer "$BOB" 100000 --created-at-time "$t" --memo 2 --identity alice --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles transfer "$BOB" 100000 --created-at-time "$t" --memo 2 --identity alice
   assert_contains "Transfer sent at block index 2"
 
-  assert_command dfx cycles balance --precise --identity alice --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles balance --precise --identity alice
   assert_eq "2999799800000 cycles."
 
-  assert_command dfx cycles balance --precise --identity bob --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "200000 cycles."
 
   # same memo and different created-at-time same: not dupe
-  assert_command dfx cycles transfer "$BOB" 100000 --created-at-time $((t+1)) --memo 1 --identity alice --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles transfer "$BOB" 100000 --created-at-time $((t+1)) --memo 1 --identity alice
   assert_contains "Transfer sent at block index 3"
 
-  assert_command dfx cycles balance --precise --identity alice --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles balance --precise --identity alice
   assert_eq "2999699700000 cycles."
 
-  assert_command dfx cycles balance --precise --identity bob --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "300000 cycles."
 }
 
@@ -251,7 +251,7 @@ current_time_nanoseconds() {
 
   assert_command dfx deploy cycles-ledger
 
-  assert_command_fail dfx cycles top-up "$BOB" 600000 --identity alice --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)"
+  assert_command_fail dfx cycles top-up "$BOB" 600000 --identity alice
   assert_contains "Invalid receiver: $BOB.  Make sure the receiver is a canister."
 }
 
@@ -276,40 +276,40 @@ current_time_nanoseconds() {
   assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$BOB\"; subaccount = opt blob \"$BOB_SUBACCT2_CANDID\"};cycles = 2_700_000_000_000;})" --identity cycle-giver
 
   # account to canister
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "2400000000000 cycles."
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_000_000_000 Cycles"
 
-  assert_command dfx cycles top-up e2e_project_backend 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+  assert_command dfx cycles top-up e2e_project_backend 100000 --identity bob
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "2399899900000 cycles."
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_000_100_000 Cycles"
 
   # subaccount to canister
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob --subaccount "$BOB_SUBACCT1"
+  assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT1"
   assert_eq "2600000000000 cycles."
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_000_100_000 Cycles"
 
-  assert_command dfx cycles top-up e2e_project_backend 300000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob  --from-subaccount "$BOB_SUBACCT1"
+  assert_command dfx cycles top-up e2e_project_backend 300000 --identity bob  --from-subaccount "$BOB_SUBACCT1"
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob  --subaccount "$BOB_SUBACCT1"
+  assert_command dfx cycles balance --precise --identity bob  --subaccount "$BOB_SUBACCT1"
   assert_eq "2599899700000 cycles."
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_000_400_000 Cycles"
 
   # subaccount to canister - by canister id
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob --subaccount "$BOB_SUBACCT2"
+  assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT2"
   assert_eq "2700000000000 cycles."
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_000_400_000 Cycles"
 
-  assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" 600000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob  --from-subaccount "$BOB_SUBACCT2"
+  assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" 600000 --identity bob  --from-subaccount "$BOB_SUBACCT2"
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob  --subaccount "$BOB_SUBACCT2"
+  assert_command dfx cycles balance --precise --identity bob  --subaccount "$BOB_SUBACCT2"
   assert_eq "2699899400000 cycles."
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_001_000_000 Cycles"
@@ -336,33 +336,33 @@ current_time_nanoseconds() {
   assert_command dfx canister call cycles-depositor deposit "(record {to = record{owner = principal \"$BOB\"; subaccount = opt blob \"$BOB_SUBACCT2_CANDID\"};cycles = 2_700_000_000_000;})" --identity cycle-giver
 
   # account to canister
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "2400000000000 cycles."
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_000_000_000 Cycles"
 
   t=$(current_time_nanoseconds)
-  assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" --created-at-time "$t" 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+  assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" --created-at-time "$t" 100000 --identity bob
   assert_eq "Transfer sent at block index 3"
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "2399899900000 cycles."
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_000_100_000 Cycles"
 
   # same created-at-time: dupe
-  assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" --created-at-time "$t" 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+  assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" --created-at-time "$t" 100000 --identity bob
   # shellcheck disable=SC2154
   assert_contains "transaction is a duplicate of another transaction in block 3" "$stderr"
   # shellcheck disable=SC2154
   assert_contains "Transfer sent at block index 3" "$stdout"
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "2399899900000 cycles."
 
   # different created-at-time: not dupe
-  assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" --created-at-time $((t+1)) 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob
+  assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" --created-at-time $((t+1)) 100000 --identity bob
   assert_eq "Transfer sent at block index 4"
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --precise --identity bob
+  assert_command dfx cycles balance --precise --identity bob
   assert_eq "2399799800000 cycles."
 }
 
@@ -382,10 +382,10 @@ current_time_nanoseconds() {
 
   dfx canister status cycles-depositor
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice --precise
+  assert_command dfx cycles balance --identity alice --precise
   assert_eq "0 cycles."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob --precise
+  assert_command dfx cycles balance --identity bob --precise
   assert_eq "0 cycles."
 
 
@@ -395,22 +395,22 @@ current_time_nanoseconds() {
   assert_command dfx canister status cycles-depositor
   assert_contains "Balance: 9_999_500_000_000 Cycles"
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice --precise
+  assert_command dfx cycles balance --identity alice --precise
   assert_eq "500000000 cycles."
 
-  assert_command dfx cycles transfer "$BOB" 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice
+  assert_command dfx cycles transfer "$BOB" 100000 --identity alice
   assert_eq "Transfer sent at block index 1"
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice --precise
+  assert_command dfx cycles balance --identity alice --precise
   assert_eq "399900000 cycles."
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity bob --precise
+  assert_command dfx cycles balance --identity bob --precise
   assert_eq "100000 cycles."
 
-  assert_command dfx cycles top-up cycles-depositor 100000 --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice
+  assert_command dfx cycles top-up cycles-depositor 100000 --identity alice
   assert_eq "Transfer sent at block index 2"
 
-  assert_command dfx cycles balance --cycles-ledger-canister-id "$(dfx canister id cycles-ledger)" --identity alice --precise
+  assert_command dfx cycles balance --identity alice --precise
   assert_eq "299800000 cycles."
 
   assert_command dfx canister status cycles-depositor

--- a/src/dfx/src/commands/cycles/balance.rs
+++ b/src/dfx/src/commands/cycles/balance.rs
@@ -21,12 +21,6 @@ pub struct CyclesBalanceOpts {
     /// Get balance raw value (without upscaling to trillions of cycles).
     #[arg(long)]
     precise: bool,
-
-    /// Canister ID of the cycles ledger canister.
-    /// If not specified, the default cycles ledger canister ID will be used.
-    // todo: remove this.  See https://dfinity.atlassian.net/browse/SDK-1262
-    #[arg(long)]
-    cycles_ledger_canister_id: Principal,
 }
 
 pub async fn exec(env: &dyn Environment, opts: CyclesBalanceOpts) -> DfxResult {
@@ -41,8 +35,7 @@ pub async fn exec(env: &dyn Environment, opts: CyclesBalanceOpts) -> DfxResult {
 
     let subaccount = opts.subaccount.map(|x| x.0);
 
-    let balance =
-        cycles_ledger::balance(agent, owner, subaccount, opts.cycles_ledger_canister_id).await?;
+    let balance = cycles_ledger::balance(agent, owner, subaccount).await?;
 
     if opts.precise {
         println!("{} cycles.", balance);

--- a/src/dfx/src/commands/cycles/top_up.rs
+++ b/src/dfx/src/commands/cycles/top_up.rs
@@ -27,12 +27,6 @@ pub struct TopUpOpts {
     /// https://internetcomputer.org/docs/current/developer-docs/integrations/icrc-1/#transaction-deduplication-
     #[arg(long)]
     created_at_time: Option<u64>,
-
-    /// Canister ID of the cycles ledger canister.
-    /// If not specified, the default cycles ledger canister ID will be used.
-    // todo: remove this.  See https://dfinity.atlassian.net/browse/SDK-1262
-    #[arg(long)]
-    cycles_ledger_canister_id: Principal,
 }
 
 pub async fn exec(env: &dyn Environment, opts: TopUpOpts) -> DfxResult {
@@ -58,7 +52,6 @@ pub async fn exec(env: &dyn Environment, opts: TopUpOpts) -> DfxResult {
         amount,
         created_at_time,
         from_subaccount,
-        opts.cycles_ledger_canister_id,
     )
     .await;
     if result.is_err() && opts.created_at_time.is_none() {

--- a/src/dfx/src/commands/cycles/transfer.rs
+++ b/src/dfx/src/commands/cycles/transfer.rs
@@ -35,12 +35,6 @@ pub struct TransferOpts {
     /// Memo.
     #[arg(long)]
     memo: Option<u64>,
-
-    /// Canister ID of the cycles ledger canister.
-    /// If not specified, the default cycles ledger canister ID will be used.
-    // todo: remove this.  See https://dfinity.atlassian.net/browse/SDK-1262
-    #[arg(long)]
-    cycles_ledger_canister_id: Principal,
 }
 
 pub async fn exec(env: &dyn Environment, opts: TransferOpts) -> DfxResult {
@@ -68,7 +62,6 @@ pub async fn exec(env: &dyn Environment, opts: TransferOpts) -> DfxResult {
         to_subaccount,
         created_at_time,
         opts.memo,
-        opts.cycles_ledger_canister_id,
     )
     .await;
     if result.is_err() && opts.created_at_time.is_none() {

--- a/src/dfx/src/lib/operations/cycles_ledger.rs
+++ b/src/dfx/src/lib/operations/cycles_ledger.rs
@@ -16,7 +16,15 @@ use slog::{info, Logger};
 const ICRC1_BALANCE_OF_METHOD: &str = "icrc1_balance_of";
 const ICRC1_TRANSFER_METHOD: &str = "icrc1_transfer";
 const SEND_METHOD: &str = "send";
-const CYCLES_LEDGER_CANISTER_ID: &str = "um5iw-rqaaa-aaaaq-qaaba-cai";
+const CYCLES_LEDGER_CANISTER_ID: Principal =
+    Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x02, 0x10, 0x00, 0x02, 0x01, 0x01]);
+#[test]
+fn ledger_canister_id_text_representation() {
+    assert_eq!(
+        "um5iw-rqaaa-aaaaq-qaaba-cai",
+        CYCLES_LEDGER_CANISTER_ID.to_text()
+    );
+}
 
 pub async fn balance(
     agent: &Agent,

--- a/src/dfx/src/lib/operations/cycles_ledger.rs
+++ b/src/dfx/src/lib/operations/cycles_ledger.rs
@@ -16,7 +16,6 @@ use slog::{info, Logger};
 const ICRC1_BALANCE_OF_METHOD: &str = "icrc1_balance_of";
 const ICRC1_TRANSFER_METHOD: &str = "icrc1_transfer";
 const SEND_METHOD: &str = "send";
-/// "um5iw-rqaaa-aaaaq-qaaba-cai" == CYCLES_LEDGER_CANISTER_ID.to_text()
 const CYCLES_LEDGER_CANISTER_ID: Principal =
     Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x02, 0x10, 0x00, 0x02, 0x01, 0x01]);
 
@@ -169,4 +168,12 @@ pub async fn send(
     .await?;
 
     Ok(block_index)
+}
+
+#[test]
+fn ledger_canister_id_text_representation() {
+    assert_eq!(
+        Principal::from_text("um5iw-rqaaa-aaaaq-qaaba-cai").unwrap(),
+        CYCLES_LEDGER_CANISTER_ID
+    );
 }

--- a/src/dfx/src/lib/operations/cycles_ledger.rs
+++ b/src/dfx/src/lib/operations/cycles_ledger.rs
@@ -16,16 +16,16 @@ use slog::{info, Logger};
 const ICRC1_BALANCE_OF_METHOD: &str = "icrc1_balance_of";
 const ICRC1_TRANSFER_METHOD: &str = "icrc1_transfer";
 const SEND_METHOD: &str = "send";
+const CYCLES_LEDGER_CANISTER_ID: &str = "um5iw-rqaaa-aaaaq-qaaba-cai";
 
 pub async fn balance(
     agent: &Agent,
     owner: Principal,
     subaccount: Option<icrc1::account::Subaccount>,
-    cycles_ledger_canister_id: Principal,
 ) -> DfxResult<u128> {
     let canister = Canister::builder()
         .with_agent(agent)
-        .with_canister_id(cycles_ledger_canister_id)
+        .with_canister_id(CYCLES_LEDGER_CANISTER_ID)
         .build()?;
     let arg = icrc1::account::Account { owner, subaccount };
 
@@ -58,11 +58,10 @@ pub async fn transfer(
     to_subaccount: Option<icrc1::account::Subaccount>,
     created_at_time: u64,
     memo: Option<u64>,
-    cycles_ledger_canister_id: Principal,
 ) -> DfxResult<BlockIndex> {
     let canister = Canister::builder()
         .with_agent(agent)
-        .with_canister_id(cycles_ledger_canister_id)
+        .with_canister_id(CYCLES_LEDGER_CANISTER_ID)
         .build()?;
 
     let retry_policy = ExponentialBackoff::default();
@@ -118,11 +117,10 @@ pub async fn send(
     amount: u128,
     created_at_time: u64,
     from_subaccount: Option<icrc1::account::Subaccount>,
-    cycles_ledger_canister_id: Principal,
 ) -> DfxResult<BlockIndex> {
     let canister = Canister::builder()
         .with_agent(agent)
-        .with_canister_id(cycles_ledger_canister_id)
+        .with_canister_id(CYCLES_LEDGER_CANISTER_ID)
         .build()?;
 
     let retry_policy = ExponentialBackoff::default();

--- a/src/dfx/src/lib/operations/cycles_ledger.rs
+++ b/src/dfx/src/lib/operations/cycles_ledger.rs
@@ -16,15 +16,9 @@ use slog::{info, Logger};
 const ICRC1_BALANCE_OF_METHOD: &str = "icrc1_balance_of";
 const ICRC1_TRANSFER_METHOD: &str = "icrc1_transfer";
 const SEND_METHOD: &str = "send";
+/// "um5iw-rqaaa-aaaaq-qaaba-cai" == CYCLES_LEDGER_CANISTER_ID.to_text()
 const CYCLES_LEDGER_CANISTER_ID: Principal =
     Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x02, 0x10, 0x00, 0x02, 0x01, 0x01]);
-#[test]
-fn ledger_canister_id_text_representation() {
-    assert_eq!(
-        "um5iw-rqaaa-aaaaq-qaaba-cai",
-        CYCLES_LEDGER_CANISTER_ID.to_text()
-    );
-}
 
 pub async fn balance(
     agent: &Agent,


### PR DESCRIPTION
# Description

[The canister ID for `cycles-ledger` became known](https://forum.dfinity.org/t/improving-the-cycle-management-experience/19895/10), therefore, it is no longer required to pass it as an CLI argument.  

# How Has This Been Tested?

covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
