### PR TITLE
fix: failed to install when specify id without dfx.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ Also the warning of hash mismatch is removed since it scares users and users can
 
 Fixed a bug where `dfx generate` would delete a canister's source candid file if the `declarations.bindings` in `dfx.json` did not include "did".
 
+### fix: failed to install when specify id without dfx.json
+
+Fixed a bug where `dfx canister install` would fail when specify a canister id and there is no dfx.json.
+
 # 0.17.0
 
 ### feat: new starter templates

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -255,3 +255,13 @@ teardown() {
   assert_command dfx canister call dependency greet
   assert_match "Hello, icp!"
 }
+
+@test "install succeeds when specify canister id and wasm, in dir without dfx.json" {
+  dfx_start
+
+  dfx canister create --all
+  CANISTER_ID=$(dfx canister id e2e_project_backend)
+  dfx build
+  rm dfx.json
+  assert_command dfx canister install "$CANISTER_ID" --wasm .dfx/local/canisters/e2e_project_backend/e2e_project_backend.wasm
+}


### PR DESCRIPTION
# Description

Fixed a bug where `dfx canister install` would fail when specify a canister id and there is no dfx.json.

A sample error:
```
Error: Failed to get pull canisters defined in dfx.json.
   Caused by: Failed to get pull canisters defined in dfx.json.
     Cannot find dfx configuration file in the current working directory. Did you forget to create one?
```

Fixes SDK-1384

# How Has This Been Tested?

Add an e2e test in install.bash

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
