### PR TITLE
fix: nanosecond precision for playground canister acquisition timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The `dfx cycles` command no longer needs nor accepts the `--cycles-ledger-canist
 
 Updated to candid 0.10, ic-cdk 0.12, and ic-cdk-timers 0.6
 
+### fix: store playground canister acquisition timestamps with nanosecond precision on all platforms
+
+They've always been stored with nanosecond precisions on Linux and Macos.
+Now they are stored with nanosecond precision on Windows too.
+
 # 0.15.3
 
 ### fix: allow `http://localhost:*` as `connect-src` in the asset canister's CSP


### PR DESCRIPTION
# Description

The playground backend returns acquisition timestamps with nanosecond precision, and uses nanosecond precision when looking up reserved canisters.

SystemDateTime has OS-specific precision.  On Linux and OSX this is nanosecond precision, but on Windows it's 100ns precision.  OffsetDateTime has nanosecond precision on all platforms.

The result was `dfx deploy --playground` on Windows would return a "Canister not found" error from the playground backend.

Part of https://dfinity.atlassian.net/browse/SDK-1343

# How Has This Been Tested?

Covered by CI, and tested locally on OSX and Windows.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
