### PR TITLE
feat: add open flag to dfx deploy command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,12 @@
 
 # UNRELEASED
 
-### feat: add --open flag to dfx deploy
-
-The `--open` flag will open the browser to the canister's URL after deployment.
-
 ### feat: unify CLI options to specify arguments
 
 There are a few subcommands that take `--argument`/`--argument-file` options to set canister call/init arguments.
 
 We unify the related logic to provide consistent user experience.
-
+ 
 The notable changes are:
 
 - `dfx deploy` now accepts `--argument-file`.
@@ -19,7 +15,7 @@ The notable changes are:
 
 ### feat: candid assist feature
 
-Ask for user input when Candid argument is not provided in `dfx canister call`, `dfx canister install` and `dfx deploy`.
+Ask for user input when Candid argument is not provided in `dfx canister call`, `dfx canister install` and `dfx deploy`. 
 Previously, we cannot call `dfx deploy --all` when multiple canisters require init args, unless the init args are specified in `dfx.json`. With the Candid assist feature, dfx now asks for init args in terminal when a canister requires init args.
 
 ### fix: restored access to URLs like http://localhost:8080/api/v2/status through icx-proxy
@@ -27,7 +23,6 @@ Previously, we cannot call `dfx deploy --all` when multiple canisters require in
 Pinned icx-proxy at 69e1408347723dbaa7a6cd2faa9b65c42abbe861, shipped with dfx 0.15.2
 
 This means commands like the following will work again:
-
 ```
 curl -v --http2-prior-knowledge "http://localhost:$(dfx info webserver-port)/api/v2/status" --output -
 ```
@@ -123,7 +118,7 @@ If you build with custom canister type, add the following into `dfx.json`:
 
 ```
 "metadata": [
-  {
+  { 
     "name": "candid:service"
   }
 ]
@@ -158,7 +153,7 @@ Fix the bug that when parsing `vec {1;2;3}` with `blob` type, dfx silently ignor
 ### fix: support `import` for local did file
 
 If the local did file contains `import` or init args, dfx will rewrite the did file when storing in canister metadata.
-Due to current limitations of the Candid parser, comments will be dropped during rewriting.
+Due to current limitations of the Candid parser, comments will be dropped during rewriting. 
 If the local did file doesn't contain `import` or init args, we will not perform the rewriting, thus preserving the comments.
 
 ### fix: subtyping check reports the special opt rule as error
@@ -166,7 +161,6 @@ If the local did file doesn't contain `import` or init args, we will not perform
 ### fix: can now run several dfx canister commands outside of a project
 
 The following commands now work outside of a project:
-
 - `dfx canister start <specific canister id>`
 - `dfx canister stop <specific canister id>`
 - `dfx canister deposit-cycles <amount> <specific canister id>`
@@ -295,8 +289,8 @@ dfx now no longer sets a memory allocation. We anticipate fewer problems this wa
 ### feat: Added support for icx-proxy `--domain` parameter
 
 In order to access a local replica through a domain name or domain names,
-it's necessary to pass the `--domain` parameter to icx-proxy. dfx now supports
-this in configuration and as a parameter to dfx start. You can specify a single
+it's necessary to pass the `--domain` parameter to icx-proxy.  dfx now supports
+this in configuration and as a parameter to dfx start.  You can specify a single
 domain or a list of domains in any of the following ways:
 
 - in networks.json, in `.<network>.proxy.domain`
@@ -310,7 +304,7 @@ domain or a list of domains in any of the following ways:
 
 - Module hash: d172df265a14397a460b752ff07598380bc7ebd9c43ece1e82495ae478a88719c
 - Internet identity integration in Candid UI. Thanks to @Web3NL!
-  - You can customize the II url and derivationOrigin via URL parameter `ii` and `origin` respectively.
+  + You can customize the II url and derivationOrigin via URL parameter `ii` and `origin` respectively.
 - Update with the new profiling API
 
 ### Motoko
@@ -343,6 +337,7 @@ to the project root, rather than relative to the current working directory.
 
 Enables passing large arguments that cannot be passed directly in the command line using the `--argument-file` flag. For example `dfx canister install --argument-file ./my/argument/file.txt my_canister_name`.
 
+
 ### feat: change `list_permitted` and `list_authorized` to an update call.
 
 This requires the `list_authorized` and `list_permitted` methods to be called as an update and disables the ability to
@@ -357,7 +352,6 @@ The message "transaction is a duplicate of another transaction in block ...", pr
 Underscores (`_`) can now be used to make large numbers more readable. For example: `dfx canister deposit-cycles 1_234_567 mycanister`
 
 Certain suffixes that replace a number of zeros are now supported. The (case-insensitive) suffixes are:
-
 - `k` for `000`, e.g. `500k`
 - `m` for `000_000`, e.g. `5m`
 - `b` for `000_000_000`, e.g. `50B`
@@ -370,10 +364,9 @@ For cycles an additional `c` or `C` is also acceptable. For example: `dfx canist
 This won't work on mainnet yet, but can work locally after installing the cycles ledger.
 
 Added the following subcommands:
-
-- `dfx cycles balance`
-- `dfx cycles transfer <to> <amount>` (transfer cycles from one account to another account)
-- `dfx cycles top-up <to> <amount>` (send cycles from an account to a canister)
+ - `dfx cycles balance`
+ - `dfx cycles transfer <to> <amount>` (transfer cycles from one account to another account)
+ - `dfx cycles top-up <to> <amount>` (send cycles from an account to a canister)
 
 ## Dependencies
 
@@ -427,9 +420,8 @@ Updated Bitcoin canister to [release/2023-10-13](https://github.com/dfinity/bitc
 `dfx canister status` will now display the reserved cycles balance and reserved cycles limit for a canister.
 
 Added command-line options:
-
-- `dfx canister create --reserved-cycles-limit <limit>`
-- `dfx canister update-settings --reserved-cycles-limit <limit>`
+  - `dfx canister create --reserved-cycles-limit <limit>`
+  - `dfx canister update-settings --reserved-cycles-limit <limit>`
 
 In addition, `dfx deploy` will set `reserved_cycles_limit` when creating canisters if specified in `canisters.<canister>.initialization_values.reserved_cycles_limit` in dfx.json.
 
@@ -469,7 +461,6 @@ Updates node engines to reflect the same engines supported in agent-js.
 Introduced a new network type called `playground`. Canisters on such networks are not created through standard means, but are instead borrowed from a canister pool.
 The canisters time out after a while and new canisters need to be borrowed for further deployments.
 To define custom playground networks, use a network definition that includes the `playground` key:
-
 ```json
 "<network name>": {
   "playground": {
@@ -494,19 +485,18 @@ For example, `dfx deploy --ic` rather than `dfx deploy --network ic`.
 ### feat: `dfx start` for shared network warns if ignoring 'defaults' in dfx.json
 
 Background: In order to determine whether to start a project-specific network or the shared network, `dfx start` looks for the `local` network in dfx.json.
+   - If found, `dfx start` starts the project-specific local network, applying any `defaults` from dfx.json.
+   - If there is no dfx.json, or if dfx.json does not define a `local` network, `dfx start` starts the shared network.  Because the shared network is not specific to any project, `dfx start` ignores any other settings from dfx.json, including `defaults`.
 
-- If found, `dfx start` starts the project-specific local network, applying any `defaults` from dfx.json.
-- If there is no dfx.json, or if dfx.json does not define a `local` network, `dfx start` starts the shared network. Because the shared network is not specific to any project, `dfx start` ignores any other settings from dfx.json, including `defaults`.
-
-If `dfx start` is starting the shared network from within a dfx project, and that dfx.json contains settings in the `defaults` key for `bitcoin`, `replica`, or `canister_http`, then `dfx start` will warn that it is ignoring those settings. It will also describe how to define equivalent settings in networks.json.
+If `dfx start` is starting the shared network from within a dfx project, and that dfx.json contains settings in the `defaults` key for `bitcoin`, `replica`, or `canister_http`, then `dfx start` will warn that it is ignoring those settings.  It will also describe how to define equivalent settings in networks.json.
 
 ### fix: dfx canister call --wallet no longer passes the parameter twice
 
-The parameter was erroneously passed twice. Now it is passed only once.
+The parameter was erroneously passed twice.  Now it is passed only once.
 
 ### fix: Removed deprecation warning about project-specific networks
 
-Removed this warning: "Project-specific networks are deprecated and will be removed after February 2023." While we may remove project-specific networks in the future, it is not imminent. One key requirement is the ability to run more than one subnet type at one time.
+Removed this warning: "Project-specific networks are deprecated and will be removed after February 2023." While we may remove project-specific networks in the future, it is not imminent.  One key requirement is the ability to run more than one subnet type at one time.
 
 ## Dependencies
 
@@ -515,13 +505,12 @@ Removed this warning: "Project-specific networks are deprecated and will be remo
 Updated to a version of the icx-proxy that is released with the replica and other related binaries.
 
 Changes in behavior:
-
-- "%%" is no longer accepted when url-decoding filenames for the asset canister. Though curl supports this, it's not part of the standard. Please replace with %25.
-- The icx-proxy now performs response verification. This has exposed some bugs in the asset canister. However, since this new icx-proxy matches what the boundary nodes use, this will better match the behavior seen on the mainnet.
+- "%%" is no longer accepted when url-decoding filenames for the asset canister.  Though curl supports this, it's not part of the standard. Please replace with %25.
+- The icx-proxy now performs response verification.  This has exposed some bugs in the asset canister.  However, since this new icx-proxy matches what the boundary nodes use, this will better match the behavior seen on the mainnet.
 - Bugs that this has exposed in the asset canister:
   - after disabling aliasing for an asset, the asset canister will return an incorrect certification in the 404 response.
   - after setting a custom "etag" header in .ic-assets.json, the asset canister will return an incorrect certification in the 200 response.
-  - assets with certain characters in the filename (example: "æ") will no longer be served correctly. The definition of "certain characters" is not yet known.
+  - assets with certain characters in the filename (example: "æ") will no longer be served correctly.  The definition of "certain characters" is not yet known.
 
 ### Candid UI
 
@@ -552,7 +541,7 @@ This incorporates the following executed proposals:
 - [124537](https://dashboard.internetcomputer.org/proposal/124537)
 - [124488](https://dashboard.internetcomputer.org/proposal/124488)
 - [124487](https://dashboard.internetcomputer.org/proposal/124487)
-
+  
 # 0.15.0
 
 ## DFX
@@ -571,7 +560,7 @@ All projects will need to redeploy.
 
 ### fix: access to raw assets is now enabled by default
 
-The default value for `allow_raw_access` is now `true`. This means that by default, the frontend canister will no longer restrict the access of traffic to the `<canister-id>.raw.icp0.io` domain, and will no longer automatically redirect all requests to the certified domain (`<canister-id>.icp0.io`), unless configured explicitly.
+The default value for `allow_raw_access` is now `true`.  This means that by default, the frontend canister will no longer restrict the access of traffic to the `<canister-id>.raw.icp0.io` domain, and will no longer automatically redirect all requests to the certified domain (`<canister-id>.icp0.io`), unless configured explicitly.
 
 Note that existing projects that specify `"allow_raw_access": false` in .ic-assets.json5 will need to change or remove this value manually in order to allow raw access.
 
@@ -581,7 +570,7 @@ Both have now been turned into the dfx extensions. In order to obtain them, plea
 
 ### feat!: Removed dfx replica and dfx bootstrap commands
 
-Use `dfx start` instead. If you have a good reason why we should keep these commands, please contribute to the discussion at https://github.com/dfinity/sdk/discussions/3163
+Use `dfx start` instead.  If you have a good reason why we should keep these commands, please contribute to the discussion at https://github.com/dfinity/sdk/discussions/3163
 
 ### fix: Wait for new module hash when installing wallet
 
@@ -600,13 +589,11 @@ WARN: The <identity> identity is not stored securely. Do not use it to control a
 ```
 
 To do so, export the environment variable `DFX_WARNING` with the value `-mainnet_plaintext_identity`.
-
 ```bash
 export DFX_WARNING="-mainnet_plaintext_identity"
 ```
 
 Note that this can be combined to also disable the dfx version check warning:
-
 ```bash
 export DFX_WARNING="-version_check,-mainnet_plaintext_identity"
 ```
@@ -639,11 +626,11 @@ Previously, the operation was a no-op if the content type matched, but ignored o
 
 ### fix!: http_request_streaming_callback and get_chunk now require the sha256 parameter to be set
 
-The `http_request_streaming_callback()` and `get_chunk()` methods use the `sha256` parameter to ensure that the chunks they return are part of the same asset contents returned by the initial call. This parameter is now required to be Some(hash).
+The `http_request_streaming_callback()` and `get_chunk()` methods use the `sha256` parameter to ensure that the chunks they return are part of the same asset contents returned by the initial call.  This parameter is now required to be Some(hash).
 
 For `http_request()` and `http_request_streaming_callback()`, there should be no change: all callers of `http_request_streaming_callback()` are expected to pass the entire token returned by `http_request()`, which includes the sha256 parameter.
 
-Any callers of `get_chunk()` should make sure to always pass the `sha256` value returned by the `get()` method. It will always be present.
+Any callers of `get_chunk()` should make sure to always pass the `sha256` value returned by the `get()` method.  It will always be present.
 
 ## Dependencies
 
@@ -741,34 +728,30 @@ The redirect from `.raw.ic0.app` now redirects to `.ic0.app` instead of `.icp0.i
 
 The `validate_commit_proposed_batch()` method no longer requires any permission to call.
 
-The asset canister now enforces limits during upload. These limits to not apply to assets already uploaded.
+The asset canister now enforces limits during upload.  These limits to not apply to assets already uploaded.
 
 Unconditional limits:
-
 - `create_batch()` now fails if `dfx deploy --by-proposal` got as far as calling `propose_commit_batch()`, and the batch has not since been committed or deleted.
 
 Configurable limits:
-
 - `max_batches`: limits number of batches being uploaded.
 - `max_chunks`: limits total number of chunks across all batches being uploaded.
 - `max_bytes`: limits total size of content bytes across all chunks being uploaded.
 
 Added methods:
-
 - `configure()` to set limits
 - `validate_configure()`: companion method for SNS
 - `get_configuration()`: to view limits
 
 Suggestions for configured limits:
-
 - dapps controlled by SNS: max_batches=1; max_chunks and max_bytes based on asset composition.
 - dapps not controlled by SNS: unlimited (which is the default)
 
-Note that as always, if `dfx deploy` does not completely upload and commit a batch, the asset canister will retain the batch until 5 minutes have passed since the last chunk was uploaded. If you have configured limits and the combination of an unsuccessful deployment and a subsequent attempt would exceed those limits, you can either wait 5 minutes before running `dfx deploy` again, or delete the incomplete batch with `delete_batch()`.
+Note that as always, if `dfx deploy` does not completely upload and commit a batch, the asset canister will retain the batch until 5 minutes have passed since the last chunk was uploaded.  If you have configured limits and the combination of an unsuccessful deployment and a subsequent attempt would exceed those limits, you can either wait 5 minutes before running `dfx deploy` again, or delete the incomplete batch with `delete_batch()`.
 
 ### fix: return the correct expr_path for index.html fallback routes
 
-Previously, the requested path was used to construct the `expr_path` for the `index.html` fallback route. This was incorrect, as the `expr_path` should be the path of the `index.html` file itself in this case.
+Previously, the requested path was used to construct the `expr_path` for the `index.html` fallback route.  This was incorrect, as the `expr_path` should be the path of the `index.html` file itself in this case.
 
 ## Frontend canister assets synchronization
 
@@ -778,7 +761,7 @@ Previously, it would only retry when waiting for the request to complete.
 
 ### fix: now considers fewer error types to be retryable
 
-Previously, errors were assumed to be retryable, except for a few specific error messages and 403/unauthorized responses. This could cause deployment to appear to hang until timeout.
+Previously, errors were assumed to be retryable, except for a few specific error messages and 403/unauthorized responses.  This could cause deployment to appear to hang until timeout.
 
 Now, only transport errors and timeout errors are considered retryable.
 
@@ -800,7 +783,6 @@ Updated ic-ref to 0.0.1-a9f73dba
 ### Cycles wallet
 
 Updated cycles wallet to `20230530` release:
-
 - Module hash: c1290ad65e6c9f840928637ed7672b688216a9c1e919eacbacc22af8c904a5e3
 - https://github.com/dfinity/cycles-wallet/commit/313fb01d59689df90bd3381659d94164c2a61cf4
 
@@ -812,7 +794,6 @@ Updated Motoko to 0.9.3
 
 Updated replica to elected commit ef8ca68771baa20a14af650ab89c9b31b1dc9a5e.
 This incorporates the following executed proposals:
-
 - [123248](https://dashboard.internetcomputer.org/proposal/123248)
 - [123021](https://dashboard.internetcomputer.org/proposal/123021)
 - [123007](https://dashboard.internetcomputer.org/proposal/123007)
@@ -843,9 +824,9 @@ You can enable it in `dfx.json`:
 
 ```json
 {
-  "canisters": {
-    "app": {
-      "gzip": true
+  "canisters" : {
+    "app" : {
+      "gzip" : true
     }
   }
 }
@@ -874,11 +855,9 @@ This feature was named `dfx pull` before. To make a complete, intuitive user exp
 All generated files in `deps/` are encouraged to be version controlled.
 
 ### chore: Add the `nns-dapp` and `internet_identity` to the local canister IDs set by `dfx nns import`
-
-`dfx nns install` installs a set of canisters in a local replica. `dfx nns import` complements this by setting the canister IDs so that they can be queried by the user. But `dfx nns import` is incomplete. Now it will also provide the IDs of the `nns-dapp` and `internet_identity` canisters.
+`dfx nns install` installs a set of canisters in a local replica.  `dfx nns import` complements this by setting the canister IDs so that they can be queried by the user.  But `dfx nns import` is incomplete.  Now it will also provide the IDs of the `nns-dapp` and `internet_identity` canisters.
 
 ### feat: `.env` file includes all created canister IDs
-
 Previously the `.env` file only included canister IDs for canisters that were listed as explicit dependencies during the build process.
 Now all canisters that have a canister ID for the specified network are included in `.env`.
 
@@ -897,7 +876,7 @@ dfx will terminate and restart it.
 
 This is required for future replica versions.
 
-Adds a new field `canister_init_arg` to the bitcoin configuration in dfx.json and networks.json. Its default is documented in the JSON schema and is appropriate for the canister wasm bundled with dfx.
+Adds a new field `canister_init_arg` to the bitcoin configuration in dfx.json and networks.json.  Its default is documented in the JSON schema and is appropriate for the canister wasm bundled with dfx.
 
 ### fix: no longer enable the bitcoin_regtest feature
 
@@ -910,7 +889,6 @@ Cleaned up documentation of IC SDK.
 ### feat: Added more detailed logging to `ic-asset`.
 
 Now, `dfx deploy -v` (or `-vv`) will print the following information:
-
 - The count for each `BatchOperationKind` in `CommitBatchArgs`
 - The number of chunks uploaded and the total bytes
 - The API version of both the `ic-asset` and the canister
@@ -919,7 +897,6 @@ Now, `dfx deploy -v` (or `-vv`) will print the following information:
 ### fix: Commit batches incrementally in order to account for more expensive v2 certification calculation
 
 In order to allow larger changes without exceeding the per-message instruction limit, the sync process now:
-
 - sets properties of assets already in the canister separately from the rest of the batch.
 - splits up the rest of the batch into groups of up to 500 operations.
 
@@ -929,7 +906,7 @@ Previously, it would only retry when waiting for the request to complete.
 
 ### fix: now considers fewer error types to be retryable
 
-Previously, errors were assumed to be retryable, except for a few specific error messages and 403/unauthorized responses. This could cause deployment to appear to hang until timeout.
+Previously, errors were assumed to be retryable, except for a few specific error messages and 403/unauthorized responses.  This could cause deployment to appear to hang until timeout.
 
 Now, only transport errors and timeout errors are considered retryable.
 
@@ -957,7 +934,6 @@ Updated Motoko to 0.8.8
 
 Updated replica to elected commit b3b00ba59c366384e3e0cd53a69457e9053ec987.
 This incorporates the following executed proposals:
-
 - [122529](https://dashboard.internetcomputer.org/proposal/122529)
 - [122284](https://dashboard.internetcomputer.org/proposal/122284)
 - [122198](https://dashboard.internetcomputer.org/proposal/122198)
@@ -1003,7 +979,7 @@ If you want to enable this behavior, you can do so in dfx.json:
         }
     }
 
-The options are "cycles", "size", "O4", "O3", "O2", "O1", "O0", "Oz", and "Os". The options starting with "O" are the optimization levels that `wasm-opt` provides. The "cycles" and "size" options are recommended defaults for optimizing for cycle usage and binary size respectively.
+The options are "cycles", "size", "O4", "O3", "O2", "O1", "O0", "Oz", and "Os".  The options starting with "O" are the optimization levels that `wasm-opt` provides. The "cycles" and "size" options are recommended defaults for optimizing for cycle usage and binary size respectively.
 
 ### feat: updates the dfx new starter project for env vars
 
@@ -1050,7 +1026,6 @@ Canisters communicating with `ic0.app` will continue to function nominally.
 ### feat: confirmation dialogues are no longer case sensitive and accept 'y' in addition to 'yes'
 
 ### fix: `dfx generate` no longer requires canisters to have a canister ID
-
 Previously, canisters required that the canister was created before `dfx generate` could be called.
 
 As a result, the `--network` parameter does not have an impact on the result of `dfx generate` anymore.
@@ -1088,11 +1063,11 @@ This supports asset updates through SNS proposal.
 
 Uploads asset changes to an asset canister (propose_commit_batch()), but does not commit them.
 
-The SNS will call `commit_proposed_batch()` to commit the changes. If the proposal fails, the caller of `dfx deploy --by-proposal` should call `delete_batch()`.
+The SNS will call `commit_proposed_batch()` to commit the changes.  If the proposal fails, the caller of `dfx deploy --by-proposal` should call `delete_batch()`.
 
 ### feat: dfx deploy <frontend canister name> --compute-evidence
 
-Builds the specified asset canister, determines the batch operations required to synchronize the assets, and computes a hash ("evidence") over those batch operations. This evidence will match the evidence computed by `dfx deploy --by-proposal`, and which will be specified in the update proposal.
+Builds the specified asset canister, determines the batch operations required to synchronize the assets, and computes a hash ("evidence") over those batch operations.  This evidence will match the evidence computed by `dfx deploy --by-proposal`, and which will be specified in the update proposal.
 
 No permissions are required to compute evidence, so this can be called with `--identity anonymous` or any other identity.
 
@@ -1103,8 +1078,7 @@ Added `validate_take_ownership()` method so that an SNS is able to add a custom 
 Added `is_aliased` field to `get_asset_properties` and `set_asset_properties`.
 
 Added partial support for proposal-based asset updates:
-
-- Batch ids are now stable. With upcoming changes to support asset updates by proposal,
+- Batch ids are now stable.  With upcoming changes to support asset updates by proposal,
   having the asset canister not reuse batch ids will make it easier to verify that a particular
   batch has been proposed.
 - Added methods:
@@ -1122,7 +1096,6 @@ Added canister metadata field `supported_certificate_versions`, which contains a
 
 Fixed a bug in `http_request` that served assets with the wrong certificate. If no encoding specified in the `Accept-Encoding` header is available with a certificate, an available encoding is returned without a certificate (instead of a wrong certificate, which was the case previously). Otherwise, nothing changed.
 For completeness' sake, the new behavior is as follows:
-
 - If one of the encodings specified in the `Accept-Encoding` header is available with certification, it now is served with the correct certificate.
 - If no requested encoding is available with certification, one of the requested encodings is returned without a certificate (instead of a wrong certificate, which was the case previously).
 - If no encoding specified in the `Accept-Encoding` header is available, a certified encoding that is available is returned instead.
@@ -1189,7 +1162,6 @@ Added validate_grant_permission() and validate_revoke_permission() methods per S
 This allows users to download SNS canister WASMs.
 
 ### fix: fixed error text
-
 - `dfx nns install` had the wrong instructions for setting up the local replica type
 
 ### fix: creating an identity with `--force` no longer switches to the newly created identity
@@ -1197,8 +1169,7 @@ This allows users to download SNS canister WASMs.
 ### feat(frontend-canister)!: reworked to use permissions-based access control
 
 The permissions are as follows:
-
-- ManagePermissions: Can grant and revoke permissions to any principal. Controllers implicitly have this permission.
+- ManagePermissions: Can grant and revoke permissions to any principal.  Controllers implicitly have this permission.
 - Prepare: Can call create_batch and create_chunk
 - Commit: Can call commit_batch and methods that manipulate assets directly, as well as any method permitted by Prepare.
 
@@ -1206,7 +1177,6 @@ For upgraded frontend canisters, all authorized principals will be granted the C
 For newly deployed frontend canisters, the initializer (first deployer of the canister) will be granted the Commit permission.
 
 Added three new methods:
-
 - list_permitted: lists principals with a given permission.
   - Callable by anyone.
 - grant_permission: grants a single permission to a principal
@@ -1215,8 +1185,7 @@ Added three new methods:
   - Any principal can revoke its own permissions.
   - Only Controllers and principals with the ManagePermissions permission can revoke the permissions of other principals.
 
-Altered the behavior of the existing authorization-related methods to operate only on the "Commit" permission. In this way, they are backwards-compatible.
-
+Altered the behavior of the existing authorization-related methods to operate only on the "Commit" permission.  In this way, they are backwards-compatible.
 - authorize(principal): same as grant_permission(principal, Commit)
 - deauthorize(principal): same as revoke_permission(permission, Commit)
 - list_authorized(): same as list_permitted(Commit)
@@ -1224,7 +1193,7 @@ Altered the behavior of the existing authorization-related methods to operate on
 ### fix(frontend-canister)!: removed ability of some types of authorized principals to manage the ACL
 
 It used to be the case that any authorized principal could authorize and deauthorize any other principal.
-This is no longer the case. See rules above for grant_permission and revoke_permission.
+This is no longer the case.  See rules above for grant_permission and revoke_permission.
 
 ### feat(frontend-canister)!: default secure configuration for assets in frontend project template
 
@@ -1234,7 +1203,6 @@ This is no longer the case. See rules above for grant_permission and revoke_perm
 ### feat(frontend-canister)!: add `allow_raw_access` config option
 
 By default, the frontend canister will now restrict the access of traffic to the `<canister-id>.raw.ic0.app` domain, and will automatically redirect all requests to the certified domain (`<canister-id>.ic0.app`), unless configured explicitly. Below is an example configuration to allow access to the `robots.txt` file from the "raw" domain:
-
 ```json
 [
   {
@@ -1244,28 +1212,26 @@ By default, the frontend canister will now restrict the access of traffic to the
 ]
 ```
 
-**Important**: Note that any assets already uploaded to an asset canister will be protected by this redirection, because at present the asset synchronization process does not update the `allow_raw_access` property, or any other properties, after creating an asset. This also applies to assets that are deployed without any configuration, and later configured to allow raw access.
+**Important**: Note that any assets already uploaded to an asset canister will be protected by this redirection, because at present the asset synchronization process does not update the `allow_raw_access` property, or any other properties, after creating an asset.  This also applies to assets that are deployed without any configuration, and later configured to allow raw access.
 At the present time, there are two ways to reconfigure an existing asset:
-
 1. re-create the asset
-   1. delete the asset in your project's directory
-   1. execute `dfx deploy`
-   1. re-create the asset in your project's directory
-   1. modify `.ic-assets.json` acordingly
-   1. execute `dfx deploy`
+    1. delete the asset in your project's directory
+    1. execute `dfx deploy`
+    1. re-create the asset in your project's directory
+    1. modify `.ic-assets.json` acordingly
+    1. execute `dfx deploy`
 2. via manual candid call
-   ```
-   dfx canister call PROJECT_NAME_frontend set_asset_properties '( record { key="/robots.txt"; allow_raw_access=opt(opt(true)) })'
-   ```
+    ```
+    dfx canister call PROJECT_NAME_frontend set_asset_properties '( record { key="/robots.txt"; allow_raw_access=opt(opt(true)) })'
+    ```
 
 ### feat(frontend-canister): pretty print asset properties when deploying assets to the canister
 
 ### feat(frontend-canister): add take_ownership() method
 
-Callable only by a controller. Clears list of authorized principals and adds the caller (controller) as the only authorized principal.
+Callable only by a controller.  Clears list of authorized principals and adds the caller (controller) as the only authorized principal.
 
 ### feat(ic-ref):
-
 - `effective_canister_id` used for `provisional_create_canister_with_cycles` is passed as an command-line argument (defaults to `rwlgt-iiaaa-aaaaa-aaaaa-cai` if not provided or upon parse failure)
 
 ### feat(frontend-canister): add `get_asset_properties` and `set_asset_properties` to frontend canister
@@ -1278,7 +1244,7 @@ Similar to how this argument works in `dfx canister call`, this argument allows 
 
 ### feat: Add support for a default network key
 
-A remote canister ID can now be specified for the `__default` network. If specified, `dfx` will assume that the canister is remote at the specified canister ID for all networks that don't have a dedicated entry.
+A remote canister ID can now be specified for the `__default` network.  If specified, `dfx` will assume that the canister is remote at the specified canister ID for all networks that don't have a dedicated entry.
 
 ### feat: use OS-native keyring for pem file storage
 
@@ -1294,7 +1260,6 @@ The flag `--disable-encryption` is deprecated in favour of `--storage-mode plain
 ### feat(frontend-canister): better control and overview for asset canister authorized principals
 
 The asset canister now has two new functions:
-
 - Query function `list_authorized` displays a list of all principals that are currently authorized to change assets and the list of authorized principals.
 - Update function `deauthorize` that removes a principal from the list of authorized principals. It can be called by authorized principals and cotrollers of the canister.
 
@@ -1322,7 +1287,6 @@ The number of cycles left in the canister is bumped a little bit so that people 
 ## Dependencies
 
 Updated candid to 0.8.4
-
 - Bug fix in TS bindings
 - Pretty print numbers
 
@@ -1386,26 +1350,24 @@ This incorporates the following executed proposals:
 ### fix(frontend-canister): Allow overwriting default HTTP Headers for assets in frontend canister
 
 Allows to overwrite `Content-Type`, `Content-Encoding`, and `Cache-Control` HTTP headers with custom values via `.ic-assets.json5` config file. Example `.ic-assets.json5` file:
-
 ```json5
 [
-  {
-    match: "web-gz.data.gz",
-    headers: {
-      "Content-Type": "application/octet-stream",
-      "Content-Encoding": "gzip",
-    },
-  },
+    {
+        "match": "web-gz.data.gz",
+        "headers": {
+            "Content-Type": "application/octet-stream",
+            "Content-Encoding": "gzip"
+        }
+    }
 ]
 ```
-
 This change will trigger the update process for frontend canister (new module hash: `2ff0513123f11c57716d889ca487083fac7d94a4c9434d5879f8d0342ad9d759`).
 
 ### feat: warn if an unencrypted identity is used on mainnet
 
 ### fix: Save SNS canister IDs
 
-SNS canister IDs were not being parsed reliably. Now the candid file is being specified explicitly, which resolves the issue in at least some cases.
+SNS canister IDs were not being parsed reliably.  Now the candid file is being specified explicitly, which resolves the issue in at least some cases.
 
 ### feat: NNS usability improvements
 
@@ -1444,7 +1406,6 @@ This can be disabled by setting the field `"enable_aliasing"` to `false` in a ru
 This change will trigger frontend canister upgrades upon redeploying any asset canister.
 
 ### fix: Only kill main process on `dfx stop`
-
 Removes misleading panics when running `dfx stop`.
 
 ### feat: `dfx nns install` works offline if all assets have been cached.
@@ -1452,7 +1413,6 @@ Removes misleading panics when running `dfx stop`.
 ### feat: Initialise the nns with an account controlled by a secp256k1 key
 
 This enables easy access to toy ICP using command line tools and this key:
-
 ```
 -----BEGIN EC PRIVATE KEY-----
 MHQCAQEEICJxApEbuZznKFpV+VKACRK30i6+7u5Z13/DOl18cIC+oAcGBSuBBAAK
@@ -1460,16 +1420,13 @@ oUQDQgAEPas6Iag4TUx+Uop+3NhE6s3FlayFtbwdhRVjvOar0kPTfE/N8N6btRnd
 74ly5xXEBNSXiENyxhEuzOZrIWMCNQ==
 -----END EC PRIVATE KEY-----
 ```
-
 For example, you can create an identity in dfx by putting this key in the file `ident-1.pem` and importing it:
-
 ```
 dfx identity import ident-1 ident-1.pem
 dfx --identity ident-1 ledger balance
 ```
 
 ### feat: default to run ic-wasm shrink when build canisters
-
 This behavior applies to Motoko, Rust and Custom canisters.
 If you want to disable this behavior, you can config it in dfx.json:
 
@@ -1483,9 +1440,9 @@ If you want to disable this behavior, you can config it in dfx.json:
 
 It's now possible to define custom wasm metadata sections and their visibility in dfx.json.
 
-At present, dfx can only add wasm metadata sections to canisters that are in wasm format. It cannot add metadata sections to compressed canisters. Since the frontend canister is now compressed, this means that at present it is not possible to add custom metadata sections to the frontend canister.
+At present, dfx can only add wasm metadata sections to canisters that are in wasm format.  It cannot add metadata sections to compressed canisters.  Since the frontend canister is now compressed, this means that at present it is not possible to add custom metadata sections to the frontend canister.
 
-dfx no longer adds `candid:service` metadata to canisters of type `"custom"` by default. If you want dfx to add your canister's candid definition to your custom canister, you can do so like this:
+dfx no longer adds `candid:service` metadata to canisters of type `"custom"` by default.  If you want dfx to add your canister's candid definition to your custom canister, you can do so like this:
 
 ```
     "my_canister_name": {
@@ -1500,11 +1457,11 @@ dfx no longer adds `candid:service` metadata to canisters of type `"custom"` by 
     },
 ```
 
-This changelog entry doesn't go into all of the details of the possible configuration. For that, please see [concepts/canister-metadata](docs/concepts/canister-metadata.md) and the docs in the JSON schema.
+This changelog entry doesn't go into all of the details of the possible configuration.  For that, please see [concepts/canister-metadata](docs/concepts/canister-metadata.md) and the docs in the JSON schema.
 
 ### fix: Valid canister-based env vars
 
-Hyphens are not valid in shell environment variables, but do occur in canister names such as `smiley-dapp`. This poses a problem for vars with names such as `CANISTER_ID_${CANISTER_NAME}`. With this change, hyphens are replaced with underscores in environment variables. The canister id of `smiley-dapp` will be available as `CANISTER_ID_smiley_dapp`. Other environment variables are unaffected.
+Hyphens are not valid in shell environment variables, but do occur in canister names such as `smiley-dapp`. This poses a problem for vars with names such as `CANISTER_ID_${CANISTER_NAME}`.  With this change, hyphens are replaced with underscores in environment variables.  The canister id of `smiley-dapp` will be available as `CANISTER_ID_smiley_dapp`.  Other environment variables are unaffected.
 
 ### feat: Add dfx sns deploy
 
@@ -1547,7 +1504,6 @@ Previously the did files and wasms could be incompatible.
 `dfx start` and `dfx replica` now ignore the `--enable-canister-http` parameter.
 
 You can still disable the canister http feature through configuration:
-
 - ~/.config/dfx/networks.json: `.local.canister_http.enabled=false`
 - dfx.json (project-specific networks) : `.networks.local.canister_http.enabled=false`
 
@@ -1559,8 +1515,7 @@ You can still disable the canister http feature through configuration:
 
 ### feat: deploy NNS canisters
 
-A developer is now able to install NNS canisters, including back end canisters such as ledger and governance, and front end canisters such as nns-dapp and internet-identity, on their local DFX server. Usage:
-
+A developer is now able to install NNS canisters, including back end canisters such as ledger and governance, and front end canisters such as nns-dapp and internet-identity, on their local DFX server.  Usage:
 ```
 dfx start --clean --background
 dfx nns install
@@ -1595,13 +1550,13 @@ When creating a new identity with `dfx identity new`, whereas previously it woul
 
 ### chore: update Candid UI canister with commit 528a4b04807904899f67b919a88597656e0cd6fa
 
-- Allow passing did files larger than 2KB.
-- Better integration with Motoko Playground.
+* Allow passing did files larger than 2KB.
+* Better integration with Motoko Playground.
 
 ### feat: simplify verification of assets served by asset canister
 
-- SHA256 hashes of all assets are displayed when deploying the asset canister.
-- A query method is added to the asset canister that returns the entire asset hash tree together with the certificate containing the certified variables of the asset canister.
+* SHA256 hashes of all assets are displayed when deploying the asset canister.
+* A query method is added to the asset canister that returns the entire asset hash tree together with the certificate containing the certified variables of the asset canister.
 
 ### breaking change: dfx canister update-settings --compute-allocation always fails
 
@@ -1609,7 +1564,6 @@ See https://forum.dfinity.org/t/fixing-incorrect-compute-allocation-fee/14830
 
 Until the rollout is complete, `dfx canister update-settings --compute-allocation <N>`
 will fail with an error from the replica such as the following:
-
 ```
 The Replica returned an error: code 1, message: "Canister requested a compute allocation of 1% which cannot be satisfied because the Subnet's remaining compute capacity is 0%"
 ```
@@ -1637,7 +1591,7 @@ Additionally, after build step, the `.wasm` file is archived with `gzip`.
 ### chore: Move all `frontend canister`-related code into the SDK repo
 
 | from (`repository` `path`)                  | to (path in `dfinity/sdk` repository)          | summary                                                                                     |
-| :------------------------------------------ | :--------------------------------------------- | :------------------------------------------------------------------------------------------ |
+|:--------------------------------------------|:-----------------------------------------------|:--------------------------------------------------------------------------------------------|
 | `dfinity/cdk-rs` `/src/ic-certified-assets` | `/src/canisters/frontend/ic-certified-asset`   | the core of the frontend canister                                                           |
 | `dfinity/certified-assets` `/`              | `/src/canisters/frontend/ic-frontend-canister` | wraps `ic-certified-assets` to build the canister wasm                                      |
 | `dfinity/agent-rs` `/ic-asset`              | `/src/canisters/frontend/ic-asset`             | library facilitating interactions with frontend canister (e.g. uploading or listing assets) |
@@ -1647,19 +1601,17 @@ Additionally, after build step, the `.wasm` file is archived with `gzip`.
 
 Both `.ic-assets.json` and `.ic-assets.json5` are valid filenames config filename, though both will get parsed
 as if they were [JSON5](https://json5.org/) format. Example content of the `.ic-assets.json5` file:
-
 ```json5
 // comment
 [
   {
-    match: "*", // comment
+    "match": "*", // comment
     /*
     keys below not wrapped in quotes
-*/ cache: { max_age: 999 }, // trailing comma
+*/  cache: { max_age: 999 }, // trailing comma
   },
 ]
 ```
-
 - Learn more about JSON5: https://json5.org/
 
 ### fix: Update nns binaries unless `NO_CLOBBER` is set
@@ -1668,7 +1620,7 @@ Previously existing NNS binaries were not updated regardless of the `NO_CLOBBER`
 
 ### feat!: Support installing canisters not in dfx.json
 
-`install_canister_wasm` used to fail if installing a canister not listed in dfx.json. This use case is now supported.
+`install_canister_wasm` used to fail if installing a canister not listed in dfx.json.  This use case is now supported.
 
 ### feat: print the dashboard URL on startup
 
@@ -1682,32 +1634,30 @@ In combination with the "system-wide dfx start" feature, there is a potential di
 
 Since previous versions of dfx populate dfx.json with a `networks.local` definition that specifies port 8000, the behavior for existing projects won't change.
 
-However, if you've edited dfx.json and removed the `networks.local` definition, the behavior within the project will change: dfx will connect to the shared local network on port 4943 rather than to the project-specific network on port 8000. You would need to edit webpack.config.js to match. If you have scripts, you can run the new command `dfx info webserver-port` from the project directory to retrieve the port value.
+However, if you've edited dfx.json and removed the `networks.local` definition, the behavior within the project will change: dfx will connect to the shared local network on port 4943 rather than to the project-specific network on port 8000.  You would need to edit webpack.config.js to match.  If you have scripts, you can run the new command `dfx info webserver-port` from the project directory to retrieve the port value.
 
 ### feat!: "system-wide dfx start"
 
-By default, dfx now manages the replica process in a way that is independent of any given dfx project. We've called this feature "system-wide dfx", even though it's actually specific to your user
+By default, dfx now manages the replica process in a way that is independent of any given dfx project.  We've called this feature "system-wide dfx", even though it's actually specific to your user
 (storing data files under $HOME), because we think it communicates the idea adequately.
 
 The intended benefits:
-
 - deploying dapps from separate projects alongside one another, similar to working with separate dapps on mainnet
 - run `dfx start` from any directory
 - run `dfx stop` from any directory, rather than having to remember where you last ran `dfx start`
 
-We're calling this the "shared local network." `dfx start` and `dfx stop` will manage this network when run outside any project directory, or when a project's dfx.json does not define the `local` network. The dfx.json template for new projects no longer defines any networks.
+We're calling this the "shared local network."  `dfx start` and `dfx stop` will manage this network when run outside any project directory, or when a project's dfx.json does not define the `local` network.  The dfx.json template for new projects no longer defines any networks.
 
-We recommend that you remove the `local` network definition from dfx.json and instead use the shared local network. As mentioned above, doing so will make dfx use port 4943 rather than port 8000.
+We recommend that you remove the `local` network definition from dfx.json and instead use the shared local network.  As mentioned above, doing so will make dfx use port 4943 rather than port 8000.
 
 See [Local Server Configuration](docs/cli-reference/dfx-start.md#local-server-configuration) for details.
 
 dfx now stores data and control files in one of three places, rather than directly under `.dfx/`:
-
 - `.dfx/network/local` (for projects in which dfx.json defines the local network)
 - `$HOME/.local/share/dfx/network/local` (for the shared local network on Linux)
 - `$HOME/Library/Application Support/org.dfinity.dfx/network/local` (for the shared local network on MacOS)
 
-There is also a new configuration file: `$HOME/.config/dfx/networks.json`. Its [schema](docs/networks-json-schema.json) is the same as the `networks` element in dfx.json. Any networks you define here will be available from any project, unless a project's dfx.json defines a network with the same name. See [The Shared Local Network](docs/cli-reference/dfx-start.md#the-shared-local-network) for the default definitions that dfx provides if this file does not exist or does not define a `local` network.
+There is also a new configuration file: `$HOME/.config/dfx/networks.json`.  Its [schema](docs/networks-json-schema.json) is the same as the `networks` element in dfx.json.  Any networks you define here will be available from any project, unless a project's dfx.json defines a network with the same name.  See [The Shared Local Network](docs/cli-reference/dfx-start.md#the-shared-local-network) for the default definitions that dfx provides if this file does not exist or does not define a `local` network.
 
 ### fix: `dfx start` and `dfx stop` will take into account dfx/replica processes from dfx <= 0.11.x
 
@@ -1737,7 +1687,7 @@ This displays the path to your user's `networks.json` file where all networks ar
 
 ### feat: dfx schema --for networks
 
-The `dfx schema` command can now display the schema for either dfx.json or for networks.json. By default, it still displays the schema for dfx.json.
+The `dfx schema` command can now display the schema for either dfx.json or for networks.json.  By default, it still displays the schema for dfx.json.
 
 ```bash
 dfx schema --for networks
@@ -1749,8 +1699,8 @@ If you have a pre-initialized agent in your JS code, you can now pass it to crea
 
 ```js
 const plugActor = createActor(canisterId, {
-  agent: plugAgent,
-});
+  agent: plugAgent
+})
 ```
 
 ### feat!: option for nodejs compatibility in dfx generate
@@ -1788,12 +1738,10 @@ If the active identity has a wallet configured already, the faucet will top up t
 
 Alternative faucets can be used, assuming they follow the same interface. To direct dfx to a different faucet, use the `--faucet <alternative faucet id>` flag.
 The expected interface looks like the following candid functions:
-
-```candid
+``` candid
 redeem: (text) -> (principal);
 redeem_to_wallet: (text, principal) -> (nat);
 ```
-
 The function `redeem` takes a coupon code and returns the principal to an already-installed wallet that is controlled by the identity that called the function.
 The function `redeem_to_wallet` takes a coupon code and a wallet (or any other canister) principal, deposits the cycles into that canister and returns how many cycles were deposited.
 
@@ -1815,17 +1763,13 @@ When installing a new WASM module to a canister, DFX will now wait for the updat
 ### feat: move all the flags to the end
 
 Command flags have been moved to a more traditional location; they are no longer positioned per subcommand, but instead are able to be all positioned after the final subcommand. In prior versions, a command might look like:
-
 ```bash
 dfx --identity alice canister --network ic --wallet "$WALLET" create --all
 ```
-
 This command can now be written:
-
 ```bash
 dfx canister create --all --network ic --wallet "$WALLET" --identity alice
 ```
-
 The old syntax is still available, though, so you don't need to migrate your scripts.
 
 ### feat!: changed update-settings syntax
@@ -1834,7 +1778,7 @@ When using `dfx canister update-settings`, it is easy to mistake `--controller` 
 
 ### feat!: removed the internal webserver
 
-This is a breaking change. The only thing this was still serving was the /\_/candid endpoint. If you need to retrieve the candid interface for a local canister, you can use `dfx canister metadata <canister> candid:service`.
+This is a breaking change.  The only thing this was still serving was the /_/candid endpoint.  If you need to retrieve the candid interface for a local canister, you can use `dfx canister metadata <canister> candid:service`.
 
 ### fix: dfx wallet upgrade: improved error messages:
 
@@ -1848,16 +1792,15 @@ Canister creation fee was calculated with 1T cycles instead of 0.1T.
 ### fix: dfx deploy and dfx canister install write .old.did files under .dfx/
 
 When dfx deploy and dfx canister install upgrade a canister, they ensure that the
-new candid interface is compatible with the previous candid interface. They write
-a file with extension .old.did that contains the previous interface. In some
-circumstances these files could be written in the project directory. dfx now
+new candid interface is compatible with the previous candid interface.  They write
+a file with extension .old.did that contains the previous interface.  In some
+circumstances these files could be written in the project directory.  dfx now
 always writes them under the .dfx/ directory.
 
 ### fix: dfx canister install now accepts arbitrary canister ids
 
 This fixes the following error:
-
-```bash
+``` bash
 > dfx canister install --wasm ~/counter.wasm eop7r-riaaa-aaaak-qasxq-cai
 Error: Failed while determining if canister 'eop7r-riaaa-aaaak-qasxq-cai' is remote on network 'ic'.
 Caused by: Failed while determining if canister 'eop7r-riaaa-aaaak-qasxq-cai' is remote on network 'ic'.
@@ -1870,7 +1813,6 @@ Caused by: Failed while determining if canister 'eop7r-riaaa-aaaak-qasxq-cai' is
 It is now possible to specify the replica's log level. Possible values are `critical`, `error`, `warning`, `info`, `debug`, and `trace`.
 The log level defaults to the level 'error'. Debug prints (e.g. `Debug.print("...")` in Motoko) still show up in the console.
 The log level can be specified in the following places (See [system-wide dfx start](#feat-system-wide-dfx-start) for more detailed explanations on the network types):
-
 - In file `networks.json` in the field `<network name>.replica.log_level` for shared networks.
 - In file `dfx.json` in the field `networks.<network name>.replica.log_level` for project-specific networks.
 - In file `dfx.json` in the field `defaults.replica.log_level` for project-specific networks. Requires a project-specific network to be run, otherwise this will have no effect.
@@ -1899,10 +1841,10 @@ It is still possible to pin the dfx version by adding `"dfx":"<dfx version to pi
 ### fix: Small grammar change to identity password decryption prompt
 
 The prompt for entering your passphrase in order to decrypt an identity password read:
-"Please enter a passphrase for your identity"
-However, at that point, it isn't "a" passphrase. It's either your passphrase, or incorrect.
+    "Please enter a passphrase for your identity"
+However, at that point, it isn't "a" passphrase.  It's either your passphrase, or incorrect.
 Changed the text in this case to read:
-"Please enter the passphrase for your identity"
+    "Please enter the passphrase for your identity"
 
 ### chore: add retry logic to dfx download script
 
@@ -1924,7 +1866,6 @@ This also incorporates the following executed proposals:
 - [87631](https://dashboard.internetcomputer.org/proposal/87631)
 - [86738](https://dashboard.internetcomputer.org/proposal/86738)
 - [86279](https://dashboard.internetcomputer.org/proposal/86279)
-
 * [85007](https://dashboard.internetcomputer.org/proposal/85007)
 * [84391](https://dashboard.internetcomputer.org/proposal/84391)
 * [83786](https://dashboard.internetcomputer.org/proposal/83786)
@@ -1947,7 +1888,6 @@ This also incorporates the following executed proposals:
 ### ic-ref
 
 Updated ic-ref to 0.0.1-1fba03ee
-
 - introduce awaitKnown
 - trivial implementation of idle_cycles_burned_per_day
 
@@ -1955,13 +1895,13 @@ Updated ic-ref to 0.0.1-1fba03ee
 
 - See https://github.com/dfinity/motoko/blob/master/Changelog.md#073-2022-11-01
 
+
 ### Cycles wallet
 
 - Module hash: b944b1e5533064d12e951621d5045d5291bcfd8cf9d60c28fef02c8fdb68e783
 - https://github.com/dfinity/cycles-wallet/commit/fa86dd3a65b2509ca1e0c2bb9d7d4c5be95de378
 
 ### Frontend canister:
-
 - Module hash: 6c8f7a094060b096c35e4c4499551e7a8a29ee0f86c456e521c09480ebbaa8ab
 - https://github.com/dfinity/sdk/pull/2720
 
@@ -1996,38 +1936,34 @@ Patches a JavaScript language binding compatibility issue encountered in web bro
 dfx is now capable of displaying the schema for `dfx.json`. You can see the schema by running `dfx schema` or write the schema to a file with `dfx schema --outfile path/to/file/schema.json`.
 
 ### feat: support for configuring assets in assets canister
-
 - The `.ic-assets.json` file should be placed inside directory with assets, or its subdirectories. Multiple config files can be used (nested in subdirectories). Example of `.ic-assets.json` file format:
-
-```json
+``` json
 [
-  {
-    "match": ".*",
-    "cache": {
-      "max_age": 20
+    {
+        "match": ".*",
+        "cache": {
+            "max_age": 20
+        },
+        "headers": {
+            "X-Content-Type-Options": "nosniff"
+        },
+        "ignore": false
     },
-    "headers": {
-      "X-Content-Type-Options": "nosniff"
+    {
+        "match": "**/*",
+        "headers": null
     },
-    "ignore": false
-  },
-  {
-    "match": "**/*",
-    "headers": null
-  },
-  {
-    "match": "file.json",
-    "ignore": true
-  }
+    {
+        "match": "file.json",
+        "ignore": true
+    }
 ]
 ```
-
 - Configuring assets works only during asset creation - any changes to `.ic-assets.json` files won't have any effect effect for assets that have already been created. We are working on follow up implementation with improvements to handle updating these properties.
 - `headers` from multiple applicable rules are being stacked/concatenated, unless `null` is specified, which resets/empties the headers.
 - Both `"headers": {}` and absence of `headers` field don't have any effect on end result.
 - Valid JSON format is required, i.e. the array of maps, `match` field is required. Only the following fields are accepted: `cache`, `ignore`, `headers`, `match`. The glob pattern has to be valid.
 - The way matching rules work:
-
   1. The most deeply nested config file takes precedence over the one in parent dir. In other words, properties from a rule matching a file in a subdirectory override properties from a rule matching a file in a parent directory
   2. Order of rules within file matters - last rule in config file takes precedence over the first one
 
@@ -2036,6 +1972,7 @@ dfx is now capable of displaying the schema for `dfx.json`. You can see the sche
   2. The `.ignore` field overrides this, if present.
   3. If a directory is ignored, file and directories within it cannot be un-ignored.
   4. A file can be ignored and un-ignored many times, as long as any of its parent directories haven't been ignored.
+
 
 ### fix: Allow `dfx deploy` to not take arguments for canisters not being installed
 
@@ -2069,17 +2006,17 @@ A test key id "Secp256k1:dfx_test_key" is ready to be used by locally created ca
 Updated replica to elected commit 6e86169e98904047833ba6133e5413d2758d90eb.
 This incorporates the following executed proposals:
 
-- [72225](https://dashboard.internetcomputer.org/proposal/72225)
-- [71669](https://dashboard.internetcomputer.org/proposal/71669)
-- [71164](https://dashboard.internetcomputer.org/proposal/71164)
-- [70375](https://dashboard.internetcomputer.org/proposal/70375)
-- [70002](https://dashboard.internetcomputer.org/proposal/70002)
+* [72225](https://dashboard.internetcomputer.org/proposal/72225)
+* [71669](https://dashboard.internetcomputer.org/proposal/71669)
+* [71164](https://dashboard.internetcomputer.org/proposal/71164)
+* [70375](https://dashboard.internetcomputer.org/proposal/70375)
+* [70002](https://dashboard.internetcomputer.org/proposal/70002)
 
 # 0.11.0
 
 ## DFX
 
-### feat: renamed canisters in new projects to <project>\_frontend and <project>\_backend
+### feat: renamed canisters in new projects to <project>_frontend and <project>_backend
 
 The names of canisters created for new projects have changed.
 After `dfx new <project>`, the canister names are:
@@ -2093,10 +2030,10 @@ After `dfx new <project>`, the canister names are:
 
 For example, to query a canister's candid service definition: `dfx canister metadata hello_backend candid:service`
 
-### refactor: deprecate /\_/candid internal webserver
+### refactor: deprecate /_/candid internal webserver
 
-The dfx internal webserver now only services the /\_/candid endpoint. This
-is now deprecated. If you were using this to query candid definitions, you
+The dfx internal webserver now only services the /_/candid endpoint.  This
+is now deprecated.  If you were using this to query candid definitions, you
 can instead use `dfx canister metadata`.
 
 ### refactor: optimize from ic-wasm
@@ -2108,9 +2045,8 @@ The actual optimization was kept the same.
 ### feat: Read dfx canister call argument from a file or stdin
 
 Enables passing large arguments that cannot be passed directly in the command line using the `--argument-file` flag. For example:
-
-- Named file: `dfx canister call --argument-file ./my/argument/file.txt my_canister_name greet`
-- Stdin: `echo '( null )' | dfx canister call --argument-file - my_canister_name greet`
+ * Named file: `dfx canister call --argument-file ./my/argument/file.txt my_canister_name greet`
+ * Stdin: `echo '( null )' | dfx canister call --argument-file - my_canister_name greet`
 
 ### fix: Use default setting for BTC adapter idle seconds
 
@@ -2134,18 +2070,18 @@ By default, a log level of "info" is used, which is relatively quiet. Users can 
 
 This includes the following changes:
 
-- Fetch did file from canister metadata
-- Better flamegraph support
-- Fix bigint error for vec nat8 type
+* Fetch did file from canister metadata
+* Better flamegraph support
+* Fix bigint error for vec nat8 type
 
 ### feat: dfx will look up the port of the running webserver from .dfx/webserver-port, if present
 
-After `dfx start --host 127.0.0.1:0`, the dfx webserver will listen on an ephemeral port. It stores the port value in .dfx/webserver-port. dfx will now look for this file, and if a port is contained within, use that port to connect to the dfx webserver.
+After `dfx start --host 127.0.0.1:0`, the dfx webserver will listen on an ephemeral port.  It stores the port value in .dfx/webserver-port.  dfx will now look for this file, and if a port is contained within, use that port to connect to the dfx webserver.
 
 ### fix: dfx commands once again work from any subdirectory of a dfx project
 
 Running `dfx deploy`, `dfx canister id`, `dfx canister call` and so forth work as expected
-if run from within any subdirectory of a dfx project. Previously, this would create
+if run from within any subdirectory of a dfx project.  Previously, this would create
 canister_ids.json or .dfx/local/canister_ids.json within the subdirectory.
 
 ### feat: Post-installation tasks
@@ -2157,7 +2093,7 @@ You can now add your own custom post-installation/post-deployment tasks to any c
 Assets are now uploaded directly from their source directories, rather than first being copied
 to an output directory.
 
-If you're using `dfx deploy`, you won't see any change in functionality. If you're running
+If you're using `dfx deploy`, you won't see any change in functionality.  If you're running
 `dfx canister install --mode=upgrade`, changed files in asset source directories will
 be detected and uploaded even without an intervening `dfx build`.
 
@@ -2195,7 +2131,7 @@ Resolves an issue where `webpack-cli` was was breaking when users tried to run `
 ### feat: Support for new ledger notify function
 
 Ledger 7424ea8 deprecates the existing `notify` function with a switch parameter between creating and topping up a canister, and introduces two
-functions for doing the same. This should _mostly_ be invisible to users, except that previously, if `dfx ledger create-canister` or `dfx ledger top-up`
+functions for doing the same. This should *mostly* be invisible to users, except that previously, if `dfx ledger create-canister` or `dfx ledger top-up`
 failed, you would call `dfx ledger notify` after correcting the issue. In order to support the change, this command has been changed to two subcommands:
 `dfx ledger notify create-canister` and `dfx ledger notify top-up`.
 
@@ -2227,7 +2163,7 @@ The candid file specified in the field `canisters.<canister name>.candid` of dfx
 ### fix: btc/canister http adapter socket not found by replica after restart
 
 After running `dfx start --enable-bitcoin` twice in a row (stopping dfx in between), the second
-launched replica would fail to connect to the btc adapter. This is because ic-starter
+launched replica would fail to connect to the btc adapter.  This is because ic-starter
 does not write a new configuration file if one already exists, so the configuration file
 used by the replica referred to one socket path, while dfx passed a different socket path
 to the btc adapter.
@@ -2246,6 +2182,7 @@ a dfx process that is starting.
 ### fix: dfx ping no longer creates a default identity
 
 dfx ping now uses the anonymous identity, and no longer requires dfx.json to be present.
+
 
 ### fix: Initialize replica with bitcoin regtest flag
 
@@ -2269,8 +2206,7 @@ If one of these four fields is set for the local network, the corresponding fiel
 in `defaults` will be ignored.
 
 Example:
-
-```json
+``` json
 {
   "networks": {
     "local": {
@@ -2298,27 +2234,26 @@ Updated Motoko from 0.6.28 to 0.6.29.
 Updated replica to elected commit 8993849de5fab76e796d67750facee55a0bf6649.
 This incorporates the following executed proposals:
 
-- [69804](https://dashboard.internetcomputer.org/proposal/69804)
-- [67990](https://dashboard.internetcomputer.org/proposal/67990)
-- [67483](https://dashboard.internetcomputer.org/proposal/67483)
-- [66895](https://dashboard.internetcomputer.org/proposal/66895)
-- [66888](https://dashboard.internetcomputer.org/proposal/66888)
-- [65530](https://dashboard.internetcomputer.org/proposal/65530)
-- [65327](https://dashboard.internetcomputer.org/proposal/65327)
-- [65043](https://dashboard.internetcomputer.org/proposal/65043)
-- [64355](https://dashboard.internetcomputer.org/proposal/64355)
-- [63228](https://dashboard.internetcomputer.org/proposal/63228)
-- [62143](https://dashboard.internetcomputer.org/proposal/62143)
+* [69804](https://dashboard.internetcomputer.org/proposal/69804)
+* [67990](https://dashboard.internetcomputer.org/proposal/67990)
+* [67483](https://dashboard.internetcomputer.org/proposal/67483)
+* [66895](https://dashboard.internetcomputer.org/proposal/66895)
+* [66888](https://dashboard.internetcomputer.org/proposal/66888)
+* [65530](https://dashboard.internetcomputer.org/proposal/65530)
+* [65327](https://dashboard.internetcomputer.org/proposal/65327)
+* [65043](https://dashboard.internetcomputer.org/proposal/65043)
+* [64355](https://dashboard.internetcomputer.org/proposal/64355)
+* [63228](https://dashboard.internetcomputer.org/proposal/63228)
+* [62143](https://dashboard.internetcomputer.org/proposal/62143)
 
 ### ic-ref
 
 Updated ic-ref to 0.0.1-173cbe84
-
-- add ic0.performance_counter system interface
-- add system API for ECDSA signing
-- allow optional "error_code" field in responses
-- support gzip-compressed canister modules
-- enable canisters to send HTTP requests
+ - add ic0.performance_counter system interface
+ - add system API for ECDSA signing
+ - allow optional "error_code" field in responses
+ - support gzip-compressed canister modules
+ - enable canisters to send HTTP requests
 
 # 0.10.1
 
@@ -2332,11 +2267,9 @@ lead to an annoying "too many open files" error.
 ### fix: HSMs are once again supported on Linux
 
 On Linux, dfx 0.10.0 failed any operation with an HSM with the following error:
-
 ```
 Error: IO: Dynamic loading not supported
 ```
-
 The fix was to once again dynamically-link the Linux build.
 
 ### feat: error explanation and fixing instructions engine
@@ -2360,8 +2293,7 @@ The behavior for identities without any configured wallets is unchanged.
 ### feat: bitcoin integration: dfx now generates the bitcoin adapter config file
 
 dfx command-line parameters for bitcoin integration:
-
-```bash
+``` bash
 dfx start   --enable-bitcoin  # use default node 127.0.0.1:18444
 dfx start   --enable-bitcoin --bitcoin-node <node>
 ```
@@ -2369,7 +2301,6 @@ dfx start   --enable-bitcoin --bitcoin-node <node>
 The above examples also work for dfx replica.
 
 These default to values from dfx.json:
-
 ```
 .defaults.bitcoin.nodes
 .defaults.bitcoin.enabled
@@ -2378,6 +2309,7 @@ These default to values from dfx.json:
 The --bitcoin-node parameter, if specified on the command line, implies --enable-bitcoin.
 
 If --enable-bitcoin or .defaults.bitcoin.enabled is set, then dfx start/replica will launch the ic-btc-adapter process and configure the replica to communicate with it.
+
 
 ### feat: print wallet balance in a human readable form #2184
 
@@ -2388,14 +2320,12 @@ New flag `--precise` added to `dfx wallet balance`. Allows to get exact amount o
 ### feat: canister http integration
 
 dfx command-line parameters for canister http requests integration:
-
 ```
 dfx start --enable-canister-http
 dfx replica --enable-canister-http
 ```
 
 This defaults to the following value in dfx.json:
-
 ```
 .defaults.canister_http.enabled
 ```
@@ -2421,22 +2351,22 @@ Updated Motoko from 0.6.26 to 0.6.28.
 Updated replica to elected commit b90edb9897718730f65e92eb4ff6057b1b25f766.
 This incorporates the following executed proposals:
 
-- [61004](https://dashboard.internetcomputer.org/proposal/61004)
-- [60222](https://dashboard.internetcomputer.org/proposal/60222)
-- [59187](https://dashboard.internetcomputer.org/proposal/59187)
-- [58479](https://dashboard.internetcomputer.org/proposal/58479)
-- [58376](https://dashboard.internetcomputer.org/proposal/58376)
-- [57843](https://dashboard.internetcomputer.org/proposal/57843)
-- [57395](https://dashboard.internetcomputer.org/proposal/57395)
+* [61004](https://dashboard.internetcomputer.org/proposal/61004)
+* [60222](https://dashboard.internetcomputer.org/proposal/60222)
+* [59187](https://dashboard.internetcomputer.org/proposal/59187)
+* [58479](https://dashboard.internetcomputer.org/proposal/58479)
+* [58376](https://dashboard.internetcomputer.org/proposal/58376)
+* [57843](https://dashboard.internetcomputer.org/proposal/57843)
+* [57395](https://dashboard.internetcomputer.org/proposal/57395)
 
 ## icx-proxy
 
 Updated icx-proxy to commit c312760a62b20931431ba45e5b0168ee79ea5cda
 
-- Added gzip and deflate body decoding before certification validation.
-- Fixed unzip and streaming bugs
-- Added Prometheus metrics endpoint
-- Added root and invalid ssl and dns mapping
+* Added gzip and deflate body decoding before certification validation.
+* Fixed unzip and streaming bugs
+* Added Prometheus metrics endpoint
+* Added root and invalid ssl and dns mapping
 
 # 0.10.0
 
@@ -2444,9 +2374,10 @@ Updated icx-proxy to commit c312760a62b20931431ba45e5b0168ee79ea5cda
 
 ### feat: Use null as default value for opt arguments
 
+
 Before this, `deploy`ing a canister with an `opt Foo` init argument without specifying an `--argument` would lead to an error:
 
-```bash
+``` bash
 $ dfx deploy
 Error: Invalid data: Expected arguments but found none.
 ```
@@ -2477,7 +2408,7 @@ dfx will once again display 'dfx is already running' if dfx is already running,
 rather than 'Address already in use'.
 
 As a consequence, after `dfx start` failed to notice that dfx was already running,
-it would replace .dfx/pid with an empty file. Later invocations of `dfx stop`
+it would replace .dfx/pid with an empty file.  Later invocations of `dfx stop`
 would display no output and return a successful exit code, but leave dfx running.
 
 ### fix: dfx canister update-settings <canister id> works even if the canister id is not known to the project.
@@ -2488,8 +2419,8 @@ This makes the behavior match the usage text of the command:
 ### feat: dfx deploy --upgrade-unchanged or dfx canister install --mode upgrade --upgrade-unchanged
 
 When upgrading a canister, `dfx deploy` and `dfx canister install` skip installing the .wasm
-if the wasm hash did not change. This avoids a round trip through stable memory for all
-assets on every dfx deploy, for example. By passing this argument, dfx will instead
+if the wasm hash did not change.  This avoids a round trip through stable memory for all
+assets on every dfx deploy, for example.  By passing this argument, dfx will instead
 install the wasm even if its hash matches the already-installed wasm.
 
 ### feat: Introduce DFX_CACHE_ROOT environment variable
@@ -2505,12 +2436,11 @@ Previously, `dfx canister call --with-cycles 1` would silently ignore the `--wit
 ### feat: Configure subnet type of local replica
 
 The local replica sets its parameters according to the subnet type defined in defaults.replica.subnet_type, defaulting to 'application' when none is specified.
-This makes it less likely to accidentally hit the 'cycles limit exceeded' error in production. Since the previous default was `system`, you may see these types errors in development instead.
+This makes it less likely to accidentally hit the 'cycles limit exceeded' error in production.  Since the previous default was `system`, you may see these types errors in development instead.
 Possible values for defaults.replica.subnet_type are: "application", "verifiedapplication", "system"
 
 Example how to specify the subnet type:
-
-```json
+``` json
 {
   "defaults": {
     "replica": {
@@ -2531,8 +2461,7 @@ If you decide to use a password, your key will never be written to disk in plain
 In case you don't want to enter your password all the time and want to take the risk of storing your private key in plain text, you can use the `--disable-encryption` flag.
 
 The `default` identity as well as already existing identities will NOT be encrypted. If you want to encrypt an existing identity, use the following commands:
-
-```bash
+``` bash
 dfx identity export identity_name > identity.pem
 # if you have set old_identity_name as the identity that is used by default, switch to a different one
 dfx identity use other_identity
@@ -2562,14 +2491,12 @@ But when trying to create an identity with that name, it was considered to be al
 ### feat: dfx start and dfx replica can now launch the ic-btc-adapter process
 
 Added command-line parameters:
-
-```bash
+``` bash
 dfx start   --enable-bitcoin --btc-adapter-config <path>
 dfx replica --enable-bitcoin --btc-adapter-config <path>
 ```
 
 These default to values from dfx.json:
-
 ```
 .defaults.bitcoin.btc_adapter_config
 .defaults.bitcoin.enabled
@@ -2605,14 +2532,14 @@ Updated to version 0.14.0 of agent-rs
 Updated replica to elected commit b3788091fbdb8bed7e527d2df4cc5e50312f476c.
 This incorporates the following executed proposals:
 
-- [57150](https://dashboard.internetcomputer.org/proposal/57150)
-- [54964](https://dashboard.internetcomputer.org/proposal/54964)
-- [53702](https://dashboard.internetcomputer.org/proposal/53702)
-- [53231](https://dashboard.internetcomputer.org/proposal/53231)
-- [53134](https://dashboard.internetcomputer.org/proposal/53134)
-- [52627](https://dashboard.internetcomputer.org/proposal/52627)
-- [52144](https://dashboard.internetcomputer.org/proposal/52144)
-- [50282](https://dashboard.internetcomputer.org/proposal/50282)
+* [57150](https://dashboard.internetcomputer.org/proposal/57150)
+* [54964](https://dashboard.internetcomputer.org/proposal/54964)
+* [53702](https://dashboard.internetcomputer.org/proposal/53702)
+* [53231](https://dashboard.internetcomputer.org/proposal/53231)
+* [53134](https://dashboard.internetcomputer.org/proposal/53134)
+* [52627](https://dashboard.internetcomputer.org/proposal/52627)
+* [52144](https://dashboard.internetcomputer.org/proposal/52144)
+* [50282](https://dashboard.internetcomputer.org/proposal/50282)
 
 Added the ic-btc-adapter binary to the cache.
 
@@ -2630,7 +2557,7 @@ Updated Motoko from 0.6.25 to 0.6.26.
 
 In preparation for BTC integration, added configuration for the bitcoind port:
 
-```json
+``` json
 {
   "canisters": {},
   "defaults": {
@@ -2645,23 +2572,23 @@ In preparation for BTC integration, added configuration for the bitcoind port:
 
 Updated icx-proxy to commit 594b6c81cde6da4e08faee8aa8e5a2e6ae815602, now static-linked.
 
-- upgrade HTTP calls upon canister request
-- no longer proxies /\_/raw to the dfx internal webserver
-- allows for generic StreamingCallback tokens
+* upgrade HTTP calls upon canister request
+* no longer proxies /_/raw to the dfx internal webserver
+* allows for generic StreamingCallback tokens
 
 ## Replica
 
 Updated replica to blessed commit d004accc3904e24dddb13a11d93451523e1a8a5f.
 This incorporates the following executed proposals:
 
-- [49653](https://dashboard.internetcomputer.org/proposal/49653)
-- [49011](https://dashboard.internetcomputer.org/proposal/49011)
-- [48427](https://dashboard.internetcomputer.org/proposal/48427)
-- [47611](https://dashboard.internetcomputer.org/proposal/47611)
-- [47512](https://dashboard.internetcomputer.org/proposal/47512)
-- [47472](https://dashboard.internetcomputer.org/proposal/47472)
-- [45984](https://dashboard.internetcomputer.org/proposal/45984)
-- [45982](https://dashboard.internetcomputer.org/proposal/45982)
+* [49653](https://dashboard.internetcomputer.org/proposal/49653)
+* [49011](https://dashboard.internetcomputer.org/proposal/49011)
+* [48427](https://dashboard.internetcomputer.org/proposal/48427)
+* [47611](https://dashboard.internetcomputer.org/proposal/47611)
+* [47512](https://dashboard.internetcomputer.org/proposal/47512)
+* [47472](https://dashboard.internetcomputer.org/proposal/47472)
+* [45984](https://dashboard.internetcomputer.org/proposal/45984)
+* [45982](https://dashboard.internetcomputer.org/proposal/45982)
 
 ## Motoko
 
@@ -2676,8 +2603,8 @@ Updated Motoko from 0.6.21 to 0.6.25.
 Newly deployed Motoko canisters now embed the Candid interface and Motoko stable signatures in the Wasm module.
 `dfx deploy` and `dfx canister install` will automatically check
 
-    1) the backward compatible of Candid interface in both upgrade and reinstall mode;
-    2) the type safety of Motoko stable variable type in upgrade mode to avoid accidentally lossing data;
+	1) the backward compatible of Candid interface in both upgrade and reinstall mode;
+	2) the type safety of Motoko stable variable type in upgrade mode to avoid accidentally lossing data;
 
 See [Upgrade compatibility](https://internetcomputer.org/docs/language-guide/compatibility) for more details.
 
@@ -2685,13 +2612,13 @@ See [Upgrade compatibility](https://internetcomputer.org/docs/language-guide/com
 
 The three canister types that use a custom build tool - `assets`, `rust`, and `custom` - now all support the same set of environment variables during the build task:
 
-- `DFX_VERSION` - The version of DFX that was used to build the canister.
-- `DFX_NETWORK` - The network name being built for. Usually `ic` or `local`.
-- `CANISTER_ID_{canister}` - The canister principal ID of the canister `{canister}` registered in `dfx.json`.
-- `CANISTER_CANDID_PATH_{canister}` - The path to the Candid interface file for the canister `{canister}` among your canister's dependencies.
-- `CANISTER_CANDID_{canister}` (deprecated) - the same as `CANISTER_CANDID_PATH_{canister}`. This is provided for backwards compatibility with `rust` and `custom` canisters, and will be removed in dfx 0.10.0.
-- `CANISTER_ID` - Same as `CANISTER_ID_{self}`, where `{self}` is the name of _this_ canister.
-- `CANISTER_CANDID_PATH` - Same as `CANISTER_CANDID_PATH_{self}`, where `{self}` is the name of _this_ canister.
+* `DFX_VERSION` - The version of DFX that was used to build the canister.
+* `DFX_NETWORK` - The network name being built for. Usually `ic` or `local`.
+* `CANISTER_ID_{canister}` - The canister principal ID of the canister `{canister}` registered in `dfx.json`.
+* `CANISTER_CANDID_PATH_{canister}` - The path to the Candid interface file for the canister `{canister}` among your canister's dependencies.
+* `CANISTER_CANDID_{canister}` (deprecated) - the same as `CANISTER_CANDID_PATH_{canister}`.  This is provided for backwards compatibility with `rust` and `custom` canisters, and will be removed in dfx 0.10.0.
+* `CANISTER_ID` - Same as `CANISTER_ID_{self}`, where `{self}` is the name of _this_ canister.
+* `CANISTER_CANDID_PATH` - Same as `CANISTER_CANDID_PATH_{self}`, where `{self}` is the name of _this_ canister.
 
 ### feat: Support for local ledger calls
 
@@ -2699,8 +2626,7 @@ If you have an installation of the ICP Ledger (see [Ledger Installation Guide](h
 `--ledger-canister-id` parameter.
 
 Some examples:
-
-```bash
+``` bash
 $ dfx ledger \
   --network local \
   balance \
@@ -2719,7 +2645,7 @@ Transfer sent at block height: 1
 The `dfx ledger account-id` can now compute addresses of principals and canisters.
 The command also supports ledger subaccounts now.
 
-```bash
+``` bash
 dfx ledger account-id --of-principal 53zcu-tiaaa-aaaaa-qaaba-cai
 dfx ledger --network small02 account-id --of-canister ledger_demo
 dfx ledger account-id --of-principal 53zcu-tiaaa-aaaaa-qaaba-cai --subaccount 0000000000000000000000000000000000000000000000000000000000000001
@@ -2745,9 +2671,9 @@ Caused by:
 
 dfx now calls `transfer` rather than `send_dfx`, and sets the created_at_time field in order to retry the following commands:
 
-- dfx ledger create-canister
-- dfx ledger top-up
-- dfx ledger transfer
+* dfx ledger create-canister
+* dfx ledger top-up
+* dfx ledger transfer
 
 ### feat: Remote canister support
 
@@ -2757,8 +2683,7 @@ that is, a canister that already exists on that network and is managed by some o
 Motoko, Rust, and custom canisters may be configured in this way.
 
 This is the general format of the configuration in dfx.json:
-
-```json
+``` json
 {
   "canisters": {
     "<canister name>": {
@@ -2778,15 +2703,14 @@ The canister will not be created or installed on these remote networks.
 For other networks, the canister will be created and installed as usual.
 
 The "candid" field, if set within the remote object, specifies the candid file to build against when
-building other canisters on a network for which the canister is remote. This definition can differ
+building other canisters on a network for which the canister is remote.  This definition can differ
 from the candid definitions for local builds.
 
 For example, if have an installation of the ICP Ledger (see [Ledger Installation Guide](https://github.com/dfinity/ic/tree/master/rs/rosetta-api/ledger_canister#deploying-locally))
-in your dfx.json, you could configure the canister ID of the Ledger canister on the ic network as below. In this case,
+in your dfx.json, you could configure the canister ID of the Ledger canister on the ic network as below.  In this case,
 the private interfaces would be available for local builds, but only the public interfaces would be available
 when building for `--network ic`.
-
-```json
+``` json
 {
   "canisters": {
     "ledger": {
@@ -2803,7 +2727,7 @@ when building for `--network ic`.
     "app": {
       "type": "motoko",
       "main": "src/app/main.mo",
-      "dependencies": ["ledger"]
+      "dependencies": [ "ledger" ]
     }
   }
 }
@@ -2819,7 +2743,7 @@ This way, you can define public update/query functions to aid in local testing, 
 when building/deploying to mainnet, references to methods not found in `ledger.public.did`
 will be reports as compilation errors.
 
-```json
+``` json
 {
   "canisters": {
     "ledger": {
@@ -2835,7 +2759,7 @@ will be reports as compilation errors.
     "app": {
       "type": "motoko",
       "main": "src/app/main.mo",
-      "dependencies": ["ledger"]
+      "dependencies": [ "ledger" ]
     }
   }
 }
@@ -2848,8 +2772,7 @@ It's now possible to generate the interface of a remote canister using a .did fi
 Currently, dfx can generate .mo, .rs, .ts, and .js bindings.
 
 This is how you specify how to generate the bindings in dfx.json:
-
-```json
+``` json
 {
   "canisters": {
     "<canister name>": {
@@ -2867,25 +2790,25 @@ This is how you specify how to generate the bindings in dfx.json:
 
 Upgraded from a432156f24faa16d387c9d36815f7ddc5d50e09f to ab8e3f5a04f0f061b8157c2889f8f5de05f952bb
 
-- Support 128-bit system api for cycles
-- Include canister_ranges in the state tree
-- Removed limit on cycles in a canister
+* Support 128-bit system api for cycles
+* Include canister_ranges in the state tree
+* Removed limit on cycles in a canister
 
 ## Replica
 
 Updated replica to blessed commit 04fe8b0a1262f07c0cec1fdfa838a37607370a61.
 This incorporates the following executed proposals:
 
-- [45091](https://dashboard.internetcomputer.org/proposal/45091)
-- [43635](https://dashboard.internetcomputer.org/proposal/43635)
-- [43633](https://dashboard.internetcomputer.org/proposal/43633)
-- [42783](https://dashboard.internetcomputer.org/proposal/42783)
-- [42410](https://dashboard.internetcomputer.org/proposal/42410)
-- [40908](https://dashboard.internetcomputer.org/proposal/40908)
-- [40647](https://dashboard.internetcomputer.org/proposal/40647)
-- [40328](https://dashboard.internetcomputer.org/proposal/40328)
-- [39791](https://dashboard.internetcomputer.org/proposal/39791)
-- [38541](https://dashboard.internetcomputer.org/proposal/38541)
+* [45091](https://dashboard.internetcomputer.org/proposal/45091)
+* [43635](https://dashboard.internetcomputer.org/proposal/43635)
+* [43633](https://dashboard.internetcomputer.org/proposal/43633)
+* [42783](https://dashboard.internetcomputer.org/proposal/42783)
+* [42410](https://dashboard.internetcomputer.org/proposal/42410)
+* [40908](https://dashboard.internetcomputer.org/proposal/40908)
+* [40647](https://dashboard.internetcomputer.org/proposal/40647)
+* [40328](https://dashboard.internetcomputer.org/proposal/40328)
+* [39791](https://dashboard.internetcomputer.org/proposal/39791)
+* [38541](https://dashboard.internetcomputer.org/proposal/38541)
 
 ## Motoko
 
@@ -2901,16 +2824,13 @@ Breaking change: Canister commands, except for `dfx canister create`, will make 
 
 When working with existing canisters, use the `--wallet` flag in conjunction with `dfx identity get-wallet` in order to restore the old behavior.
 
-You will need to upgrade your wallet and each of your existing canisters to work with the new system. To do so, execute the following in each of your dfx projects:
-
-```bash
+You will need to upgrade your wallet and each of your existing canisters to work with the new system.  To do so, execute the following in each of your dfx projects:
+``` bash
 dfx wallet upgrade
 dfx canister --wallet "$(dfx identity get-wallet)" update-settings --all --add-controller "$(dfx identity get-principal)"
 ```
-
 To upgrade projects that you have deployed to the IC mainnet, execute the following:
-
-```bash
+``` bash
 dfx wallet --network ic upgrade
 dfx canister --network ic --wallet "$(dfx identity --network ic get-wallet)" update-settings --all --add-controller "$(dfx identity get-principal)"
 ```
@@ -2935,17 +2855,17 @@ Fixed a defect in asset synchronization where no retries would be attempted afte
 
 Updated Motoko from 0.6.11 to 0.6.20.
 
-- Implement type union/intersection
-- Transform for-loops on arrays into while-loops
-- Tighten typing rules for type annotations in patterns
-- Candid decoding: skip vec any fast
-- Bump up MAX_HP_FOR_GC from 1GB to 3GB
-- Candid decoder: Trap if a principal value is too large
-- Eliminate bignum calls from for-iteration on arrays
-- Improve scheduling
-- Improve performance of bignum equality
-- Stable signatures: frontend, metadata, command-line args
-- Added heartbeat support
+* Implement type union/intersection
+* Transform for-loops on arrays into while-loops
+* Tighten typing rules for type annotations in patterns
+* Candid decoding: skip vec any fast
+* Bump up MAX_HP_FOR_GC from 1GB to 3GB
+* Candid decoder: Trap if a principal value is too large
+* Eliminate bignum calls from for-iteration on arrays
+* Improve scheduling
+* Improve performance of bignum equality
+* Stable signatures: frontend, metadata, command-line args
+* Added heartbeat support
 
 ## Cycles wallet
 
@@ -2957,17 +2877,17 @@ Updated Motoko from 0.6.11 to 0.6.20.
 Updated replica to blessed commit 75138bbf11e201aac47266f07bee289dc18a082b.
 This incorporates the following executed proposals:
 
-- [33828](https://dashboard.internetcomputer.org/proposal/33828)
-- [31275](https://dashboard.internetcomputer.org/proposal/31275)
-- [31165](https://dashboard.internetcomputer.org/proposal/31165)
-- [30392](https://dashboard.internetcomputer.org/proposal/30392)
-- [30078](https://dashboard.internetcomputer.org/proposal/30078)
-- [29235](https://dashboard.internetcomputer.org/proposal/29235)
-- [28784](https://dashboard.internetcomputer.org/proposal/28784)
-- [27975](https://dashboard.internetcomputer.org/proposal/27975)
-- [26833](https://dashboard.internetcomputer.org/proposal/26833)
-- [25343](https://dashboard.internetcomputer.org/proposal/25343)
-- [23633](https://dashboard.internetcomputer.org/proposal/23633)
+* [33828](https://dashboard.internetcomputer.org/proposal/33828)
+* [31275](https://dashboard.internetcomputer.org/proposal/31275)
+* [31165](https://dashboard.internetcomputer.org/proposal/31165)
+* [30392](https://dashboard.internetcomputer.org/proposal/30392)
+* [30078](https://dashboard.internetcomputer.org/proposal/30078)
+* [29235](https://dashboard.internetcomputer.org/proposal/29235)
+* [28784](https://dashboard.internetcomputer.org/proposal/28784)
+* [27975](https://dashboard.internetcomputer.org/proposal/27975)
+* [26833](https://dashboard.internetcomputer.org/proposal/26833)
+* [25343](https://dashboard.internetcomputer.org/proposal/25343)
+* [23633](https://dashboard.internetcomputer.org/proposal/23633)
 
 # 0.8.4
 
@@ -2976,8 +2896,7 @@ This incorporates the following executed proposals:
 ### feat: "rust" canister type
 
 You can now declare "rust" canisters in dfx.json.
-
-```json
+``` json
 {
   "canisters": {
     "canister_name": {
@@ -2993,13 +2912,13 @@ Don't forget to place a `Cargo.toml` in your project root.
 Then dfx will build the rust canister with your rust toolchain.
 Please also make sure that you have added the WebAssembly compilation target.
 
-```bash
+``` bash
 rustup target add wasm32-unknown-unknown
 ```
 
 You can also create new dfx project with a default rust canister.
 
-```bash
+``` bash
 dfx new --type=rust <project-name>
 ```
 
@@ -3025,7 +2944,7 @@ and no longer works with `--all`.
 
 ## Replica
 
-The included replica now supports canister_heartbeat. This only works with rust canisters for the time being,
+The included replica now supports canister_heartbeat.  This only works with rust canisters for the time being,
 and does not work with the emulator (`dfx start --emulator`).
 
 # 0.8.3
@@ -3039,7 +2958,7 @@ This has always been broken, even before dfx 0.7.0.
 
 ### fix: replica and ic-starter linux binaries no longer reference /nix/store
 
-This means `dfx start` will work again on linux. This bug was introduced in dfx 0.8.2.
+This means `dfx start` will work again on linux.  This bug was introduced in dfx 0.8.2.
 
 ### feat: replaced --no_artificial_delay option with a sensible default.
 
@@ -3051,7 +2970,7 @@ we have set the same default for dfx and removed the option.
 
 Updated Motoko from 0.6.10 to 0.6.11.
 
-- Assertion error messages are now reproducible (#2821)
+* Assertion error messages are now reproducible (#2821)
 
 # 0.8.2
 
@@ -3107,22 +3026,22 @@ You will need to upgrade your wallet with `dfx wallet upgrade`, or `dfx wallet -
 
 The included replica now supports public spec 0.18.0
 
-- Canisters can now have more than one controller
-- Adds support for 64-bit stable memory
-- The replica now goes through an initialization sequence, reported in its status
-  as `replica_health_status`. Until this reports as `healthy`, queries or updates will
-  fail.
-  ** `dfx start --background` waits to exit until `replica_health_status` is `healthy`.
-  ** If you run `dfx start` without `--background`, you can call `dfx ping --wait-healthy`
-  to wait until the replica is healthy.
+* Canisters can now have more than one controller
+* Adds support for 64-bit stable memory
+* The replica now goes through an initialization sequence, reported in its status
+as `replica_health_status`.  Until this reports as `healthy`, queries or updates will
+fail.
+** `dfx start --background` waits to exit until `replica_health_status` is `healthy`.
+** If you run `dfx start` without `--background`, you can call `dfx ping --wait-healthy`
+to wait until the replica is healthy.
 
 ## Motoko
 
 Updated Motoko from 0.6.7 to 0.6.10
 
-- add Debug.trap : Text -> None (motoko-base #288)
-- Introduce primitives for `Int` ⇔ `Float` conversions (#2733)
-- Fix crashing bug for formatting huge floats (#2737)
+* add Debug.trap : Text -> None (motoko-base #288)
+* Introduce primitives for `Int` ⇔ `Float` conversions (#2733)
+* Fix crashing bug for formatting huge floats (#2737)
 
 # 0.8.1
 
@@ -3130,7 +3049,7 @@ Updated Motoko from 0.6.7 to 0.6.10
 
 ### feat: dfx generate types command
 
-```bash
+``` bash
 dfx generate
 ```
 
@@ -3140,35 +3059,34 @@ You can control what will be generated and how with corresponding configuration 
 
 Under dfx.json → "canisters" → "<canister_name>", developers can add a "declarations" config. Options are:
 
-- "output" → directory to place declarations for that canister | default is "src/declarations/<canister_name>"
+* "output" → directory to place declarations for that canister | default is "src/declarations/<canister_name>"
 
-- "bindings" → [] list of options, ("js", "ts", "did", "mo") | default is "js", "ts", "did"
+* "bindings" → [] list of options, ("js", "ts", "did", "mo") | default is "js", "ts", "did"
 
-- "env_override" → a string that will replace process.env.{canister_name_uppercase}\_CANISTER_ID in the "src/dfx/assets/language_bindings/canister.js" template.
+* "env_override" → a string that will replace process.env.{canister_name_uppercase}_CANISTER_ID in the "src/dfx/assets/language_bindings/canister.js" template.
 
 js declarations output
 
-- index.js (generated from "src/dfx/assets/language_bindings/canister.js" template)
+* index.js (generated from "src/dfx/assets/language_bindings/canister.js" template)
 
-- <canister_name>.did.js - candid js binding output
+* <canister_name>.did.js - candid js binding output
 
 ts declarations output
 
-- <canister_name>.did.d.ts - candid ts binding output
+  * <canister_name>.did.d.ts - candid ts binding output
 
 did declarations output
 
-- <canister_name>.did - candid did binding output
+  * <canister_name>.did - candid did binding output
 
 mo declarations output
 
-- <canister_name>.mo - candid mo binding output
+  * <canister_name>.mo - candid mo binding output
 
 ### feat: dfx now supports the anonymous identity
 
 Use it with either of these forms:
-
-```bash
+``` bash
 dfx identity use anonymous
 dfx --identity anonymous ...
 ```
@@ -3179,7 +3097,7 @@ Default identities are the pem files generated by `dfx identity new ...` which c
 They are located at `~/.config/dfx/identity/xxx/identity.pem`.
 Now, you can copy such pem file to another computer and import it there.
 
-```bash
+``` bash
 dfx identity new alice
 cp ~/.config/dfx/identity/xxx/identity.pem alice.pem
 # copy the pem file to another computer, then
@@ -3198,7 +3116,7 @@ Define DFX_WALLET_WASM in the environment to use a different wasm module when cr
 ### fix: trust full asset SHA-256 hashes provided by the caller
 
 When the caller provides SHA-256 hashes (which dfx does), the asset canister will no longer
-recompute these hashes when committing the changes. These recomputations were causing
+recompute these hashes when committing the changes.  These recomputations were causing
 canisters to run out of cycles, or to attempt to exceed the maximum cycle limit per update.
 
 # 0.8.0
@@ -3214,17 +3132,17 @@ but ended up only writing to the wallets.json file if --force was passed.
 
 ### chore: updating dependencies
 
-- Support for the latest version of the {IC} specification and replica.
+* Support for the latest version of the {IC} specification and replica.
 
-- Updating to latest versions of Motoko, Candid, and agent-rs
+* Updating to latest versions of Motoko, Candid, and agent-rs
 
 ### feat: Type Inference Update
 
-- Changes to `dfx new` project template and JavaScript codegen to support type inference in IDE's
+* Changes to `dfx new` project template and JavaScript codegen to support type inference in IDE's
 
-- Adding webpack dev server to project template
+* Adding webpack dev server to project template
 
-- Migration path documented at https://sdk.dfinity.org/docs/release-notes/0.8.0-rn.html
+* Migration path documented at https://sdk.dfinity.org/docs/release-notes/0.8.0-rn.html
 
 # 0.7.7
 
@@ -3235,16 +3153,16 @@ Breaking changes to frontend code generation, documented in 0.8.0
 ### feat: deploy and canister install will now only upgrade a canister if the wasm actually changed
 
 dfx deploy and dfx canister install now compare the hash of the already-installed module
-with the hash of the built canister's wasm output. If they are the same, they leave the canister
-in place rather than upgrade it. They will still synchronize assets to an asset canister regardless
+with the hash of the built canister's wasm output.  If they are the same, they leave the canister
+in place rather than upgrade it.  They will still synchronize assets to an asset canister regardless
 of the result of this comparison.
+
 
 # 0.7.6
 
 ## icx-proxy
 
 The streaming callback mechanism now requires the following record structure for the token:
-
 ```
 type StreamingCallbackToken = record {
     key: text;
@@ -3452,13 +3370,12 @@ Users can sign the message on an air-gapped computer which is secure to host pri
 
 #### Note
 
-- `sign` and `send` currently don't proxy through wallet canister. Users should use the subcommands with `dfx canister --no-wallet sign ...`.
+* `sign` and `send` currently don't proxy through wallet canister. Users should use the subcommands with `dfx canister --no-wallet sign ...`.
 
-- The `sign` option `--expire-after` will set the `ingress_expiry` to a future timestamp which is current plus the duration.
-  Then users can send the message during a 5 minutes time window ending in that `ingress_expiry` timestamp. Sending the message earlier or later than the time window will both result in a replica error.
+* The `sign` option `--expire-after` will set the `ingress_expiry` to a future timestamp which is current plus the duration.
+Then users can send the message during a 5 minutes time window ending in that `ingress_expiry` timestamp. Sending the message earlier or later than the time window will both result in a replica error.
 
 ### feat: implement the HTTP Request proposal in dfx' bootstrap webserver. +
-
 And add support for http requests in the base storage canister (with a default to `/index.html`).
 
 This does not support other encodings than `identity` for now (and doesn't even return any headers). This support will be added to the upgraded asset storage canister built in #1482.
@@ -3473,7 +3390,7 @@ Renamed the `project_name` in our own generated assets to `canister_name`, for t
 
 You can now a generate private key via OpenSSL or a simlar tool, import it into dfx, and use it to sign an ingress message.
 
-```bash
+``` bash
 openssl ecparam -name secp256k1 -genkey -out identity.pem
 dfx identity import <name> identity.pem
 dfx identity use <name>
@@ -3484,24 +3401,24 @@ dfx canister call ...
 
 ### feat: The asset canister can now store assets that exceed the message ingress limit (2 MB)
 
-- Please note that neither the JS agent nor the HTTP server have been updated yet to server such large assets.
-- The existing interface is left in place for backwards-compatibility, but deprecated:
-  ** retrieve(): use get() and get_chunk() instead
-  ** store(): use create_batch(), create_chunk(), and commit_batch() instead
-  \*\* list(): use keys() instead
+* Please note that neither the JS agent nor the HTTP server have been updated yet to server such large assets.
+* The existing interface is left in place for backwards-compatibility, but deprecated:
+** retrieve(): use get() and get_chunk() instead
+** store(): use create_batch(), create_chunk(), and commit_batch() instead
+** list(): use keys() instead
 
 # 0.6.25
 
 ## DFX
 
-- feat: dfx now provides CANISTER*ID*<canister_name> environment variables for all canisters to "npm build" when building the frontend.
+- feat: dfx now provides CANISTER_ID_<canister_name> environment variables for all canisters to "npm build" when building the frontend.
 
 ## Agents
 
 ### Rust Agent
 
 - feat: AgentError due to request::Error will now include the reqwest error message
-  in addition to "Could not reach the server"
+in addition to "Could not reach the server"
 - feat: Add secp256k1 support (dfx support to follow)
 
 # 0.6.24
@@ -3514,13 +3431,12 @@ Added option to `dfx canister create` and `dfx deploy` commands: `--with-cycles 
 This allows the user to specify the initial cycle balance of a canister created by their wallet.
 This option is a no-op for the Sodium network.
 
-```bash
+``` bash
 dfx canister create --with-cycles 8000000000 some_canister
 dfx deploy --with-cycles 8000000000
 ```
 
 Help string:
-
 ```
 Specifies the initial cycle balance to deposit into the newly
 created canister. The specified amount needs to take the
@@ -3533,7 +3449,7 @@ from the wallet's cycle balance
 This feature adds a new dfx command `toolchain` which have intuitive subcommands.
 The toolchain specifiers can be a complete version number, major minor version, or a tag name.
 
-```bash
+``` bash
 dfx toolchain install 0.6.24 # complete version
 dfx toolchain install 0.6    # major minor
 dfx toolchain install latest # tag name
@@ -3546,8 +3462,7 @@ dfx toolchain uninstall latest
 
 Now that the Mercury Alpha application subnetwork is up and we are getting ready to onboard devs, the dfx error message for wallet creation has changed:
 For example,
-
-```bash
+``` bash
 dfx canister --network=alpha create hello
 Creating canister "hello"...
 Creating the canister using the wallet canister...
@@ -3563,7 +3478,7 @@ Please submit your Principal ("dfx identity get-principal") in the intake form t
 This feature adds the deploy-wallet subcommand to the dfx identity.
 The User provides the ID of the canister onto which the wallet WASM is deployed.
 
-```bash
+``` bash
 dfx identity deploy-wallet --help
 dfx-identity-deploy-wallet
 Installs the wallet WASM to the provided canister id
@@ -3593,9 +3508,9 @@ FLAGS:
 
 - There have been updates, improvements, and new sample apps added to the [examples](https://github.com/dfinity/examples/tree/master/motoko) repository.
 
-  All of Motoko sample apps in the [examples](https://github.com/dfinity/examples/tree/master/motoko) repository have been updated to work with the latest release of the SDK.
+    All of Motoko sample apps in the [examples](https://github.com/dfinity/examples/tree/master/motoko) repository have been updated to work with the latest release of the SDK.
 
-  There are new sample apps to illustrate using arrays ([Quicksort](https://github.com/dfinity/examples/tree/master/motoko/quicksort)) and building create/read/update/delete (CRUD) operations for a web application [Superheroes](https://github.com/dfinity/examples/tree/master/motoko/superheroes).
+    There are new sample apps to illustrate using arrays ([Quicksort](https://github.com/dfinity/examples/tree/master/motoko/quicksort)) and building create/read/update/delete (CRUD) operations for a web application [Superheroes](https://github.com/dfinity/examples/tree/master/motoko/superheroes).
 
 - The [LinkedUp](https://github.com/dfinity/linkedup) sample application has been updated to work with the latest release of Motoko and the SDK.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 # UNRELEASED
 
+### feat: add --open flag to dfx deploy
+
+The `--open` flag will open the browser to the canister's URL after deployment.
+
 ### feat: unify CLI options to specify arguments
 
 There are a few subcommands that take `--argument`/`--argument-file` options to set canister call/init arguments.
 
 We unify the related logic to provide consistent user experience.
- 
+
 The notable changes are:
 
 - `dfx deploy` now accepts `--argument-file`.
@@ -15,7 +19,7 @@ The notable changes are:
 
 ### feat: candid assist feature
 
-Ask for user input when Candid argument is not provided in `dfx canister call`, `dfx canister install` and `dfx deploy`. 
+Ask for user input when Candid argument is not provided in `dfx canister call`, `dfx canister install` and `dfx deploy`.
 Previously, we cannot call `dfx deploy --all` when multiple canisters require init args, unless the init args are specified in `dfx.json`. With the Candid assist feature, dfx now asks for init args in terminal when a canister requires init args.
 
 ### fix: restored access to URLs like http://localhost:8080/api/v2/status through icx-proxy
@@ -23,6 +27,7 @@ Previously, we cannot call `dfx deploy --all` when multiple canisters require in
 Pinned icx-proxy at 69e1408347723dbaa7a6cd2faa9b65c42abbe861, shipped with dfx 0.15.2
 
 This means commands like the following will work again:
+
 ```
 curl -v --http2-prior-knowledge "http://localhost:$(dfx info webserver-port)/api/v2/status" --output -
 ```
@@ -118,7 +123,7 @@ If you build with custom canister type, add the following into `dfx.json`:
 
 ```
 "metadata": [
-  { 
+  {
     "name": "candid:service"
   }
 ]
@@ -153,7 +158,7 @@ Fix the bug that when parsing `vec {1;2;3}` with `blob` type, dfx silently ignor
 ### fix: support `import` for local did file
 
 If the local did file contains `import` or init args, dfx will rewrite the did file when storing in canister metadata.
-Due to current limitations of the Candid parser, comments will be dropped during rewriting. 
+Due to current limitations of the Candid parser, comments will be dropped during rewriting.
 If the local did file doesn't contain `import` or init args, we will not perform the rewriting, thus preserving the comments.
 
 ### fix: subtyping check reports the special opt rule as error
@@ -161,6 +166,7 @@ If the local did file doesn't contain `import` or init args, we will not perform
 ### fix: can now run several dfx canister commands outside of a project
 
 The following commands now work outside of a project:
+
 - `dfx canister start <specific canister id>`
 - `dfx canister stop <specific canister id>`
 - `dfx canister deposit-cycles <amount> <specific canister id>`
@@ -289,8 +295,8 @@ dfx now no longer sets a memory allocation. We anticipate fewer problems this wa
 ### feat: Added support for icx-proxy `--domain` parameter
 
 In order to access a local replica through a domain name or domain names,
-it's necessary to pass the `--domain` parameter to icx-proxy.  dfx now supports
-this in configuration and as a parameter to dfx start.  You can specify a single
+it's necessary to pass the `--domain` parameter to icx-proxy. dfx now supports
+this in configuration and as a parameter to dfx start. You can specify a single
 domain or a list of domains in any of the following ways:
 
 - in networks.json, in `.<network>.proxy.domain`
@@ -304,7 +310,7 @@ domain or a list of domains in any of the following ways:
 
 - Module hash: d172df265a14397a460b752ff07598380bc7ebd9c43ece1e82495ae478a88719c
 - Internet identity integration in Candid UI. Thanks to @Web3NL!
-  + You can customize the II url and derivationOrigin via URL parameter `ii` and `origin` respectively.
+  - You can customize the II url and derivationOrigin via URL parameter `ii` and `origin` respectively.
 - Update with the new profiling API
 
 ### Motoko
@@ -337,7 +343,6 @@ to the project root, rather than relative to the current working directory.
 
 Enables passing large arguments that cannot be passed directly in the command line using the `--argument-file` flag. For example `dfx canister install --argument-file ./my/argument/file.txt my_canister_name`.
 
-
 ### feat: change `list_permitted` and `list_authorized` to an update call.
 
 This requires the `list_authorized` and `list_permitted` methods to be called as an update and disables the ability to
@@ -352,6 +357,7 @@ The message "transaction is a duplicate of another transaction in block ...", pr
 Underscores (`_`) can now be used to make large numbers more readable. For example: `dfx canister deposit-cycles 1_234_567 mycanister`
 
 Certain suffixes that replace a number of zeros are now supported. The (case-insensitive) suffixes are:
+
 - `k` for `000`, e.g. `500k`
 - `m` for `000_000`, e.g. `5m`
 - `b` for `000_000_000`, e.g. `50B`
@@ -364,9 +370,10 @@ For cycles an additional `c` or `C` is also acceptable. For example: `dfx canist
 This won't work on mainnet yet, but can work locally after installing the cycles ledger.
 
 Added the following subcommands:
- - `dfx cycles balance`
- - `dfx cycles transfer <to> <amount>` (transfer cycles from one account to another account)
- - `dfx cycles top-up <to> <amount>` (send cycles from an account to a canister)
+
+- `dfx cycles balance`
+- `dfx cycles transfer <to> <amount>` (transfer cycles from one account to another account)
+- `dfx cycles top-up <to> <amount>` (send cycles from an account to a canister)
 
 ## Dependencies
 
@@ -420,8 +427,9 @@ Updated Bitcoin canister to [release/2023-10-13](https://github.com/dfinity/bitc
 `dfx canister status` will now display the reserved cycles balance and reserved cycles limit for a canister.
 
 Added command-line options:
-  - `dfx canister create --reserved-cycles-limit <limit>`
-  - `dfx canister update-settings --reserved-cycles-limit <limit>`
+
+- `dfx canister create --reserved-cycles-limit <limit>`
+- `dfx canister update-settings --reserved-cycles-limit <limit>`
 
 In addition, `dfx deploy` will set `reserved_cycles_limit` when creating canisters if specified in `canisters.<canister>.initialization_values.reserved_cycles_limit` in dfx.json.
 
@@ -461,6 +469,7 @@ Updates node engines to reflect the same engines supported in agent-js.
 Introduced a new network type called `playground`. Canisters on such networks are not created through standard means, but are instead borrowed from a canister pool.
 The canisters time out after a while and new canisters need to be borrowed for further deployments.
 To define custom playground networks, use a network definition that includes the `playground` key:
+
 ```json
 "<network name>": {
   "playground": {
@@ -485,18 +494,19 @@ For example, `dfx deploy --ic` rather than `dfx deploy --network ic`.
 ### feat: `dfx start` for shared network warns if ignoring 'defaults' in dfx.json
 
 Background: In order to determine whether to start a project-specific network or the shared network, `dfx start` looks for the `local` network in dfx.json.
-   - If found, `dfx start` starts the project-specific local network, applying any `defaults` from dfx.json.
-   - If there is no dfx.json, or if dfx.json does not define a `local` network, `dfx start` starts the shared network.  Because the shared network is not specific to any project, `dfx start` ignores any other settings from dfx.json, including `defaults`.
 
-If `dfx start` is starting the shared network from within a dfx project, and that dfx.json contains settings in the `defaults` key for `bitcoin`, `replica`, or `canister_http`, then `dfx start` will warn that it is ignoring those settings.  It will also describe how to define equivalent settings in networks.json.
+- If found, `dfx start` starts the project-specific local network, applying any `defaults` from dfx.json.
+- If there is no dfx.json, or if dfx.json does not define a `local` network, `dfx start` starts the shared network. Because the shared network is not specific to any project, `dfx start` ignores any other settings from dfx.json, including `defaults`.
+
+If `dfx start` is starting the shared network from within a dfx project, and that dfx.json contains settings in the `defaults` key for `bitcoin`, `replica`, or `canister_http`, then `dfx start` will warn that it is ignoring those settings. It will also describe how to define equivalent settings in networks.json.
 
 ### fix: dfx canister call --wallet no longer passes the parameter twice
 
-The parameter was erroneously passed twice.  Now it is passed only once.
+The parameter was erroneously passed twice. Now it is passed only once.
 
 ### fix: Removed deprecation warning about project-specific networks
 
-Removed this warning: "Project-specific networks are deprecated and will be removed after February 2023." While we may remove project-specific networks in the future, it is not imminent.  One key requirement is the ability to run more than one subnet type at one time.
+Removed this warning: "Project-specific networks are deprecated and will be removed after February 2023." While we may remove project-specific networks in the future, it is not imminent. One key requirement is the ability to run more than one subnet type at one time.
 
 ## Dependencies
 
@@ -505,12 +515,13 @@ Removed this warning: "Project-specific networks are deprecated and will be remo
 Updated to a version of the icx-proxy that is released with the replica and other related binaries.
 
 Changes in behavior:
-- "%%" is no longer accepted when url-decoding filenames for the asset canister.  Though curl supports this, it's not part of the standard. Please replace with %25.
-- The icx-proxy now performs response verification.  This has exposed some bugs in the asset canister.  However, since this new icx-proxy matches what the boundary nodes use, this will better match the behavior seen on the mainnet.
+
+- "%%" is no longer accepted when url-decoding filenames for the asset canister. Though curl supports this, it's not part of the standard. Please replace with %25.
+- The icx-proxy now performs response verification. This has exposed some bugs in the asset canister. However, since this new icx-proxy matches what the boundary nodes use, this will better match the behavior seen on the mainnet.
 - Bugs that this has exposed in the asset canister:
   - after disabling aliasing for an asset, the asset canister will return an incorrect certification in the 404 response.
   - after setting a custom "etag" header in .ic-assets.json, the asset canister will return an incorrect certification in the 200 response.
-  - assets with certain characters in the filename (example: "æ") will no longer be served correctly.  The definition of "certain characters" is not yet known.
+  - assets with certain characters in the filename (example: "æ") will no longer be served correctly. The definition of "certain characters" is not yet known.
 
 ### Candid UI
 
@@ -541,7 +552,7 @@ This incorporates the following executed proposals:
 - [124537](https://dashboard.internetcomputer.org/proposal/124537)
 - [124488](https://dashboard.internetcomputer.org/proposal/124488)
 - [124487](https://dashboard.internetcomputer.org/proposal/124487)
-  
+
 # 0.15.0
 
 ## DFX
@@ -560,7 +571,7 @@ All projects will need to redeploy.
 
 ### fix: access to raw assets is now enabled by default
 
-The default value for `allow_raw_access` is now `true`.  This means that by default, the frontend canister will no longer restrict the access of traffic to the `<canister-id>.raw.icp0.io` domain, and will no longer automatically redirect all requests to the certified domain (`<canister-id>.icp0.io`), unless configured explicitly.
+The default value for `allow_raw_access` is now `true`. This means that by default, the frontend canister will no longer restrict the access of traffic to the `<canister-id>.raw.icp0.io` domain, and will no longer automatically redirect all requests to the certified domain (`<canister-id>.icp0.io`), unless configured explicitly.
 
 Note that existing projects that specify `"allow_raw_access": false` in .ic-assets.json5 will need to change or remove this value manually in order to allow raw access.
 
@@ -570,7 +581,7 @@ Both have now been turned into the dfx extensions. In order to obtain them, plea
 
 ### feat!: Removed dfx replica and dfx bootstrap commands
 
-Use `dfx start` instead.  If you have a good reason why we should keep these commands, please contribute to the discussion at https://github.com/dfinity/sdk/discussions/3163
+Use `dfx start` instead. If you have a good reason why we should keep these commands, please contribute to the discussion at https://github.com/dfinity/sdk/discussions/3163
 
 ### fix: Wait for new module hash when installing wallet
 
@@ -589,11 +600,13 @@ WARN: The <identity> identity is not stored securely. Do not use it to control a
 ```
 
 To do so, export the environment variable `DFX_WARNING` with the value `-mainnet_plaintext_identity`.
+
 ```bash
 export DFX_WARNING="-mainnet_plaintext_identity"
 ```
 
 Note that this can be combined to also disable the dfx version check warning:
+
 ```bash
 export DFX_WARNING="-version_check,-mainnet_plaintext_identity"
 ```
@@ -626,11 +639,11 @@ Previously, the operation was a no-op if the content type matched, but ignored o
 
 ### fix!: http_request_streaming_callback and get_chunk now require the sha256 parameter to be set
 
-The `http_request_streaming_callback()` and `get_chunk()` methods use the `sha256` parameter to ensure that the chunks they return are part of the same asset contents returned by the initial call.  This parameter is now required to be Some(hash).
+The `http_request_streaming_callback()` and `get_chunk()` methods use the `sha256` parameter to ensure that the chunks they return are part of the same asset contents returned by the initial call. This parameter is now required to be Some(hash).
 
 For `http_request()` and `http_request_streaming_callback()`, there should be no change: all callers of `http_request_streaming_callback()` are expected to pass the entire token returned by `http_request()`, which includes the sha256 parameter.
 
-Any callers of `get_chunk()` should make sure to always pass the `sha256` value returned by the `get()` method.  It will always be present.
+Any callers of `get_chunk()` should make sure to always pass the `sha256` value returned by the `get()` method. It will always be present.
 
 ## Dependencies
 
@@ -728,30 +741,34 @@ The redirect from `.raw.ic0.app` now redirects to `.ic0.app` instead of `.icp0.i
 
 The `validate_commit_proposed_batch()` method no longer requires any permission to call.
 
-The asset canister now enforces limits during upload.  These limits to not apply to assets already uploaded.
+The asset canister now enforces limits during upload. These limits to not apply to assets already uploaded.
 
 Unconditional limits:
+
 - `create_batch()` now fails if `dfx deploy --by-proposal` got as far as calling `propose_commit_batch()`, and the batch has not since been committed or deleted.
 
 Configurable limits:
+
 - `max_batches`: limits number of batches being uploaded.
 - `max_chunks`: limits total number of chunks across all batches being uploaded.
 - `max_bytes`: limits total size of content bytes across all chunks being uploaded.
 
 Added methods:
+
 - `configure()` to set limits
 - `validate_configure()`: companion method for SNS
 - `get_configuration()`: to view limits
 
 Suggestions for configured limits:
+
 - dapps controlled by SNS: max_batches=1; max_chunks and max_bytes based on asset composition.
 - dapps not controlled by SNS: unlimited (which is the default)
 
-Note that as always, if `dfx deploy` does not completely upload and commit a batch, the asset canister will retain the batch until 5 minutes have passed since the last chunk was uploaded.  If you have configured limits and the combination of an unsuccessful deployment and a subsequent attempt would exceed those limits, you can either wait 5 minutes before running `dfx deploy` again, or delete the incomplete batch with `delete_batch()`.
+Note that as always, if `dfx deploy` does not completely upload and commit a batch, the asset canister will retain the batch until 5 minutes have passed since the last chunk was uploaded. If you have configured limits and the combination of an unsuccessful deployment and a subsequent attempt would exceed those limits, you can either wait 5 minutes before running `dfx deploy` again, or delete the incomplete batch with `delete_batch()`.
 
 ### fix: return the correct expr_path for index.html fallback routes
 
-Previously, the requested path was used to construct the `expr_path` for the `index.html` fallback route.  This was incorrect, as the `expr_path` should be the path of the `index.html` file itself in this case.
+Previously, the requested path was used to construct the `expr_path` for the `index.html` fallback route. This was incorrect, as the `expr_path` should be the path of the `index.html` file itself in this case.
 
 ## Frontend canister assets synchronization
 
@@ -761,7 +778,7 @@ Previously, it would only retry when waiting for the request to complete.
 
 ### fix: now considers fewer error types to be retryable
 
-Previously, errors were assumed to be retryable, except for a few specific error messages and 403/unauthorized responses.  This could cause deployment to appear to hang until timeout.
+Previously, errors were assumed to be retryable, except for a few specific error messages and 403/unauthorized responses. This could cause deployment to appear to hang until timeout.
 
 Now, only transport errors and timeout errors are considered retryable.
 
@@ -783,6 +800,7 @@ Updated ic-ref to 0.0.1-a9f73dba
 ### Cycles wallet
 
 Updated cycles wallet to `20230530` release:
+
 - Module hash: c1290ad65e6c9f840928637ed7672b688216a9c1e919eacbacc22af8c904a5e3
 - https://github.com/dfinity/cycles-wallet/commit/313fb01d59689df90bd3381659d94164c2a61cf4
 
@@ -794,6 +812,7 @@ Updated Motoko to 0.9.3
 
 Updated replica to elected commit ef8ca68771baa20a14af650ab89c9b31b1dc9a5e.
 This incorporates the following executed proposals:
+
 - [123248](https://dashboard.internetcomputer.org/proposal/123248)
 - [123021](https://dashboard.internetcomputer.org/proposal/123021)
 - [123007](https://dashboard.internetcomputer.org/proposal/123007)
@@ -824,9 +843,9 @@ You can enable it in `dfx.json`:
 
 ```json
 {
-  "canisters" : {
-    "app" : {
-      "gzip" : true
+  "canisters": {
+    "app": {
+      "gzip": true
     }
   }
 }
@@ -855,9 +874,11 @@ This feature was named `dfx pull` before. To make a complete, intuitive user exp
 All generated files in `deps/` are encouraged to be version controlled.
 
 ### chore: Add the `nns-dapp` and `internet_identity` to the local canister IDs set by `dfx nns import`
-`dfx nns install` installs a set of canisters in a local replica.  `dfx nns import` complements this by setting the canister IDs so that they can be queried by the user.  But `dfx nns import` is incomplete.  Now it will also provide the IDs of the `nns-dapp` and `internet_identity` canisters.
+
+`dfx nns install` installs a set of canisters in a local replica. `dfx nns import` complements this by setting the canister IDs so that they can be queried by the user. But `dfx nns import` is incomplete. Now it will also provide the IDs of the `nns-dapp` and `internet_identity` canisters.
 
 ### feat: `.env` file includes all created canister IDs
+
 Previously the `.env` file only included canister IDs for canisters that were listed as explicit dependencies during the build process.
 Now all canisters that have a canister ID for the specified network are included in `.env`.
 
@@ -876,7 +897,7 @@ dfx will terminate and restart it.
 
 This is required for future replica versions.
 
-Adds a new field `canister_init_arg` to the bitcoin configuration in dfx.json and networks.json.  Its default is documented in the JSON schema and is appropriate for the canister wasm bundled with dfx.
+Adds a new field `canister_init_arg` to the bitcoin configuration in dfx.json and networks.json. Its default is documented in the JSON schema and is appropriate for the canister wasm bundled with dfx.
 
 ### fix: no longer enable the bitcoin_regtest feature
 
@@ -889,6 +910,7 @@ Cleaned up documentation of IC SDK.
 ### feat: Added more detailed logging to `ic-asset`.
 
 Now, `dfx deploy -v` (or `-vv`) will print the following information:
+
 - The count for each `BatchOperationKind` in `CommitBatchArgs`
 - The number of chunks uploaded and the total bytes
 - The API version of both the `ic-asset` and the canister
@@ -897,6 +919,7 @@ Now, `dfx deploy -v` (or `-vv`) will print the following information:
 ### fix: Commit batches incrementally in order to account for more expensive v2 certification calculation
 
 In order to allow larger changes without exceeding the per-message instruction limit, the sync process now:
+
 - sets properties of assets already in the canister separately from the rest of the batch.
 - splits up the rest of the batch into groups of up to 500 operations.
 
@@ -906,7 +929,7 @@ Previously, it would only retry when waiting for the request to complete.
 
 ### fix: now considers fewer error types to be retryable
 
-Previously, errors were assumed to be retryable, except for a few specific error messages and 403/unauthorized responses.  This could cause deployment to appear to hang until timeout.
+Previously, errors were assumed to be retryable, except for a few specific error messages and 403/unauthorized responses. This could cause deployment to appear to hang until timeout.
 
 Now, only transport errors and timeout errors are considered retryable.
 
@@ -934,6 +957,7 @@ Updated Motoko to 0.8.8
 
 Updated replica to elected commit b3b00ba59c366384e3e0cd53a69457e9053ec987.
 This incorporates the following executed proposals:
+
 - [122529](https://dashboard.internetcomputer.org/proposal/122529)
 - [122284](https://dashboard.internetcomputer.org/proposal/122284)
 - [122198](https://dashboard.internetcomputer.org/proposal/122198)
@@ -979,7 +1003,7 @@ If you want to enable this behavior, you can do so in dfx.json:
         }
     }
 
-The options are "cycles", "size", "O4", "O3", "O2", "O1", "O0", "Oz", and "Os".  The options starting with "O" are the optimization levels that `wasm-opt` provides. The "cycles" and "size" options are recommended defaults for optimizing for cycle usage and binary size respectively.
+The options are "cycles", "size", "O4", "O3", "O2", "O1", "O0", "Oz", and "Os". The options starting with "O" are the optimization levels that `wasm-opt` provides. The "cycles" and "size" options are recommended defaults for optimizing for cycle usage and binary size respectively.
 
 ### feat: updates the dfx new starter project for env vars
 
@@ -1026,6 +1050,7 @@ Canisters communicating with `ic0.app` will continue to function nominally.
 ### feat: confirmation dialogues are no longer case sensitive and accept 'y' in addition to 'yes'
 
 ### fix: `dfx generate` no longer requires canisters to have a canister ID
+
 Previously, canisters required that the canister was created before `dfx generate` could be called.
 
 As a result, the `--network` parameter does not have an impact on the result of `dfx generate` anymore.
@@ -1063,11 +1088,11 @@ This supports asset updates through SNS proposal.
 
 Uploads asset changes to an asset canister (propose_commit_batch()), but does not commit them.
 
-The SNS will call `commit_proposed_batch()` to commit the changes.  If the proposal fails, the caller of `dfx deploy --by-proposal` should call `delete_batch()`.
+The SNS will call `commit_proposed_batch()` to commit the changes. If the proposal fails, the caller of `dfx deploy --by-proposal` should call `delete_batch()`.
 
 ### feat: dfx deploy <frontend canister name> --compute-evidence
 
-Builds the specified asset canister, determines the batch operations required to synchronize the assets, and computes a hash ("evidence") over those batch operations.  This evidence will match the evidence computed by `dfx deploy --by-proposal`, and which will be specified in the update proposal.
+Builds the specified asset canister, determines the batch operations required to synchronize the assets, and computes a hash ("evidence") over those batch operations. This evidence will match the evidence computed by `dfx deploy --by-proposal`, and which will be specified in the update proposal.
 
 No permissions are required to compute evidence, so this can be called with `--identity anonymous` or any other identity.
 
@@ -1078,7 +1103,8 @@ Added `validate_take_ownership()` method so that an SNS is able to add a custom 
 Added `is_aliased` field to `get_asset_properties` and `set_asset_properties`.
 
 Added partial support for proposal-based asset updates:
-- Batch ids are now stable.  With upcoming changes to support asset updates by proposal,
+
+- Batch ids are now stable. With upcoming changes to support asset updates by proposal,
   having the asset canister not reuse batch ids will make it easier to verify that a particular
   batch has been proposed.
 - Added methods:
@@ -1096,6 +1122,7 @@ Added canister metadata field `supported_certificate_versions`, which contains a
 
 Fixed a bug in `http_request` that served assets with the wrong certificate. If no encoding specified in the `Accept-Encoding` header is available with a certificate, an available encoding is returned without a certificate (instead of a wrong certificate, which was the case previously). Otherwise, nothing changed.
 For completeness' sake, the new behavior is as follows:
+
 - If one of the encodings specified in the `Accept-Encoding` header is available with certification, it now is served with the correct certificate.
 - If no requested encoding is available with certification, one of the requested encodings is returned without a certificate (instead of a wrong certificate, which was the case previously).
 - If no encoding specified in the `Accept-Encoding` header is available, a certified encoding that is available is returned instead.
@@ -1162,6 +1189,7 @@ Added validate_grant_permission() and validate_revoke_permission() methods per S
 This allows users to download SNS canister WASMs.
 
 ### fix: fixed error text
+
 - `dfx nns install` had the wrong instructions for setting up the local replica type
 
 ### fix: creating an identity with `--force` no longer switches to the newly created identity
@@ -1169,7 +1197,8 @@ This allows users to download SNS canister WASMs.
 ### feat(frontend-canister)!: reworked to use permissions-based access control
 
 The permissions are as follows:
-- ManagePermissions: Can grant and revoke permissions to any principal.  Controllers implicitly have this permission.
+
+- ManagePermissions: Can grant and revoke permissions to any principal. Controllers implicitly have this permission.
 - Prepare: Can call create_batch and create_chunk
 - Commit: Can call commit_batch and methods that manipulate assets directly, as well as any method permitted by Prepare.
 
@@ -1177,6 +1206,7 @@ For upgraded frontend canisters, all authorized principals will be granted the C
 For newly deployed frontend canisters, the initializer (first deployer of the canister) will be granted the Commit permission.
 
 Added three new methods:
+
 - list_permitted: lists principals with a given permission.
   - Callable by anyone.
 - grant_permission: grants a single permission to a principal
@@ -1185,7 +1215,8 @@ Added three new methods:
   - Any principal can revoke its own permissions.
   - Only Controllers and principals with the ManagePermissions permission can revoke the permissions of other principals.
 
-Altered the behavior of the existing authorization-related methods to operate only on the "Commit" permission.  In this way, they are backwards-compatible.
+Altered the behavior of the existing authorization-related methods to operate only on the "Commit" permission. In this way, they are backwards-compatible.
+
 - authorize(principal): same as grant_permission(principal, Commit)
 - deauthorize(principal): same as revoke_permission(permission, Commit)
 - list_authorized(): same as list_permitted(Commit)
@@ -1193,7 +1224,7 @@ Altered the behavior of the existing authorization-related methods to operate on
 ### fix(frontend-canister)!: removed ability of some types of authorized principals to manage the ACL
 
 It used to be the case that any authorized principal could authorize and deauthorize any other principal.
-This is no longer the case.  See rules above for grant_permission and revoke_permission.
+This is no longer the case. See rules above for grant_permission and revoke_permission.
 
 ### feat(frontend-canister)!: default secure configuration for assets in frontend project template
 
@@ -1203,6 +1234,7 @@ This is no longer the case.  See rules above for grant_permission and revoke_per
 ### feat(frontend-canister)!: add `allow_raw_access` config option
 
 By default, the frontend canister will now restrict the access of traffic to the `<canister-id>.raw.ic0.app` domain, and will automatically redirect all requests to the certified domain (`<canister-id>.ic0.app`), unless configured explicitly. Below is an example configuration to allow access to the `robots.txt` file from the "raw" domain:
+
 ```json
 [
   {
@@ -1212,26 +1244,28 @@ By default, the frontend canister will now restrict the access of traffic to the
 ]
 ```
 
-**Important**: Note that any assets already uploaded to an asset canister will be protected by this redirection, because at present the asset synchronization process does not update the `allow_raw_access` property, or any other properties, after creating an asset.  This also applies to assets that are deployed without any configuration, and later configured to allow raw access.
+**Important**: Note that any assets already uploaded to an asset canister will be protected by this redirection, because at present the asset synchronization process does not update the `allow_raw_access` property, or any other properties, after creating an asset. This also applies to assets that are deployed without any configuration, and later configured to allow raw access.
 At the present time, there are two ways to reconfigure an existing asset:
+
 1. re-create the asset
-    1. delete the asset in your project's directory
-    1. execute `dfx deploy`
-    1. re-create the asset in your project's directory
-    1. modify `.ic-assets.json` acordingly
-    1. execute `dfx deploy`
+   1. delete the asset in your project's directory
+   1. execute `dfx deploy`
+   1. re-create the asset in your project's directory
+   1. modify `.ic-assets.json` acordingly
+   1. execute `dfx deploy`
 2. via manual candid call
-    ```
-    dfx canister call PROJECT_NAME_frontend set_asset_properties '( record { key="/robots.txt"; allow_raw_access=opt(opt(true)) })'
-    ```
+   ```
+   dfx canister call PROJECT_NAME_frontend set_asset_properties '( record { key="/robots.txt"; allow_raw_access=opt(opt(true)) })'
+   ```
 
 ### feat(frontend-canister): pretty print asset properties when deploying assets to the canister
 
 ### feat(frontend-canister): add take_ownership() method
 
-Callable only by a controller.  Clears list of authorized principals and adds the caller (controller) as the only authorized principal.
+Callable only by a controller. Clears list of authorized principals and adds the caller (controller) as the only authorized principal.
 
 ### feat(ic-ref):
+
 - `effective_canister_id` used for `provisional_create_canister_with_cycles` is passed as an command-line argument (defaults to `rwlgt-iiaaa-aaaaa-aaaaa-cai` if not provided or upon parse failure)
 
 ### feat(frontend-canister): add `get_asset_properties` and `set_asset_properties` to frontend canister
@@ -1244,7 +1278,7 @@ Similar to how this argument works in `dfx canister call`, this argument allows 
 
 ### feat: Add support for a default network key
 
-A remote canister ID can now be specified for the `__default` network.  If specified, `dfx` will assume that the canister is remote at the specified canister ID for all networks that don't have a dedicated entry.
+A remote canister ID can now be specified for the `__default` network. If specified, `dfx` will assume that the canister is remote at the specified canister ID for all networks that don't have a dedicated entry.
 
 ### feat: use OS-native keyring for pem file storage
 
@@ -1260,6 +1294,7 @@ The flag `--disable-encryption` is deprecated in favour of `--storage-mode plain
 ### feat(frontend-canister): better control and overview for asset canister authorized principals
 
 The asset canister now has two new functions:
+
 - Query function `list_authorized` displays a list of all principals that are currently authorized to change assets and the list of authorized principals.
 - Update function `deauthorize` that removes a principal from the list of authorized principals. It can be called by authorized principals and cotrollers of the canister.
 
@@ -1287,6 +1322,7 @@ The number of cycles left in the canister is bumped a little bit so that people 
 ## Dependencies
 
 Updated candid to 0.8.4
+
 - Bug fix in TS bindings
 - Pretty print numbers
 
@@ -1350,24 +1386,26 @@ This incorporates the following executed proposals:
 ### fix(frontend-canister): Allow overwriting default HTTP Headers for assets in frontend canister
 
 Allows to overwrite `Content-Type`, `Content-Encoding`, and `Cache-Control` HTTP headers with custom values via `.ic-assets.json5` config file. Example `.ic-assets.json5` file:
+
 ```json5
 [
-    {
-        "match": "web-gz.data.gz",
-        "headers": {
-            "Content-Type": "application/octet-stream",
-            "Content-Encoding": "gzip"
-        }
-    }
+  {
+    match: "web-gz.data.gz",
+    headers: {
+      "Content-Type": "application/octet-stream",
+      "Content-Encoding": "gzip",
+    },
+  },
 ]
 ```
+
 This change will trigger the update process for frontend canister (new module hash: `2ff0513123f11c57716d889ca487083fac7d94a4c9434d5879f8d0342ad9d759`).
 
 ### feat: warn if an unencrypted identity is used on mainnet
 
 ### fix: Save SNS canister IDs
 
-SNS canister IDs were not being parsed reliably.  Now the candid file is being specified explicitly, which resolves the issue in at least some cases.
+SNS canister IDs were not being parsed reliably. Now the candid file is being specified explicitly, which resolves the issue in at least some cases.
 
 ### feat: NNS usability improvements
 
@@ -1406,6 +1444,7 @@ This can be disabled by setting the field `"enable_aliasing"` to `false` in a ru
 This change will trigger frontend canister upgrades upon redeploying any asset canister.
 
 ### fix: Only kill main process on `dfx stop`
+
 Removes misleading panics when running `dfx stop`.
 
 ### feat: `dfx nns install` works offline if all assets have been cached.
@@ -1413,6 +1452,7 @@ Removes misleading panics when running `dfx stop`.
 ### feat: Initialise the nns with an account controlled by a secp256k1 key
 
 This enables easy access to toy ICP using command line tools and this key:
+
 ```
 -----BEGIN EC PRIVATE KEY-----
 MHQCAQEEICJxApEbuZznKFpV+VKACRK30i6+7u5Z13/DOl18cIC+oAcGBSuBBAAK
@@ -1420,13 +1460,16 @@ oUQDQgAEPas6Iag4TUx+Uop+3NhE6s3FlayFtbwdhRVjvOar0kPTfE/N8N6btRnd
 74ly5xXEBNSXiENyxhEuzOZrIWMCNQ==
 -----END EC PRIVATE KEY-----
 ```
+
 For example, you can create an identity in dfx by putting this key in the file `ident-1.pem` and importing it:
+
 ```
 dfx identity import ident-1 ident-1.pem
 dfx --identity ident-1 ledger balance
 ```
 
 ### feat: default to run ic-wasm shrink when build canisters
+
 This behavior applies to Motoko, Rust and Custom canisters.
 If you want to disable this behavior, you can config it in dfx.json:
 
@@ -1440,9 +1483,9 @@ If you want to disable this behavior, you can config it in dfx.json:
 
 It's now possible to define custom wasm metadata sections and their visibility in dfx.json.
 
-At present, dfx can only add wasm metadata sections to canisters that are in wasm format.  It cannot add metadata sections to compressed canisters.  Since the frontend canister is now compressed, this means that at present it is not possible to add custom metadata sections to the frontend canister.
+At present, dfx can only add wasm metadata sections to canisters that are in wasm format. It cannot add metadata sections to compressed canisters. Since the frontend canister is now compressed, this means that at present it is not possible to add custom metadata sections to the frontend canister.
 
-dfx no longer adds `candid:service` metadata to canisters of type `"custom"` by default.  If you want dfx to add your canister's candid definition to your custom canister, you can do so like this:
+dfx no longer adds `candid:service` metadata to canisters of type `"custom"` by default. If you want dfx to add your canister's candid definition to your custom canister, you can do so like this:
 
 ```
     "my_canister_name": {
@@ -1457,11 +1500,11 @@ dfx no longer adds `candid:service` metadata to canisters of type `"custom"` by 
     },
 ```
 
-This changelog entry doesn't go into all of the details of the possible configuration.  For that, please see [concepts/canister-metadata](docs/concepts/canister-metadata.md) and the docs in the JSON schema.
+This changelog entry doesn't go into all of the details of the possible configuration. For that, please see [concepts/canister-metadata](docs/concepts/canister-metadata.md) and the docs in the JSON schema.
 
 ### fix: Valid canister-based env vars
 
-Hyphens are not valid in shell environment variables, but do occur in canister names such as `smiley-dapp`. This poses a problem for vars with names such as `CANISTER_ID_${CANISTER_NAME}`.  With this change, hyphens are replaced with underscores in environment variables.  The canister id of `smiley-dapp` will be available as `CANISTER_ID_smiley_dapp`.  Other environment variables are unaffected.
+Hyphens are not valid in shell environment variables, but do occur in canister names such as `smiley-dapp`. This poses a problem for vars with names such as `CANISTER_ID_${CANISTER_NAME}`. With this change, hyphens are replaced with underscores in environment variables. The canister id of `smiley-dapp` will be available as `CANISTER_ID_smiley_dapp`. Other environment variables are unaffected.
 
 ### feat: Add dfx sns deploy
 
@@ -1504,6 +1547,7 @@ Previously the did files and wasms could be incompatible.
 `dfx start` and `dfx replica` now ignore the `--enable-canister-http` parameter.
 
 You can still disable the canister http feature through configuration:
+
 - ~/.config/dfx/networks.json: `.local.canister_http.enabled=false`
 - dfx.json (project-specific networks) : `.networks.local.canister_http.enabled=false`
 
@@ -1515,7 +1559,8 @@ You can still disable the canister http feature through configuration:
 
 ### feat: deploy NNS canisters
 
-A developer is now able to install NNS canisters, including back end canisters such as ledger and governance, and front end canisters such as nns-dapp and internet-identity, on their local DFX server.  Usage:
+A developer is now able to install NNS canisters, including back end canisters such as ledger and governance, and front end canisters such as nns-dapp and internet-identity, on their local DFX server. Usage:
+
 ```
 dfx start --clean --background
 dfx nns install
@@ -1550,13 +1595,13 @@ When creating a new identity with `dfx identity new`, whereas previously it woul
 
 ### chore: update Candid UI canister with commit 528a4b04807904899f67b919a88597656e0cd6fa
 
-* Allow passing did files larger than 2KB.
-* Better integration with Motoko Playground.
+- Allow passing did files larger than 2KB.
+- Better integration with Motoko Playground.
 
 ### feat: simplify verification of assets served by asset canister
 
-* SHA256 hashes of all assets are displayed when deploying the asset canister.
-* A query method is added to the asset canister that returns the entire asset hash tree together with the certificate containing the certified variables of the asset canister.
+- SHA256 hashes of all assets are displayed when deploying the asset canister.
+- A query method is added to the asset canister that returns the entire asset hash tree together with the certificate containing the certified variables of the asset canister.
 
 ### breaking change: dfx canister update-settings --compute-allocation always fails
 
@@ -1564,6 +1609,7 @@ See https://forum.dfinity.org/t/fixing-incorrect-compute-allocation-fee/14830
 
 Until the rollout is complete, `dfx canister update-settings --compute-allocation <N>`
 will fail with an error from the replica such as the following:
+
 ```
 The Replica returned an error: code 1, message: "Canister requested a compute allocation of 1% which cannot be satisfied because the Subnet's remaining compute capacity is 0%"
 ```
@@ -1591,7 +1637,7 @@ Additionally, after build step, the `.wasm` file is archived with `gzip`.
 ### chore: Move all `frontend canister`-related code into the SDK repo
 
 | from (`repository` `path`)                  | to (path in `dfinity/sdk` repository)          | summary                                                                                     |
-|:--------------------------------------------|:-----------------------------------------------|:--------------------------------------------------------------------------------------------|
+| :------------------------------------------ | :--------------------------------------------- | :------------------------------------------------------------------------------------------ |
 | `dfinity/cdk-rs` `/src/ic-certified-assets` | `/src/canisters/frontend/ic-certified-asset`   | the core of the frontend canister                                                           |
 | `dfinity/certified-assets` `/`              | `/src/canisters/frontend/ic-frontend-canister` | wraps `ic-certified-assets` to build the canister wasm                                      |
 | `dfinity/agent-rs` `/ic-asset`              | `/src/canisters/frontend/ic-asset`             | library facilitating interactions with frontend canister (e.g. uploading or listing assets) |
@@ -1601,17 +1647,19 @@ Additionally, after build step, the `.wasm` file is archived with `gzip`.
 
 Both `.ic-assets.json` and `.ic-assets.json5` are valid filenames config filename, though both will get parsed
 as if they were [JSON5](https://json5.org/) format. Example content of the `.ic-assets.json5` file:
+
 ```json5
 // comment
 [
   {
-    "match": "*", // comment
+    match: "*", // comment
     /*
     keys below not wrapped in quotes
-*/  cache: { max_age: 999 }, // trailing comma
+*/ cache: { max_age: 999 }, // trailing comma
   },
 ]
 ```
+
 - Learn more about JSON5: https://json5.org/
 
 ### fix: Update nns binaries unless `NO_CLOBBER` is set
@@ -1620,7 +1668,7 @@ Previously existing NNS binaries were not updated regardless of the `NO_CLOBBER`
 
 ### feat!: Support installing canisters not in dfx.json
 
-`install_canister_wasm` used to fail if installing a canister not listed in dfx.json.  This use case is now supported.
+`install_canister_wasm` used to fail if installing a canister not listed in dfx.json. This use case is now supported.
 
 ### feat: print the dashboard URL on startup
 
@@ -1634,30 +1682,32 @@ In combination with the "system-wide dfx start" feature, there is a potential di
 
 Since previous versions of dfx populate dfx.json with a `networks.local` definition that specifies port 8000, the behavior for existing projects won't change.
 
-However, if you've edited dfx.json and removed the `networks.local` definition, the behavior within the project will change: dfx will connect to the shared local network on port 4943 rather than to the project-specific network on port 8000.  You would need to edit webpack.config.js to match.  If you have scripts, you can run the new command `dfx info webserver-port` from the project directory to retrieve the port value.
+However, if you've edited dfx.json and removed the `networks.local` definition, the behavior within the project will change: dfx will connect to the shared local network on port 4943 rather than to the project-specific network on port 8000. You would need to edit webpack.config.js to match. If you have scripts, you can run the new command `dfx info webserver-port` from the project directory to retrieve the port value.
 
 ### feat!: "system-wide dfx start"
 
-By default, dfx now manages the replica process in a way that is independent of any given dfx project.  We've called this feature "system-wide dfx", even though it's actually specific to your user
+By default, dfx now manages the replica process in a way that is independent of any given dfx project. We've called this feature "system-wide dfx", even though it's actually specific to your user
 (storing data files under $HOME), because we think it communicates the idea adequately.
 
 The intended benefits:
+
 - deploying dapps from separate projects alongside one another, similar to working with separate dapps on mainnet
 - run `dfx start` from any directory
 - run `dfx stop` from any directory, rather than having to remember where you last ran `dfx start`
 
-We're calling this the "shared local network."  `dfx start` and `dfx stop` will manage this network when run outside any project directory, or when a project's dfx.json does not define the `local` network.  The dfx.json template for new projects no longer defines any networks.
+We're calling this the "shared local network." `dfx start` and `dfx stop` will manage this network when run outside any project directory, or when a project's dfx.json does not define the `local` network. The dfx.json template for new projects no longer defines any networks.
 
-We recommend that you remove the `local` network definition from dfx.json and instead use the shared local network.  As mentioned above, doing so will make dfx use port 4943 rather than port 8000.
+We recommend that you remove the `local` network definition from dfx.json and instead use the shared local network. As mentioned above, doing so will make dfx use port 4943 rather than port 8000.
 
 See [Local Server Configuration](docs/cli-reference/dfx-start.md#local-server-configuration) for details.
 
 dfx now stores data and control files in one of three places, rather than directly under `.dfx/`:
+
 - `.dfx/network/local` (for projects in which dfx.json defines the local network)
 - `$HOME/.local/share/dfx/network/local` (for the shared local network on Linux)
 - `$HOME/Library/Application Support/org.dfinity.dfx/network/local` (for the shared local network on MacOS)
 
-There is also a new configuration file: `$HOME/.config/dfx/networks.json`.  Its [schema](docs/networks-json-schema.json) is the same as the `networks` element in dfx.json.  Any networks you define here will be available from any project, unless a project's dfx.json defines a network with the same name.  See [The Shared Local Network](docs/cli-reference/dfx-start.md#the-shared-local-network) for the default definitions that dfx provides if this file does not exist or does not define a `local` network.
+There is also a new configuration file: `$HOME/.config/dfx/networks.json`. Its [schema](docs/networks-json-schema.json) is the same as the `networks` element in dfx.json. Any networks you define here will be available from any project, unless a project's dfx.json defines a network with the same name. See [The Shared Local Network](docs/cli-reference/dfx-start.md#the-shared-local-network) for the default definitions that dfx provides if this file does not exist or does not define a `local` network.
 
 ### fix: `dfx start` and `dfx stop` will take into account dfx/replica processes from dfx <= 0.11.x
 
@@ -1687,7 +1737,7 @@ This displays the path to your user's `networks.json` file where all networks ar
 
 ### feat: dfx schema --for networks
 
-The `dfx schema` command can now display the schema for either dfx.json or for networks.json.  By default, it still displays the schema for dfx.json.
+The `dfx schema` command can now display the schema for either dfx.json or for networks.json. By default, it still displays the schema for dfx.json.
 
 ```bash
 dfx schema --for networks
@@ -1699,8 +1749,8 @@ If you have a pre-initialized agent in your JS code, you can now pass it to crea
 
 ```js
 const plugActor = createActor(canisterId, {
-  agent: plugAgent
-})
+  agent: plugAgent,
+});
 ```
 
 ### feat!: option for nodejs compatibility in dfx generate
@@ -1738,10 +1788,12 @@ If the active identity has a wallet configured already, the faucet will top up t
 
 Alternative faucets can be used, assuming they follow the same interface. To direct dfx to a different faucet, use the `--faucet <alternative faucet id>` flag.
 The expected interface looks like the following candid functions:
-``` candid
+
+```candid
 redeem: (text) -> (principal);
 redeem_to_wallet: (text, principal) -> (nat);
 ```
+
 The function `redeem` takes a coupon code and returns the principal to an already-installed wallet that is controlled by the identity that called the function.
 The function `redeem_to_wallet` takes a coupon code and a wallet (or any other canister) principal, deposits the cycles into that canister and returns how many cycles were deposited.
 
@@ -1763,13 +1815,17 @@ When installing a new WASM module to a canister, DFX will now wait for the updat
 ### feat: move all the flags to the end
 
 Command flags have been moved to a more traditional location; they are no longer positioned per subcommand, but instead are able to be all positioned after the final subcommand. In prior versions, a command might look like:
+
 ```bash
 dfx --identity alice canister --network ic --wallet "$WALLET" create --all
 ```
+
 This command can now be written:
+
 ```bash
 dfx canister create --all --network ic --wallet "$WALLET" --identity alice
 ```
+
 The old syntax is still available, though, so you don't need to migrate your scripts.
 
 ### feat!: changed update-settings syntax
@@ -1778,7 +1834,7 @@ When using `dfx canister update-settings`, it is easy to mistake `--controller` 
 
 ### feat!: removed the internal webserver
 
-This is a breaking change.  The only thing this was still serving was the /_/candid endpoint.  If you need to retrieve the candid interface for a local canister, you can use `dfx canister metadata <canister> candid:service`.
+This is a breaking change. The only thing this was still serving was the /\_/candid endpoint. If you need to retrieve the candid interface for a local canister, you can use `dfx canister metadata <canister> candid:service`.
 
 ### fix: dfx wallet upgrade: improved error messages:
 
@@ -1792,15 +1848,16 @@ Canister creation fee was calculated with 1T cycles instead of 0.1T.
 ### fix: dfx deploy and dfx canister install write .old.did files under .dfx/
 
 When dfx deploy and dfx canister install upgrade a canister, they ensure that the
-new candid interface is compatible with the previous candid interface.  They write
-a file with extension .old.did that contains the previous interface.  In some
-circumstances these files could be written in the project directory.  dfx now
+new candid interface is compatible with the previous candid interface. They write
+a file with extension .old.did that contains the previous interface. In some
+circumstances these files could be written in the project directory. dfx now
 always writes them under the .dfx/ directory.
 
 ### fix: dfx canister install now accepts arbitrary canister ids
 
 This fixes the following error:
-``` bash
+
+```bash
 > dfx canister install --wasm ~/counter.wasm eop7r-riaaa-aaaak-qasxq-cai
 Error: Failed while determining if canister 'eop7r-riaaa-aaaak-qasxq-cai' is remote on network 'ic'.
 Caused by: Failed while determining if canister 'eop7r-riaaa-aaaak-qasxq-cai' is remote on network 'ic'.
@@ -1813,6 +1870,7 @@ Caused by: Failed while determining if canister 'eop7r-riaaa-aaaak-qasxq-cai' is
 It is now possible to specify the replica's log level. Possible values are `critical`, `error`, `warning`, `info`, `debug`, and `trace`.
 The log level defaults to the level 'error'. Debug prints (e.g. `Debug.print("...")` in Motoko) still show up in the console.
 The log level can be specified in the following places (See [system-wide dfx start](#feat-system-wide-dfx-start) for more detailed explanations on the network types):
+
 - In file `networks.json` in the field `<network name>.replica.log_level` for shared networks.
 - In file `dfx.json` in the field `networks.<network name>.replica.log_level` for project-specific networks.
 - In file `dfx.json` in the field `defaults.replica.log_level` for project-specific networks. Requires a project-specific network to be run, otherwise this will have no effect.
@@ -1841,10 +1899,10 @@ It is still possible to pin the dfx version by adding `"dfx":"<dfx version to pi
 ### fix: Small grammar change to identity password decryption prompt
 
 The prompt for entering your passphrase in order to decrypt an identity password read:
-    "Please enter a passphrase for your identity"
-However, at that point, it isn't "a" passphrase.  It's either your passphrase, or incorrect.
+"Please enter a passphrase for your identity"
+However, at that point, it isn't "a" passphrase. It's either your passphrase, or incorrect.
 Changed the text in this case to read:
-    "Please enter the passphrase for your identity"
+"Please enter the passphrase for your identity"
 
 ### chore: add retry logic to dfx download script
 
@@ -1866,6 +1924,7 @@ This also incorporates the following executed proposals:
 - [87631](https://dashboard.internetcomputer.org/proposal/87631)
 - [86738](https://dashboard.internetcomputer.org/proposal/86738)
 - [86279](https://dashboard.internetcomputer.org/proposal/86279)
+
 * [85007](https://dashboard.internetcomputer.org/proposal/85007)
 * [84391](https://dashboard.internetcomputer.org/proposal/84391)
 * [83786](https://dashboard.internetcomputer.org/proposal/83786)
@@ -1888,6 +1947,7 @@ This also incorporates the following executed proposals:
 ### ic-ref
 
 Updated ic-ref to 0.0.1-1fba03ee
+
 - introduce awaitKnown
 - trivial implementation of idle_cycles_burned_per_day
 
@@ -1895,13 +1955,13 @@ Updated ic-ref to 0.0.1-1fba03ee
 
 - See https://github.com/dfinity/motoko/blob/master/Changelog.md#073-2022-11-01
 
-
 ### Cycles wallet
 
 - Module hash: b944b1e5533064d12e951621d5045d5291bcfd8cf9d60c28fef02c8fdb68e783
 - https://github.com/dfinity/cycles-wallet/commit/fa86dd3a65b2509ca1e0c2bb9d7d4c5be95de378
 
 ### Frontend canister:
+
 - Module hash: 6c8f7a094060b096c35e4c4499551e7a8a29ee0f86c456e521c09480ebbaa8ab
 - https://github.com/dfinity/sdk/pull/2720
 
@@ -1936,34 +1996,38 @@ Patches a JavaScript language binding compatibility issue encountered in web bro
 dfx is now capable of displaying the schema for `dfx.json`. You can see the schema by running `dfx schema` or write the schema to a file with `dfx schema --outfile path/to/file/schema.json`.
 
 ### feat: support for configuring assets in assets canister
+
 - The `.ic-assets.json` file should be placed inside directory with assets, or its subdirectories. Multiple config files can be used (nested in subdirectories). Example of `.ic-assets.json` file format:
-``` json
+
+```json
 [
-    {
-        "match": ".*",
-        "cache": {
-            "max_age": 20
-        },
-        "headers": {
-            "X-Content-Type-Options": "nosniff"
-        },
-        "ignore": false
+  {
+    "match": ".*",
+    "cache": {
+      "max_age": 20
     },
-    {
-        "match": "**/*",
-        "headers": null
+    "headers": {
+      "X-Content-Type-Options": "nosniff"
     },
-    {
-        "match": "file.json",
-        "ignore": true
-    }
+    "ignore": false
+  },
+  {
+    "match": "**/*",
+    "headers": null
+  },
+  {
+    "match": "file.json",
+    "ignore": true
+  }
 ]
 ```
+
 - Configuring assets works only during asset creation - any changes to `.ic-assets.json` files won't have any effect effect for assets that have already been created. We are working on follow up implementation with improvements to handle updating these properties.
 - `headers` from multiple applicable rules are being stacked/concatenated, unless `null` is specified, which resets/empties the headers.
 - Both `"headers": {}` and absence of `headers` field don't have any effect on end result.
 - Valid JSON format is required, i.e. the array of maps, `match` field is required. Only the following fields are accepted: `cache`, `ignore`, `headers`, `match`. The glob pattern has to be valid.
 - The way matching rules work:
+
   1. The most deeply nested config file takes precedence over the one in parent dir. In other words, properties from a rule matching a file in a subdirectory override properties from a rule matching a file in a parent directory
   2. Order of rules within file matters - last rule in config file takes precedence over the first one
 
@@ -1972,7 +2036,6 @@ dfx is now capable of displaying the schema for `dfx.json`. You can see the sche
   2. The `.ignore` field overrides this, if present.
   3. If a directory is ignored, file and directories within it cannot be un-ignored.
   4. A file can be ignored and un-ignored many times, as long as any of its parent directories haven't been ignored.
-
 
 ### fix: Allow `dfx deploy` to not take arguments for canisters not being installed
 
@@ -2006,17 +2069,17 @@ A test key id "Secp256k1:dfx_test_key" is ready to be used by locally created ca
 Updated replica to elected commit 6e86169e98904047833ba6133e5413d2758d90eb.
 This incorporates the following executed proposals:
 
-* [72225](https://dashboard.internetcomputer.org/proposal/72225)
-* [71669](https://dashboard.internetcomputer.org/proposal/71669)
-* [71164](https://dashboard.internetcomputer.org/proposal/71164)
-* [70375](https://dashboard.internetcomputer.org/proposal/70375)
-* [70002](https://dashboard.internetcomputer.org/proposal/70002)
+- [72225](https://dashboard.internetcomputer.org/proposal/72225)
+- [71669](https://dashboard.internetcomputer.org/proposal/71669)
+- [71164](https://dashboard.internetcomputer.org/proposal/71164)
+- [70375](https://dashboard.internetcomputer.org/proposal/70375)
+- [70002](https://dashboard.internetcomputer.org/proposal/70002)
 
 # 0.11.0
 
 ## DFX
 
-### feat: renamed canisters in new projects to <project>_frontend and <project>_backend
+### feat: renamed canisters in new projects to <project>\_frontend and <project>\_backend
 
 The names of canisters created for new projects have changed.
 After `dfx new <project>`, the canister names are:
@@ -2030,10 +2093,10 @@ After `dfx new <project>`, the canister names are:
 
 For example, to query a canister's candid service definition: `dfx canister metadata hello_backend candid:service`
 
-### refactor: deprecate /_/candid internal webserver
+### refactor: deprecate /\_/candid internal webserver
 
-The dfx internal webserver now only services the /_/candid endpoint.  This
-is now deprecated.  If you were using this to query candid definitions, you
+The dfx internal webserver now only services the /\_/candid endpoint. This
+is now deprecated. If you were using this to query candid definitions, you
 can instead use `dfx canister metadata`.
 
 ### refactor: optimize from ic-wasm
@@ -2045,8 +2108,9 @@ The actual optimization was kept the same.
 ### feat: Read dfx canister call argument from a file or stdin
 
 Enables passing large arguments that cannot be passed directly in the command line using the `--argument-file` flag. For example:
- * Named file: `dfx canister call --argument-file ./my/argument/file.txt my_canister_name greet`
- * Stdin: `echo '( null )' | dfx canister call --argument-file - my_canister_name greet`
+
+- Named file: `dfx canister call --argument-file ./my/argument/file.txt my_canister_name greet`
+- Stdin: `echo '( null )' | dfx canister call --argument-file - my_canister_name greet`
 
 ### fix: Use default setting for BTC adapter idle seconds
 
@@ -2070,18 +2134,18 @@ By default, a log level of "info" is used, which is relatively quiet. Users can 
 
 This includes the following changes:
 
-* Fetch did file from canister metadata
-* Better flamegraph support
-* Fix bigint error for vec nat8 type
+- Fetch did file from canister metadata
+- Better flamegraph support
+- Fix bigint error for vec nat8 type
 
 ### feat: dfx will look up the port of the running webserver from .dfx/webserver-port, if present
 
-After `dfx start --host 127.0.0.1:0`, the dfx webserver will listen on an ephemeral port.  It stores the port value in .dfx/webserver-port.  dfx will now look for this file, and if a port is contained within, use that port to connect to the dfx webserver.
+After `dfx start --host 127.0.0.1:0`, the dfx webserver will listen on an ephemeral port. It stores the port value in .dfx/webserver-port. dfx will now look for this file, and if a port is contained within, use that port to connect to the dfx webserver.
 
 ### fix: dfx commands once again work from any subdirectory of a dfx project
 
 Running `dfx deploy`, `dfx canister id`, `dfx canister call` and so forth work as expected
-if run from within any subdirectory of a dfx project.  Previously, this would create
+if run from within any subdirectory of a dfx project. Previously, this would create
 canister_ids.json or .dfx/local/canister_ids.json within the subdirectory.
 
 ### feat: Post-installation tasks
@@ -2093,7 +2157,7 @@ You can now add your own custom post-installation/post-deployment tasks to any c
 Assets are now uploaded directly from their source directories, rather than first being copied
 to an output directory.
 
-If you're using `dfx deploy`, you won't see any change in functionality.  If you're running
+If you're using `dfx deploy`, you won't see any change in functionality. If you're running
 `dfx canister install --mode=upgrade`, changed files in asset source directories will
 be detected and uploaded even without an intervening `dfx build`.
 
@@ -2131,7 +2195,7 @@ Resolves an issue where `webpack-cli` was was breaking when users tried to run `
 ### feat: Support for new ledger notify function
 
 Ledger 7424ea8 deprecates the existing `notify` function with a switch parameter between creating and topping up a canister, and introduces two
-functions for doing the same. This should *mostly* be invisible to users, except that previously, if `dfx ledger create-canister` or `dfx ledger top-up`
+functions for doing the same. This should _mostly_ be invisible to users, except that previously, if `dfx ledger create-canister` or `dfx ledger top-up`
 failed, you would call `dfx ledger notify` after correcting the issue. In order to support the change, this command has been changed to two subcommands:
 `dfx ledger notify create-canister` and `dfx ledger notify top-up`.
 
@@ -2163,7 +2227,7 @@ The candid file specified in the field `canisters.<canister name>.candid` of dfx
 ### fix: btc/canister http adapter socket not found by replica after restart
 
 After running `dfx start --enable-bitcoin` twice in a row (stopping dfx in between), the second
-launched replica would fail to connect to the btc adapter.  This is because ic-starter
+launched replica would fail to connect to the btc adapter. This is because ic-starter
 does not write a new configuration file if one already exists, so the configuration file
 used by the replica referred to one socket path, while dfx passed a different socket path
 to the btc adapter.
@@ -2182,7 +2246,6 @@ a dfx process that is starting.
 ### fix: dfx ping no longer creates a default identity
 
 dfx ping now uses the anonymous identity, and no longer requires dfx.json to be present.
-
 
 ### fix: Initialize replica with bitcoin regtest flag
 
@@ -2206,7 +2269,8 @@ If one of these four fields is set for the local network, the corresponding fiel
 in `defaults` will be ignored.
 
 Example:
-``` json
+
+```json
 {
   "networks": {
     "local": {
@@ -2234,26 +2298,27 @@ Updated Motoko from 0.6.28 to 0.6.29.
 Updated replica to elected commit 8993849de5fab76e796d67750facee55a0bf6649.
 This incorporates the following executed proposals:
 
-* [69804](https://dashboard.internetcomputer.org/proposal/69804)
-* [67990](https://dashboard.internetcomputer.org/proposal/67990)
-* [67483](https://dashboard.internetcomputer.org/proposal/67483)
-* [66895](https://dashboard.internetcomputer.org/proposal/66895)
-* [66888](https://dashboard.internetcomputer.org/proposal/66888)
-* [65530](https://dashboard.internetcomputer.org/proposal/65530)
-* [65327](https://dashboard.internetcomputer.org/proposal/65327)
-* [65043](https://dashboard.internetcomputer.org/proposal/65043)
-* [64355](https://dashboard.internetcomputer.org/proposal/64355)
-* [63228](https://dashboard.internetcomputer.org/proposal/63228)
-* [62143](https://dashboard.internetcomputer.org/proposal/62143)
+- [69804](https://dashboard.internetcomputer.org/proposal/69804)
+- [67990](https://dashboard.internetcomputer.org/proposal/67990)
+- [67483](https://dashboard.internetcomputer.org/proposal/67483)
+- [66895](https://dashboard.internetcomputer.org/proposal/66895)
+- [66888](https://dashboard.internetcomputer.org/proposal/66888)
+- [65530](https://dashboard.internetcomputer.org/proposal/65530)
+- [65327](https://dashboard.internetcomputer.org/proposal/65327)
+- [65043](https://dashboard.internetcomputer.org/proposal/65043)
+- [64355](https://dashboard.internetcomputer.org/proposal/64355)
+- [63228](https://dashboard.internetcomputer.org/proposal/63228)
+- [62143](https://dashboard.internetcomputer.org/proposal/62143)
 
 ### ic-ref
 
 Updated ic-ref to 0.0.1-173cbe84
- - add ic0.performance_counter system interface
- - add system API for ECDSA signing
- - allow optional "error_code" field in responses
- - support gzip-compressed canister modules
- - enable canisters to send HTTP requests
+
+- add ic0.performance_counter system interface
+- add system API for ECDSA signing
+- allow optional "error_code" field in responses
+- support gzip-compressed canister modules
+- enable canisters to send HTTP requests
 
 # 0.10.1
 
@@ -2267,9 +2332,11 @@ lead to an annoying "too many open files" error.
 ### fix: HSMs are once again supported on Linux
 
 On Linux, dfx 0.10.0 failed any operation with an HSM with the following error:
+
 ```
 Error: IO: Dynamic loading not supported
 ```
+
 The fix was to once again dynamically-link the Linux build.
 
 ### feat: error explanation and fixing instructions engine
@@ -2293,7 +2360,8 @@ The behavior for identities without any configured wallets is unchanged.
 ### feat: bitcoin integration: dfx now generates the bitcoin adapter config file
 
 dfx command-line parameters for bitcoin integration:
-``` bash
+
+```bash
 dfx start   --enable-bitcoin  # use default node 127.0.0.1:18444
 dfx start   --enable-bitcoin --bitcoin-node <node>
 ```
@@ -2301,6 +2369,7 @@ dfx start   --enable-bitcoin --bitcoin-node <node>
 The above examples also work for dfx replica.
 
 These default to values from dfx.json:
+
 ```
 .defaults.bitcoin.nodes
 .defaults.bitcoin.enabled
@@ -2309,7 +2378,6 @@ These default to values from dfx.json:
 The --bitcoin-node parameter, if specified on the command line, implies --enable-bitcoin.
 
 If --enable-bitcoin or .defaults.bitcoin.enabled is set, then dfx start/replica will launch the ic-btc-adapter process and configure the replica to communicate with it.
-
 
 ### feat: print wallet balance in a human readable form #2184
 
@@ -2320,12 +2388,14 @@ New flag `--precise` added to `dfx wallet balance`. Allows to get exact amount o
 ### feat: canister http integration
 
 dfx command-line parameters for canister http requests integration:
+
 ```
 dfx start --enable-canister-http
 dfx replica --enable-canister-http
 ```
 
 This defaults to the following value in dfx.json:
+
 ```
 .defaults.canister_http.enabled
 ```
@@ -2351,22 +2421,22 @@ Updated Motoko from 0.6.26 to 0.6.28.
 Updated replica to elected commit b90edb9897718730f65e92eb4ff6057b1b25f766.
 This incorporates the following executed proposals:
 
-* [61004](https://dashboard.internetcomputer.org/proposal/61004)
-* [60222](https://dashboard.internetcomputer.org/proposal/60222)
-* [59187](https://dashboard.internetcomputer.org/proposal/59187)
-* [58479](https://dashboard.internetcomputer.org/proposal/58479)
-* [58376](https://dashboard.internetcomputer.org/proposal/58376)
-* [57843](https://dashboard.internetcomputer.org/proposal/57843)
-* [57395](https://dashboard.internetcomputer.org/proposal/57395)
+- [61004](https://dashboard.internetcomputer.org/proposal/61004)
+- [60222](https://dashboard.internetcomputer.org/proposal/60222)
+- [59187](https://dashboard.internetcomputer.org/proposal/59187)
+- [58479](https://dashboard.internetcomputer.org/proposal/58479)
+- [58376](https://dashboard.internetcomputer.org/proposal/58376)
+- [57843](https://dashboard.internetcomputer.org/proposal/57843)
+- [57395](https://dashboard.internetcomputer.org/proposal/57395)
 
 ## icx-proxy
 
 Updated icx-proxy to commit c312760a62b20931431ba45e5b0168ee79ea5cda
 
-* Added gzip and deflate body decoding before certification validation.
-* Fixed unzip and streaming bugs
-* Added Prometheus metrics endpoint
-* Added root and invalid ssl and dns mapping
+- Added gzip and deflate body decoding before certification validation.
+- Fixed unzip and streaming bugs
+- Added Prometheus metrics endpoint
+- Added root and invalid ssl and dns mapping
 
 # 0.10.0
 
@@ -2374,10 +2444,9 @@ Updated icx-proxy to commit c312760a62b20931431ba45e5b0168ee79ea5cda
 
 ### feat: Use null as default value for opt arguments
 
-
 Before this, `deploy`ing a canister with an `opt Foo` init argument without specifying an `--argument` would lead to an error:
 
-``` bash
+```bash
 $ dfx deploy
 Error: Invalid data: Expected arguments but found none.
 ```
@@ -2408,7 +2477,7 @@ dfx will once again display 'dfx is already running' if dfx is already running,
 rather than 'Address already in use'.
 
 As a consequence, after `dfx start` failed to notice that dfx was already running,
-it would replace .dfx/pid with an empty file.  Later invocations of `dfx stop`
+it would replace .dfx/pid with an empty file. Later invocations of `dfx stop`
 would display no output and return a successful exit code, but leave dfx running.
 
 ### fix: dfx canister update-settings <canister id> works even if the canister id is not known to the project.
@@ -2419,8 +2488,8 @@ This makes the behavior match the usage text of the command:
 ### feat: dfx deploy --upgrade-unchanged or dfx canister install --mode upgrade --upgrade-unchanged
 
 When upgrading a canister, `dfx deploy` and `dfx canister install` skip installing the .wasm
-if the wasm hash did not change.  This avoids a round trip through stable memory for all
-assets on every dfx deploy, for example.  By passing this argument, dfx will instead
+if the wasm hash did not change. This avoids a round trip through stable memory for all
+assets on every dfx deploy, for example. By passing this argument, dfx will instead
 install the wasm even if its hash matches the already-installed wasm.
 
 ### feat: Introduce DFX_CACHE_ROOT environment variable
@@ -2436,11 +2505,12 @@ Previously, `dfx canister call --with-cycles 1` would silently ignore the `--wit
 ### feat: Configure subnet type of local replica
 
 The local replica sets its parameters according to the subnet type defined in defaults.replica.subnet_type, defaulting to 'application' when none is specified.
-This makes it less likely to accidentally hit the 'cycles limit exceeded' error in production.  Since the previous default was `system`, you may see these types errors in development instead.
+This makes it less likely to accidentally hit the 'cycles limit exceeded' error in production. Since the previous default was `system`, you may see these types errors in development instead.
 Possible values for defaults.replica.subnet_type are: "application", "verifiedapplication", "system"
 
 Example how to specify the subnet type:
-``` json
+
+```json
 {
   "defaults": {
     "replica": {
@@ -2461,7 +2531,8 @@ If you decide to use a password, your key will never be written to disk in plain
 In case you don't want to enter your password all the time and want to take the risk of storing your private key in plain text, you can use the `--disable-encryption` flag.
 
 The `default` identity as well as already existing identities will NOT be encrypted. If you want to encrypt an existing identity, use the following commands:
-``` bash
+
+```bash
 dfx identity export identity_name > identity.pem
 # if you have set old_identity_name as the identity that is used by default, switch to a different one
 dfx identity use other_identity
@@ -2491,12 +2562,14 @@ But when trying to create an identity with that name, it was considered to be al
 ### feat: dfx start and dfx replica can now launch the ic-btc-adapter process
 
 Added command-line parameters:
-``` bash
+
+```bash
 dfx start   --enable-bitcoin --btc-adapter-config <path>
 dfx replica --enable-bitcoin --btc-adapter-config <path>
 ```
 
 These default to values from dfx.json:
+
 ```
 .defaults.bitcoin.btc_adapter_config
 .defaults.bitcoin.enabled
@@ -2532,14 +2605,14 @@ Updated to version 0.14.0 of agent-rs
 Updated replica to elected commit b3788091fbdb8bed7e527d2df4cc5e50312f476c.
 This incorporates the following executed proposals:
 
-* [57150](https://dashboard.internetcomputer.org/proposal/57150)
-* [54964](https://dashboard.internetcomputer.org/proposal/54964)
-* [53702](https://dashboard.internetcomputer.org/proposal/53702)
-* [53231](https://dashboard.internetcomputer.org/proposal/53231)
-* [53134](https://dashboard.internetcomputer.org/proposal/53134)
-* [52627](https://dashboard.internetcomputer.org/proposal/52627)
-* [52144](https://dashboard.internetcomputer.org/proposal/52144)
-* [50282](https://dashboard.internetcomputer.org/proposal/50282)
+- [57150](https://dashboard.internetcomputer.org/proposal/57150)
+- [54964](https://dashboard.internetcomputer.org/proposal/54964)
+- [53702](https://dashboard.internetcomputer.org/proposal/53702)
+- [53231](https://dashboard.internetcomputer.org/proposal/53231)
+- [53134](https://dashboard.internetcomputer.org/proposal/53134)
+- [52627](https://dashboard.internetcomputer.org/proposal/52627)
+- [52144](https://dashboard.internetcomputer.org/proposal/52144)
+- [50282](https://dashboard.internetcomputer.org/proposal/50282)
 
 Added the ic-btc-adapter binary to the cache.
 
@@ -2557,7 +2630,7 @@ Updated Motoko from 0.6.25 to 0.6.26.
 
 In preparation for BTC integration, added configuration for the bitcoind port:
 
-``` json
+```json
 {
   "canisters": {},
   "defaults": {
@@ -2572,23 +2645,23 @@ In preparation for BTC integration, added configuration for the bitcoind port:
 
 Updated icx-proxy to commit 594b6c81cde6da4e08faee8aa8e5a2e6ae815602, now static-linked.
 
-* upgrade HTTP calls upon canister request
-* no longer proxies /_/raw to the dfx internal webserver
-* allows for generic StreamingCallback tokens
+- upgrade HTTP calls upon canister request
+- no longer proxies /\_/raw to the dfx internal webserver
+- allows for generic StreamingCallback tokens
 
 ## Replica
 
 Updated replica to blessed commit d004accc3904e24dddb13a11d93451523e1a8a5f.
 This incorporates the following executed proposals:
 
-* [49653](https://dashboard.internetcomputer.org/proposal/49653)
-* [49011](https://dashboard.internetcomputer.org/proposal/49011)
-* [48427](https://dashboard.internetcomputer.org/proposal/48427)
-* [47611](https://dashboard.internetcomputer.org/proposal/47611)
-* [47512](https://dashboard.internetcomputer.org/proposal/47512)
-* [47472](https://dashboard.internetcomputer.org/proposal/47472)
-* [45984](https://dashboard.internetcomputer.org/proposal/45984)
-* [45982](https://dashboard.internetcomputer.org/proposal/45982)
+- [49653](https://dashboard.internetcomputer.org/proposal/49653)
+- [49011](https://dashboard.internetcomputer.org/proposal/49011)
+- [48427](https://dashboard.internetcomputer.org/proposal/48427)
+- [47611](https://dashboard.internetcomputer.org/proposal/47611)
+- [47512](https://dashboard.internetcomputer.org/proposal/47512)
+- [47472](https://dashboard.internetcomputer.org/proposal/47472)
+- [45984](https://dashboard.internetcomputer.org/proposal/45984)
+- [45982](https://dashboard.internetcomputer.org/proposal/45982)
 
 ## Motoko
 
@@ -2603,8 +2676,8 @@ Updated Motoko from 0.6.21 to 0.6.25.
 Newly deployed Motoko canisters now embed the Candid interface and Motoko stable signatures in the Wasm module.
 `dfx deploy` and `dfx canister install` will automatically check
 
-	1) the backward compatible of Candid interface in both upgrade and reinstall mode;
-	2) the type safety of Motoko stable variable type in upgrade mode to avoid accidentally lossing data;
+    1) the backward compatible of Candid interface in both upgrade and reinstall mode;
+    2) the type safety of Motoko stable variable type in upgrade mode to avoid accidentally lossing data;
 
 See [Upgrade compatibility](https://internetcomputer.org/docs/language-guide/compatibility) for more details.
 
@@ -2612,13 +2685,13 @@ See [Upgrade compatibility](https://internetcomputer.org/docs/language-guide/com
 
 The three canister types that use a custom build tool - `assets`, `rust`, and `custom` - now all support the same set of environment variables during the build task:
 
-* `DFX_VERSION` - The version of DFX that was used to build the canister.
-* `DFX_NETWORK` - The network name being built for. Usually `ic` or `local`.
-* `CANISTER_ID_{canister}` - The canister principal ID of the canister `{canister}` registered in `dfx.json`.
-* `CANISTER_CANDID_PATH_{canister}` - The path to the Candid interface file for the canister `{canister}` among your canister's dependencies.
-* `CANISTER_CANDID_{canister}` (deprecated) - the same as `CANISTER_CANDID_PATH_{canister}`.  This is provided for backwards compatibility with `rust` and `custom` canisters, and will be removed in dfx 0.10.0.
-* `CANISTER_ID` - Same as `CANISTER_ID_{self}`, where `{self}` is the name of _this_ canister.
-* `CANISTER_CANDID_PATH` - Same as `CANISTER_CANDID_PATH_{self}`, where `{self}` is the name of _this_ canister.
+- `DFX_VERSION` - The version of DFX that was used to build the canister.
+- `DFX_NETWORK` - The network name being built for. Usually `ic` or `local`.
+- `CANISTER_ID_{canister}` - The canister principal ID of the canister `{canister}` registered in `dfx.json`.
+- `CANISTER_CANDID_PATH_{canister}` - The path to the Candid interface file for the canister `{canister}` among your canister's dependencies.
+- `CANISTER_CANDID_{canister}` (deprecated) - the same as `CANISTER_CANDID_PATH_{canister}`. This is provided for backwards compatibility with `rust` and `custom` canisters, and will be removed in dfx 0.10.0.
+- `CANISTER_ID` - Same as `CANISTER_ID_{self}`, where `{self}` is the name of _this_ canister.
+- `CANISTER_CANDID_PATH` - Same as `CANISTER_CANDID_PATH_{self}`, where `{self}` is the name of _this_ canister.
 
 ### feat: Support for local ledger calls
 
@@ -2626,7 +2699,8 @@ If you have an installation of the ICP Ledger (see [Ledger Installation Guide](h
 `--ledger-canister-id` parameter.
 
 Some examples:
-``` bash
+
+```bash
 $ dfx ledger \
   --network local \
   balance \
@@ -2645,7 +2719,7 @@ Transfer sent at block height: 1
 The `dfx ledger account-id` can now compute addresses of principals and canisters.
 The command also supports ledger subaccounts now.
 
-``` bash
+```bash
 dfx ledger account-id --of-principal 53zcu-tiaaa-aaaaa-qaaba-cai
 dfx ledger --network small02 account-id --of-canister ledger_demo
 dfx ledger account-id --of-principal 53zcu-tiaaa-aaaaa-qaaba-cai --subaccount 0000000000000000000000000000000000000000000000000000000000000001
@@ -2671,9 +2745,9 @@ Caused by:
 
 dfx now calls `transfer` rather than `send_dfx`, and sets the created_at_time field in order to retry the following commands:
 
-* dfx ledger create-canister
-* dfx ledger top-up
-* dfx ledger transfer
+- dfx ledger create-canister
+- dfx ledger top-up
+- dfx ledger transfer
 
 ### feat: Remote canister support
 
@@ -2683,7 +2757,8 @@ that is, a canister that already exists on that network and is managed by some o
 Motoko, Rust, and custom canisters may be configured in this way.
 
 This is the general format of the configuration in dfx.json:
-``` json
+
+```json
 {
   "canisters": {
     "<canister name>": {
@@ -2703,14 +2778,15 @@ The canister will not be created or installed on these remote networks.
 For other networks, the canister will be created and installed as usual.
 
 The "candid" field, if set within the remote object, specifies the candid file to build against when
-building other canisters on a network for which the canister is remote.  This definition can differ
+building other canisters on a network for which the canister is remote. This definition can differ
 from the candid definitions for local builds.
 
 For example, if have an installation of the ICP Ledger (see [Ledger Installation Guide](https://github.com/dfinity/ic/tree/master/rs/rosetta-api/ledger_canister#deploying-locally))
-in your dfx.json, you could configure the canister ID of the Ledger canister on the ic network as below.  In this case,
+in your dfx.json, you could configure the canister ID of the Ledger canister on the ic network as below. In this case,
 the private interfaces would be available for local builds, but only the public interfaces would be available
 when building for `--network ic`.
-``` json
+
+```json
 {
   "canisters": {
     "ledger": {
@@ -2727,7 +2803,7 @@ when building for `--network ic`.
     "app": {
       "type": "motoko",
       "main": "src/app/main.mo",
-      "dependencies": [ "ledger" ]
+      "dependencies": ["ledger"]
     }
   }
 }
@@ -2743,7 +2819,7 @@ This way, you can define public update/query functions to aid in local testing, 
 when building/deploying to mainnet, references to methods not found in `ledger.public.did`
 will be reports as compilation errors.
 
-``` json
+```json
 {
   "canisters": {
     "ledger": {
@@ -2759,7 +2835,7 @@ will be reports as compilation errors.
     "app": {
       "type": "motoko",
       "main": "src/app/main.mo",
-      "dependencies": [ "ledger" ]
+      "dependencies": ["ledger"]
     }
   }
 }
@@ -2772,7 +2848,8 @@ It's now possible to generate the interface of a remote canister using a .did fi
 Currently, dfx can generate .mo, .rs, .ts, and .js bindings.
 
 This is how you specify how to generate the bindings in dfx.json:
-``` json
+
+```json
 {
   "canisters": {
     "<canister name>": {
@@ -2790,25 +2867,25 @@ This is how you specify how to generate the bindings in dfx.json:
 
 Upgraded from a432156f24faa16d387c9d36815f7ddc5d50e09f to ab8e3f5a04f0f061b8157c2889f8f5de05f952bb
 
-* Support 128-bit system api for cycles
-* Include canister_ranges in the state tree
-* Removed limit on cycles in a canister
+- Support 128-bit system api for cycles
+- Include canister_ranges in the state tree
+- Removed limit on cycles in a canister
 
 ## Replica
 
 Updated replica to blessed commit 04fe8b0a1262f07c0cec1fdfa838a37607370a61.
 This incorporates the following executed proposals:
 
-* [45091](https://dashboard.internetcomputer.org/proposal/45091)
-* [43635](https://dashboard.internetcomputer.org/proposal/43635)
-* [43633](https://dashboard.internetcomputer.org/proposal/43633)
-* [42783](https://dashboard.internetcomputer.org/proposal/42783)
-* [42410](https://dashboard.internetcomputer.org/proposal/42410)
-* [40908](https://dashboard.internetcomputer.org/proposal/40908)
-* [40647](https://dashboard.internetcomputer.org/proposal/40647)
-* [40328](https://dashboard.internetcomputer.org/proposal/40328)
-* [39791](https://dashboard.internetcomputer.org/proposal/39791)
-* [38541](https://dashboard.internetcomputer.org/proposal/38541)
+- [45091](https://dashboard.internetcomputer.org/proposal/45091)
+- [43635](https://dashboard.internetcomputer.org/proposal/43635)
+- [43633](https://dashboard.internetcomputer.org/proposal/43633)
+- [42783](https://dashboard.internetcomputer.org/proposal/42783)
+- [42410](https://dashboard.internetcomputer.org/proposal/42410)
+- [40908](https://dashboard.internetcomputer.org/proposal/40908)
+- [40647](https://dashboard.internetcomputer.org/proposal/40647)
+- [40328](https://dashboard.internetcomputer.org/proposal/40328)
+- [39791](https://dashboard.internetcomputer.org/proposal/39791)
+- [38541](https://dashboard.internetcomputer.org/proposal/38541)
 
 ## Motoko
 
@@ -2824,13 +2901,16 @@ Breaking change: Canister commands, except for `dfx canister create`, will make 
 
 When working with existing canisters, use the `--wallet` flag in conjunction with `dfx identity get-wallet` in order to restore the old behavior.
 
-You will need to upgrade your wallet and each of your existing canisters to work with the new system.  To do so, execute the following in each of your dfx projects:
-``` bash
+You will need to upgrade your wallet and each of your existing canisters to work with the new system. To do so, execute the following in each of your dfx projects:
+
+```bash
 dfx wallet upgrade
 dfx canister --wallet "$(dfx identity get-wallet)" update-settings --all --add-controller "$(dfx identity get-principal)"
 ```
+
 To upgrade projects that you have deployed to the IC mainnet, execute the following:
-``` bash
+
+```bash
 dfx wallet --network ic upgrade
 dfx canister --network ic --wallet "$(dfx identity --network ic get-wallet)" update-settings --all --add-controller "$(dfx identity get-principal)"
 ```
@@ -2855,17 +2935,17 @@ Fixed a defect in asset synchronization where no retries would be attempted afte
 
 Updated Motoko from 0.6.11 to 0.6.20.
 
-* Implement type union/intersection
-* Transform for-loops on arrays into while-loops
-* Tighten typing rules for type annotations in patterns
-* Candid decoding: skip vec any fast
-* Bump up MAX_HP_FOR_GC from 1GB to 3GB
-* Candid decoder: Trap if a principal value is too large
-* Eliminate bignum calls from for-iteration on arrays
-* Improve scheduling
-* Improve performance of bignum equality
-* Stable signatures: frontend, metadata, command-line args
-* Added heartbeat support
+- Implement type union/intersection
+- Transform for-loops on arrays into while-loops
+- Tighten typing rules for type annotations in patterns
+- Candid decoding: skip vec any fast
+- Bump up MAX_HP_FOR_GC from 1GB to 3GB
+- Candid decoder: Trap if a principal value is too large
+- Eliminate bignum calls from for-iteration on arrays
+- Improve scheduling
+- Improve performance of bignum equality
+- Stable signatures: frontend, metadata, command-line args
+- Added heartbeat support
 
 ## Cycles wallet
 
@@ -2877,17 +2957,17 @@ Updated Motoko from 0.6.11 to 0.6.20.
 Updated replica to blessed commit 75138bbf11e201aac47266f07bee289dc18a082b.
 This incorporates the following executed proposals:
 
-* [33828](https://dashboard.internetcomputer.org/proposal/33828)
-* [31275](https://dashboard.internetcomputer.org/proposal/31275)
-* [31165](https://dashboard.internetcomputer.org/proposal/31165)
-* [30392](https://dashboard.internetcomputer.org/proposal/30392)
-* [30078](https://dashboard.internetcomputer.org/proposal/30078)
-* [29235](https://dashboard.internetcomputer.org/proposal/29235)
-* [28784](https://dashboard.internetcomputer.org/proposal/28784)
-* [27975](https://dashboard.internetcomputer.org/proposal/27975)
-* [26833](https://dashboard.internetcomputer.org/proposal/26833)
-* [25343](https://dashboard.internetcomputer.org/proposal/25343)
-* [23633](https://dashboard.internetcomputer.org/proposal/23633)
+- [33828](https://dashboard.internetcomputer.org/proposal/33828)
+- [31275](https://dashboard.internetcomputer.org/proposal/31275)
+- [31165](https://dashboard.internetcomputer.org/proposal/31165)
+- [30392](https://dashboard.internetcomputer.org/proposal/30392)
+- [30078](https://dashboard.internetcomputer.org/proposal/30078)
+- [29235](https://dashboard.internetcomputer.org/proposal/29235)
+- [28784](https://dashboard.internetcomputer.org/proposal/28784)
+- [27975](https://dashboard.internetcomputer.org/proposal/27975)
+- [26833](https://dashboard.internetcomputer.org/proposal/26833)
+- [25343](https://dashboard.internetcomputer.org/proposal/25343)
+- [23633](https://dashboard.internetcomputer.org/proposal/23633)
 
 # 0.8.4
 
@@ -2896,7 +2976,8 @@ This incorporates the following executed proposals:
 ### feat: "rust" canister type
 
 You can now declare "rust" canisters in dfx.json.
-``` json
+
+```json
 {
   "canisters": {
     "canister_name": {
@@ -2912,13 +2993,13 @@ Don't forget to place a `Cargo.toml` in your project root.
 Then dfx will build the rust canister with your rust toolchain.
 Please also make sure that you have added the WebAssembly compilation target.
 
-``` bash
+```bash
 rustup target add wasm32-unknown-unknown
 ```
 
 You can also create new dfx project with a default rust canister.
 
-``` bash
+```bash
 dfx new --type=rust <project-name>
 ```
 
@@ -2944,7 +3025,7 @@ and no longer works with `--all`.
 
 ## Replica
 
-The included replica now supports canister_heartbeat.  This only works with rust canisters for the time being,
+The included replica now supports canister_heartbeat. This only works with rust canisters for the time being,
 and does not work with the emulator (`dfx start --emulator`).
 
 # 0.8.3
@@ -2958,7 +3039,7 @@ This has always been broken, even before dfx 0.7.0.
 
 ### fix: replica and ic-starter linux binaries no longer reference /nix/store
 
-This means `dfx start` will work again on linux.  This bug was introduced in dfx 0.8.2.
+This means `dfx start` will work again on linux. This bug was introduced in dfx 0.8.2.
 
 ### feat: replaced --no_artificial_delay option with a sensible default.
 
@@ -2970,7 +3051,7 @@ we have set the same default for dfx and removed the option.
 
 Updated Motoko from 0.6.10 to 0.6.11.
 
-* Assertion error messages are now reproducible (#2821)
+- Assertion error messages are now reproducible (#2821)
 
 # 0.8.2
 
@@ -3026,22 +3107,22 @@ You will need to upgrade your wallet with `dfx wallet upgrade`, or `dfx wallet -
 
 The included replica now supports public spec 0.18.0
 
-* Canisters can now have more than one controller
-* Adds support for 64-bit stable memory
-* The replica now goes through an initialization sequence, reported in its status
-as `replica_health_status`.  Until this reports as `healthy`, queries or updates will
-fail.
-** `dfx start --background` waits to exit until `replica_health_status` is `healthy`.
-** If you run `dfx start` without `--background`, you can call `dfx ping --wait-healthy`
-to wait until the replica is healthy.
+- Canisters can now have more than one controller
+- Adds support for 64-bit stable memory
+- The replica now goes through an initialization sequence, reported in its status
+  as `replica_health_status`. Until this reports as `healthy`, queries or updates will
+  fail.
+  ** `dfx start --background` waits to exit until `replica_health_status` is `healthy`.
+  ** If you run `dfx start` without `--background`, you can call `dfx ping --wait-healthy`
+  to wait until the replica is healthy.
 
 ## Motoko
 
 Updated Motoko from 0.6.7 to 0.6.10
 
-* add Debug.trap : Text -> None (motoko-base #288)
-* Introduce primitives for `Int` ⇔ `Float` conversions (#2733)
-* Fix crashing bug for formatting huge floats (#2737)
+- add Debug.trap : Text -> None (motoko-base #288)
+- Introduce primitives for `Int` ⇔ `Float` conversions (#2733)
+- Fix crashing bug for formatting huge floats (#2737)
 
 # 0.8.1
 
@@ -3049,7 +3130,7 @@ Updated Motoko from 0.6.7 to 0.6.10
 
 ### feat: dfx generate types command
 
-``` bash
+```bash
 dfx generate
 ```
 
@@ -3059,34 +3140,35 @@ You can control what will be generated and how with corresponding configuration 
 
 Under dfx.json → "canisters" → "<canister_name>", developers can add a "declarations" config. Options are:
 
-* "output" → directory to place declarations for that canister | default is "src/declarations/<canister_name>"
+- "output" → directory to place declarations for that canister | default is "src/declarations/<canister_name>"
 
-* "bindings" → [] list of options, ("js", "ts", "did", "mo") | default is "js", "ts", "did"
+- "bindings" → [] list of options, ("js", "ts", "did", "mo") | default is "js", "ts", "did"
 
-* "env_override" → a string that will replace process.env.{canister_name_uppercase}_CANISTER_ID in the "src/dfx/assets/language_bindings/canister.js" template.
+- "env_override" → a string that will replace process.env.{canister_name_uppercase}\_CANISTER_ID in the "src/dfx/assets/language_bindings/canister.js" template.
 
 js declarations output
 
-* index.js (generated from "src/dfx/assets/language_bindings/canister.js" template)
+- index.js (generated from "src/dfx/assets/language_bindings/canister.js" template)
 
-* <canister_name>.did.js - candid js binding output
+- <canister_name>.did.js - candid js binding output
 
 ts declarations output
 
-  * <canister_name>.did.d.ts - candid ts binding output
+- <canister_name>.did.d.ts - candid ts binding output
 
 did declarations output
 
-  * <canister_name>.did - candid did binding output
+- <canister_name>.did - candid did binding output
 
 mo declarations output
 
-  * <canister_name>.mo - candid mo binding output
+- <canister_name>.mo - candid mo binding output
 
 ### feat: dfx now supports the anonymous identity
 
 Use it with either of these forms:
-``` bash
+
+```bash
 dfx identity use anonymous
 dfx --identity anonymous ...
 ```
@@ -3097,7 +3179,7 @@ Default identities are the pem files generated by `dfx identity new ...` which c
 They are located at `~/.config/dfx/identity/xxx/identity.pem`.
 Now, you can copy such pem file to another computer and import it there.
 
-``` bash
+```bash
 dfx identity new alice
 cp ~/.config/dfx/identity/xxx/identity.pem alice.pem
 # copy the pem file to another computer, then
@@ -3116,7 +3198,7 @@ Define DFX_WALLET_WASM in the environment to use a different wasm module when cr
 ### fix: trust full asset SHA-256 hashes provided by the caller
 
 When the caller provides SHA-256 hashes (which dfx does), the asset canister will no longer
-recompute these hashes when committing the changes.  These recomputations were causing
+recompute these hashes when committing the changes. These recomputations were causing
 canisters to run out of cycles, or to attempt to exceed the maximum cycle limit per update.
 
 # 0.8.0
@@ -3132,17 +3214,17 @@ but ended up only writing to the wallets.json file if --force was passed.
 
 ### chore: updating dependencies
 
-* Support for the latest version of the {IC} specification and replica.
+- Support for the latest version of the {IC} specification and replica.
 
-* Updating to latest versions of Motoko, Candid, and agent-rs
+- Updating to latest versions of Motoko, Candid, and agent-rs
 
 ### feat: Type Inference Update
 
-* Changes to `dfx new` project template and JavaScript codegen to support type inference in IDE's
+- Changes to `dfx new` project template and JavaScript codegen to support type inference in IDE's
 
-* Adding webpack dev server to project template
+- Adding webpack dev server to project template
 
-* Migration path documented at https://sdk.dfinity.org/docs/release-notes/0.8.0-rn.html
+- Migration path documented at https://sdk.dfinity.org/docs/release-notes/0.8.0-rn.html
 
 # 0.7.7
 
@@ -3153,16 +3235,16 @@ Breaking changes to frontend code generation, documented in 0.8.0
 ### feat: deploy and canister install will now only upgrade a canister if the wasm actually changed
 
 dfx deploy and dfx canister install now compare the hash of the already-installed module
-with the hash of the built canister's wasm output.  If they are the same, they leave the canister
-in place rather than upgrade it.  They will still synchronize assets to an asset canister regardless
+with the hash of the built canister's wasm output. If they are the same, they leave the canister
+in place rather than upgrade it. They will still synchronize assets to an asset canister regardless
 of the result of this comparison.
-
 
 # 0.7.6
 
 ## icx-proxy
 
 The streaming callback mechanism now requires the following record structure for the token:
+
 ```
 type StreamingCallbackToken = record {
     key: text;
@@ -3370,12 +3452,13 @@ Users can sign the message on an air-gapped computer which is secure to host pri
 
 #### Note
 
-* `sign` and `send` currently don't proxy through wallet canister. Users should use the subcommands with `dfx canister --no-wallet sign ...`.
+- `sign` and `send` currently don't proxy through wallet canister. Users should use the subcommands with `dfx canister --no-wallet sign ...`.
 
-* The `sign` option `--expire-after` will set the `ingress_expiry` to a future timestamp which is current plus the duration.
-Then users can send the message during a 5 minutes time window ending in that `ingress_expiry` timestamp. Sending the message earlier or later than the time window will both result in a replica error.
+- The `sign` option `--expire-after` will set the `ingress_expiry` to a future timestamp which is current plus the duration.
+  Then users can send the message during a 5 minutes time window ending in that `ingress_expiry` timestamp. Sending the message earlier or later than the time window will both result in a replica error.
 
 ### feat: implement the HTTP Request proposal in dfx' bootstrap webserver. +
+
 And add support for http requests in the base storage canister (with a default to `/index.html`).
 
 This does not support other encodings than `identity` for now (and doesn't even return any headers). This support will be added to the upgraded asset storage canister built in #1482.
@@ -3390,7 +3473,7 @@ Renamed the `project_name` in our own generated assets to `canister_name`, for t
 
 You can now a generate private key via OpenSSL or a simlar tool, import it into dfx, and use it to sign an ingress message.
 
-``` bash
+```bash
 openssl ecparam -name secp256k1 -genkey -out identity.pem
 dfx identity import <name> identity.pem
 dfx identity use <name>
@@ -3401,24 +3484,24 @@ dfx canister call ...
 
 ### feat: The asset canister can now store assets that exceed the message ingress limit (2 MB)
 
-* Please note that neither the JS agent nor the HTTP server have been updated yet to server such large assets.
-* The existing interface is left in place for backwards-compatibility, but deprecated:
-** retrieve(): use get() and get_chunk() instead
-** store(): use create_batch(), create_chunk(), and commit_batch() instead
-** list(): use keys() instead
+- Please note that neither the JS agent nor the HTTP server have been updated yet to server such large assets.
+- The existing interface is left in place for backwards-compatibility, but deprecated:
+  ** retrieve(): use get() and get_chunk() instead
+  ** store(): use create_batch(), create_chunk(), and commit_batch() instead
+  \*\* list(): use keys() instead
 
 # 0.6.25
 
 ## DFX
 
-- feat: dfx now provides CANISTER_ID_<canister_name> environment variables for all canisters to "npm build" when building the frontend.
+- feat: dfx now provides CANISTER*ID*<canister_name> environment variables for all canisters to "npm build" when building the frontend.
 
 ## Agents
 
 ### Rust Agent
 
 - feat: AgentError due to request::Error will now include the reqwest error message
-in addition to "Could not reach the server"
+  in addition to "Could not reach the server"
 - feat: Add secp256k1 support (dfx support to follow)
 
 # 0.6.24
@@ -3431,12 +3514,13 @@ Added option to `dfx canister create` and `dfx deploy` commands: `--with-cycles 
 This allows the user to specify the initial cycle balance of a canister created by their wallet.
 This option is a no-op for the Sodium network.
 
-``` bash
+```bash
 dfx canister create --with-cycles 8000000000 some_canister
 dfx deploy --with-cycles 8000000000
 ```
 
 Help string:
+
 ```
 Specifies the initial cycle balance to deposit into the newly
 created canister. The specified amount needs to take the
@@ -3449,7 +3533,7 @@ from the wallet's cycle balance
 This feature adds a new dfx command `toolchain` which have intuitive subcommands.
 The toolchain specifiers can be a complete version number, major minor version, or a tag name.
 
-``` bash
+```bash
 dfx toolchain install 0.6.24 # complete version
 dfx toolchain install 0.6    # major minor
 dfx toolchain install latest # tag name
@@ -3462,7 +3546,8 @@ dfx toolchain uninstall latest
 
 Now that the Mercury Alpha application subnetwork is up and we are getting ready to onboard devs, the dfx error message for wallet creation has changed:
 For example,
-``` bash
+
+```bash
 dfx canister --network=alpha create hello
 Creating canister "hello"...
 Creating the canister using the wallet canister...
@@ -3478,7 +3563,7 @@ Please submit your Principal ("dfx identity get-principal") in the intake form t
 This feature adds the deploy-wallet subcommand to the dfx identity.
 The User provides the ID of the canister onto which the wallet WASM is deployed.
 
-``` bash
+```bash
 dfx identity deploy-wallet --help
 dfx-identity-deploy-wallet
 Installs the wallet WASM to the provided canister id
@@ -3508,9 +3593,9 @@ FLAGS:
 
 - There have been updates, improvements, and new sample apps added to the [examples](https://github.com/dfinity/examples/tree/master/motoko) repository.
 
-    All of Motoko sample apps in the [examples](https://github.com/dfinity/examples/tree/master/motoko) repository have been updated to work with the latest release of the SDK.
+  All of Motoko sample apps in the [examples](https://github.com/dfinity/examples/tree/master/motoko) repository have been updated to work with the latest release of the SDK.
 
-    There are new sample apps to illustrate using arrays ([Quicksort](https://github.com/dfinity/examples/tree/master/motoko/quicksort)) and building create/read/update/delete (CRUD) operations for a web application [Superheroes](https://github.com/dfinity/examples/tree/master/motoko/superheroes).
+  There are new sample apps to illustrate using arrays ([Quicksort](https://github.com/dfinity/examples/tree/master/motoko/quicksort)) and building create/read/update/delete (CRUD) operations for a web application [Superheroes](https://github.com/dfinity/examples/tree/master/motoko/superheroes).
 
 - The [LinkedUp](https://github.com/dfinity/linkedup) sample application has been updated to work with the latest release of Motoko and the SDK.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+### feat: add --open flag to dfx deploy
+
+The `--open` flag will open the browser to the canister's URL after deployment.
+
 ### feat: unify CLI options to specify arguments
 
 There are a few subcommands that take `--argument`/`--argument-file` options to set canister call/init arguments.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +974,16 @@ checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
  "lazy_static",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1513,6 +1529,7 @@ dependencies = [
  "url",
  "walkdir",
  "walrus",
+ "webbrowser",
  "which",
 ]
 
@@ -3343,6 +3360,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3618,6 +3657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3713,6 +3761,12 @@ dependencies = [
  "libc",
  "socket2 0.4.10",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -3905,6 +3959,15 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
 
 [[package]]
 name = "object"
@@ -4526,6 +4589,12 @@ name = "rangemap"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "977b1e897f9d764566891689e642653e5ed90c6895106acd005eb4c1d0203991"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "rayon"
@@ -6263,6 +6332,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b2391658b02c27719fc5a0a73d6e696285138e8b12fba9d4baa70451023c71"
+dependencies = [
+ "core-foundation",
+ "home",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc",
+ "raw-window-handle",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6322,6 +6408,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -6336,6 +6431,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6370,6 +6480,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6379,6 +6495,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6394,6 +6516,12 @@ checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -6403,6 +6531,12 @@ name = "windows_i686_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6418,6 +6552,12 @@ checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -6430,6 +6570,12 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6439,6 +6585,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/docs/cli-reference/dfx-deploy.md
+++ b/docs/cli-reference/dfx-deploy.md
@@ -12,7 +12,7 @@ Note that you can only run this command from within the project directory struct
 
 ## Basic usage
 
-``` bash
+```bash
 dfx deploy [options] [canister_name]
 ```
 
@@ -20,21 +20,22 @@ dfx deploy [options] [canister_name]
 
 You can use the following options with the `dfx deploy` command.
 
-| Option                             | Description                                                                                                                                                                                                                                                 |
-|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--network <network>`              | Overrides the environment to connect to. By default, the local canister execution environment is used.                                                                                                                                                      |
-| `--playground       `              | Alias for `--network playground`. By default, canisters on this network are borrowed from the Motoko Playground.                                                                                                                                            |
-| `--ic               `              | Alias for `--network ic`.                                                                                                                                                                                                                                   |
-| `--argument <argument>`            | Specifies an argument to pass to the canister during installation.                                                                                                                                                                                          |
-| `--argument-type <argument-type>`  | Specifies the data type for the argument when making the call using an argument [possible values: idl, raw]                                                                                                                                                 |
-| `--argument-file <argument-file>`  | Specifies the file from which to read the argument to pass to the init method.  Stdin may be referred to as `-`.                                                                                                                                            |
-| `--with-cycles <number-of-cycles>` | Enables you to specify the initial number of cycles for a canister in a project.                                                                                                                                                                            |
-| `--specified-id <PRINCIPAL>`       | Attempts to create the canister with this Canister ID                                                                                                                                                                                                       |
-| `--by-proposal`                    | Upload proposed changed assets, but do not commit them.  Follow up by calling either commit_proposed_batch() or delete_batch().                                                                                                                             |
-| `--compute-evidence`               | Build a frontend canister, determine batch operations required to synchronize asset canister contents, and compute a hash over those operations.  Displays this hash ("evidence"), which should match the evidence displayed by `dfx deploy --by-proposal`. |
-| `--subnet-type <subnet-type>`      | Specify the subnet type to create the canister on. If no subnet type is provided, the canister will be created on a random default application subnet.                                                                                                      |
-| `--subnet <subnet-principal>`      | Specify the subnet to create the canister on. If no subnet is provided, the canister will be created on a random default application subnet.                                                                                                                |
-| `--next-to <canister-principal>`   | Create canisters on the same subnet as this canister.                                                                                                                                                                                                       |
+| Option                             | Description                                                                                                                                                                                                                                                |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--network <network>`              | Overrides the environment to connect to. By default, the local canister execution environment is used.                                                                                                                                                     |
+| `--playground       `              | Alias for `--network playground`. By default, canisters on this network are borrowed from the Motoko Playground.                                                                                                                                           |
+| `--ic               `              | Alias for `--network ic`.                                                                                                                                                                                                                                  |
+| `--argument <argument>`            | Specifies an argument to pass to the canister during installation.                                                                                                                                                                                         |
+| `--argument-type <argument-type>`  | Specifies the data type for the argument when making the call using an argument [possible values: idl, raw]                                                                                                                                                |
+| `--argument-file <argument-file>`  | Specifies the file from which to read the argument to pass to the init method. Stdin may be referred to as `-`.                                                                                                                                            |
+| `--with-cycles <number-of-cycles>` | Enables you to specify the initial number of cycles for a canister in a project.                                                                                                                                                                           |
+| `--specified-id <PRINCIPAL>`       | Attempts to create the canister with this Canister ID                                                                                                                                                                                                      |
+| `--by-proposal`                    | Upload proposed changed assets, but do not commit them. Follow up by calling either commit_proposed_batch() or delete_batch().                                                                                                                             |
+| `--compute-evidence`               | Build a frontend canister, determine batch operations required to synchronize asset canister contents, and compute a hash over those operations. Displays this hash ("evidence"), which should match the evidence displayed by `dfx deploy --by-proposal`. |
+| `--subnet-type <subnet-type>`      | Specify the subnet type to create the canister on. If no subnet type is provided, the canister will be created on a random default application subnet.                                                                                                     |
+| `--subnet <subnet-principal>`      | Specify the subnet to create the canister on. If no subnet is provided, the canister will be created on a random default application subnet.                                                                                                               |
+| `--next-to <canister-principal>`   | Create canisters on the same subnet as this canister.                                                                                                                                                                                                      |
+| `--open`                           | Automatically open the browser after deployment.                                                                                                                                                                                                           |
 
 ### Specifies the argument to pass to the init entrypoint
 
@@ -45,7 +46,7 @@ With `--argument-type`, you can specify the data format for the argument when yo
 You can specify the following arguments for the `dfx deploy` command.
 
 | Argument        | Description                                                                                                                                                                                                                                                                                                                                    |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `canister_name` | Specifies the name of the canister you want to register, build, and deploy. Note that the canister name you specify must match at least one name in the `canisters` section of the `dfx.json` configuration file for the project. If you don’t specify a canister name, `dfx deploy` will deploy all canisters defined in the `dfx.json` file. |
 
 ## Examples
@@ -54,13 +55,13 @@ You can use the `dfx deploy` command to deploy all or specific canisters on the 
 
 For example, to deploy the `hello` project on the hypothetical `ic-pubs` testnet configured in the `dfx.json` configuration file, you can run the following command:
 
-``` bash
+```bash
 dfx deploy hello_backend --network ic-pubs
 ```
 
 To deploy a project on the local canister execution environment and pass a single argument to the installation step, you can run a command similar to the following:
 
-``` bash
+```bash
 dfx deploy hello_actor_class --argument '("from DFINITY")'
 ```
 
@@ -74,6 +75,6 @@ Note that currently you must use an actor class in your Motoko dapp. In this exa
 
 You can use the `dfx deploy` command with the `--with-cycles` option to specify the initial balance of a canister created by your wallet. If you don’t specify a canister, the number of cycles you specify will be added to all canisters by default. To avoid this, specify a specific canister by name. For example, to add an initial balance of 8000000000000 cycles to a canister called "hello-assets", run the following command:
 
-``` bash
+```bash
 dfx deploy --with-cycles 8000000000000 hello-assets
 ```

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -28,6 +28,7 @@ toml = "0.7.3"
 walkdir = "2.3.2"
 
 [dependencies]
+webbrowser = "0.8.12"
 actix = "0.13.0"
 aes-gcm.workspace = true
 anstyle.workspace = true


### PR DESCRIPTION
# Description

This pull request adds a new feature to the dfx deploy command where users can specify the --open flag to automatically open the URL of the deployed canisters in the default browser of the machine. This enhancement aims to improve user experience by providing a convenient way to access the deployed canisters immediately after deployment.

# How Has This Been Tested?

To test this feature:

- Ensure the dfx command-line tool is installed and configured properly.
- Run the dfx deploy --open command with a project that has deployable canisters.
- Verify that after deployment, the default browser opens with the URL of the deployed canisters.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
