### PR TITLE
fix: no more disappearing canister ids from .env files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # UNRELEASED
 
+### fix: .env files sometimes missing some canister ids
+
+Made it so `dfx deploy` and `dfx canister install` will always write canister ids for
+all canisters in the project to the .env file, even if they aren't being deployed/installed or
+a dependency of a canister being deployed/installed.
+
 ### feat: unify CLI options to specify arguments
 
 There are a few subcommands that take `--argument`/`--argument-file` options to set canister call/init arguments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### fix: .env files sometimes missing some canister ids
 
-Made it so `dfx deploy` and `dfx canister install` will always write canister ids for
-all canisters in the project to the .env file, even if they aren't being deployed/installed or
-a dependency of a canister being deployed/installed.
+Made it so `dfx deploy` and `dfx canister install` will always write 
+environment variables for all canisters in the project that have canister ids
+to the .env file, even if they aren't being deployed/installed
+or a dependency of a canister being deployed/installed.
 
 ### feat: unify CLI options to specify arguments
 

--- a/e2e/tests-dfx/build.bash
+++ b/e2e/tests-dfx/build.bash
@@ -96,6 +96,14 @@ teardown() {
   assert_match "syntax error"
 }
 
+@test "build --check fails on invalid motoko" {
+  install_asset invalid
+  dfx_start
+  # --check does not need create --all
+  assert_command_fail dfx build --check
+  assert_match "syntax error"
+}
+
 @test "build supports relative imports" {
   install_asset import
   dfx_start

--- a/e2e/tests-dfx/build.bash
+++ b/e2e/tests-dfx/build.bash
@@ -61,8 +61,6 @@ teardown() {
 
 @test "build uses default build args" {
   install_asset default_args
-  dfx_start
-  dfx canister create --all
   assert_command_fail dfx build --check
   assert_match "unknown option"
   assert_match "compacting-gcX"
@@ -70,8 +68,6 @@ teardown() {
 
 @test "build uses canister build args" {
   install_asset canister_args
-  dfx_start
-  dfx canister create --all
   assert_command_fail dfx build --check
   assert_match "unknown option"
   assert_match "compacting-gcY"
@@ -80,8 +76,6 @@ teardown() {
 
 @test "empty canister build args don't shadow default" {
   install_asset empty_canister_args
-  dfx_start
-  dfx canister create --all
   assert_command_fail dfx build --check
   assert_match '"--error-detail" "5"'
   assert_match "unknown option"
@@ -96,10 +90,16 @@ teardown() {
   assert_match "syntax error"
 }
 
-@test "build --check fails on invalid motoko" {
+@test "build --check fails on build error when there are no canister ids" {
   install_asset invalid
+  assert_command_fail dfx build --check
+  assert_match "syntax error"
+}
+
+@test "build --check fails on build error when there are canister ids" {
   dfx_start
-  # --check does not need create --all
+  dfx canister create --all
+  install_asset invalid
   assert_command_fail dfx build --check
   assert_match "syntax error"
 }

--- a/e2e/tests-dfx/dotenv.bash
+++ b/e2e/tests-dfx/dotenv.bash
@@ -55,14 +55,14 @@ teardown() {
   dfx_start
   dfx canister create --all
 
-  writes_all_environment_variables_to_env build
+  assert_dotenv_contains_all_variables_after_command build
 }
 
 @test "deploy writes all environment variables to .env" {
   dfx_start
   dfx canister create --all
 
-  writes_all_environment_variables_to_env deploy
+  assert_dotenv_contains_all_variables_after_command deploy
 }
 
 @test "canister install writes all environment variables to .env" {
@@ -72,10 +72,10 @@ teardown() {
   # set a post-install script so the install will create a .env file
   jq '.canisters.e2e_project_frontend.post_install="echo post install"' dfx.json | sponge dfx.json
 
-  writes_all_environment_variables_to_env canister install
+  assert_dotenv_contains_all_variables_after_command canister install
 }
 
-writes_all_environment_variables_to_env() {
+assert_dotenv_contains_all_variables_after_command() {
   install_asset wasm/identity
   jq '.canisters."nns-cycles-minting".remote.id.local="rkp4c-7iaaa-aaaaa-aaaca-cai"' dfx.json | sponge dfx.json
   jq '.canisters."nns-cycles-minting".type="custom"' dfx.json | sponge dfx.json

--- a/e2e/tests-dfx/dotenv.bash
+++ b/e2e/tests-dfx/dotenv.bash
@@ -51,8 +51,18 @@ teardown() {
   assert_match "The output_env_file must be within the project root, but is .*/working-dir/e2e_project/../outside/.env"
 }
 
-@test "writes environment variables to .env" {
+@test "build writes all environment variables to .env" {
+  install_asset wasm/identity
   dfx_start
+  jq '.canisters."nns-cycles-minting".remote.id.local="rkp4c-7iaaa-aaaaa-aaaca-cai"' dfx.json | sponge dfx.json
+  jq '.canisters."nns-cycles-minting".type="custom"' dfx.json | sponge dfx.json
+  jq '.canisters."nns-cycles-minting".candid="main.did"' dfx.json | sponge dfx.json
+  jq '.canisters."nns-cycles-minting".wasm="main.wasm"' dfx.json | sponge dfx.json
+  jq '.canisters.lifeline.type="pull"' dfx.json | sponge dfx.json
+  jq '.canisters.lifeline.id="rno2w-sqaaa-aaaaa-aaacq-cai"' dfx.json | sponge dfx.json
+  mkdir -p deps/candid
+  echo "service: {}" >deps/candid/rno2w-sqaaa-aaaaa-aaacq-cai.did
+
   dfx canister create --all
   # .env should also include canisters that are not explicit dependencies
   jq 'del(.canisters.e2e_project_frontend.dependencies)' dfx.json  | sponge dfx.json
@@ -68,6 +78,10 @@ teardown() {
   assert_contains "E2E_PROJECT_BACKEND_CANISTER_ID='$backend_canister'" "$env"
   assert_contains "CANISTER_ID_E2E_PROJECT_FRONTEND='$frontend_canister'" "$env"
   assert_contains "E2E_PROJECT_FRONTEND_CANISTER_ID='$frontend_canister'" "$env"
+  assert_contains "CANISTER_ID_NNS_CYCLES_MINTING='rkp4c-7iaaa-aaaaa-aaaca-cai'" "$env"
+  assert_contains "NNS_CYCLES_MINTING_CANISTER_ID='rkp4c-7iaaa-aaaaa-aaaca-cai'" "$env"
+  assert_contains "CANISTER_ID_LIFELINE='rno2w-sqaaa-aaaaa-aaacq-cai'" "$env"
+  assert_contains "LIFELINE_CANISTER_ID='rno2w-sqaaa-aaaaa-aaacq-cai'" "$env"
 
   setup_actuallylocal_project_network
   dfx canister create --all --network actuallylocal
@@ -76,8 +90,17 @@ teardown() {
 }
 
 @test "deploy writes all environment variables to .env" {
+  install_asset wasm/identity
   dfx_start
   dfx canister create --all
+  jq '.canisters."nns-cycles-minting".remote.id.local="rkp4c-7iaaa-aaaaa-aaaca-cai"' dfx.json | sponge dfx.json
+  jq '.canisters."nns-cycles-minting".type="custom"' dfx.json | sponge dfx.json
+  jq '.canisters."nns-cycles-minting".candid="main.did"' dfx.json | sponge dfx.json
+  jq '.canisters."nns-cycles-minting".wasm="main.wasm"' dfx.json | sponge dfx.json
+  jq '.canisters.lifeline.type="pull"' dfx.json | sponge dfx.json
+  jq '.canisters.lifeline.id="rno2w-sqaaa-aaaaa-aaacq-cai"' dfx.json | sponge dfx.json
+  mkdir -p deps/candid
+  echo "service: {}" >deps/candid/rno2w-sqaaa-aaaaa-aaacq-cai.did
   # .env should also include canisters that are not explicit dependencies
   jq 'del(.canisters.e2e_project_frontend.dependencies)' dfx.json  | sponge dfx.json
   backend_canister=$(dfx canister id e2e_project_backend)
@@ -92,6 +115,10 @@ teardown() {
   assert_contains "E2E_PROJECT_BACKEND_CANISTER_ID='$backend_canister'" "$env"
   assert_contains "CANISTER_ID_E2E_PROJECT_FRONTEND='$frontend_canister'" "$env"
   assert_contains "E2E_PROJECT_FRONTEND_CANISTER_ID='$frontend_canister'" "$env"
+  assert_contains "CANISTER_ID_NNS_CYCLES_MINTING='rkp4c-7iaaa-aaaaa-aaaca-cai'" "$env"
+  assert_contains "NNS_CYCLES_MINTING_CANISTER_ID='rkp4c-7iaaa-aaaaa-aaaca-cai'" "$env"
+  assert_contains "CANISTER_ID_LIFELINE='rno2w-sqaaa-aaaaa-aaacq-cai'" "$env"
+  assert_contains "LIFELINE_CANISTER_ID='rno2w-sqaaa-aaaaa-aaacq-cai'" "$env"
 
   setup_actuallylocal_project_network
   dfx canister create --all --network actuallylocal
@@ -99,11 +126,20 @@ teardown() {
   assert_contains "DFX_NETWORK='actuallylocal'" "$(< .env)"
 }
 
-@test "install writes all environment variables to .env" {
+@test "canister install writes all environment variables to .env" {
+  install_asset wasm/identity
   dfx_start
   dfx canister create --all
   dfx build
 
+  jq '.canisters."nns-cycles-minting".remote.id.local="rkp4c-7iaaa-aaaaa-aaaca-cai"' dfx.json | sponge dfx.json
+  jq '.canisters."nns-cycles-minting".type="custom"' dfx.json | sponge dfx.json
+  jq '.canisters."nns-cycles-minting".candid="main.did"' dfx.json | sponge dfx.json
+  jq '.canisters."nns-cycles-minting".wasm="main.wasm"' dfx.json | sponge dfx.json
+  jq '.canisters.lifeline.type="pull"' dfx.json | sponge dfx.json
+  jq '.canisters.lifeline.id="rno2w-sqaaa-aaaaa-aaacq-cai"' dfx.json | sponge dfx.json
+  mkdir -p deps/candid
+  echo "service: {}" >deps/candid/rno2w-sqaaa-aaaaa-aaacq-cai.did
   # .env should also include canisters that are not explicit dependencies
   jq 'del(.canisters.e2e_project_frontend.dependencies)' dfx.json  | sponge dfx.json
   # set a post-install script so the install will create a .env file
@@ -114,8 +150,6 @@ teardown() {
   rm .env
   assert_command dfx canister install e2e_project_frontend
 
-  cat .env
-
   assert_file_exists .env
   env=$(< .env)
   assert_contains "DFX_NETWORK='local'" "$env"
@@ -123,38 +157,10 @@ teardown() {
   assert_contains "E2E_PROJECT_BACKEND_CANISTER_ID='$backend_canister'" "$env"
   assert_contains "CANISTER_ID_E2E_PROJECT_FRONTEND='$frontend_canister'" "$env"
   assert_contains "E2E_PROJECT_FRONTEND_CANISTER_ID='$frontend_canister'" "$env"
-
-  setup_actuallylocal_project_network
-  dfx canister create --all --network actuallylocal
-  assert_command dfx build --network actuallylocal
-  assert_contains "DFX_NETWORK='actuallylocal'" "$(< .env)"
-}
-
-@test "writes all environment variables to .env" {
-  dfx_start
-  cat dfx.json
-  jq '.canisters.second_backend.type="motoko"' dfx.json | sponge dfx.json
-  jq '.canisters.second_backend.main="src/e2e_project_backend/main.mo"' dfx.json | sponge dfx.json
-  cat dfx.json
-  # .env should also include canisters that are not explicit dependencies
-  jq 'del(.canisters.e2e_project_frontend.dependencies)' dfx.json  | sponge dfx.json
-  cat dfx.json
-  dfx canister create --all
-  backend_canister=$(dfx canister id e2e_project_backend)
-  frontend_canister=$(dfx canister id e2e_project_frontend)
-  second_backend_canister=$(dfx canister id second_backend)
-
-  assert_command dfx deploy e2e_project_frontend
-
-  assert_file_exists .env
-  env=$(< .env)
-  assert_contains "DFX_NETWORK='local'" "$env"
-  assert_contains "CANISTER_ID_E2E_PROJECT_BACKEND='$backend_canister'" "$env"
-  assert_contains "E2E_PROJECT_BACKEND_CANISTER_ID='$backend_canister'" "$env"
-  assert_contains "CANISTER_ID_E2E_PROJECT_FRONTEND='$frontend_canister'" "$env"
-  assert_contains "E2E_PROJECT_FRONTEND_CANISTER_ID='$frontend_canister'" "$env"
-  assert_contains "CANISTER_ID_SECOND_BACKEND='$second_backend_canister'" "$env"
-  assert_contains "SECOND_BACKEND_CANISTER_ID='$second_backend_canister'" "$env"
+  assert_contains "CANISTER_ID_NNS_CYCLES_MINTING='rkp4c-7iaaa-aaaaa-aaaca-cai'" "$env"
+  assert_contains "NNS_CYCLES_MINTING_CANISTER_ID='rkp4c-7iaaa-aaaaa-aaaca-cai'" "$env"
+  assert_contains "CANISTER_ID_LIFELINE='rno2w-sqaaa-aaaaa-aaacq-cai'" "$env"
+  assert_contains "LIFELINE_CANISTER_ID='rno2w-sqaaa-aaaaa-aaacq-cai'" "$env"
 
   setup_actuallylocal_project_network
   dfx canister create --all --network actuallylocal

--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -52,9 +52,10 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
     let required_canisters = config
         .get_config()
         .get_canister_names_with_dependencies(opts.canister_name.as_deref())?;
+    //let canisters_to_load = add_canisters_with_ids(&required_canisters, &env, &config);
     let canisters_to_load = all_project_canisters_with_ids(&env, &config);
 
-    let canisters_to_build = required_canisters
+    let canisters_to_build = required_canisters.clone()
         .into_iter()
         .filter(|canister_name| {
             !config
@@ -76,9 +77,8 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
         // CanisterIds would have been set in CanisterPool::load, if available.
         // This is just to display an error if trying to build before creating the canister.
         let store = env.get_canister_id_store()?;
-        for canister in canister_pool.get_canister_list() {
-            let canister_name = canister.get_name();
-            store.get(canister_name)?;
+        for canister_name in required_canisters {
+            store.get(&canister_name)?;
         }
     }
 

--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -55,7 +55,8 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
     //let canisters_to_load = add_canisters_with_ids(&required_canisters, &env, &config);
     let canisters_to_load = all_project_canisters_with_ids(&env, &config);
 
-    let canisters_to_build = required_canisters.clone()
+    let canisters_to_build = required_canisters
+        .clone()
         .into_iter()
         .filter(|canister_name| {
             !config

--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -5,7 +5,7 @@ use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::models::canister::CanisterPool;
 use crate::lib::network::network_opt::NetworkOpt;
-use crate::lib::operations::canister::all_project_canisters_with_ids;
+use crate::lib::operations::canister::add_canisters_with_ids;
 use clap::Parser;
 use std::path::PathBuf;
 use tokio::runtime::Runtime;
@@ -52,11 +52,9 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
     let required_canisters = config
         .get_config()
         .get_canister_names_with_dependencies(opts.canister_name.as_deref())?;
-    //let canisters_to_load = add_canisters_with_ids(&required_canisters, &env, &config);
-    let canisters_to_load = all_project_canisters_with_ids(&env, &config);
+    let canisters_to_load = add_canisters_with_ids(&required_canisters, &env, &config);
 
     let canisters_to_build = required_canisters
-        .clone()
         .into_iter()
         .filter(|canister_name| {
             !config
@@ -78,8 +76,9 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
         // CanisterIds would have been set in CanisterPool::load, if available.
         // This is just to display an error if trying to build before creating the canister.
         let store = env.get_canister_id_store()?;
-        for canister_name in required_canisters {
-            store.get(&canister_name)?;
+        for canister in canister_pool.get_canister_list() {
+            let canister_name = canister.get_name();
+            store.get(canister_name)?;
         }
     }
 

--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -1,15 +1,14 @@
 use crate::config::cache::DiskBasedCache;
 use crate::lib::agent::create_agent_environment;
 use crate::lib::builders::BuildConfig;
-use crate::lib::environment::{AgentEnvironment, Environment};
+use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::models::canister::CanisterPool;
 use crate::lib::network::network_opt::NetworkOpt;
+use crate::lib::operations::canister::add_canisters_with_ids;
 use clap::Parser;
-use dfx_core::config::model::dfinity::Config;
 use std::path::PathBuf;
 use tokio::runtime::Runtime;
-use crate::lib::operations::canister::canisters_with_assigned_ids;
 
 /// Builds all or specific canisters from the code in your project. By default, all canisters are built.
 #[derive(Parser)]
@@ -53,13 +52,7 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
     let required_canisters = config
         .get_config()
         .get_canister_names_with_dependencies(opts.canister_name.as_deref())?;
-    let extra_canisters: Vec<_> = canisters_with_assigned_ids(&env, &config)
-        .into_iter()
-        .filter(|extra| !required_canisters.contains(extra))
-        .collect();
-
-    let mut canisters_to_load = required_canisters.clone();
-    canisters_to_load.extend_from_slice(extra_canisters.as_slice());
+    let canisters_to_load = add_canisters_with_ids(&required_canisters, &env, &config);
 
     let canisters_to_build = required_canisters
         .into_iter()
@@ -101,4 +94,3 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
 
     Ok(())
 }
-

--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -5,7 +5,7 @@ use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::models::canister::CanisterPool;
 use crate::lib::network::network_opt::NetworkOpt;
-use crate::lib::operations::canister::add_canisters_with_ids;
+use crate::lib::operations::canister::all_project_canisters_with_ids;
 use clap::Parser;
 use std::path::PathBuf;
 use tokio::runtime::Runtime;
@@ -52,7 +52,7 @@ pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
     let required_canisters = config
         .get_config()
         .get_canister_names_with_dependencies(opts.canister_name.as_deref())?;
-    let canisters_to_load = add_canisters_with_ids(&required_canisters, &env, &config);
+    let canisters_to_load = all_project_canisters_with_ids(&env, &config);
 
     let canisters_to_build = required_canisters
         .into_iter()

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -392,6 +392,9 @@ pub fn get_and_write_environment_variables<'a>(
             ));
         }
     }
+    let canister_names =
+    pool.get_canister_list().iter().map(|c|c.get_name().to_string()).collect::<Vec<String>>();
+    eprintln!("**\n\n\ncanister_names: {:?}\n\n\n**\n", canister_names);
     for canister in pool.get_canister_list() {
         // Insert both suffixed and prefixed versions of the canister name for backwards compatibility
         vars.push((

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -392,12 +392,6 @@ pub fn get_and_write_environment_variables<'a>(
             ));
         }
     }
-    let canister_names = pool
-        .get_canister_list()
-        .iter()
-        .map(|c| c.get_name().to_string())
-        .collect::<Vec<String>>();
-    eprintln!("**\n\n\ncanister_names: {:?}\n\n\n**\n", canister_names);
     for canister in pool.get_canister_list() {
         // Insert both suffixed and prefixed versions of the canister name for backwards compatibility
         vars.push((

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -392,8 +392,11 @@ pub fn get_and_write_environment_variables<'a>(
             ));
         }
     }
-    let canister_names =
-    pool.get_canister_list().iter().map(|c|c.get_name().to_string()).collect::<Vec<String>>();
+    let canister_names = pool
+        .get_canister_list()
+        .iter()
+        .map(|c| c.get_name().to_string())
+        .collect::<Vec<String>>();
     eprintln!("**\n\n\ncanister_names: {:?}\n\n\n**\n", canister_names);
     for canister in pool.get_canister_list() {
         // Insert both suffixed and prefixed versions of the canister name for backwards compatibility

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -12,7 +12,7 @@ use crate::lib::operations::canister::deploy_canisters::DeployMode::{
 };
 use crate::lib::operations::canister::motoko_playground::reserve_canister_with_playground;
 use crate::lib::operations::canister::{
-    add_canisters_with_ids, create_canister, install_canister::install_canister,
+    all_project_canisters_with_ids, create_canister, install_canister::install_canister,
 };
 use anyhow::{anyhow, bail, Context};
 use candid::Principal;
@@ -128,7 +128,7 @@ pub async fn deploy_canisters(
         info!(env.get_logger(), "All canisters have already been created.");
     }
 
-    let canisters_to_load = add_canisters_with_ids(&canisters_to_deploy, env, &config);
+    let canisters_to_load = all_project_canisters_with_ids(env, &config);
 
     let pool = build_canisters(
         env,

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -11,7 +11,9 @@ use crate::lib::operations::canister::deploy_canisters::DeployMode::{
     ComputeEvidence, ForceReinstallSingleCanister, NormalDeploy, PrepareForProposal,
 };
 use crate::lib::operations::canister::motoko_playground::reserve_canister_with_playground;
-use crate::lib::operations::canister::{canisters_with_assigned_ids, create_canister, install_canister::install_canister};
+use crate::lib::operations::canister::{
+    add_canisters_with_ids, create_canister, install_canister::install_canister,
+};
 use anyhow::{anyhow, bail, Context};
 use candid::Principal;
 use dfx_core::config::model::canister_id_store::CanisterIdStore;
@@ -126,14 +128,7 @@ pub async fn deploy_canisters(
         info!(env.get_logger(), "All canisters have already been created.");
     }
 
-    let extra_canisters: Vec<_> = canisters_with_assigned_ids(env, &config)
-        .into_iter()
-        .filter(|extra| !canisters_to_deploy.contains(extra))
-        .collect();
-
-    let mut canisters_to_load = canisters_to_deploy.clone();
-    canisters_to_load.extend_from_slice(extra_canisters.as_slice());
-
+    let canisters_to_load = add_canisters_with_ids(&canisters_to_deploy, env, &config);
 
     let pool = build_canisters(
         env,

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -5,6 +5,7 @@ use crate::lib::error::DfxResult;
 use crate::lib::installers::assets::post_install_store_assets;
 use crate::lib::models::canister::CanisterPool;
 use crate::lib::named_canister;
+use crate::lib::operations::canister::add_canisters_with_ids;
 use crate::lib::operations::canister::motoko_playground::authorize_asset_uploader;
 use crate::lib::state_tree::canister_info::read_state_tree_canister_module_hash;
 use crate::util::assets::wallet_wasm;
@@ -30,7 +31,6 @@ use slog::{debug, info, warn};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use crate::lib::operations::canister::{add_canisters_with_ids, canisters_with_assigned_ids};
 
 use super::motoko_playground::playground_install_code;
 

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -5,7 +5,7 @@ use crate::lib::error::DfxResult;
 use crate::lib::installers::assets::post_install_store_assets;
 use crate::lib::models::canister::CanisterPool;
 use crate::lib::named_canister;
-use crate::lib::operations::canister::add_canisters_with_ids;
+use crate::lib::operations::canister::all_project_canisters_with_ids;
 use crate::lib::operations::canister::motoko_playground::authorize_asset_uploader;
 use crate::lib::state_tree::canister_info::read_state_tree_canister_module_hash;
 use crate::util::assets::wallet_wasm;
@@ -405,11 +405,7 @@ fn run_post_install_tasks(
         Some(pool) => pool,
         None => {
             let config = env.get_config_or_anyhow()?;
-            let deps = config
-                .get_config()
-                .get_canister_names_with_dependencies(Some(canister.get_name()))?;
-
-            let canisters_to_load = add_canisters_with_ids(&deps, env, &config);
+            let canisters_to_load = all_project_canisters_with_ids(env, &config);
 
             tmp = CanisterPool::load(env, false, &canisters_to_load)
                 .context("Error collecting canisters for post-install task")?;

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod install_canister;
 pub use create_canister::create_canister;
 
 use crate::lib::canister_info::CanisterInfo;
-use crate::lib::environment::Environment;
+use crate::lib::environment::{AgentEnvironment, Environment};
 use crate::lib::error::DfxResult;
 use crate::lib::ic_attributes::CanisterSettings as DfxCanisterSettings;
 use anyhow::{bail, Context};
@@ -21,6 +21,7 @@ use ic_utils::interfaces::ManagementCanister;
 use ic_utils::Argument;
 pub use install_canister::install_wallet;
 use std::path::PathBuf;
+use dfx_core::config::model::dfinity::Config;
 
 pub mod motoko_playground;
 
@@ -292,4 +293,24 @@ pub fn get_local_cid_and_candid_path(
         canister_info.get_canister_id()?,
         canister_info.get_output_idl_path(),
     ))
+}
+
+/// Produces all canister names that have canister IDs assigned
+pub fn canisters_with_assigned_ids(env: &dyn Environment, config: &Config) -> Vec<String> {
+    env.get_canister_id_store()
+        .map(|store| {
+            config
+                .get_config()
+                .canisters
+                .as_ref()
+                .map(|canisters| {
+                    canisters
+                        .keys()
+                        .filter(|canister| store.get(canister).is_ok())
+                        .cloned()
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        })
+        .unwrap_or_default()
 }

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod deploy_canisters;
 pub(crate) mod install_canister;
 
 pub use create_canister::create_canister;
-use std::collections::HashSet;
 
 use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
@@ -297,50 +296,6 @@ pub fn get_local_cid_and_candid_path(
     ))
 }
 
-pub fn add_canisters_with_ids0(
-    start_with: &[String],
-    env: &dyn Environment,
-    config: &Config,
-) -> Vec<String> {
-    let mut canister_names: HashSet<_> = start_with.iter().cloned().collect();
-
-    if let Ok(store) = env.get_canister_id_store() {
-        if let Some(canisters) = config.get_config().canisters.as_ref() {
-            for canister_name in canisters.keys() {
-                if store.get(canister_name).is_ok() {
-                    canister_names.insert(canister_name.clone());
-                }
-            }
-        }
-    }
-
-    canister_names.into_iter().collect()
-}
-
-pub fn add_canisters_with_ids(
-    _start_with: &[String],
-    env: &dyn Environment,
-    config: &Config,
-) -> Vec<String> {
-    all_project_canisters_with_ids(env, config)
-}
-
-pub fn all_project_canisters_with_ids1(env: &dyn Environment, config: &Config) -> Vec<String> {
-    let mut canister_names: HashSet<_> = HashSet::new();
-
-    if let Ok(store) = env.get_canister_id_store() {
-        if let Some(canisters) = config.get_config().canisters.as_ref() {
-            for canister_name in canisters.keys() {
-                if store.get(canister_name).is_ok() {
-                    canister_names.insert(canister_name.clone());
-                }
-            }
-        }
-    }
-
-    canister_names.into_iter().collect()
-}
-
 pub fn all_project_canisters_with_ids(env: &dyn Environment, config: &Config) -> Vec<String> {
     env.get_canister_id_store()
         .map(|store| {
@@ -358,23 +313,4 @@ pub fn all_project_canisters_with_ids(env: &dyn Environment, config: &Config) ->
                 .unwrap_or_default()
         })
         .unwrap_or_default()
-}
-
-pub fn all_project_canisters_with_ids3(env: &dyn Environment, config: &Config) -> Vec<String> {
-    let mut canister_names: HashSet<_> = HashSet::new();
-
-    if let Ok(store) = env.get_canister_id_store() {
-        if let Some(canisters) = config.get_config().canisters.as_ref() {
-            let canister_names_with_ids = canisters.keys().filter_map(|canister_name| {
-                store.get(canister_name).ok().map(|_| canister_name.clone())
-            });
-            for canister_name in canisters.keys() {
-                if store.get(canister_name).is_ok() {
-                    canister_names.insert(canister_name.clone());
-                }
-            }
-        }
-    }
-
-    canister_names.into_iter().collect()
 }

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -1,10 +1,12 @@
 pub(crate) mod create_canister;
 pub(crate) mod deploy_canisters;
 pub(crate) mod install_canister;
+pub mod motoko_playground;
 
 pub use create_canister::create_canister;
-use std::collections::HashSet;
+pub use install_canister::install_wallet;
 
+use std::collections::HashSet;
 use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
@@ -22,10 +24,7 @@ use ic_utils::interfaces::management_canister::builders::CanisterSettings;
 use ic_utils::interfaces::management_canister::{MgmtMethod, StatusCallResult};
 use ic_utils::interfaces::ManagementCanister;
 use ic_utils::Argument;
-pub use install_canister::install_wallet;
 use std::path::PathBuf;
-
-pub mod motoko_playground;
 
 #[context(
     "Failed to call update function '{}' regarding canister '{}'.",
@@ -298,14 +297,14 @@ pub fn get_local_cid_and_candid_path(
 }
 
 pub fn add_canisters_with_ids(
-    start_with: &[String],
+    canister_names: &[String],
     env: &dyn Environment,
     config: &Config,
 ) -> Vec<String> {
-    let mut canister_names: HashSet<_> = start_with.iter().cloned().collect();
+    let mut canister_names: HashSet<_> = canister_names.iter().cloned().collect();
 
     for canister_name in all_project_canisters_with_ids(env, config) {
-        canister_names.insert(canister_name.clone());
+        canister_names.insert(canister_name);
     }
 
     canister_names.into_iter().collect()

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -1,7 +1,6 @@
 pub(crate) mod create_canister;
 pub(crate) mod deploy_canisters;
 pub(crate) mod install_canister;
-
 pub use create_canister::create_canister;
 
 use crate::lib::canister_info::CanisterInfo;

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -303,9 +303,7 @@ pub fn add_canisters_with_ids(
 ) -> Vec<String> {
     let mut canister_names: HashSet<_> = canister_names.iter().cloned().collect();
 
-    for canister_name in all_project_canisters_with_ids(env, config) {
-        canister_names.insert(canister_name);
-    }
+    canister_names.extend(all_project_canisters_with_ids(env, config));
 
     canister_names.into_iter().collect()
 }

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -6,7 +6,6 @@ pub mod motoko_playground;
 pub use create_canister::create_canister;
 pub use install_canister::install_wallet;
 
-use std::collections::HashSet;
 use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
@@ -24,6 +23,7 @@ use ic_utils::interfaces::management_canister::builders::CanisterSettings;
 use ic_utils::interfaces::management_canister::{MgmtMethod, StatusCallResult};
 use ic_utils::interfaces::ManagementCanister;
 use ic_utils::Argument;
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 #[context(

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -2,8 +2,8 @@ pub(crate) mod create_canister;
 pub(crate) mod deploy_canisters;
 pub(crate) mod install_canister;
 
-use std::collections::HashSet;
 pub use create_canister::create_canister;
+use std::collections::HashSet;
 
 use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -314,3 +314,14 @@ pub fn canisters_with_assigned_ids(env: &dyn Environment, config: &Config) -> Ve
         })
         .unwrap_or_default()
 }
+
+pub fn add_canisters_with_ids(start_with: &[String], env: &dyn Environment, config: &Config) -> Vec<String> {
+    let mut canister_names = start_with.to_vec();
+    let extra_canisters: Vec<_> = canisters_with_assigned_ids(env, config)
+        .into_iter()
+        .filter(|extra| !canister_names.contains(extra))
+        .collect();
+
+    canister_names.extend_from_slice(extra_canisters.as_slice());
+    canister_names
+}

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -1,6 +1,8 @@
 pub(crate) mod create_canister;
 pub(crate) mod deploy_canisters;
 pub(crate) mod install_canister;
+
+use std::collections::HashSet;
 pub use create_canister::create_canister;
 
 use crate::lib::canister_info::CanisterInfo;
@@ -293,6 +295,20 @@ pub fn get_local_cid_and_candid_path(
         canister_info.get_canister_id()?,
         canister_info.get_output_idl_path(),
     ))
+}
+
+pub fn add_canisters_with_ids(
+    start_with: &[String],
+    env: &dyn Environment,
+    config: &Config,
+) -> Vec<String> {
+    let mut canister_names: HashSet<_> = start_with.iter().cloned().collect();
+
+    for canister_name in all_project_canisters_with_ids(env, config) {
+        canister_names.insert(canister_name.clone());
+    }
+
+    canister_names.into_iter().collect()
 }
 
 pub fn all_project_canisters_with_ids(env: &dyn Environment, config: &Config) -> Vec<String> {


### PR DESCRIPTION
# Description

Made it so `dfx deploy` and `dfx canister install` will always write canister ids for
all canisters in the project to the .env file, even if they aren't being deployed/installed or
a dependency of a canister being deployed/installed.

Fixes https://dfinity.atlassian.net/browse/SDK-1369

# How Has This Been Tested?

Updated an e2e test (dfx build) and added two more (dfx deploy, dfx canister install)

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
