### PR TITLE
fix: always compile candid type because imports need to be resolved

### DIFF
--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -324,9 +324,8 @@ fn separate_candid(path: &Path) -> DfxResult<(String, String)> {
         let init_args = enclose("(", doc, ")").pretty(80).to_string();
         Ok((service_did, init_args))
     } else {
-        // The original candid from builder output doesn't contain init_args
-        // Use it directly to avoid items reordering
-        let service_did = dfx_core::fs::read_to_string(path)?;
+        // Note for migration to candid 0.10: this function is now candid_parser::pretty::candid::compile
+        let service_did = candid::bindings::candid::compile(&env, &Some(actor));
         let init_args = String::from("()");
         Ok((service_did, init_args))
     }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes [SDK-746](https://dfinity.atlassian.net/browse/SDK-746)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-746]: https://dfinity.atlassian.net/browse/SDK-746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ