### PR TITLE
refactor: use const Principal for default faucet principal

### DIFF
--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -27,7 +27,6 @@ use num_traits::cast::ToPrimitive;
 use slog::info;
 use std::convert::TryFrom;
 
-#[allow(deprecated)]
 const DANK_PRINCIPAL: Principal =
     Principal::from_slice(&[0, 0, 0, 0, 0, 0xe0, 1, 0x11, 0x01, 0x01]); // Principal: aanaa-xaaaa-aaaah-aaeiq-cai
 

--- a/src/dfx/src/commands/wallet/redeem_faucet_coupon.rs
+++ b/src/dfx/src/commands/wallet/redeem_faucet_coupon.rs
@@ -10,7 +10,8 @@ use candid::{encode_args, Decode, Principal};
 use clap::Parser;
 use slog::{info, warn};
 
-const DEFAULT_FAUCET_PRINCIPAL: &str = "fg7gi-vyaaa-aaaal-qadca-cai";
+pub const DEFAULT_FAUCET_PRINCIPAL: Principal =
+    Principal::from_slice(&[0, 0, 0, 0, 1, 112, 0, 196, 1, 1]);
 
 /// Redeem a code at the cycles faucet.
 #[derive(Parser)]
@@ -31,7 +32,7 @@ pub async fn exec(env: &dyn Environment, opts: RedeemFaucetCouponOpts) -> DfxRes
         Principal::from_text(&alternative_faucet)
             .or_else(|_| canister_id_store.get(&alternative_faucet))?
     } else {
-        Principal::from_text(DEFAULT_FAUCET_PRINCIPAL).unwrap()
+        DEFAULT_FAUCET_PRINCIPAL
     };
     let agent = env.get_agent();
     if fetch_root_key_if_needed(env).await.is_err() {
@@ -99,5 +100,18 @@ pub async fn exec(env: &dyn Environment, opts: RedeemFaucetCouponOpts) -> DfxRes
             info!(log, "New wallet set.");
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_faucet_canister_id() {
+        assert_eq!(
+            DEFAULT_FAUCET_PRINCIPAL,
+            Principal::from_text("fg7gi-vyaaa-aaaal-qadca-cai").unwrap()
+        );
     }
 }

--- a/src/dfx/src/lib/ledger_types/mod.rs
+++ b/src/dfx/src/lib/ledger_types/mod.rs
@@ -10,11 +10,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Id of the ledger canister on the IC.
-#[allow(deprecated)]
 pub const MAINNET_LEDGER_CANISTER_ID: Principal =
     Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x01, 0x01]);
 
-#[allow(deprecated)]
 pub const MAINNET_CYCLE_MINTER_CANISTER_ID: Principal =
     Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x01, 0x01]);
 


### PR DESCRIPTION
# Description

Changes `DEFAULT_FAUCET_PRINCIPAL` from `const &str` to `const Principal` for type safety and for consistency with other principal constants (see `MAINNET_BITCOIN_CANISTER_ID`, `MAINNET_LEDGER_CANISTER_ID`, among others).

Also removed the `allow_deprecated` flag since `Principal::from_slice` is no longer deprecated (to allow for this specific use case).

# How Has This Been Tested?

Added a test
