### PR TITLE
fix: allow some canister commands outside of a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ If the local did file doesn't contain `import` or init args, we will not perform
 
 ### fix: subtyping check reports the special opt rule as error
 
+### fix: can now run several dfx canister commands outside of a project
+
+The following commands now work outside of a project:
+- `dfx canister start <specific canister id>`
+- `dfx canister stop <specific canister id>`
+- `dfx canister deposit-cycles <amount> <specific canister id>`
+- `dfx canister uninstall-code <specific canister id>`
+
 # 0.16.0
 
 ### feat: large canister modules now supported

--- a/e2e/tests-dfx/start.bash
+++ b/e2e/tests-dfx/start.bash
@@ -12,6 +12,43 @@ teardown() {
   standard_teardown
 }
 
+@test "start and stop outside project" {
+  dfx_start
+
+  mkdir subdir
+  cd subdir || exit 1
+  dfx_new
+  assert_command dfx deploy
+  CANISTER_ID="$(dfx canister id e2e_project_backend)"
+  cd ..
+  assert_command dfx canister status "$CANISTER_ID"
+  assert_contains "Status: Running"
+  assert_command dfx canister stop "$CANISTER_ID"
+  assert_command dfx canister status "$CANISTER_ID"
+  assert_contains "Status: Stopped"
+  assert_command dfx canister start "$CANISTER_ID"
+  assert_command dfx canister status "$CANISTER_ID"
+  assert_contains "Status: Running"
+}
+
+@test "uninstall-code outside of a project" {
+  dfx_start
+
+  mkdir subdir
+  cd subdir || exit 1
+  dfx_new
+  assert_command dfx deploy
+  CANISTER_ID="$(dfx canister id e2e_project_backend)"
+  cd ..
+  assert_command dfx canister status "$CANISTER_ID"
+  assert_contains "Module hash: 0x"
+  assert_command dfx canister uninstall-code "$CANISTER_ID"
+  assert_contains "Uninstalling code for canister $CANISTER_ID"
+  assert_command dfx canister status "$CANISTER_ID"
+  assert_contains "Module hash: None"
+}
+
+
 @test "icx-proxy domain configuration in string form" {
   create_networks_json
   jq '.local.proxy.domain="xyz.domain"' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"

--- a/e2e/tests-dfx/wallet.bash
+++ b/e2e/tests-dfx/wallet.bash
@@ -12,6 +12,28 @@ teardown() {
   standard_teardown
 }
 
+@test "deposit cycles inside a project" {
+    dfx_start
+
+    dfx_new
+    assert_command dfx deploy
+    assert_command dfx canister deposit-cycles 47 e2e_project_backend
+    assert_contains "Deposited 47 cycles"
+}
+
+@test "deposit cycles outside a project" {
+    dfx_start
+
+    mkdir subdir
+    cd subdir || exit 1
+    dfx_new
+    assert_command dfx deploy
+    CANISTER_ID="$(dfx canister id e2e_project_backend)"
+    cd ..
+    assert_command dfx canister deposit-cycles 42 "$CANISTER_ID"
+    assert_contains "Deposited 42 cycles"
+}
+
 @test "DFX_WALLET_WASM environment variable overrides wallet module wasm at installation" {
   dfx_new hello
   dfx_start

--- a/src/dfx/src/commands/canister/deposit_cycles.rs
+++ b/src/dfx/src/commands/canister/deposit_cycles.rs
@@ -79,11 +79,11 @@ pub async fn exec(
     // amount has been validated by cycle_amount_validator
     let cycles = opts.cycles;
 
-    let config = env.get_config_or_anyhow()?;
-
     if let Some(canister) = opts.canister.as_deref() {
         deposit_cycles(env, canister, call_sender, cycles).await
     } else if opts.all {
+        let config = env.get_config_or_anyhow()?;
+
         if let Some(canisters) = &config.get_config().canisters {
             for canister in canisters.keys() {
                 deposit_cycles(env, canister, call_sender, cycles)

--- a/src/dfx/src/commands/canister/start.rs
+++ b/src/dfx/src/commands/canister/start.rs
@@ -45,12 +45,12 @@ pub async fn exec(
     opts: CanisterStartOpts,
     call_sender: &CallSender,
 ) -> DfxResult {
-    let config = env.get_config_or_anyhow()?;
     fetch_root_key_if_needed(env).await?;
 
     if let Some(canister) = opts.canister.as_deref() {
         start_canister(env, canister, call_sender).await
     } else if opts.all {
+        let config = env.get_config_or_anyhow()?;
         if let Some(canisters) = &config.get_config().canisters {
             for canister in canisters.keys() {
                 start_canister(env, canister, call_sender).await?;

--- a/src/dfx/src/commands/canister/stop.rs
+++ b/src/dfx/src/commands/canister/stop.rs
@@ -46,13 +46,12 @@ pub async fn exec(
     opts: CanisterStopOpts,
     call_sender: &CallSender,
 ) -> DfxResult {
-    let config = env.get_config_or_anyhow()?;
-
     fetch_root_key_if_needed(env).await?;
 
     if let Some(canister) = opts.canister.as_deref() {
         stop_canister(env, canister, call_sender).await
     } else if opts.all {
+        let config = env.get_config_or_anyhow()?;
         if let Some(canisters) = &config.get_config().canisters {
             for canister in canisters.keys() {
                 stop_canister(env, canister, call_sender).await?;

--- a/src/dfx/src/commands/canister/uninstall_code.rs
+++ b/src/dfx/src/commands/canister/uninstall_code.rs
@@ -47,13 +47,13 @@ pub async fn exec(
     opts: UninstallCodeOpts,
     call_sender: &CallSender,
 ) -> DfxResult {
-    let config = env.get_config_or_anyhow()?;
-
     fetch_root_key_if_needed(env).await?;
 
     if let Some(canister) = opts.canister.as_deref() {
         uninstall_code(env, canister, call_sender).await
     } else if opts.all {
+        let config = env.get_config_or_anyhow()?;
+
         if let Some(canisters) = &config.get_config().canisters {
             for canister in canisters.keys() {
                 uninstall_code(env, canister, call_sender).await?;


### PR DESCRIPTION
# Description

Make it so the following `dfx canister` commands work outside of a project, when specifying a single canister by id:
- `dfx canister stop <canister id>`
- `dfx canister stop <specific canister id>`
- `dfx canister deposit-cycles <amount> <specific canister id>`
- `dfx canister uninstall-code <specific canister id>`

Fixes https://dfinity.atlassian.net/browse/SDK-871

# How Has This Been Tested?

Added tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
