### PR TITLE
feat: Added query stats to canister status output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+### feat: query stats support
+
+When using `dfx canister status`, the output now includes the new query statistics. Those might initially be 0, if the feature is not yet enabled on the subnet the canister is installed in.
+
 # 0.17.0
 
 ### fix!: always fetch did file from canister when making canister calls
@@ -1443,7 +1447,7 @@ Additionally, after build step, the `.wasm` file is archived with `gzip`.
 ### chore: Move all `frontend canister`-related code into the SDK repo
 
 | from (`repository` `path`)                  | to (path in `dfinity/sdk` repository)          | summary                                                                                     |
-|:--------------------------------------------|:-----------------------------------------------|:--------------------------------------------------------------------------------------------|
+| :------------------------------------------ | :--------------------------------------------- | :------------------------------------------------------------------------------------------ |
 | `dfinity/cdk-rs` `/src/ic-certified-assets` | `/src/canisters/frontend/ic-certified-asset`   | the core of the frontend canister                                                           |
 | `dfinity/certified-assets` `/`              | `/src/canisters/frontend/ic-frontend-canister` | wraps `ic-certified-assets` to build the canister wasm                                      |
 | `dfinity/agent-rs` `/ic-asset`              | `/src/canisters/frontend/ic-asset`             | library facilitating interactions with frontend canister (e.g. uploading or listing assets) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1447,7 +1447,7 @@ Additionally, after build step, the `.wasm` file is archived with `gzip`.
 ### chore: Move all `frontend canister`-related code into the SDK repo
 
 | from (`repository` `path`)                  | to (path in `dfinity/sdk` repository)          | summary                                                                                     |
-| :------------------------------------------ | :--------------------------------------------- | :------------------------------------------------------------------------------------------ |
+|:--------------------------------------------|:-----------------------------------------------|:--------------------------------------------------------------------------------------------|
 | `dfinity/cdk-rs` `/src/ic-certified-assets` | `/src/canisters/frontend/ic-certified-asset`   | the core of the frontend canister                                                           |
 | `dfinity/certified-assets` `/`              | `/src/canisters/frontend/ic-frontend-canister` | wraps `ic-certified-assets` to build the canister wasm                                      |
 | `dfinity/agent-rs` `/ic-asset`              | `/src/canisters/frontend/ic-asset`             | library facilitating interactions with frontend canister (e.g. uploading or listing assets) |

--- a/src/dfx/src/commands/canister/status.rs
+++ b/src/dfx/src/commands/canister/status.rs
@@ -47,7 +47,7 @@ async fn canister_status(
         "Not Set".to_string()
     };
 
-    info!(log, "Canister status call result for {}.\nStatus: {}\nControllers: {}\nMemory allocation: {}\nCompute allocation: {}\nFreezing threshold: {}\nMemory Size: {:?}\nBalance: {} Cycles\nReserved: {} Cycles\nReserved Cycles Limit: {}\nModule hash: {}",
+    info!(log, "Canister status call result for {}.\nStatus: {}\nControllers: {}\nMemory allocation: {}\nCompute allocation: {}\nFreezing threshold: {}\nMemory Size: {:?}\nBalance: {} Cycles\nReserved: {} Cycles\nReserved Cycles Limit: {}\nModule hash: {}\nNumber of queries: {}\nInstructions spent in queries: {}\nTotal query request paylod size (bytes): {}\nTotal query response payload size (bytes): {}",
         canister,
         status.status,
         controllers.join(" "),
@@ -58,7 +58,11 @@ async fn canister_status(
         status.cycles,
         status.reserved_cycles,
         reserved_cycles_limit,
-        status.module_hash.map_or_else(|| "None".to_string(), |v| format!("0x{}", hex::encode(v)))
+        status.module_hash.map_or_else(|| "None".to_string(), |v| format!("0x{}", hex::encode(v))),
+        status.query_stats.num_calls_total,
+        status.query_stats.num_instructions_total,
+        status.query_stats.request_payload_bytes_total,
+        status.query_stats.response_payload_bytes_total,
     );
     Ok(())
 }


### PR DESCRIPTION
# Description

Display query stats when doing a canister status call via `dfx`.

# How Has This Been Tested?

Ran against a `dfx start` deployed replica. All counters are reported as `0` as expected (since the query stats feature is currently disabled).

```
./dfx canister status canister_status_backend
Canister status call result for canister_status_backend.
Status: Running
Controllers: bnz7o-iuaaa-aaaaa-qaaaa-cai zp6ar-te3c2-c6t6s-5bhid-g4iax-2lsk5-7vuol-nk7qj-qbnie-znajy-iqe
Memory allocation: 0
Compute allocation: 0
Freezing threshold: 2_592_000
Memory Size: Nat(1936150)
Balance: 3_092_003_934_543 Cycles
Reserved: 0 Cycles
Reserved Cycles Limit: 5_000_000_000_000 Cycles
Module hash: 0x682631dae48a2628a6ed7ee01f022c33ddcfd75c1e1e1d8b218e4b877c7b11e4
Number of queries: 0
Instructions spent in queries: 0
Total query request paylod size (bytes): 0
Total query response payload size (bytes): 0
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
