### PR TITLE
fix: curl access to /api/v2/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,14 @@ The dfxvm install script now accepts `DFXVM_INIT_YES=<non empty string>` to skip
 
 ### chore: bump `ic-agent`, `ic-utils` and `ic-identity-hsm` to 0.32.0
 
+### fix: restored access to URLs like http://localhost:8080/api/v2/status through icx-proxy
+
+Pinned icx-proxy at 69e1408347723dbaa7a6cd2faa9b65c42abbe861, shipped with dfx 0.15.2
+
+This means commands like the following will work again:
+```
+curl -v --http2-prior-knowledge "http://localhost:$(dfx info webserver-port)/api/v2/status" --output -
+```
 
 # 0.16.1
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -111,18 +111,18 @@
     },
     "icx-proxy-x86_64-darwin": {
         "builtin": false,
-        "rev": "044cfd5147fc97d7e5a214966941b6580c325d72",
-        "sha256": "0x0b73khf9a7kjbilyp30hdhv1iyjxl1qzkdfgippn9wiszkzs6p",
+        "rev": "69e1408347723dbaa7a6cd2faa9b65c42abbe861",
+        "sha256": "1p9gmlz85j514s6da189hwaghg18p62pbknkn3q59jyxmf22fzxh",
         "type": "file",
-        "url": "https://download.dfinity.systems/ic/044cfd5147fc97d7e5a214966941b6580c325d72/binaries/x86_64-darwin/icx-proxy-dev.gz",
+        "url": "https://download.dfinity.systems/ic/69e1408347723dbaa7a6cd2faa9b65c42abbe861/binaries/x86_64-darwin/icx-proxy-dev.gz",
         "url_template": "https://download.dfinity.systems/ic/<rev>/binaries/x86_64-darwin/icx-proxy-dev.gz"
     },
     "icx-proxy-x86_64-linux": {
         "builtin": false,
-        "rev": "044cfd5147fc97d7e5a214966941b6580c325d72",
+        "rev": "69e1408347723dbaa7a6cd2faa9b65c42abbe861",
         "sha256": "1r73b5far02qwjy4dl7p7bxdgnawzmbv60r8g6280zfk2s52m0n2",
         "type": "file",
-        "url": "https://download.dfinity.systems/ic/044cfd5147fc97d7e5a214966941b6580c325d72/binaries/x86_64-linux/icx-proxy-dev.gz",
+        "url": "https://download.dfinity.systems/ic/105jm3px6ky88jc86am8dkxz1vnhzcxy0p7skzs98baylr96kzrb/binaries/x86_64-linux/icx-proxy-dev.gz",
         "url_template": "https://download.dfinity.systems/ic/<rev>/binaries/x86_64-linux/icx-proxy-dev.gz"
     },
     "motoko-base": {

--- a/scripts/update-replica.sh
+++ b/scripts/update-replica.sh
@@ -20,8 +20,11 @@ niv update ic-nns-init-x86_64-darwin -a rev=$SHA
 niv update ic-nns-init-x86_64-linux -a rev=$SHA
 niv update ic-starter-x86_64-darwin -a rev=$SHA
 niv update ic-starter-x86_64-linux -a rev=$SHA
-niv update icx-proxy-x86_64-darwin -a rev=$SHA
-niv update icx-proxy-x86_64-linux -a rev=$SHA
+
+# icx-proxy is pinned at 69e1408347723dbaa7a6cd2faa9b65c42abbe861
+# niv update icx-proxy-x86_64-darwin -a rev=$SHA
+# niv update icx-proxy-x86_64-linux -a rev=$SHA
+
 niv update replica-x86_64-darwin -a rev=$SHA
 niv update replica-x86_64-linux -a rev=$SHA
 niv update canister_sandbox-x86_64-darwin -a rev=$SHA

--- a/src/dfx/assets/dfx-asset-sources.toml
+++ b/src/dfx/assets/dfx-asset-sources.toml
@@ -2,8 +2,8 @@
 replica-rev = '044cfd5147fc97d7e5a214966941b6580c325d72'
 
 [x86_64-darwin.icx-proxy]
-url = 'https://download.dfinity.systems/ic/044cfd5147fc97d7e5a214966941b6580c325d72/binaries/x86_64-darwin/icx-proxy-dev.gz'
-sha256 = 'd7e83fbf8e3cd97be3736d7e1c68973e860d1b04e37a1a979c472507e7380b74'
+url = 'https://download.dfinity.systems/ic/69e1408347723dbaa7a6cd2faa9b65c42abbe861/binaries/x86_64-darwin/icx-proxy-dev.gz'
+sha256 = 'b07f2784abddcb54f0b0d3ce7585b9283cf814870905d58c26a1c8823ead2fdd'
 
 [x86_64-darwin.ic-admin]
 url = 'https://download.dfinity.systems/ic/044cfd5147fc97d7e5a214966941b6580c325d72/binaries/x86_64-darwin/ic-admin.gz'
@@ -56,8 +56,8 @@ url = 'https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2
 sha256 = '09f5647a45ff6d5d05b2b0ed48613fb2365b5fe6573ba0e901509c39fb9564ac'
 
 [x86_64-linux.icx-proxy]
-url = 'https://download.dfinity.systems/ic/044cfd5147fc97d7e5a214966941b6580c325d72/binaries/x86_64-linux/icx-proxy-dev.gz'
-sha256 = 'c2822a8a16d37d8084792803b357fd5cd9d7fa3af7d046bce45880ac5c59e3e4'
+url = 'https://download.dfinity.systems/ic/69e1408347723dbaa7a6cd2faa9b65c42abbe861/binaries/x86_64-linux/icx-proxy-dev.gz'
+sha256 = '2bff6952a65e2d94f49ffa5ce03bfbd0eef0fb6ca82a839844c84fd3efa8b280'
 
 [x86_64-linux.ic-admin]
 url = 'https://download.dfinity.systems/ic/044cfd5147fc97d7e5a214966941b6580c325d72/binaries/x86_64-linux/ic-admin.gz'


### PR DESCRIPTION
# Description

It's been reported that commands like the following don't work as of dfx 0.16.0

```
curl -v --http2-prior-knowledge http://localhost:8080/api/v2/status
```

This behavior isn't tested or officially supported by the sdk, but older versions of icx-proxy supported it, so we're pinning icx-proxy at an earlier version for now.


# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
