### PR TITLE
chore: fix CI warnings

### DIFF
--- a/.github/workflows/broadcast-frontend-hash.yml
+++ b/.github/workflows/broadcast-frontend-hash.yml
@@ -26,7 +26,7 @@ jobs:
         run: sudo apt-get install --yes moreutils
 
       - name: Checkout dfinity/sdk repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # workaround to fetch all tags: https://github.com/actions/checkout/issues/701
           path: sdk
@@ -40,7 +40,7 @@ jobs:
           echo "NEW_HASH=$(shasum -a 256 src/distributed/assetstorage.wasm.gz | cut -f1 -d" ")" >> $GITHUB_ENV
 
       - name: Checkout dfinity/motoko-playground repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.NIV_UPDATER_TOKEN }}
           repository: ${{ env.PLAYGROUND_REPO }}

--- a/.github/workflows/build-frontend-canister.yml
+++ b/.github/workflows/build-frontend-canister.yml
@@ -26,7 +26,7 @@ jobs:
     name: frontend-canister-up-to-date:required
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build frontend canister
         run: |
           ./scripts/update-frontend-canister.sh --release-build

--- a/.github/workflows/build-frontend-canister.yml
+++ b/.github/workflows/build-frontend-canister.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           ./scripts/update-frontend-canister.sh --release-build
       - name: Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: assetstorage
           path: ${{ github.workspace }}/src/distributed/assetstorage.wasm.gz

--- a/.github/workflows/consistent-sources.yml
+++ b/.github/workflows/consistent-sources.yml
@@ -19,7 +19,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-21.05-small

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -21,7 +21,7 @@ jobs:
     name: license-check:required
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check bans licenses sources # skip advisories, which are handled by audit.yml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,14 +35,14 @@ jobs:
             target: x86_64-unknown-linux-gnu
             binary_path: target/x86_64-unknown-linux-gnu/release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup environment variables
         run: |
           echo "RUSTFLAGS=--remap-path-prefix=${GITHUB_WORKSPACE}=/builds/dfinity" >> $GITHUB_ENV
       - name: Cache Cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -72,7 +72,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: set-matrix
         run: echo "matrix=$(scripts/workflows/e2e-matrix.py)" >> $GITHUB_OUTPUT
 
@@ -88,7 +88,7 @@ jobs:
         #     /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found
         os: [macos-12, ubuntu-20.04, ubuntu-22.04]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download dfx binary
         uses: actions/download-artifact@v3
         with:
@@ -121,7 +121,7 @@ jobs:
     env:
       E2E_TEST: tests-${{ matrix.test }}.bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download dfx binary
         uses: actions/download-artifact@v3
         with:
@@ -144,7 +144,7 @@ jobs:
       - name: Download bats-support as a git submodule
         run: git submodule update --init --recursive
       - name: Cache mops files
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             e2e/assets/playground_backend/.mops

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,7 +62,7 @@ jobs:
           strip dfx
         if: contains(matrix.os, 'ubuntu')
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dfx-${{ matrix.os }}-rs-${{ hashFiles('rust-toolchain.toml') }}
           path: ${{ matrix.binary_path }}/dfx
@@ -90,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download dfx binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dfx-${{ matrix.os }}-rs-${{ hashFiles('rust-toolchain.toml') }}
           path: /usr/local/bin
@@ -123,7 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download dfx binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dfx-${{ matrix.os }}-rs-${{ hashFiles('rust-toolchain.toml') }}
           path: /usr/local/bin
@@ -163,7 +163,7 @@ jobs:
       - name: Checking out repo
         uses: actions/checkout@v4
       - name: Setting up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Installing playwright
@@ -172,7 +172,7 @@ jobs:
           playwright install
           playwright install-deps
       - name: Download dfx binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dfx-${{ matrix.os }}-rs-${{ hashFiles('rust-toolchain.toml') }}
           path: /usr/local/bin

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -21,10 +21,10 @@ jobs:
         os: [ ubuntu-latest ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache Cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,9 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/prepare-dfx-assets.yml
+++ b/.github/workflows/prepare-dfx-assets.yml
@@ -26,8 +26,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -21,7 +21,7 @@ jobs:
     name: install-script-shellcheck:required
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
       - name: Generate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload Artifacts
         if: github.ref_type == 'tag'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dfx-artifacts-${{ hashFiles('rust-toolchain.toml') }}-${{ matrix.name }}
           path: |
@@ -144,7 +144,7 @@ jobs:
         run: echo "VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dfx-artifacts-${{ hashFiles('rust-toolchain.toml') }}-${{ matrix.name }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
             name: x86_64-linux
             tar: tar
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup environment variables
         run: |
@@ -57,7 +57,7 @@ jobs:
           echo "SHA256_FILENAME=dfx-$GITHUB_REF_NAME-${{ matrix.name }}.tar.gz.sha256" >> $GITHUB_ENV
 
       - name: Cache Cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -138,7 +138,7 @@ jobs:
       matrix:
         name: [ 'x86_64-darwin', 'x86_64-linux' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup environment variables
         run: echo "VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -26,7 +26,7 @@ jobs:
     # ubuntu-latest has shellcheck 0.4.6, while macos-latest has 0.7.1
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install shellcheck
         run: |
           mkdir $HOME/bin

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ ubuntu-20.04 ]
     steps:
-      - uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/update-motoko.yml
+++ b/.github/workflows/update-motoko.yml
@@ -24,7 +24,7 @@ jobs:
   update-motoko:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.0.2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.sdkBranch }}
 

--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -31,7 +31,7 @@ jobs:
   update-replica:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.0.2
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.sdkBranch }}
 


### PR DESCRIPTION
GitHub is deprecating Node 16.
This PR upgrade all dependency actions to the version for Node 20.