### PR TITLE
fix: call npm.cmd and node.exe on Windows

### DIFF
--- a/src/dfx/src/commands/new.rs
+++ b/src/dfx/src/commands/new.rs
@@ -2,6 +2,7 @@ use crate::config::cache::DiskBasedCache;
 use crate::lib::environment::Environment;
 use crate::lib::error::{DfxError, DfxResult};
 use crate::lib::manifest::{get_latest_version, is_upgrade_necessary};
+use crate::lib::program;
 use crate::util::assets;
 use crate::util::clap::parsers::project_name_parser;
 use anyhow::{anyhow, bail, ensure, Context};
@@ -249,12 +250,12 @@ fn write_files_from_entries<R: Sized + Read>(
 
 #[context("Failed to run 'npm install'.")]
 fn npm_install(location: &Path) -> DfxResult<std::process::Child> {
-    std::process::Command::new("npm")
+    Command::new(program::NPM)
         .arg("install")
         .arg("--quiet")
         .arg("--no-progress")
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
         .current_dir(location)
         .spawn()
         .map_err(DfxError::from)
@@ -271,7 +272,7 @@ fn scaffold_frontend_code(
     variables: &BTreeMap<String, String>,
 ) -> DfxResult {
     let log = env.get_logger();
-    let node_installed = std::process::Command::new("node")
+    let node_installed = Command::new(program::NODE)
         .arg("--version")
         .output()
         .is_ok();
@@ -383,12 +384,12 @@ fn scaffold_frontend_code(
 }
 
 fn get_agent_js_version_from_npm(dist_tag: &str) -> DfxResult<String> {
-    std::process::Command::new("npm")
+    Command::new(program::NPM)
         .arg("show")
         .arg("@dfinity/agent")
         .arg(&format!("dist-tags.{}", dist_tag))
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::inherit())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
         .spawn()
         .map_err(DfxError::from)
         .and_then(|child| {

--- a/src/dfx/src/lib/builders/assets.rs
+++ b/src/dfx/src/lib/builders/assets.rs
@@ -6,6 +6,7 @@ use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
 use crate::lib::error::{BuildError, DfxError, DfxResult};
 use crate::lib::models::canister::CanisterPool;
+use crate::lib::program;
 use crate::util;
 use anyhow::{anyhow, Context};
 use candid::Principal as CanisterId;
@@ -218,7 +219,7 @@ fn build_frontend(
     } else if build_frontend {
         // Frontend build.
         slog::info!(logger, "Building frontend...");
-        let mut cmd = std::process::Command::new("npm");
+        let mut cmd = std::process::Command::new(program::NPM);
 
         // Provide DFX_NETWORK at build time
         cmd.env("DFX_NETWORK", network_name);

--- a/src/dfx/src/lib/mod.rs
+++ b/src/dfx/src/lib/mod.rs
@@ -24,6 +24,7 @@ pub mod network;
 pub mod nns_types;
 pub mod operations;
 pub mod package_arguments;
+pub mod program;
 pub mod progress_bar;
 pub mod project;
 pub mod replica;

--- a/src/dfx/src/lib/program.rs
+++ b/src/dfx/src/lib/program.rs
@@ -1,0 +1,9 @@
+#[cfg(target_os = "windows")]
+pub const NPM: &str = "npm.cmd";
+#[cfg(unix)]
+pub const NPM: &str = "npm";
+
+#[cfg(target_os = "windows")]
+pub const NODE: &str = "node.exe";
+#[cfg(unix)]
+pub const NODE: &str = "node";


### PR DESCRIPTION
# Description

On Windows, calls to `npm` and `node` fail.  They need to be `npm.cmd` and `node.exe` respectively.

# How Has This Been Tested?

Tested locally

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
