### PR TITLE
fix(generate): Rust canister source candid wrongly deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Also the warning of hash mismatch is removed since it scares users and users can
 
 ### fix(generate): Rust canister source candid wrongly deleted
 
+Fixed a bug where `dfx generate` would delete a canister's source candid file if the `declarations.bindings` in `dfx.json` did not include "did".
+
 # 0.17.0
 
 ### feat: new starter templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ The `dfx upgrade` command now prints a message directing the user to install dfx
 
 Also the warning of hash mismatch is removed since it scares users and users can't fix it locally.
 
+### fix(generate): Rust canister source candid wrongly deleted
+
 # 0.17.0
 
 ### feat: new starter templates

--- a/e2e/tests-dfx/generate.bash
+++ b/e2e/tests-dfx/generate.bash
@@ -148,3 +148,10 @@ teardown() {
   assert_command dfx generate --help
   assert_not_contains "--network"
 }
+
+@test "dfx generate does not delete source candid file of Rust canister when bindings contains no did" {
+  dfx_new_rust hello
+  jq '.canisters.hello_backend.declarations.bindings=["js"]' dfx.json | sponge dfx.json
+  assert_command dfx generate
+  assert_file_exists "src/hello_backend/hello_backend.did"
+}

--- a/src/dfx/src/lib/builders/assets.rs
+++ b/src/dfx/src/lib/builders/assets.rs
@@ -140,32 +140,14 @@ impl CanisterBuilder for AssetsBuilder {
     }
 
     #[context("Failed to generate idl for canister '{}'.", info.get_name())]
-    fn generate_idl(
+    fn get_candid_path(
         &self,
         _pool: &CanisterPool,
         info: &CanisterInfo,
         _config: &BuildConfig,
     ) -> DfxResult<std::path::PathBuf> {
-        let generate_output_dir = info
-            .get_declarations_config()
-            .output
-            .as_ref()
-            .context("`declarations.output` must not be None")?;
-
-        unpack_did(generate_output_dir)?;
-
-        let idl_path = generate_output_dir.join(Path::new("assetstorage.did"));
-        let idl_path_rename = generate_output_dir
-            .join(info.get_name())
-            .with_extension("")
-            .with_extension("did");
-        if idl_path.exists() {
-            std::fs::rename(&idl_path, &idl_path_rename)
-                .with_context(|| format!("Failed to rename {}.", idl_path.to_string_lossy()))?;
-            dfx_core::fs::set_permissions_readwrite(&idl_path_rename)?;
-        }
-
-        Ok(idl_path_rename)
+        let idl_path = info.get_output_root().join(Path::new("assetstorage.did"));
+        Ok(idl_path)
     }
 }
 

--- a/src/dfx/src/lib/builders/assets.rs
+++ b/src/dfx/src/lib/builders/assets.rs
@@ -139,7 +139,6 @@ impl CanisterBuilder for AssetsBuilder {
         Ok(())
     }
 
-    #[context("Failed to generate idl for canister '{}'.", info.get_name())]
     fn get_candid_path(
         &self,
         _pool: &CanisterPool,

--- a/src/dfx/src/lib/builders/custom.rs
+++ b/src/dfx/src/lib/builders/custom.rs
@@ -144,36 +144,15 @@ impl CanisterBuilder for CustomBuilder {
         })
     }
 
-    fn generate_idl(
+    fn get_candid_path(
         &self,
         pool: &CanisterPool,
         info: &CanisterInfo,
         _config: &BuildConfig,
     ) -> DfxResult<PathBuf> {
-        let generate_output_dir = &info
-            .get_declarations_config()
-            .output
-            .as_ref()
-            .context("output here must not be None")?;
-
-        std::fs::create_dir_all(generate_output_dir).with_context(|| {
-            format!(
-                "Failed to create {}.",
-                generate_output_dir.to_string_lossy()
-            )
-        })?;
-
-        let output_idl_path = generate_output_dir
-            .join(info.get_name())
-            .with_extension("did");
-
         // get the path to candid file
         let CustomBuilderExtra { candid, .. } = CustomBuilderExtra::try_from(info, pool)?;
-
-        dfx_core::fs::copy(&candid, &output_idl_path)?;
-        dfx_core::fs::set_permissions_readwrite(&output_idl_path)?;
-
-        Ok(output_idl_path)
+        Ok(candid)
     }
 }
 

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -134,12 +134,12 @@ pub trait CanisterBuilder {
         if bindings.is_empty() {
             eprintln!("`{}.declarations.bindings` in dfx.json was set to be an empty list, so no type declarations will be generated.", &info.get_name());
             return Ok(());
-        } else {
-            eprintln!(
-                "Generating type declarations for canister {}:",
-                &info.get_name()
-            );
         }
+
+        eprintln!(
+            "Generating type declarations for canister {}:",
+            &info.get_name()
+        );
 
         std::fs::create_dir_all(generate_output_dir).with_context(|| {
             format!(
@@ -148,9 +148,15 @@ pub trait CanisterBuilder {
             )
         })?;
 
-        let generated_idl_path = self.generate_idl(pool, info, config)?;
+        let did_from_build = self.get_candid_path(pool, info, config)?;
+        if !did_from_build.exists() {
+            bail!(
+                "Candid file: {} doesn't exist.",
+                did_from_build.to_string_lossy()
+            );
+        }
 
-        let (env, ty) = CandidSource::File(generated_idl_path.as_path()).load()?;
+        let (env, ty) = CandidSource::File(did_from_build.as_path()).load()?;
 
         // Typescript
         if bindings.contains(&"ts".to_string()) {
@@ -202,29 +208,26 @@ pub trait CanisterBuilder {
             eprintln!("  {}", &output_mo_path.display());
         }
 
-        // Candid, delete if not required
-        if !bindings.contains(&"did".to_string()) {
-            std::fs::remove_file(&generated_idl_path).with_context(|| {
-                format!("Failed to remove {}.", generated_idl_path.to_string_lossy())
-            })?;
-        } else {
-            let relative_idl_path = generated_idl_path
-                .strip_prefix(info.get_workspace_root())
-                .unwrap_or(&generated_idl_path);
-            eprintln!("  {}", &relative_idl_path.display());
+        // Candid
+        if bindings.contains(&"did".to_string()) {
+            let output_did_path = generate_output_dir
+                .join(info.get_name())
+                .with_extension("did");
+            dfx_core::fs::copy(&did_from_build, &output_did_path)?;
+            eprintln!("  {}", &output_did_path.display());
         }
 
         Ok(())
     }
 
-    fn generate_idl(
+    /// Get the path to the provided candid file for the canister.
+    /// No need to guarantee the file exists, as the caller will handle that.
+    fn get_candid_path(
         &self,
-        _pool: &CanisterPool,
-        _info: &CanisterInfo,
-        _config: &BuildConfig,
-    ) -> DfxResult<PathBuf> {
-        Ok(PathBuf::new())
-    }
+        pool: &CanisterPool,
+        info: &CanisterInfo,
+        config: &BuildConfig,
+    ) -> DfxResult<PathBuf>;
 }
 
 fn compile_handlebars_files(

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -214,6 +214,7 @@ pub trait CanisterBuilder {
                 .join(info.get_name())
                 .with_extension("did");
             dfx_core::fs::copy(&did_from_build, &output_did_path)?;
+            dfx_core::fs::set_permissions_readwrite(&output_did_path)?;
             eprintln!("  {}", &output_did_path.display());
         }
 

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -191,37 +191,16 @@ impl CanisterBuilder for MotokoBuilder {
         })
     }
 
-    fn generate_idl(
+    fn get_candid_path(
         &self,
         _pool: &CanisterPool,
         info: &CanisterInfo,
         _config: &BuildConfig,
     ) -> DfxResult<PathBuf> {
-        let generate_output_dir = &info
-            .get_declarations_config()
-            .output
-            .as_ref()
-            .context("output here must not be None")?;
-
-        std::fs::create_dir_all(generate_output_dir).with_context(|| {
-            format!(
-                "Failed to create {}.",
-                generate_output_dir.to_string_lossy()
-            )
-        })?;
-
-        let output_idl_path = generate_output_dir
-            .join(info.get_name())
-            .with_extension("did");
-
         // get the path to candid file from dfx build
         let motoko_info = info.as_info::<MotokoCanisterInfo>()?;
         let idl_from_build = motoko_info.get_output_idl_path().to_path_buf();
-
-        dfx_core::fs::copy(&idl_from_build, &output_idl_path)?;
-        dfx_core::fs::set_permissions_readwrite(&output_idl_path)?;
-
-        Ok(output_idl_path)
+        Ok(idl_from_build)
     }
 }
 

--- a/src/dfx/src/lib/builders/pull.rs
+++ b/src/dfx/src/lib/builders/pull.rs
@@ -6,7 +6,6 @@ use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::models::canister::CanisterPool;
-use anyhow::bail;
 use candid::Principal as CanisterId;
 use fn_error_context::context;
 use slog::o;
@@ -53,7 +52,7 @@ impl CanisterBuilder for PullBuilder {
         })
     }
 
-    fn generate_idl(
+    fn get_candid_path(
         &self,
         _pool: &CanisterPool,
         info: &CanisterInfo,
@@ -61,13 +60,6 @@ impl CanisterBuilder for PullBuilder {
     ) -> DfxResult<PathBuf> {
         let pull_info = info.as_info::<PullCanisterInfo>()?;
         let output_idl_path = pull_info.get_output_idl_path();
-        if output_idl_path.exists() {
-            Ok(output_idl_path.to_path_buf())
-        } else {
-            bail!(
-                "Candid file: {} doesn't exist.",
-                output_idl_path.to_string_lossy()
-            );
-        }
+        Ok(output_idl_path.to_path_buf())
     }
 }

--- a/src/dfx/src/lib/builders/rust.rs
+++ b/src/dfx/src/lib/builders/rust.rs
@@ -106,7 +106,7 @@ impl CanisterBuilder for RustBuilder {
         })
     }
 
-    fn generate_idl(
+    fn get_candid_path(
         &self,
         _pool: &CanisterPool,
         info: &CanisterInfo,
@@ -114,13 +114,6 @@ impl CanisterBuilder for RustBuilder {
     ) -> DfxResult<PathBuf> {
         let rust_info = info.as_info::<RustCanisterInfo>()?;
         let output_idl_path = rust_info.get_output_idl_path();
-        if output_idl_path.exists() {
-            Ok(output_idl_path.to_path_buf())
-        } else {
-            bail!(
-                "Candid file: {} doesn't exist.",
-                output_idl_path.to_string_lossy()
-            );
-        }
+        Ok(output_idl_path.to_path_buf())
     }
 }


### PR DESCRIPTION
SDK-1380

# Description

Fixed a bug where `dfx generate` would delete a canister's source candid file if the `declarations.bindings` in `dfx.json` did not include "did".

Reported in https://github.com/nathanosdev/sdk_rust_candid_issue

## Explanation

`dfx generate`, in brief, gets the candid file of a canister and generate other bindings based on this .

The incorrect implementation required all impl of `CanisterBuilder` to have a `generate_idl()`  method. And the `generate_idl()` method should copy the source candid file into `declarations/` dir. After generating all bindings, `dfx generate` will remove the candid file (should be `declarations/<canister>.did`) if `declarations.bindings` doesn't contains "did".

The `RustCanisterBuilder` didn't follow the requirement of `generate_id()`. Instead, its `generate_id()` returns the source candid file path directly. And this source candid file got deleted.

This PR simplifies the whole implementation. The bindings are generated from the source candid files directly. There is no logic of deleting candid files.

# How Has This Been Tested?

e2e/generate.bash

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
