### PR TITLE
chore: add changelog header 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # UNRELEASED
 
-# 0.16.1
+# 0.17.0
 
 ### fix!: always fetch did file from canister when making canister calls
 


### PR DESCRIPTION
As Eric noticed this should be 0.17.0 instead of 0.16.1 since it contains a breaking change