### PR TITLE
chore: Update agent-rs to 0.33.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,8 +2448,7 @@ dependencies = [
 [[package]]
 name = "ic-agent"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410a8c1bdd647dfc43978497e8f794378a18eeb3ec7c768b92c3885c999e1d1b"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=82dda155d22c9fafe032ac2cf66cffb6a76e97c1#82dda155d22c9fafe032ac2cf66cffb6a76e97c1"
 dependencies = [
  "backoff",
  "cached 0.46.1",
@@ -2464,6 +2463,7 @@ dependencies = [
  "ic-verify-bls-signature",
  "k256 0.13.3",
  "leb128",
+ "p256",
  "pem 2.0.1",
  "pkcs8 0.10.2",
  "rand",
@@ -2885,8 +2885,7 @@ dependencies = [
 [[package]]
 name = "ic-identity-hsm"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478f1fb56cdda5959ac4a685dbe74c56f25226212defb34ab5cf136f4b919344"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=82dda155d22c9fafe032ac2cf66cffb6a76e97c1#82dda155d22c9fafe032ac2cf66cffb6a76e97c1"
 dependencies = [
  "hex",
  "ic-agent",
@@ -2986,8 +2985,7 @@ dependencies = [
 [[package]]
 name = "ic-transport-types"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb030f03ef8332fbf8eda6bb25e80d8354d2bef88b27e671b3c167d9ee8e7a7"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=82dda155d22c9fafe032ac2cf66cffb6a76e97c1#82dda155d22c9fafe032ac2cf66cffb6a76e97c1"
 dependencies = [
  "candid",
  "hex",
@@ -3056,8 +3054,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2921308283f89a431872ba63f5ece9ffe6eadf7bc4cc5d12239eae146c7db8f0"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=82dda155d22c9fafe032ac2cf66cffb6a76e97c1#82dda155d22c9fafe032ac2cf66cffb6a76e97c1"
 dependencies = [
  "async-trait",
  "candid",
@@ -3933,6 +3930,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "pairing"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4296,6 +4305,15 @@ checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,7 +1461,7 @@ dependencies = [
  "ic-asset",
  "ic-cdk",
  "ic-identity-hsm",
- "ic-utils 0.32.0",
+ "ic-utils 0.33.0",
  "ic-wasm",
  "icrc-ledger-types",
  "indicatif",
@@ -1532,7 +1532,7 @@ dependencies = [
  "humantime-serde",
  "ic-agent",
  "ic-identity-hsm",
- "ic-utils 0.32.0",
+ "ic-utils 0.33.0",
  "k256 0.11.6",
  "keyring",
  "lazy_static",
@@ -2447,8 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.32.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=82dda155d22c9fafe032ac2cf66cffb6a76e97c1#82dda155d22c9fafe032ac2cf66cffb6a76e97c1"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f32c4711ca94eee9b7966116698b69ca99e7e24cba68c1f3dd86f2ed70218a7e"
 dependencies = [
  "backoff",
  "cached 0.46.1",
@@ -2498,7 +2499,7 @@ dependencies = [
  "globset",
  "hex",
  "ic-agent",
- "ic-utils 0.32.0",
+ "ic-utils 0.33.0",
  "itertools 0.10.5",
  "json5",
  "mime",
@@ -2884,8 +2885,9 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.32.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=82dda155d22c9fafe032ac2cf66cffb6a76e97c1#82dda155d22c9fafe032ac2cf66cffb6a76e97c1"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d363914507e81896a6edd1768aa2524bd923b94ed4c27a9793a90b0880f741"
 dependencies = [
  "hex",
  "ic-agent",
@@ -2984,8 +2986,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.32.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=82dda155d22c9fafe032ac2cf66cffb6a76e97c1#82dda155d22c9fafe032ac2cf66cffb6a76e97c1"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d595b9f72e5952bcb22e5cda37ae1c8d6579a24aaa224b63b8d245f386bdcbb2"
 dependencies = [
  "candid",
  "hex",
@@ -3053,8 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.32.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=82dda155d22c9fafe032ac2cf66cffb6a76e97c1#82dda155d22c9fafe032ac2cf66cffb6a76e97c1"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e26bd17f2f188a608deae41b8c269a85e1e98118c9a7aa0803ad252552c0b2"
 dependencies = [
  "async-trait",
  "candid",
@@ -3165,7 +3169,7 @@ dependencies = [
  "humantime",
  "ic-agent",
  "ic-asset",
- "ic-utils 0.32.0",
+ "ic-utils 0.33.0",
  "libflate",
  "num-traits",
  "pem 1.1.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ license = "Apache-2.0"
 [workspace.dependencies]
 candid = "0.10.3"
 candid_parser = "0.1.3"
-ic-agent = { git = "https://github.com/dfinity/agent-rs.git", rev = "82dda155d22c9fafe032ac2cf66cffb6a76e97c1" }
+ic-agent = "0.33.0"
 ic-asset = { path = "src/canisters/frontend/ic-asset" }
 ic-cdk = "0.12.0"
-ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs.git", rev = "82dda155d22c9fafe032ac2cf66cffb6a76e97c1" }
-ic-utils = { git = "https://github.com/dfinity/agent-rs.git", rev = "82dda155d22c9fafe032ac2cf66cffb6a76e97c1" }
+ic-identity-hsm = "0.33.0"
+ic-utils = "0.33.0"
 
 aes-gcm = "0.10.3"
 anyhow = "1.0.56"
@@ -50,7 +50,9 @@ mime_guess = "2.0.4"
 num-traits = "0.2.14"
 pem = "1.0.2"
 proptest = "1.0.0"
-reqwest = { version = "0.11.23", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.23", default-features = false, features = [
+    "rustls-tls",
+] }
 ring = "0.16.11"
 schemars = "0.8"
 sec1 = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ license = "Apache-2.0"
 [workspace.dependencies]
 candid = "0.10.3"
 candid_parser = "0.1.3"
-ic-agent = "0.32.0"
+ic-agent = { git = "https://github.com/dfinity/agent-rs.git", rev = "82dda155d22c9fafe032ac2cf66cffb6a76e97c1" }
 ic-asset = { path = "src/canisters/frontend/ic-asset" }
 ic-cdk = "0.12.0"
-ic-identity-hsm = "0.32.0"
-ic-utils = "0.32.0"
+ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs.git", rev = "82dda155d22c9fafe032ac2cf66cffb6a76e97c1" }
+ic-utils = { git = "https://github.com/dfinity/agent-rs.git", rev = "82dda155d22c9fafe032ac2cf66cffb6a76e97c1" }
 
 aes-gcm = "0.10.3"
 anyhow = "1.0.56"


### PR DESCRIPTION
This includes the compatibility change to the chunked wasm API in dfinity/agent-rs#512