### PR TITLE
fix: for canister delete with HSM trying to open two sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Updated to candid 0.10, ic-cdk 0.12, and ic-cdk-timers 0.6
 They've always been stored with nanosecond precisions on Linux and Macos.
 Now they are stored with nanosecond precision on Windows too.
 
+### fix: dfx canister delete, when using an HSM identity, no longer fails by trying to open two sessions to the HSM
+
+Previously, this would fail with a PKCS#11: CKR_CRYPTOKI_ALREADY_INITIALIZED error.
+
 ## Dependencies
 
 ### Motoko

--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -1,4 +1,3 @@
-use crate::lib::agent::create_agent_environment;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::ic_attributes::CanisterSettings;
@@ -129,8 +128,7 @@ async fn delete_canister(
                     },
                     CallSender::SelectedId => {
                         let network = env.get_network_descriptor();
-                        let agent_env = create_agent_environment(env, Some(network.name.clone()))?;
-                        let identity_name = agent_env
+                        let identity_name = env
                             .get_selected_identity()
                             .expect("No selected identity.")
                             .to_string();


### PR DESCRIPTION
# Description

A HardwareIdentity holds a session open to the HSM.  This means an attempt to create a second HardwareIdentity to the same HSM will fail.  `dfx canister delete` tried to do this, though it didn't need to.

Fixes https://dfinity.atlassian.net/browse/SDK-1346

# How Has This Been Tested?

```
$ dfx canister delete del_backend
Error: Failed to delete canister 'del_backend'.
Caused by: Failed to delete canister 'del_backend'.
  Failed to create AgentEnvironment.
    Failed to create AgentEnvironment for network 'local'.
      Failed to load identity: Failed to instantiate identity: Failed to instantiate hardware identity: Failed to instantiate hardware identity for identity 'hhssmm': PKCS#11: CKR_CRYPTOKI_ALREADY_INITIALIZED (0x191).
$ dfx-wip canister delete del_backend
Beginning withdrawal of cycles; on failure try --no-wallet --no-withdrawal.
Setting the controller to identity principal.
Installing temporary wallet in canister del_backend to enable transfer of cycles.
Attempting to transfer 3081287034302 cycles to canister bnz7o-iuaaa-aaaaa-qaaaa-cai.
Successfully withdrew 3081287034302 cycles.
Deleting canister del_backend, with canister_id bkyz2-fmaaa-aaaaa-qaaaq-cai
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
