### PR TITLE
refactor: install canister

### DIFF
--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -110,12 +110,11 @@ pub async fn exec(
         let argument_from_cli = arguments_from_file.as_deref().or(arguments);
         let arg_type = opts.argument_type.as_deref();
 
-        // opts.canister is canister_id
+        // `opts.canister` is a Principal (canister ID)
         if let Ok(canister_id) = Principal::from_text(canister) {
             if let Some(wasm_path) = &opts.wasm {
                 let args = blob_from_arguments(argument_from_cli, None, arg_type, &None)?;
-                let wasm_module = std::fs::read(wasm_path)
-                    .with_context(|| format!("Failed to read {}.", wasm_path.display()))?;
+                let wasm_module = dfx_core::fs::read(wasm_path)?;
                 let mode = mode.context("The install mode cannot be auto when using --wasm")?;
                 install_canister_wasm(
                     env.get_agent(),
@@ -134,7 +133,7 @@ pub async fn exec(
                 bail!("When installing a canister by its ID, you must specify `--wasm` option.")
             }
         } else {
-            // opts.canister is a canister name
+            // `opts.canister` is not a canister ID, but a canister name
             if pull_canisters_in_config.contains_key(canister) {
                 bail!(
                     "{0} is a pull dependency. Please deploy it using `dfx deps deploy {0}`",

--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -114,8 +114,8 @@ pub async fn exec(
         if let Ok(canister_id) = Principal::from_text(canister) {
             if let Some(wasm_path) = &opts.wasm {
                 let args = blob_from_arguments(argument_from_cli, None, arg_type, &None)?;
-                let wasm_module = std::fs::read(&wasm_path)
-                    .with_context(|| format!("Failed to read {}.", &wasm_path.display()))?;
+                let wasm_module = std::fs::read(wasm_path)
+                    .with_context(|| format!("Failed to read {}.", wasm_path.display()))?;
                 install_canister_wasm(
                     env.get_agent(),
                     canister_id,

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -12,7 +12,6 @@ use crate::lib::operations::canister::deploy_canisters::DeployMode::{
 };
 use crate::lib::operations::canister::motoko_playground::reserve_canister_with_playground;
 use crate::lib::operations::canister::{create_canister, install_canister::install_canister};
-use crate::util::{blob_from_arguments, get_candid_init_type};
 use anyhow::{anyhow, bail, Context};
 use candid::Principal;
 use dfx_core::config::model::canister_id_store::CanisterIdStore;
@@ -322,17 +321,14 @@ async fn install_canisters(
         let canister_id = canister_id_store.get(canister_name)?;
         let canister_info = CanisterInfo::load(config, canister_name, Some(canister_id))?;
 
-        let idl_path = canister_info.get_constructor_idl_path();
-        let init_type = get_candid_init_type(&idl_path);
-        let install_args = || blob_from_arguments(argument, None, argument_type, &init_type);
-
         install_canister(
             env,
             &mut canister_id_store,
             canister_id,
             &canister_info,
             None,
-            install_args,
+            argument,
+            argument_type,
             install_mode,
             call_sender,
             upgrade_unchanged,

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -330,7 +330,7 @@ async fn install_canisters(
             env,
             &mut canister_id_store,
             canister_id,
-            Some(&canister_info),
+            &canister_info,
             None,
             install_args,
             install_mode,

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -33,12 +33,12 @@ use std::process::{Command, Stdio};
 
 use super::motoko_playground::playground_install_code;
 
-#[context("Failed to install wasm module to canister '{}'.", canister_info.map(|info|info.get_name()).unwrap_or(&canister_id.to_string()))]
+#[context("Failed to install wasm module to canister '{}'.", canister_info.get_name())]
 pub async fn install_canister(
     env: &dyn Environment,
     canister_id_store: &mut CanisterIdStore,
     canister_id: Principal,
-    canister_info: Option<&CanisterInfo>,
+    canister_info: &CanisterInfo,
     wasm_path_override: Option<&Path>,
     args: impl FnOnce() -> DfxResult<Vec<u8>>,
     mode: Option<InstallMode>,
@@ -70,38 +70,34 @@ pub async fn install_canister(
             InstallMode::Install
         }
     });
-    if let Some(canister_info) = canister_info {
-        if !skip_consent && matches!(mode, InstallMode::Reinstall | InstallMode::Upgrade { .. }) {
-            let candid = read_module_metadata(agent, canister_id, "candid:service").await;
-            if let Some(candid) = &candid {
-                match check_candid_compatibility(canister_info, candid) {
-                    Ok(None) => (),
-                    Ok(Some(err)) => {
-                        let msg = format!("Candid interface compatibility check failed for canister '{}'.\nYou are making a BREAKING change. Other canisters or frontend clients relying on your canister may stop working.\n\n", canister_info.get_name()) + &err;
-                        ask_for_consent(&msg)?;
-                    }
-                    Err(e) => {
-                        let msg = format!("An error occurred during Candid interface compatibility check for canister '{}'.\n\n", canister_info.get_name()) + &e.to_string();
-                        ask_for_consent(&msg)?;
-                    }
+    if !skip_consent && matches!(mode, InstallMode::Reinstall | InstallMode::Upgrade { .. }) {
+        let candid = read_module_metadata(agent, canister_id, "candid:service").await;
+        if let Some(candid) = &candid {
+            match check_candid_compatibility(canister_info, candid) {
+                Ok(None) => (),
+                Ok(Some(err)) => {
+                    let msg = format!("Candid interface compatibility check failed for canister '{}'.\nYou are making a BREAKING change. Other canisters or frontend clients relying on your canister may stop working.\n\n", canister_info.get_name()) + &err;
+                    ask_for_consent(&msg)?;
+                }
+                Err(e) => {
+                    let msg = format!("An error occurred during Candid interface compatibility check for canister '{}'.\n\n", canister_info.get_name()) + &e.to_string();
+                    ask_for_consent(&msg)?;
                 }
             }
         }
-        if !skip_consent && canister_info.is_motoko() && matches!(mode, InstallMode::Upgrade { .. })
-        {
-            let stable_types =
-                read_module_metadata(agent, canister_id, "motoko:stable-types").await;
-            if let Some(stable_types) = &stable_types {
-                match check_stable_compatibility(canister_info, env, stable_types) {
-                    Ok(None) => (),
-                    Ok(Some(err)) => {
-                        let msg = format!("Stable interface compatibility check failed for canister '{}'.\nUpgrade will either FAIL or LOSE some stable variable data.\n\n", canister_info.get_name()) + &err;
-                        ask_for_consent(&msg)?;
-                    }
-                    Err(e) => {
-                        let msg = format!("An error occurred during stable interface compatibility check for canister '{}'.\n\n", canister_info.get_name()) + &e.to_string();
-                        ask_for_consent(&msg)?;
-                    }
+    }
+    if !skip_consent && canister_info.is_motoko() && matches!(mode, InstallMode::Upgrade { .. }) {
+        let stable_types = read_module_metadata(agent, canister_id, "motoko:stable-types").await;
+        if let Some(stable_types) = &stable_types {
+            match check_stable_compatibility(canister_info, env, stable_types) {
+                Ok(None) => (),
+                Ok(Some(err)) => {
+                    let msg = format!("Stable interface compatibility check failed for canister '{}'.\nUpgrade will either FAIL or LOSE some stable variable data.\n\n", canister_info.get_name()) + &err;
+                    ask_for_consent(&msg)?;
+                }
+                Err(e) => {
+                    let msg = format!("An error occurred during stable interface compatibility check for canister '{}'.\n\n", canister_info.get_name()) + &e.to_string();
+                    ask_for_consent(&msg)?;
                 }
             }
         }
@@ -110,9 +106,7 @@ pub async fn install_canister(
     let wasm_path: PathBuf = if let Some(wasm_override) = wasm_path_override {
         wasm_override.into()
     } else {
-        let build_wasm_path = canister_info
-            .map(|info| info.get_build_wasm_path())
-            .context("Failed to find wasm")?;
+        let build_wasm_path = canister_info.get_build_wasm_path();
         if !build_wasm_path.exists() {
             bail!("The canister must be built before install. Please run `dfx build`.");
         }
@@ -131,53 +125,39 @@ pub async fn install_canister(
             "Module hash {} is already installed.",
             hex::encode(installed_module_hash.as_ref().unwrap())
         );
-    } else if let Some(canister_info) = canister_info {
-        if !(canister_info.is_assets() && no_asset_upgrade) {
-            if let Some(timestamp) = canister_id_store.get_timestamp(canister_info.get_name()) {
-                let new_timestamp = playground_install_code(
-                    env,
-                    canister_id,
-                    timestamp,
-                    &args()?,
-                    &wasm_module,
-                    mode,
-                    canister_info.is_assets(),
-                )
-                .await?;
-                canister_id_store.add(
-                    canister_info.get_name(),
-                    &canister_id.to_string(),
-                    Some(new_timestamp),
-                )?;
-            } else {
-                install_canister_wasm(
-                    agent,
-                    canister_id,
-                    Some(canister_info.get_name()),
-                    &args()?,
-                    mode,
-                    call_sender,
-                    wasm_module,
-                    skip_consent,
-                    env.get_logger(),
-                )
-                .await?;
-            }
+    } else if !(canister_info.is_assets() && no_asset_upgrade) {
+        if let Some(timestamp) = canister_id_store.get_timestamp(canister_info.get_name()) {
+            let new_timestamp = playground_install_code(
+                env,
+                canister_id,
+                timestamp,
+                &args()?,
+                &wasm_module,
+                mode,
+                canister_info.is_assets(),
+            )
+            .await?;
+            canister_id_store.add(
+                canister_info.get_name(),
+                &canister_id.to_string(),
+                Some(new_timestamp),
+            )?;
+        } else {
+            install_canister_wasm(
+                agent,
+                canister_id,
+                Some(canister_info.get_name()),
+                &args()?,
+                mode,
+                call_sender,
+                wasm_module,
+                skip_consent,
+                env.get_logger(),
+            )
+            .await?;
         }
-    } else {
-        install_canister_wasm(
-            agent,
-            canister_id,
-            None,
-            &args()?,
-            mode,
-            call_sender,
-            wasm_module,
-            skip_consent,
-            env.get_logger(),
-        )
-        .await?;
     }
+
     wait_for_module_hash(
         env,
         agent,
@@ -187,35 +167,32 @@ pub async fn install_canister(
     )
     .await?;
 
-    if let Some(canister_info) = canister_info {
-        if canister_info.is_assets() {
-            if let Some(canister_timeout) =
-                canister_id_store.get_timestamp(canister_info.get_name())
-            {
-                // playground installed the code, so playground has to authorize call_sender to upload files
-                let uploader_principal = env
-                    .get_selected_identity_principal()
-                    .context("Failed to figure out selected identity's principal.")?;
-                authorize_asset_uploader(
-                    env,
-                    canister_info.get_canister_id()?,
-                    canister_timeout,
-                    &uploader_principal,
-                )
-                .await?;
-            }
-            if let CallSender::Wallet(wallet_id) = call_sender {
-                let wallet = build_wallet_canister(*wallet_id, agent).await?;
-                let identity_name = env.get_selected_identity().expect("No selected identity.");
-                info!(
-                    log,
-                    "Authorizing our identity ({}) to the asset canister...", identity_name
-                );
-                let self_id = env
-                    .get_selected_identity_principal()
-                    .expect("Selected identity not instantiated.");
-                // Before storing assets, make sure the DFX principal is in there first.
-                wallet
+    if canister_info.is_assets() {
+        if let Some(canister_timeout) = canister_id_store.get_timestamp(canister_info.get_name()) {
+            // playground installed the code, so playground has to authorize call_sender to upload files
+            let uploader_principal = env
+                .get_selected_identity_principal()
+                .context("Failed to figure out selected identity's principal.")?;
+            authorize_asset_uploader(
+                env,
+                canister_info.get_canister_id()?,
+                canister_timeout,
+                &uploader_principal,
+            )
+            .await?;
+        }
+        if let CallSender::Wallet(wallet_id) = call_sender {
+            let wallet = build_wallet_canister(*wallet_id, agent).await?;
+            let identity_name = env.get_selected_identity().expect("No selected identity.");
+            info!(
+                log,
+                "Authorizing our identity ({}) to the asset canister...", identity_name
+            );
+            let self_id = env
+                .get_selected_identity_principal()
+                .expect("Selected identity not instantiated.");
+            // Before storing assets, make sure the DFX principal is in there first.
+            wallet
                 .call(
                     canister_id,
                     "authorize",
@@ -225,21 +202,20 @@ pub async fn install_canister(
                 .call_and_wait()
                 .await
                 .context("Failed to authorize your principal with the canister. You can still control the canister by using your wallet with the --wallet flag.")?;
-            };
+        };
 
-            info!(log, "Uploading assets to asset canister...");
-            post_install_store_assets(canister_info, agent, log).await?;
-        }
-        if !canister_info.get_post_install().is_empty() {
-            let config = env.get_config();
-            run_post_install_tasks(
-                env,
-                canister_info,
-                network,
-                pool,
-                env_file.or_else(|| config.as_ref()?.get_config().output_env_file.as_deref()),
-            )?;
-        }
+        info!(log, "Uploading assets to asset canister...");
+        post_install_store_assets(canister_info, agent, log).await?;
+    }
+    if !canister_info.get_post_install().is_empty() {
+        let config = env.get_config();
+        run_post_install_tasks(
+            env,
+            canister_info,
+            network,
+            pool,
+            env_file.or_else(|| config.as_ref()?.get_config().output_env_file.as_deref()),
+        )?;
     }
 
     Ok(())

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -113,8 +113,7 @@ pub async fn install_canister(
         }
         build_wasm_path
     };
-    let wasm_module = std::fs::read(&wasm_path)
-        .with_context(|| format!("Failed to read {}.", &wasm_path.display()))?;
+    let wasm_module = dfx_core::fs::read(&wasm_path)?;
     let new_hash = Sha256::digest(&wasm_module);
     debug!(log, "New wasm module hash: {}", hex::encode(new_hash));
 


### PR DESCRIPTION
# Description

Notable changes:
* `dfx canister install <CANISTER_ID>` will use `install_canister_wasm()` directly which reduce a lot of conditional logic inside `install_canister()`;
* `install_canister()` takes `argument_from_cli` and `argument_type`, then assembles the install_arg blob inside
  * No need to pass argument using closure;
  * This is a preparatory refactor for SDK-1348. I plan to add the logic of loading init_arg in `dfx.json` around this part of code;

Also some DRY change is included.

# How Has This Been Tested?

existing e2e

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
