### PR TITLE
test: filter some workflows based on paths

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,8 +45,8 @@ jobs:
               - Cargo.toml
               - rust-toolchain.toml
   build_dfx:
-    needs: changes
     if: needs.changes.outputs.sources == 'true'
+    needs: changes
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -101,8 +101,8 @@ jobs:
           path: ${{ matrix.binary_path }}/dfx
 
   list_tests:
-    needs: changes
     if: needs.changes.outputs.sources == 'true'
+    needs: changes
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -112,8 +112,8 @@ jobs:
         run: echo "matrix=$(scripts/workflows/e2e-matrix.py)" >> $GITHUB_OUTPUT
 
   smoke:
-    if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
+    if: needs.changes.outputs.sources == 'true'
     needs: [changes, build_dfx]
     strategy:
       fail-fast: false
@@ -149,8 +149,8 @@ jobs:
           time dfx stop
 
   test:
-    if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
+    if: needs.changes.outputs.sources == 'true'
     needs: [changes, build_dfx, list_tests]
     strategy:
       fail-fast: false
@@ -190,8 +190,8 @@ jobs:
         run: timeout 2400 bats "e2e/$E2E_TEST"
 
   ui_test:
-    if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
+    if: needs.changes.outputs.sources == 'true'
     needs: [changes, build_dfx]
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -239,7 +239,7 @@ jobs:
 
   aggregate:
     name: e2e:required
-    if: ${{ always() }}
+    if: needs.changes.outputs.sources == 'true'
     needs: [changes, test, smoke, ui_test]
     runs-on: ubuntu-latest
     steps:
@@ -250,11 +250,11 @@ jobs:
           echo "ui_test result: ${{ needs.ui_test.result }}"
           echo "test result: ${{ needs.test.result }}"
       - name: check smoke test result
-        if: ${{ needs.smoke.result != 'skipped' && needs.smoke.result != 'success' }}
+        if: ${{ needs.smoke.result != 'success' }}
         run: exit 1
       - name: check UI test result
-        if: ${{ needs.smoke.result != 'skipped'  && needs.ui_test.result != 'success' }}
+        if: ${{ needs.ui_test.result != 'success' }}
         run: exit 1
       - name: check e2e test result
-        if: ${{ needs.smoke.result != 'skipped'  && needs.test.result != 'success' }}
+        if: ${{ needs.test.result != 'success' }}
         run: exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           filters: |
             sources:
-              - .github/workflows/e2e.yaml
+              - .github/workflows/e2e.yml
               - e2e/**
               - scripts/workflows/e2e-matrix.py
               - scripts/workflows/provision-darwin.sh
@@ -42,7 +42,7 @@ jobs:
               - src/distributed/**
               - src/lib/**
               - Cargo.lock
-              - Cargo.tml
+              - Cargo.toml
               - rust-toolchain.toml
   build_dfx:
     needs: changes

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -242,11 +242,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check smoke test result
-        if: ${{ needs.smoke.result != 'success' }}
+        if: ${{ needs.changes.outputs.sources != 'true' && needs.smoke.result != 'success' }}
         run: exit 1
       - name: check UI test result
-        if: ${{ needs.ui_test.result != 'success' }}
+        if: ${{ needs.changes.outputs.sources != 'true' && needs.ui_test.result != 'success' }}
         run: exit 1
       - name: check e2e test result
-        if: ${{ needs.test.result != 'success' }}
+        if: ${{ needs.changes.outputs.sources != 'true' && needs.test.result != 'success' }}
         run: exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -243,6 +243,12 @@ jobs:
     needs: [changes, test, smoke, ui_test]
     runs-on: ubuntu-latest
     steps:
+      - name: debug
+        run: |
+          echo "needs.changes.outputs.sources: ${{ needs.changes.outputs.sources }}"
+          echo "smoke result: ${{ needs.smoke.result }}"
+          echo "ui_test result: ${{ needs.ui_test.result }}"
+          echo "test result: ${{ needs.test.result }}"
       - name: check smoke test result
         if: ${{ needs.changes.outputs.sources != 'true' && needs.smoke.result != 'success' }}
         run: exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,7 @@ jobs:
               - Cargo.tml
               - rust-toolchain.toml
   build_dfx:
+    needs: changes
     if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
@@ -100,6 +101,7 @@ jobs:
           path: ${{ matrix.binary_path }}/dfx
 
   list_tests:
+    needs: changes
     if: needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-latest
     outputs:
@@ -112,7 +114,7 @@ jobs:
   smoke:
     if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
-    needs: build_dfx
+    needs: [changes, build_dfx]
     strategy:
       fail-fast: false
       matrix:
@@ -149,7 +151,7 @@ jobs:
   test:
     if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
-    needs: [build_dfx, list_tests]
+    needs: [changes, build_dfx, list_tests]
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.list_tests.outputs.matrix)}}
@@ -190,7 +192,7 @@ jobs:
   ui_test:
     if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
-    needs: [build_dfx]
+    needs: [changes, build_dfx]
     strategy:
       fail-fast: false
       matrix:
@@ -238,7 +240,7 @@ jobs:
   aggregate:
     name: e2e:required
     if: ${{ always() }}
-    needs: [test, smoke, ui_test]
+    needs: [changes, test, smoke, ui_test]
     runs-on: ubuntu-latest
     steps:
       - name: check smoke test result

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -250,11 +250,11 @@ jobs:
           echo "ui_test result: ${{ needs.ui_test.result }}"
           echo "test result: ${{ needs.test.result }}"
       - name: check smoke test result
-        if: ${{ needs.changes.outputs.sources != 'true' && needs.smoke.result != 'success' }}
+        if: ${{ needs.smoke.result != 'skipped' && needs.smoke.result != 'success' }}
         run: exit 1
       - name: check UI test result
-        if: ${{ needs.changes.outputs.sources != 'true' && needs.ui_test.result != 'success' }}
+        if: ${{ needs.smoke.result != 'skipped'  && needs.ui_test.result != 'success' }}
         run: exit 1
       - name: check e2e test result
-        if: ${{ needs.changes.outputs.sources != 'true' && needs.test.result != 'success' }}
+        if: ${{ needs.smoke.result != 'skipped'  && needs.test.result != 'success' }}
         run: exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           filters: |
             sources:
-              - .github/workflows/e2e.sh
+              - .github/workflows/e2e.yaml
               - e2e/**
               - scripts/workflows/e2e-matrix.py
               - scripts/workflows/provision-darwin.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,36 @@ env:
   CURL_HOME: .
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      sources: ${{ steps.filter.outputs.sources }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            sources:
+              - .github/workflows/e2e.sh
+              - e2e/**
+              - scripts/workflows/e2e-matrix.py
+              - scripts/workflows/provision-darwin.sh
+              - scripts/workflows/provision-linux.sh
+              - scripts/test-uis.py
+              - src/canisters/frontend/**
+              - src/dfx/**
+              - src/dfx-core/**
+              - src/distributed/**
+              - src/lib/**
+              - Cargo.lock
+              - Cargo.tml
+              - rust-toolchain.toml
   build_dfx:
+    if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -71,6 +100,7 @@ jobs:
           path: ${{ matrix.binary_path }}/dfx
 
   list_tests:
+    if: needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -80,6 +110,7 @@ jobs:
         run: echo "matrix=$(scripts/workflows/e2e-matrix.py)" >> $GITHUB_OUTPUT
 
   smoke:
+    if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
     needs: build_dfx
     strategy:
@@ -116,6 +147,7 @@ jobs:
           time dfx stop
 
   test:
+    if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
     needs: [build_dfx, list_tests]
     strategy:
@@ -156,6 +188,7 @@ jobs:
         run: timeout 2400 bats "e2e/$E2E_TEST"
 
   ui_test:
+    if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
     needs: [build_dfx]
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -243,12 +243,6 @@ jobs:
     needs: [changes, test, smoke, ui_test]
     runs-on: ubuntu-latest
     steps:
-      - name: debug
-        run: |
-          echo "needs.changes.outputs.sources: ${{ needs.changes.outputs.sources }}"
-          echo "smoke result: ${{ needs.smoke.result }}"
-          echo "ui_test result: ${{ needs.ui_test.result }}"
-          echo "test result: ${{ needs.test.result }}"
       - name: check smoke test result
         if: ${{ needs.smoke.result != 'success' }}
         run: exit 1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -35,8 +35,8 @@ jobs:
 
   test:
     name: fmt
-    needs: changes
     if: needs.changes.outputs.sources == 'true'
+    needs: changes
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -62,8 +62,8 @@ jobs:
 
   aggregate:
     name: fmt:required
-    needs: [changes, test]
     if: needs.changes.outputs.sources == 'true'
+    needs: [changes, test]
     runs-on: ubuntu-latest
     steps:
       - name: check step result directly

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -13,8 +13,30 @@ env:
   CURL_HOME: .
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      sources: ${{ steps.filter.outputs.sources }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            sources:
+              - .github/workflows/lint.yml
+              - src/**
+              - Cargo.lock
+              - Cargo.toml
+              - rust-toolchain.toml
+
   test:
     name: fmt
+    needs: changes
+    if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -40,8 +62,8 @@ jobs:
 
   aggregate:
     name: fmt:required
-    if: ${{ always() }}
-    needs: test
+    needs: [changes, test]
+    if: needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: check step result directly

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           filters: |
             sources:
-              - .github/workflows/lint.yml
+              - .github/workflows/fmt.yml
               - src/**
               - Cargo.lock
               - Cargo.toml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,30 @@ env:
   CURL_HOME: .
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      sources: ${{ steps.filter.outputs.sources }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            sources:
+              - .github/workflows/lint.yml
+              - src/**
+              - Cargo.lock
+              - Cargo.toml
+              - rust-toolchain.toml
+
   test:
     name: lint
+    needs: changes
+    if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -40,8 +62,8 @@ jobs:
 
   aggregate:
     name: lint:required
-    if: ${{ always() }}
-    needs: test
+    needs: [changes, test]
+    if: needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: check step result directly

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,8 +35,8 @@ jobs:
 
   test:
     name: lint
-    needs: changes
     if: needs.changes.outputs.sources == 'true'
+    needs: changes
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -62,8 +62,8 @@ jobs:
 
   aggregate:
     name: lint:required
-    needs: [changes, test]
     if: needs.changes.outputs.sources == 'true'
+    needs: [changes, test]
     runs-on: ubuntu-latest
     steps:
       - name: check step result directly

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -60,7 +60,7 @@ jobs:
 
   aggregate:
     name: unit:required
-    if: ${{ always() }}
+    if: needs.changes.outputs.sources == 'true'
     needs: [changes, test]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -37,8 +37,8 @@ jobs:
               - rust-toolchain.toml
 
   test:
-    needs: changes
     if: needs.changes.outputs.sources == 'true'
+    needs: changes
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -16,7 +16,29 @@ env:
   CURL_HOME: .
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      sources: ${{ steps.filter.outputs.sources }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            sources:
+              - .github/workflows/unit.yml
+              - src/**
+              - Cargo.lock
+              - Cargo.toml
+              - rust-toolchain.toml
+
   test:
+    needs: changes
+    if: needs.changes.outputs.sources == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -39,7 +61,7 @@ jobs:
   aggregate:
     name: unit:required
     if: ${{ always() }}
-    needs: test
+    needs: [changes, test]
     runs-on: ubuntu-latest
     steps:
       - name: check unit test result


### PR DESCRIPTION
# Description

Use dorny/paths-filter to only run e2e tests and a few other workflows when related sources change.

This will allow us to update docs without having to wait for long test workflows.

# How Has This Been Tested?

Tested by the workflows on this PR, and by opening https://github.com/dfinity/sdk/pull/3590 to this branch.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
