### PR TITLE
feat: allow dfxvm install script to bypass confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ ic-wasm canister.wasm -o canister.wasm metadata candid:service -f service.did -v
 
 Please use the [dfx version manager](https://github.com/dfinity/dfxvm) instead.
 
+### feat: allow dfxvm install script to bypass confirmation
+
+The dfxvm install script now accepts `DFXVM_INIT_YES=<non empty string>` to skip confirmation.
+
 ### chore: bump `ic-agent`, `ic-utils` and `ic-identity-hsm` to 0.32.0
 
 

--- a/public/install-dfxvm.sh
+++ b/public/install-dfxvm.sh
@@ -378,6 +378,7 @@ get_strong_ciphersuites_for() {
 
 DFXVM_GITHUB_LATEST_RELEASE_ROOT="${DFXVM_GITHUB_LATEST_RELEASE_ROOT:-https://github.com/dfinity/dfxvm/releases/latest/download}"
 DFX_VERSION="${DFX_VERSION-}"
+DFXVM_INIT_YES="${DFXVM_INIT_YES-}"
 
 # The SHA and the time of the last commit that touched this file.
 SCRIPT_COMMIT_DESC="@revision@"
@@ -406,11 +407,17 @@ download_and_install() {
     ensure chmod u+x dfxvm
     ensure mv dfxvm dfxvm-init
 
+    command="./dfxvm-init"
+
     if [ -n "${DFX_VERSION}" ]; then
-        ./dfxvm-init --dfx-version "${DFX_VERSION}"
-    else
-        ./dfxvm-init
+        command="${command} --dfx-version \"${DFX_VERSION}\""
     fi
+
+    if [ -n "${DFXVM_INIT_YES}" ]; then
+        command="${command} --yes"
+    fi
+
+    eval "${command}"
 }
 
 main() {


### PR DESCRIPTION
# Description

pass --yes to dfxvm-init if DFXVM_INIT_YES is set

This will allow https://github.com/dfinity/setup-dfx to work with dfxvm.

Fixes https://dfinity.atlassian.net/browse/SDK-1363

# How Has This Been Tested?

Tested here: https://github.com/dfinity/setup-dfx/actions/runs/7833821371/job/21375693716

Also tested locally, for example
```
DFX_VERSION=0.0.1 DFXVM_INIT_YES= sh -ci "$(cat public/install-dfxvm.sh)"
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
