### PR TITLE
test: detect errors in command pipelines

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - ens/pipefail
   pull_request:
 
 concurrency:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - ens/pipefail
   pull_request:
 
 concurrency:

--- a/e2e/tests-dfx/schema.bash
+++ b/e2e/tests-dfx/schema.bash
@@ -19,6 +19,6 @@ teardown() {
 }
 
 @test "dfx schema still works with broken dfx.json" {
-  jq '.broken_key="blahblahblah"' dfx.json | sponge dfx.json
+  echo '{}' | jq '.broken_key="blahblahblah"' > dfx.json
   assert_command dfx schema
 }

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -1,4 +1,4 @@
-set -e
+set -euo pipefail
 load ../utils/bats-support/load
 load ../utils/assertions
 load ../utils/webserver

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -1,4 +1,4 @@
-set -euo pipefail
+set -eo pipefail
 load ../utils/bats-support/load
 load ../utils/assertions
 load ../utils/webserver


### PR DESCRIPTION
# Description

In e2e test suite, `set -o pipefail` in order to detect errors anywhere in a command pipeline.

# How Has This Been Tested?

This turned up one test with such an issue

