### PR TITLE
build: release workflow generates tarballs with a top-level directory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,8 +109,8 @@ jobs:
         if: github.ref_type == 'tag'
         run: |
           mkdir dfx-${{ matrix.target }}
-          cp dfx dfx-${{ matrix.target }}
-          ${{ matrix.tar }} -zcC ${{ matrix.binary_path }} -f ${{ env.TARBALL_2_FILENAME }} ${{ matrix.target }}
+          cp ${{ matrix.binary_path }}/dfx dfx-${{ matrix.target }}
+          ${{ matrix.tar }} -zc -f ${{ env.TARBALL_2_FILENAME }} ${{ matrix.target }}
           shasum -a 256 ${{ env.TARBALL_2_FILENAME }} > ${{ env.SHA256_2_FILENAME }}
           shasum -c ${{ env.SHA256_2_FILENAME }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           mkdir dfx-${{ matrix.target }}
           cp ${{ matrix.binary_path }}/dfx dfx-${{ matrix.target }}
+          cp LICENSE dfx-${{ matrix.target }}
           ${{ matrix.tar }} -zc -f ${{ env.TARBALL_2_FILENAME }} ${{ matrix.target }}
           shasum -a 256 ${{ env.TARBALL_2_FILENAME }} > ${{ env.SHA256_2_FILENAME }}
           shasum -c ${{ env.SHA256_2_FILENAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,7 +111,7 @@ jobs:
           mkdir dfx-${{ matrix.target }}
           cp ${{ matrix.binary_path }}/dfx dfx-${{ matrix.target }}
           cp LICENSE dfx-${{ matrix.target }}
-          ${{ matrix.tar }} -zc -f ${{ env.TARBALL_2_FILENAME }} ${{ matrix.target }}
+          ${{ matrix.tar }} -zc -f ${{ env.TARBALL_2_FILENAME }} dfx-${{ matrix.target }}
           shasum -a 256 ${{ env.TARBALL_2_FILENAME }} > ${{ env.SHA256_2_FILENAME }}
           shasum -c ${{ env.SHA256_2_FILENAME }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,8 +53,10 @@ jobs:
         if: github.ref_type == 'tag'
         run: |
           echo "DFX_VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV
-          echo "TARBALL_FILENAME=dfx-$GITHUB_REF_NAME-${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
-          echo "SHA256_FILENAME=dfx-$GITHUB_REF_NAME-${{ matrix.name }}.tar.gz.sha256" >> $GITHUB_ENV
+          echo "TARBALL_1_FILENAME=dfx-$GITHUB_REF_NAME-${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
+          echo "SHA256_1_FILENAME=dfx-$GITHUB_REF_NAME-${{ matrix.name }}.tar.gz.sha256" >> $GITHUB_ENV
+          echo "TARBALL_2_FILENAME=dfx-${{ matrix.target }}.tar.gz" >> $GITHUB_ENV
+          echo "SHA256_2_FILENAME=dfx-${{ matrix.target }}.tar.gz.sha256" >> $GITHUB_ENV
 
       - name: Cache Cargo
         uses: actions/cache@v4
@@ -106,9 +108,15 @@ jobs:
       - name: Create tarball of binaries and sha256 of tarball
         if: github.ref_type == 'tag'
         run: |
-          ${{ matrix.tar }} -zcC ${{ matrix.binary_path }} -f ${{ env.TARBALL_FILENAME }} dfx
-          shasum -a 256 ${{ env.TARBALL_FILENAME }} > $SHA256_FILENAME
-          shasum -c $SHA256_FILENAME
+          mkdir dfx-${{ matrix.target }}
+          cp dfx dfx-${{ matrix.target }}
+          ${{ matrix.tar }} -zcC ${{ matrix.binary_path }} -f ${{ env.TARBALL_2_FILENAME }} ${{ matrix.target }}
+          shasum -a 256 ${{ env.TARBALL_2_FILENAME }} > ${{ env.SHA256_2_FILENAME }}
+          shasum -c ${{ env.SHA256_2_FILENAME }}
+
+          ${{ matrix.tar }} -zcC ${{ matrix.binary_path }} -f ${{ env.TARBALL_1_FILENAME }} dfx
+          shasum -a 256 ${{ env.TARBALL_1_FILENAME }} > $SHA256_1_FILENAME
+          shasum -c $SHA256_1_FILENAME
 
       - name: Upload Artifacts
         if: github.ref_type == 'tag'
@@ -116,8 +124,10 @@ jobs:
         with:
           name: dfx-artifacts-${{ hashFiles('rust-toolchain.toml') }}-${{ matrix.name }}
           path: |
-            ${{ env.TARBALL_FILENAME }}
-            ${{ env.SHA256_FILENAME }}
+            ${{ env.TARBALL_1_FILENAME }}
+            ${{ env.SHA256_1_FILENAME }}
+            ${{ env.TARBALL_2_FILENAME }}
+            ${{ env.SHA256_2_FILENAME }}
 
   aggregate:
     name: publishable:required


### PR DESCRIPTION
# Description

To simplify release handling going forward with dfxvm, with the potential to create our releases with [cargo-dist](https://github.com/axodotdev/cargo-dist), this PR makes the release publishing workflow create a second set of tarballs that match the structure generated by cargo-dist.  It also adds the LICENSE file to the archive.

Until now, dfx release tarballs contained the `dfx` binary in the root directory:
```
$ tar -tvf ~/Downloads/dfx-0.16.1-x86_64-darwin.tar.gz
-rwxr-xr-x  0 runner staff 124834024 Jan 31 09:14 dfx
```

The new format looks like this:
```
$ tar -tvf ~/Downloads/dfx-x86_64-apple-darwin.tar.gz 
drwxr-xr-x  0 runner staff       0 Feb  6 11:56 dfx-x86_64-apple-darwin/
-rw-r--r--  0 runner staff   11348 Feb  6 11:56 dfx-x86_64-apple-darwin/LICENSE
-rwxr-xr-x  0 runner staff 29369584 Feb  3  2020 dfx-x86_64-apple-darwin/dfx
```

Path of https://dfinity.atlassian.net/browse/SDK-1360

# How Has This Been Tested?

Release generated by this workflow: https://github.com/dfinity/sdk/releases/tag/0.16.1-cargodistfmt.4
Release generated by cargo-dist: https://github.com/dfinity/sdk/releases/tag/0.16.1-cargodist.4

On branch https://github.com/dfinity/dfxvm/tree/ens/sdk-1360-tarball-format, `cargo run install 0.16.1-cargodistfmt.4` on OSX and WSL.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
