### PR TITLE
refactor: remove lazy_static where const functions are available

### DIFF
--- a/src/dfx/src/commands/new.rs
+++ b/src/dfx/src/commands/new.rs
@@ -12,7 +12,6 @@ use dfx_core::config::model::dfinity::CONFIG_FILE_NAME;
 use dfx_core::json::{load_json_file, save_json_file};
 use fn_error_context::context;
 use indicatif::HumanBytes;
-use lazy_static::lazy_static;
 use semver::Version;
 use serde_json::Value;
 use slog::{info, warn, Logger};
@@ -30,15 +29,12 @@ const RELEASE_ROOT: &str = "https://sdk.dfinity.org";
 // The dist-tag to use when getting the version from NPM.
 const AGENT_JS_DEFAULT_INSTALL_DIST_TAG: &str = "latest";
 
-lazy_static! {
 // Tested on a phone tethering connection. This should be fine with
 // little impact to the user, given that "new" is supposedly a
 // heavy-weight operation. Thus, worst case we are utilizing the user
 // expectation for the duration to have a more expensive version
 // check.
-    static ref CHECK_VERSION_TIMEOUT: Duration = Duration::from_secs(2);
-
-}
+const CHECK_VERSION_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Creates a new project.
 #[derive(Parser)]
@@ -417,7 +413,7 @@ pub fn exec(env: &dyn Environment, opts: NewOpts) -> DfxResult {
 
     // It is fine for the following command to timeout or fail. We
     // drop the error.
-    let latest_version = get_latest_version(RELEASE_ROOT, Some(*CHECK_VERSION_TIMEOUT)).ok();
+    let latest_version = get_latest_version(RELEASE_ROOT, Some(CHECK_VERSION_TIMEOUT)).ok();
 
     if is_upgrade_necessary(latest_version.as_ref(), current_version) {
         warn_upgrade(log, latest_version.as_ref(), current_version);

--- a/src/dfx/src/lib/info/mod.rs
+++ b/src/dfx/src/lib/info/mod.rs
@@ -1,8 +1,5 @@
-use lazy_static::lazy_static;
-lazy_static! {
-    static ref REPLICA_REV_STR: String = env!("DFX_ASSET_REPLICA_REV").to_string();
-}
+const REPLICA_REV_STR: &str = env!("DFX_ASSET_REPLICA_REV");
 
 pub fn replica_rev() -> &'static str {
-    &REPLICA_REV_STR
+    REPLICA_REV_STR
 }


### PR DESCRIPTION
# Description

We don't need to use `lazy_static` where const functions are available.

Fixes https://dfinity.atlassian.net/browse/SDK-761

# How Has This Been Tested?

Covered by CI
