### PR TITLE
test: require UI test to pass for CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -201,6 +201,9 @@ jobs:
       - name: check smoke test result
         if: ${{ needs.smoke.result != 'success' }}
         run: exit 1
+      - name: check UI test result
+        if: ${{ needs.ui_test.result != 'success' }}
+        run: exit 1
       - name: check e2e test result
         if: ${{ needs.test.result != 'success' }}
         run: exit 1


### PR DESCRIPTION
# Description

See https://github.com/dfinity/sdk/actions/runs/7265443777/job/19796376801 for an example where the UI test failed but the `e2e:required` status passed anyway and the PR was merged.

# How Has This Been Tested?

This PR will test it
