### PR TITLE
chore: update wallet send docs to match actual behavior

### DIFF
--- a/docs/cli-reference/dfx-wallet.md
+++ b/docs/cli-reference/dfx-wallet.md
@@ -33,7 +33,7 @@ For reference information and examples that illustrate using `dfx wallet` comman
 |[`name`](#dfx-wallet-name) |Returns the name of the cycles wallet if you've used the `dfx wallet set-name` command.
 |[`redeem-faucet-coupon`](#redeem-faucet-coupon) | Redeem a code at the cycles faucet. |
 |[`remove-controller`](#dfx-wallet-remove-controller) |Removes a specified controller from the selected identity's cycles wallet. 
-|[`send`](#dfx-wallet-send) |Sends a specified amount of cycles from the selected identity's cycles wallet to another cycles wallet using the destination wallet canister ID.
+|[`send`](#dfx-wallet-send) |Sends a specified amount of cycles from the selected identity's cycles wallet to another canister.
 |[`set-name`](#dfx-wallet-set-name) |Specify a name for your cycles wallet. 
 |[`upgrade`](#dfx-wallet-upgrade) |Upgrade the cycles wallet's Wasm module to the current Wasm bundled with DFX.
 
@@ -404,7 +404,7 @@ Removed dheus-mqf6t-xafkj-d3tuo-gh4ng-7t2kn-7ikxy-vvwad-dfpgu-em25m-2ae as a con
 
 ## dfx wallet send
 
-Use the `dfx wallet send` command to send cycles from the selected identity's cycles wallet to another cycles wallet using the destination cycle wallet's Canister ID. Keep in mind that the receiving canister must be a cycles wallet or have a `wallet_receive` method to accept the cycles.
+Use the `dfx wallet send` command to send cycles from the selected identity's cycles wallet to canister.
 
 ### Basic usage
 
@@ -427,7 +427,7 @@ You must specify the following arguments for the `dfx wallet send` command.
 
 |Argument |Description
 -----------|----------
-|`<destination>` |Specify the destination cycle wallet using its Canister ID.
+|`<destination>` |Specify the destination canister using its Canister ID.
 |`<amount>` |Specify the number of cycles to send.
 
 ### Examples


### PR DESCRIPTION
# Description

https://github.com/dfinity/cycles-wallet/pull/130 made it possible to target any canister with `wallet_send`, not just cycles wallets anymore. The docs currently don't reflect that change.

# How Has This Been Tested?

Purely docs change

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
