### PR TITLE
refactor: extension run logic out of main

### DIFF
--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -2,6 +2,7 @@
 use crate::config::{dfx_version, dfx_version_str};
 use crate::lib::diagnosis::{diagnose, Diagnosis, NULL_DIAGNOSIS};
 use crate::lib::environment::{Environment, EnvironmentImpl};
+use crate::lib::error::DfxResult;
 use crate::lib::logger::{create_root_logger, LoggingMode};
 use crate::lib::warning::{is_warning_disabled, DfxWarning::VersionCheck};
 use anyhow::Error;
@@ -160,31 +161,33 @@ fn print_error_and_diagnosis(err: Error, error_diagnosis: Diagnosis) {
     }
 }
 
-fn main() {
+fn get_args_altered_for_extension_run() -> DfxResult<Vec<OsString>> {
     let mut args = std::env::args_os().collect::<Vec<OsString>>();
-    let mut error_diagnosis: Diagnosis = NULL_DIAGNOSIS;
+    let em = ExtensionManager::new(dfx_version())?;
 
-    ExtensionManager::new(dfx_version())
-        .and_then(|em| {
-            let installed_extensions = em.installed_extensions_as_clap_commands()?;
-            if !installed_extensions.is_empty() {
-                let mut app = CliOpts::command_for_update().subcommands(&installed_extensions);
-                sort_clap_commands(&mut app);
-                // here clap will display the help message if no subcommand was provided...
-                let app = app.get_matches();
-                // ...therefore we can safely unwrap here because we know a subcommand was provided
-                let subcmd = app.subcommand().unwrap().0;
-                if em.is_extension_installed(subcmd) {
-                    let idx = args.iter().position(|arg| arg == subcmd).unwrap();
-                    args.splice(idx..idx, ["extension", "run"].iter().map(OsString::from));
-                }
-            }
-            Ok(())
-        })
-        .unwrap_or_else(|err| {
-            print_error_and_diagnosis(err.into(), error_diagnosis.clone());
-            std::process::exit(255);
-        });
+    let installed_extensions = em.installed_extensions_as_clap_commands()?;
+    if !installed_extensions.is_empty() {
+        let mut app = CliOpts::command_for_update().subcommands(&installed_extensions);
+        sort_clap_commands(&mut app);
+        // here clap will display the help message if no subcommand was provided...
+        let app = app.get_matches();
+        // ...therefore we can safely unwrap here because we know a subcommand was provided
+        let subcmd = app.subcommand().unwrap().0;
+        if em.is_extension_installed(subcmd) {
+            let idx = args.iter().position(|arg| arg == subcmd).unwrap();
+            args.splice(idx..idx, ["extension", "run"].iter().map(OsString::from));
+        }
+    }
+    Ok(args)
+}
+
+fn main() {
+    let args = get_args_altered_for_extension_run().unwrap_or_else(|err| {
+        print_error_and_diagnosis(err, NULL_DIAGNOSIS);
+        std::process::exit(255);
+    });
+
+    let mut error_diagnosis: Diagnosis = NULL_DIAGNOSIS;
 
     let cli_opts = CliOpts::parse_from(args);
     let (verbose_level, log) = setup_logging(&cli_opts);


### PR DESCRIPTION
# Description

Moved the logic that injects "extension run" into the arguments into its own function.

In part this is so that `ExtensionManager::new()` and `ExtensionManager:: installed_extensions_as_clap_commands()` can return different error types, which is more complicated if one is being called in a `.and_then()` closure.

# How Has This Been Tested?

Covered by CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
