### PR TITLE
fix: failed to call a canister removed from dfx.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ Also the warning of hash mismatch is removed since it scares users and users can
 
 Fixed a bug where `dfx generate` would delete a canister's source candid file if the `declarations.bindings` in `dfx.json` did not include "did".
 
+### fix: failed to call a canister removed from dfx.json
+
+Fixed a bug where `dfx canister call` would fail when the deployed canister was removed from dfx.json.
+
 # 0.17.0
 
 ### feat: new starter templates

--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -151,3 +151,11 @@ teardown() {
     assert_match '("Hello, you!")'
   )
 }
+
+@test "call a canister which is deployed then removed from dfx.json" {
+  dfx_start
+  dfx deploy
+  jq 'del(.canisters.hello_backend)' dfx.json | sponge dfx.json
+  assert_command dfx canister call hello_backend greet '("you")'
+  assert_match '("Hello, you!")'
+}

--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -159,6 +159,6 @@ teardown() {
   jq 'del(.canisters.hello_backend)' dfx.json | sponge dfx.json
   assert_command dfx canister call hello_backend greet '("you")'
   assert_match '("Hello, you!")'
-  assert_command dfx canister call $CANISTER_ID greet '("you")'
+  assert_command dfx canister call "$CANISTER_ID" greet '("you")'
   assert_match '("Hello, you!")'
 }

--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -155,7 +155,10 @@ teardown() {
 @test "call a canister which is deployed then removed from dfx.json" {
   dfx_start
   dfx deploy
+  CANISTER_ID=$(dfx canister id hello_backend)
   jq 'del(.canisters.hello_backend)' dfx.json | sponge dfx.json
   assert_command dfx canister call hello_backend greet '("you")'
+  assert_match '("Hello, you!")'
+  assert_command dfx canister call $CANISTER_ID greet '("you")'
   assert_match '("Hello, you!")'
 }


### PR DESCRIPTION
# Description

SDK-1318

Fixed a bug where `dfx canister call` would fail when the deployed canister was removed from dfx.json.

A sample error:
```
$ dfx canister id ckbtc_kyt
aovwi-4maaa-aaaaa-qaagq-cai

$ dfx canister info ckbtc_kyt
Controllers: bkyz2-fmaaa-aaaaa-qaaaq-cai tb3st-xv2zz-fpfob-ku4oa-lmsvj-luynb-334fa-v42pq-m5avw-i4nch-bae
Module hash: 0xed21443ca58aad3e2b04502e3b5569c826eb7fa38c5df333920ae45cadafb874

$ dfx canister call ckbtc_kyt set_api_key '( record { api_key = "abc" } )' --candid kyt.did 
Error: Failed to get canister id and path to its candid definitions for 'ckbtc_kyt'.
Caused by: Failed to get canister id and path to its candid definitions for 'ckbtc_kyt'.
  Failed to load canister info for 'ckbtc_kyt'.
    Cannot find canister 'ckbtc_kyt',
```

`dfx canister id/info` can execute without issue. But `dfx canister call` couldn't.
This PR unifies the requirements of these subcommands.

# How Has This Been Tested?

e2e call.bash

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
