### PR TITLE
feat: make it easy to keep to keep a users canisters on the same subnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,9 +853,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/e2e/assets/fake_cmc/dfx.json
+++ b/e2e/assets/fake_cmc/dfx.json
@@ -3,7 +3,8 @@
     "fake-cmc": {
       "type": "custom",
       "wasm": "fake-cmc.wasm.gz",
-      "candid": "fake-cmc.did"
+      "candid": "fake-cmc.did",
+      "specified_id": "rkp4c-7iaaa-aaaaa-aaaca-cai"
     }
   }
 }

--- a/e2e/assets/fake_registry/dfx.json
+++ b/e2e/assets/fake_registry/dfx.json
@@ -2,7 +2,8 @@
     "canisters": {
         "fake_registry": {
             "type": "motoko",
-            "main": "fake_registry.mo"
+            "main": "fake_registry.mo",
+            "specified_id": "rwlgt-iiaaa-aaaaa-aaaaa-cai"
         }
     }
 }

--- a/e2e/assets/fake_registry/dfx.json
+++ b/e2e/assets/fake_registry/dfx.json
@@ -1,0 +1,8 @@
+{
+    "canisters": {
+        "fake_registry": {
+            "type": "motoko",
+            "main": "fake_registry.mo"
+        }
+    }
+}

--- a/e2e/assets/fake_registry/fake_registry.mo
+++ b/e2e/assets/fake_registry/fake_registry.mo
@@ -1,0 +1,25 @@
+import Principal "mo:base/Principal";
+import List "mo:base/List";
+import Array "mo:base/Array";
+import Debug "mo:base/Debug";
+
+actor FakeRegistry {
+
+    // list of (canister id -> subnet id) mappings
+    var subnet_per_canister : [(Principal, Principal)] = [];
+
+    public func set_subnet_for_canister(mappings : [(Principal, Principal)]) {
+        subnet_per_canister := mappings;
+    };
+
+    public query func get_subnet_for_canister(arg : { principal : Principal }) : async ({
+        #Ok : { subnet_id : ?Principal };
+        #Err : Text;
+    }) {
+        switch (Array.find<(Principal, Principal)>(subnet_per_canister, func pair { pair.0 == arg.principal })) {
+            case (null) { #Err("mapping not defined") };
+            case (?mapping) { #Ok { subnet_id = ?mapping.1 } };
+        };
+    };
+
+};

--- a/e2e/assets/fake_registry/fake_registry.mo
+++ b/e2e/assets/fake_registry/fake_registry.mo
@@ -12,11 +12,11 @@ actor FakeRegistry {
         subnet_per_canister := mappings;
     };
 
-    public query func get_subnet_for_canister(arg : { principal : Principal }) : async ({
+    public query func get_subnet_for_canister(arg : { principal : ?Principal }) : async ({
         #Ok : { subnet_id : ?Principal };
         #Err : Text;
     }) {
-        switch (Array.find<(Principal, Principal)>(subnet_per_canister, func pair { pair.0 == arg.principal })) {
+        switch (Array.find<(Principal, Principal)>(subnet_per_canister, func pair { ?pair.0 == arg.principal })) {
             case (null) { #Err("mapping not defined") };
             case (?mapping) { #Ok { subnet_id = ?mapping.1 } };
         };

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -12,17 +12,19 @@ setup() {
   dfx identity new --storage-mode plaintext cycle-giver
   dfx identity new --storage-mode plaintext alice
   dfx identity new --storage-mode plaintext bob
-
-  dfx_start_for_nns_install
-
-  dfx extension install nns --version 0.3.1 || true
-  dfx nns install --ledger-accounts "$(dfx ledger account-id --identity cycle-giver)"
 }
 
 teardown() {
   dfx_stop
 
   standard_teardown
+}
+
+start_and_install_nns() {
+  dfx_start_for_nns_install
+
+  dfx extension install nns --version 0.3.1 || true
+  dfx nns install --ledger-accounts "$(dfx ledger account-id --identity cycle-giver)"
 }
 
 add_cycles_ledger_canisters_to_project() {
@@ -39,6 +41,8 @@ current_time_nanoseconds() {
 }
 
 @test "balance" {
+  start_and_install_nns
+
   ALICE=$(dfx identity get-principal --identity alice)
   ALICE_SUBACCT1="000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
   ALICE_SUBACCT1_CANDID="\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
@@ -112,6 +116,8 @@ current_time_nanoseconds() {
 }
 
 @test "transfer" {
+  start_and_install_nns
+
   ALICE=$(dfx identity get-principal --identity alice)
   ALICE_SUBACCT1="000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
   ALICE_SUBACCT1_CANDID="\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
@@ -190,6 +196,8 @@ current_time_nanoseconds() {
 }
 
 @test "transfer deduplication" {
+  start_and_install_nns
+
   ALICE=$(dfx identity get-principal --identity alice)
   BOB=$(dfx identity get-principal --identity bob)
 
@@ -249,6 +257,8 @@ current_time_nanoseconds() {
 }
 
 @test "top up canister principal check" {
+  start_and_install_nns
+
   BOB=$(dfx identity get-principal --identity bob)
 
   deploy_cycles_ledger
@@ -258,6 +268,8 @@ current_time_nanoseconds() {
 }
 
 @test "top-up" {
+  start_and_install_nns
+
   dfx_new
   add_cycles_ledger_canisters_to_project
   install_cycles_ledger_canisters
@@ -317,6 +329,8 @@ current_time_nanoseconds() {
 }
 
 @test "top-up deduplication" {
+  start_and_install_nns
+
   dfx_new
   add_cycles_ledger_canisters_to_project
   install_cycles_ledger_canisters
@@ -367,6 +381,8 @@ current_time_nanoseconds() {
 }
 
 @test "howto" {
+  start_and_install_nns
+
   # This is the equivalent of https://www.notion.so/dfinityorg/How-to-install-and-test-the-cycles-ledger-521c9f3c410f4a438514a03e35464299
   ALICE=$(dfx identity get-principal --identity alice)
   BOB=$(dfx identity get-principal --identity bob)
@@ -417,6 +433,8 @@ current_time_nanoseconds() {
 }
 
 @test "canister creation" {
+  start_and_install_nns
+  
   skip "can't be properly tested with feature flag turned off (CYCLES_LEDGER_ENABLED). TODO(SDK-1331): re-enable this test"
   dfx_new temporary
   add_cycles_ledger_canisters_to_project
@@ -505,6 +523,8 @@ current_time_nanoseconds() {
 
 @test "canister deletion" {
   skip "can't be properly tested with feature flag turned off (CYCLES_LEDGER_ENABLED). TODO(SDK-1331): re-enable this test"
+  start_and_install_nns
+
   dfx_new temporary
   add_cycles_ledger_canisters_to_project
   install_cycles_ledger_canisters
@@ -547,6 +567,8 @@ current_time_nanoseconds() {
 }
 
 @test "redeem-faucet-coupon redeems into the cycles ledger" {
+  start_and_install_nns
+
   assert_command deploy_cycles_ledger
   dfx_new hello
   install_asset faucet
@@ -578,6 +600,8 @@ current_time_nanoseconds() {
 
 @test "create canister on specific subnet" {
   skip "can't be properly tested with feature flag turned off (CYCLES_LEDGER_ENABLED). TODO(SDK-1331): re-enable this test"
+  start_and_install_nns
+  
   dfx_new temporary
   add_cycles_ledger_canisters_to_project
   install_cycles_ledger_canisters
@@ -613,7 +637,123 @@ current_time_nanoseconds() {
   assert_contains "Provided subnet type custom_subnet_type does not exist"
 }
 
+@test "automatically choose subnet" {
+  # skip "can't be properly tested with feature flag turned off (CYCLES_LEDGER_ENABLED). TODO(SDK-1331): re-enable this test"
+  dfx_start
+
+  REGISTRY="rwlgt-iiaaa-aaaaa-aaaaa-cai"
+  CMC="rkp4c-7iaaa-aaaaa-aaaca-cai"
+  ALICE=$(dfx identity get-principal --identity alice)
+  dfx_new temporary
+  install_asset fake_registry
+  dfx deploy fake_registry --specified-id "$REGISTRY"
+  add_cycles_ledger_canisters_to_project
+  install_cycles_ledger_canisters
+  assert_command deploy_cycles_ledger
+  CYCLES_LEDGER_ID=$(dfx canister id cycles-ledger)
+  echo "Cycles ledger deployed at id $CYCLES_LEDGER_ID"
+  assert_command dfx deploy depositor --argument "(record {ledger_id = principal \"$(dfx canister id cycles-ledger)\"})"
+  echo "Cycles depositor deployed at id $(dfx canister id depositor)"
+  assert_command dfx ledger fabricate-cycles --canister depositor --t 9999
+  assert_command dfx canister call depositor deposit "(record {to = record{owner = principal \"$ALICE\";};cycles = 99_000_000_000_000;})"
+  install_asset fake_cmc
+  dfx deploy fake-cmc --specified-id "$CMC"
+  cd ..
+  # shellcheck disable=SC2030,SC2031
+  export DFX_DISABLE_AUTO_WALLET=1
+  dfx identity use alice
+  dfx_new
+
+  SUBNET1="iqd74-4xnai"
+  SUBNET2="2myss-nlbai"
+
+  jq '.canisters.one = { "main": "src/e2e_project_backend/main.mo", "type": "motoko" }' dfx.json | sponge dfx.json
+  jq '.canisters.two = { "main": "src/e2e_project_backend/main.mo", "type": "motoko" }' dfx.json | sponge dfx.json
+  # setup done
+
+
+  # no other canisters already exist
+  assert_command dfx canister create e2e_project_backend
+  assert_command dfx canister call "$CMC" last_create_canister_args --query
+  assert_contains "subnet_selection = null"
+  stop_and_delete e2e_project_backend
+
+  assert_command dfx deploy e2e_project_backend
+  assert_command dfx canister call "$CMC" last_create_canister_args --query
+  assert_contains "subnet_selection = null"
+  stop_and_delete e2e_project_backend
+
+  # one other canister already exists
+  assert_command dfx canister create one --subnet aaaaa-aa
+  ONE_ID="$(dfx canister id one)"
+  echo "Canister one: $ONE_ID"
+  assert_command dfx canister call "$REGISTRY" set_subnet_for_canister "(vec { record {0 = principal \"$ONE_ID\"; 1 = principal \"$SUBNET1\"} })"
+
+  assert_command dfx canister create e2e_project_backend
+  assert_command dfx canister call "$CMC" last_create_canister_args --query
+  assert_contains "subnet = principal \"$SUBNET1\""
+  stop_and_delete e2e_project_backend
+
+  assert_command dfx deploy e2e_project_backend
+  assert_command dfx canister call "$CMC" last_create_canister_args --query
+  assert_contains "subnet = principal \"$SUBNET1\""
+  stop_and_delete e2e_project_backend
+
+  # multiple other canisters already exist - all on same subnet
+  assert_command dfx canister create two --subnet aaaaa-aa
+  TWO_ID="$(dfx canister id two)"
+  echo "Canister two: $TWO_ID"
+  assert_command dfx canister call "$REGISTRY" set_subnet_for_canister "(vec { record {0 = principal \"$ONE_ID\"; 1 = principal \"$SUBNET1\"}; record { 0 = principal \"$TWO_ID\"; 1 = principal \"$SUBNET1\"} })"
+
+  assert_command dfx canister create e2e_project_backend
+  assert_command dfx canister call "$CMC" last_create_canister_args --query
+  assert_contains "subnet = principal \"$SUBNET1\""
+  stop_and_delete e2e_project_backend
+
+  assert_command dfx deploy e2e_project_backend
+  assert_command dfx canister call "$CMC" last_create_canister_args --query
+  assert_contains "subnet = principal \"$SUBNET1\""
+  stop_and_delete e2e_project_backend
+
+  # multiple other canisters already exist - not all on same subnet
+  assert_command dfx canister call "$REGISTRY" set_subnet_for_canister "(vec { record {0 = principal \"$ONE_ID\"; 1 = principal \"$SUBNET1\"}; record { 0 = principal \"$TWO_ID\"; 1 = principal \"$SUBNET2\"} })"
+
+  assert_command_fail dfx canister create e2e_project_backend
+  assert_contains "Cannot automatically decide which subnet to target."
+
+  assert_command_fail dfx deploy e2e_project_backend
+  assert_contains "Cannot automatically decide which subnet to target."
+  
+  # still can create if a subnet is specified
+  assert_command dfx canister create e2e_project_backend --subnet "$SUBNET2"
+  assert_command dfx canister call "$CMC" last_create_canister_args --query
+  assert_contains "subnet = principal \"$SUBNET2\""
+  stop_and_delete e2e_project_backend
+
+  assert_command dfx deploy e2e_project_backend --subnet "$SUBNET2"
+  assert_command dfx canister call "$CMC" last_create_canister_args --query
+  assert_contains "subnet = principal \"$SUBNET2\""
+  stop_and_delete e2e_project_backend
+
+  # remote canister exists on different subnet
+  THREE_ID="3333u-aiaaa-aaaar-avzbq-cai"
+  jq '.canisters.three = { "main": "src/e2e_project_backend/main.mo", "type": "motoko", "remote" : { "candid": "", "id": { "local": "'$THREE_ID'" } } }' dfx.json | sponge dfx.json
+  assert_command dfx canister call "$REGISTRY" set_subnet_for_canister "(vec { record {0 = principal \"$ONE_ID\"; 1 = principal \"$SUBNET1\"}; record { 0 = principal \"$TWO_ID\"; 1 = principal \"$SUBNET1\"}; record { 0 = principal \"$THREE_ID\"; 1 = principal \"$SUBNET2\"} })"
+
+  assert_command dfx canister create e2e_project_backend
+  assert_command dfx canister call "$CMC" last_create_canister_args --query
+  assert_contains "subnet = principal \"$SUBNET1\""
+  stop_and_delete e2e_project_backend
+
+  assert_command dfx deploy e2e_project_backend
+  assert_command dfx canister call "$CMC" last_create_canister_args --query
+  assert_contains "subnet = principal \"$SUBNET1\""
+  stop_and_delete e2e_project_backend
+}
+
 @test "convert icp to cycles" {
+  start_and_install_nns
+
   ALICE=$(dfx identity get-principal --identity alice)
   ALICE_SUBACCT1="000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
   ALICE_SUBACCT2="6C6B6A030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -259,6 +259,8 @@ current_time_nanoseconds() {
 }
 
 @test "approve and transfer_from" {
+  start_and_install_nns
+  
   ALICE=$(dfx identity get-principal --identity alice)
   ALICE_SUBACCT1="000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
   ALICE_SUBACCT1_CANDID="\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -260,7 +260,7 @@ current_time_nanoseconds() {
 
 @test "approve and transfer_from" {
   start_and_install_nns
-  
+
   ALICE=$(dfx identity get-principal --identity alice)
   ALICE_SUBACCT1="000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
   ALICE_SUBACCT1_CANDID="\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b\1c\1d\1e\1f"
@@ -726,7 +726,7 @@ current_time_nanoseconds() {
 }
 
 @test "automatically choose subnet" {
-  # skip "can't be properly tested with feature flag turned off (CYCLES_LEDGER_ENABLED). TODO(SDK-1331): re-enable this test"
+  skip "can't be properly tested with feature flag turned off (CYCLES_LEDGER_ENABLED). TODO(SDK-1331): re-enable this test"
   dfx_start
 
   REGISTRY="rwlgt-iiaaa-aaaaa-aaaaa-cai"

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -318,5 +318,5 @@ get_ephemeral_port() {
 stop_and_delete() {
     assert_command dfx canister stop "$1"
     assert_command dfx canister delete -y --no-withdrawal "$1"
-    echo "Canister "$1" deleted"
+    echo "Canister $1 deleted"
 }

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -314,3 +314,9 @@ get_ephemeral_port() {
     script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
     python3 "$script_dir/get_ephemeral_port.py"
 }
+
+stop_and_delete() {
+    assert_command dfx canister stop $1
+    assert_command dfx canister delete -y --no-withdrawal $1
+    echo "Canister $1 deleted"
+}

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -316,7 +316,7 @@ get_ephemeral_port() {
 }
 
 stop_and_delete() {
-    assert_command dfx canister stop $1
-    assert_command dfx canister delete -y --no-withdrawal $1
-    echo "Canister $1 deleted"
+    assert_command dfx canister stop "$1"
+    assert_command dfx canister delete -y --no-withdrawal "$1"
+    echo "Canister "$1" deleted"
 }

--- a/src/dfx-core/src/config/model/canister_id_store.rs
+++ b/src/dfx-core/src/config/model/canister_id_store.rs
@@ -4,6 +4,7 @@ use crate::error::canister_id_store::CanisterIdStoreError;
 use crate::error::unified_io::UnifiedIoError;
 use crate::network::directory::ensure_cohesive_network_directory;
 use candid::Principal as CanisterId;
+use ic_agent::export::Principal;
 use serde::{Deserialize, Serialize, Serializer};
 use slog::{warn, Logger};
 use std::collections::BTreeMap;
@@ -398,6 +399,17 @@ impl CanisterIdStore {
         }
 
         Ok(())
+    }
+
+    pub fn non_remote_ids(&self) -> Vec<Principal> {
+        self.ids
+            .iter()
+            .filter_map(|(_, network_to_id)| {
+                network_to_id
+                    .get(&self.network_descriptor.name)
+                    .and_then(|principal| Principal::from_text(principal).ok())
+            })
+            .collect()
     }
 }
 

--- a/src/dfx-core/src/config/model/canister_id_store.rs
+++ b/src/dfx-core/src/config/model/canister_id_store.rs
@@ -401,13 +401,14 @@ impl CanisterIdStore {
         Ok(())
     }
 
-    pub fn non_remote_ids(&self) -> Vec<Principal> {
+    pub fn non_remote_user_canisters(&self) -> Vec<(String, Principal)> {
         self.ids
             .iter()
-            .filter_map(|(_, network_to_id)| {
+            .filter_map(|(name, network_to_id)| {
                 network_to_id
                     .get(&self.network_descriptor.name)
                     .and_then(|principal| Principal::from_text(principal).ok())
+                    .map(|principal| (name.clone(), principal))
             })
             .collect()
     }

--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -141,7 +141,10 @@ pub async fn exec(
         })
         .transpose()
         .context("Failed to determine controllers.")?;
-    let subnet_selection = opts.subnet_selection.into_subnet_selection(env).await?;
+    let mut subnet_selection = opts
+        .subnet_selection
+        .into_subnet_selection_type(env)
+        .await?;
 
     let pull_canisters_in_config = get_pull_canisters_in_config(env)?;
     if let Some(canister_name) = opts.canister_name.as_deref() {
@@ -196,7 +199,7 @@ pub async fn exec(
                 reserved_cycles_limit,
             },
             opts.created_at_time,
-            subnet_selection,
+            &mut subnet_selection,
         )
         .await?;
         Ok(())
@@ -268,7 +271,7 @@ pub async fn exec(
                         reserved_cycles_limit,
                     },
                     opts.created_at_time,
-                    subnet_selection.clone(),
+                    &mut subnet_selection,
                 )
                 .await?;
             }

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -134,7 +134,8 @@ pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
         .context("Failed to parse InstallMode.")?;
     let config = env.get_config_or_anyhow()?;
     let env_file = config.get_output_env_file(opts.output_env_file)?;
-    let subnet_selection = runtime.block_on(opts.subnet_selection.into_subnet_selection(&env))?;
+    let mut subnet_selection =
+        runtime.block_on(opts.subnet_selection.into_subnet_selection_type(&env))?;
     let with_cycles = opts.with_cycles;
 
     let deploy_mode = match (mode, canister_name) {
@@ -191,7 +192,7 @@ pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
         opts.yes,
         env_file,
         opts.no_asset_upgrade,
-        subnet_selection,
+        &mut subnet_selection,
     ))?;
 
     if matches!(deploy_mode, NormalDeploy | ForceReinstallSingleCanister(_)) {

--- a/src/dfx/src/commands/ledger/create_canister.rs
+++ b/src/dfx/src/commands/ledger/create_canister.rs
@@ -86,7 +86,10 @@ pub async fn exec(env: &dyn Environment, opts: CreateCanisterOpts) -> DfxResult 
     .await?;
     println!("Using transfer at block height {height}");
 
-    let subnet_selection = opts.subnet_selection.into_subnet_selection(env).await?;
+    let subnet_selection = opts
+        .subnet_selection
+        .into_subnet_selection_type(env)
+        .await?;
     let result = notify_create(agent, controller, height, subnet_selection).await;
 
     match result {

--- a/src/dfx/src/commands/ledger/notify/create_canister.rs
+++ b/src/dfx/src/commands/ledger/notify/create_canister.rs
@@ -28,7 +28,10 @@ pub async fn exec(env: &dyn Environment, opts: NotifyCreateOpts) -> DfxResult {
 
     fetch_root_key_if_needed(env).await?;
 
-    let subnet_selection = opts.subnet_selection.into_subnet_selection(env).await?;
+    let subnet_selection = opts
+        .subnet_selection
+        .into_subnet_selection_type(env)
+        .await?;
     let result = notify_create(agent, controller, block_height, subnet_selection).await;
 
     match result {

--- a/src/dfx/src/commands/quickstart.rs
+++ b/src/dfx/src/commands/quickstart.rs
@@ -1,5 +1,6 @@
 use crate::lib::error::NotifyCreateCanisterError::Notify;
 use crate::lib::ledger_types::NotifyError::Refunded;
+use crate::util::clap::subnet_selection_opt::SubnetSelectionType;
 use crate::{
     commands::ledger::create_canister::MEMO_CREATE_CANISTER,
     lib::{
@@ -187,7 +188,13 @@ async fn step_interact_ledger(
     let notify_spinner = ProgressBar::new_spinner();
     notify_spinner.set_message("Notifying the cycles minting canister...");
     notify_spinner.enable_steady_tick(100);
-    let res = notify_create(agent, ident_principal, height, None).await;
+    let res = notify_create(
+        agent,
+        ident_principal,
+        height,
+        SubnetSelectionType::default(),
+    )
+    .await;
     let wallet = match res {
         Ok(principal) => Ok(principal),
         Err(Notify(Refunded {

--- a/src/dfx/src/lib/named_canister.rs
+++ b/src/dfx/src/lib/named_canister.rs
@@ -14,7 +14,7 @@ use ic_utils::interfaces::ManagementCanister;
 use slog::info;
 use std::io::Read;
 
-const UI_CANISTER: &str = "__Candid_UI";
+pub const UI_CANISTER: &str = "__Candid_UI";
 
 #[context("Failed to install candid UI canister.")]
 pub async fn install_ui_canister(

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -1,7 +1,6 @@
 use crate::lib::builders::BuildConfig;
 use crate::lib::canister_info::assets::AssetsCanisterInfo;
 use crate::lib::canister_info::CanisterInfo;
-use crate::lib::cycles_ledger_types::create_canister::SubnetSelection;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::ic_attributes::CanisterSettings;
@@ -12,6 +11,7 @@ use crate::lib::operations::canister::deploy_canisters::DeployMode::{
 };
 use crate::lib::operations::canister::motoko_playground::reserve_canister_with_playground;
 use crate::lib::operations::canister::{create_canister, install_canister::install_canister};
+use crate::util::clap::subnet_selection_opt::SubnetSelectionType;
 use anyhow::{anyhow, bail, Context};
 use candid::Principal;
 use dfx_core::config::model::canister_id_store::CanisterIdStore;
@@ -52,7 +52,7 @@ pub async fn deploy_canisters(
     skip_consent: bool,
     env_file: Option<PathBuf>,
     no_asset_upgrade: bool,
-    subnet_selection: Option<SubnetSelection>,
+    subnet_selection: &mut SubnetSelectionType,
 ) -> DfxResult {
     let log = env.get_logger();
 
@@ -193,7 +193,7 @@ async fn register_canisters(
     from_subaccount: Option<Subaccount>,
     created_at_time: Option<u64>,
     config: &Config,
-    subnet_selection: Option<SubnetSelection>,
+    subnet_selection: &mut SubnetSelectionType,
 ) -> DfxResult {
     let canisters_to_create = canister_names
         .iter()
@@ -259,7 +259,7 @@ async fn register_canisters(
                     reserved_cycles_limit,
                 },
                 created_at_time,
-                subnet_selection.clone(),
+                subnet_selection,
             )
             .await?;
         }

--- a/src/dfx/src/lib/operations/cmc.rs
+++ b/src/dfx/src/lib/operations/cmc.rs
@@ -1,4 +1,3 @@
-use crate::lib::cycles_ledger_types::create_canister::SubnetSelection;
 use crate::lib::error::{
     DfxResult, NotifyCreateCanisterError, NotifyMintCyclesError, NotifyTopUpError,
 };
@@ -10,6 +9,7 @@ use crate::lib::ledger_types::{
 use crate::lib::nns_types::account_identifier::{AccountIdentifier, Subaccount};
 use crate::lib::nns_types::icpts::ICPTs;
 use crate::lib::operations::ledger::transfer;
+use crate::util::clap::subnet_selection_opt::SubnetSelectionType;
 use candid::{Decode, Encode, Principal};
 use ic_agent::Agent;
 use icrc_ledger_types::icrc1::account::Subaccount as ICRCSubaccount;
@@ -51,8 +51,9 @@ pub async fn notify_create(
     agent: &Agent,
     controller: Principal,
     block_height: BlockHeight,
-    subnet_selection: Option<SubnetSelection>,
+    subnet_selection: SubnetSelectionType,
 ) -> Result<Principal, NotifyCreateCanisterError> {
+    let user_subnet_selection = subnet_selection.get_user_choice();
     let result = agent
         .update(
             &MAINNET_CYCLE_MINTER_CANISTER_ID,
@@ -62,7 +63,7 @@ pub async fn notify_create(
             Encode!(&NotifyCreateCanisterArg {
                 block_index: block_height,
                 controller,
-                subnet_selection,
+                subnet_selection: user_subnet_selection,
             })
             .map_err(NotifyCreateCanisterError::EncodeArguments)?,
         )

--- a/src/dfx/src/lib/operations/cycles_ledger.rs
+++ b/src/dfx/src/lib/operations/cycles_ledger.rs
@@ -30,7 +30,7 @@ use slog::{info, Logger};
 
 /// Cycles ledger feature flag to turn off behavior that would be confusing while cycles ledger is not enabled yet.
 //TODO(SDK-1331): feature flag can be removed
-pub const CYCLES_LEDGER_ENABLED: bool = false;
+pub const CYCLES_LEDGER_ENABLED: bool = true;
 
 const ICRC1_BALANCE_OF_METHOD: &str = "icrc1_balance_of";
 const ICRC1_TRANSFER_METHOD: &str = "icrc1_transfer";

--- a/src/dfx/src/lib/operations/cycles_ledger.rs
+++ b/src/dfx/src/lib/operations/cycles_ledger.rs
@@ -3,7 +3,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::lib::cycles_ledger_types;
 use crate::lib::cycles_ledger_types::create_canister::{
     CmcCreateCanisterArgs, CreateCanisterArgs, CreateCanisterError, CreateCanisterSuccess,
-    SubnetSelection,
 };
 use crate::lib::cycles_ledger_types::deposit::DepositArg;
 use crate::lib::cycles_ledger_types::send::SendError;
@@ -14,12 +13,12 @@ use crate::lib::operations::canister::create_canister::{
     CANISTER_CREATE_FEE, CANISTER_INITIAL_CYCLE_BALANCE,
 };
 use crate::lib::retryable::retryable;
+use crate::util::clap::subnet_selection_opt::SubnetSelectionType;
 use anyhow::{anyhow, bail, Context};
 use backoff::future::retry;
 use backoff::ExponentialBackoff;
 use candid::{Decode, Encode, Nat, Principal};
 use dfx_core::canister::build_wallet_canister;
-use dfx_core::config::model::canister_id_store::CanisterIdStore;
 use fn_error_context::context;
 use ic_agent::Agent;
 use ic_utils::call::SyncCall;
@@ -27,7 +26,6 @@ use ic_utils::{Argument, Canister};
 use icrc_ledger_types::icrc1;
 use icrc_ledger_types::icrc1::account::{Account, Subaccount};
 use icrc_ledger_types::icrc1::transfer::{BlockIndex, TransferError};
-use itertools::Itertools;
 use slog::{info, Logger};
 
 /// Cycles ledger feature flag to turn off behavior that would be confusing while cycles ledger is not enabled yet.
@@ -202,14 +200,10 @@ pub async fn create_with_cycles_ledger(
     from_subaccount: Option<Subaccount>,
     settings: DfxCanisterSettings,
     created_at_time: Option<u64>,
-    subnet_selection: Option<SubnetSelection>,
+    subnet_selection: &mut SubnetSelectionType,
 ) -> DfxResult<Principal> {
     let cycles = with_cycles.unwrap_or(CANISTER_CREATE_FEE + CANISTER_INITIAL_CYCLE_BALANCE);
-    let subnet_selection = if subnet_selection.is_some() {
-        subnet_selection
-    } else {
-        get_subnet_selection_from_existing_canisters(env.get_canister_id_store()?).await?
-    };
+    let resolved_subnet_selection = subnet_selection.resolve(env).await?;
     let created_at_time = created_at_time.or_else(|| {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -228,7 +222,7 @@ pub async fn create_with_cycles_ledger(
         amount: cycles,
         creation_args: Some(CmcCreateCanisterArgs {
             settings: Some(settings.into()),
-            subnet_selection,
+            subnet_selection: resolved_subnet_selection,
         }),
     })
     .unwrap();
@@ -293,14 +287,6 @@ pub async fn wallet_deposit_to_cycles_ledger(
         .call_and_wait()
         .await
         .context("Failed deposit call.")
-}
-
-pub async fn get_subnet_selection_from_existing_canisters(
-    store: CanisterIdStore,
-) -> DfxResult<Option<SubnetSelection>> {
-    let existing_ids = store.non_remote_ids();
-
-    todo!()
 }
 
 #[test]

--- a/src/dfx/src/lib/operations/cycles_ledger.rs
+++ b/src/dfx/src/lib/operations/cycles_ledger.rs
@@ -33,7 +33,7 @@ use slog::{info, Logger};
 
 /// Cycles ledger feature flag to turn off behavior that would be confusing while cycles ledger is not enabled yet.
 //TODO(SDK-1331): feature flag can be removed
-pub const CYCLES_LEDGER_ENABLED: bool = true;
+pub const CYCLES_LEDGER_ENABLED: bool = false;
 
 const ICRC1_BALANCE_OF_METHOD: &str = "icrc1_balance_of";
 const ICRC1_TRANSFER_METHOD: &str = "icrc1_transfer";

--- a/src/dfx/src/lib/subnet.rs
+++ b/src/dfx/src/lib/subnet.rs
@@ -12,7 +12,7 @@ use super::retryable::retryable;
 pub const MAINNET_REGISTRY_CANISTER_ID: Principal =
     Principal::from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01]);
 
-#[derive(CandidType)]
+#[derive(CandidType, Debug)]
 pub struct GetSubnetForCanisterRequest {
     pub principal: Option<Principal>,
 }

--- a/src/dfx/src/util/clap/subnet_selection_opt.rs
+++ b/src/dfx/src/util/clap/subnet_selection_opt.rs
@@ -104,7 +104,7 @@ impl SubnetSelectionType {
             canisters
                 .into_iter()
                 .filter(|(name, _)| name != UI_CANISTER)
-                .map(|(_, canister)| get_subnet_for_canister(env.get_agent(), canister.clone())),
+                .map(|(_, canister)| get_subnet_for_canister(env.get_agent(), canister)),
         )
         .await?;
 


### PR DESCRIPTION
# Description

When the cycles ledger is used to create canisters it automatically should put canisters on the same subnet so cross-canister calls don't take forever.

Fixes [SDK-1372](https://dfinity.atlassian.net/browse/SDK-1372)

# How Has This Been Tested?

added e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] TODO before merging: disable feature flag again


[SDK-1372]: https://dfinity.atlassian.net/browse/SDK-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ