### PR TITLE
chore: use the right Subaccount type in dfx cycles commands

### DIFF
--- a/src/dfx/src/commands/cycles/approve.rs
+++ b/src/dfx/src/commands/cycles/approve.rs
@@ -1,11 +1,11 @@
-use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::nns_types::account_identifier::Subaccount;
 use crate::lib::operations::cycles_ledger;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::util::clap::parsers::cycle_amount_parser;
+use crate::{lib::environment::Environment, util::clap::parsers::icrc_subaccount_parser};
 use candid::Principal;
 use clap::Parser;
+use icrc_ledger_types::icrc1::account::Subaccount;
 use slog::warn;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -20,11 +20,11 @@ pub struct ApproveOpts {
     amount: u128,
 
     /// Allow this subaccount to spend cycles.
-    #[arg(long)]
+    #[arg(long, value_parser = icrc_subaccount_parser)]
     spender_subaccount: Option<Subaccount>,
 
     /// Approve cycles to be spent from this subaccount.
-    #[arg(long)]
+    #[arg(long, value_parser = icrc_subaccount_parser)]
     from_subaccount: Option<Subaccount>,
 
     /// The number of previously approved cycles.
@@ -58,15 +58,13 @@ pub async fn exec(env: &dyn Environment, opts: ApproveOpts) -> DfxResult {
             .as_nanos() as u64,
     );
 
-    let spender_subaccount = opts.spender_subaccount.map(|x| x.0);
-    let from_subaccount = opts.from_subaccount.map(|x| x.0);
     let result = cycles_ledger::approve(
         agent,
         env.get_logger(),
         opts.amount,
         opts.spender,
-        spender_subaccount,
-        from_subaccount,
+        opts.spender_subaccount,
+        opts.from_subaccount,
         opts.expected_allowance,
         opts.expires_at,
         created_at_time,

--- a/src/dfx/src/commands/cycles/balance.rs
+++ b/src/dfx/src/commands/cycles/balance.rs
@@ -1,11 +1,12 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::nns_types::account_identifier::Subaccount;
 use crate::lib::operations::cycles_ledger;
 use crate::lib::root_key::fetch_root_key_if_needed;
+use crate::util::clap::parsers::icrc_subaccount_parser;
 use crate::util::{format_as_trillions, pretty_thousand_separators};
 use candid::Principal;
 use clap::Parser;
+use icrc_ledger_types::icrc1::account::Subaccount;
 
 /// Get the cycle balance of the selected Identity's cycles wallet.
 #[derive(Parser)]
@@ -15,7 +16,7 @@ pub struct CyclesBalanceOpts {
     owner: Option<Principal>,
 
     /// Subaccount of the selected identity to get the balance of
-    #[arg(long)]
+    #[arg(long, value_parser = icrc_subaccount_parser)]
     subaccount: Option<Subaccount>,
 
     /// Get balance raw value (without upscaling to trillions of cycles).
@@ -33,9 +34,7 @@ pub async fn exec(env: &dyn Environment, opts: CyclesBalanceOpts) -> DfxResult {
             .expect("Selected identity not instantiated.")
     });
 
-    let subaccount = opts.subaccount.map(|x| x.0);
-
-    let balance = cycles_ledger::balance(agent, owner, subaccount).await?;
+    let balance = cycles_ledger::balance(agent, owner, opts.subaccount).await?;
 
     if opts.precise {
         println!("{} cycles.", balance);

--- a/src/dfx/src/commands/cycles/top_up.rs
+++ b/src/dfx/src/commands/cycles/top_up.rs
@@ -1,11 +1,11 @@
-use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::nns_types::account_identifier::Subaccount;
 use crate::lib::operations::cycles_ledger;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::util::clap::parsers::cycle_amount_parser;
+use crate::{lib::environment::Environment, util::clap::parsers::icrc_subaccount_parser};
 use candid::Principal;
 use clap::Parser;
+use icrc_ledger_types::icrc1::account::Subaccount;
 use slog::warn;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -20,7 +20,7 @@ pub struct TopUpOpts {
     amount: u128,
 
     /// Transfer cycles from this subaccount.
-    #[arg(long)]
+    #[arg(long, value_parser = icrc_subaccount_parser)]
     from_subaccount: Option<Subaccount>,
 
     /// Transaction timestamp, in nanoseconds, for use in controlling transaction deduplication, default is system time.
@@ -44,14 +44,13 @@ pub async fn exec(env: &dyn Environment, opts: TopUpOpts) -> DfxResult {
     );
 
     let to = get_canister_id(env, &opts.to)?;
-    let from_subaccount = opts.from_subaccount.map(|x| x.0);
     let result = cycles_ledger::send(
         agent,
         env.get_logger(),
         to,
         amount,
         created_at_time,
-        from_subaccount,
+        opts.from_subaccount,
     )
     .await;
     if result.is_err() && opts.created_at_time.is_none() {

--- a/src/dfx/src/commands/cycles/transfer.rs
+++ b/src/dfx/src/commands/cycles/transfer.rs
@@ -1,12 +1,11 @@
-use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::nns_types::account_identifier::Subaccount;
 use crate::lib::operations::cycles_ledger;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::util::clap::parsers::cycle_amount_parser;
+use crate::{lib::environment::Environment, util::clap::parsers::icrc_subaccount_parser};
 use candid::Principal;
 use clap::Parser;
-use icrc_ledger_types::icrc1;
+use icrc_ledger_types::icrc1::{self, account::Subaccount};
 use slog::warn;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -25,15 +24,15 @@ pub struct TransferOpts {
     from: Option<Principal>,
 
     /// Transfer cycles from this subaccount.
-    #[arg(long)]
+    #[arg(long, value_parser = icrc_subaccount_parser)]
     from_subaccount: Option<Subaccount>,
 
     /// Deduct allowance from this subaccount.
-    #[arg(long, requires("from"))]
+    #[arg(long, value_parser = icrc_subaccount_parser, requires("from"))]
     spender_subaccount: Option<Subaccount>,
 
     /// Transfer cycles to this subaccount.
-    #[arg(long)]
+    #[arg(long, value_parser = icrc_subaccount_parser)]
     to_subaccount: Option<Subaccount>,
 
     /// Transaction timestamp, in nanoseconds, for use in controlling transaction-deduplication, default is system-time.
@@ -60,23 +59,19 @@ pub async fn exec(env: &dyn Environment, opts: TransferOpts) -> DfxResult {
             .as_nanos() as u64,
     );
 
-    let from_subaccount = opts.from_subaccount.map(|x| x.0);
-    let to_subaccount = opts.to_subaccount.map(|x| x.0);
-
     let result = if let Some(from_owner) = opts.from {
-        let spender_subaccount = opts.spender_subaccount.map(|x| x.0);
         let from = icrc1::account::Account {
             owner: from_owner,
-            subaccount: from_subaccount,
+            subaccount: opts.from_subaccount,
         };
         let to = icrc1::account::Account {
             owner: opts.to,
-            subaccount: to_subaccount,
+            subaccount: opts.to_subaccount,
         };
         cycles_ledger::transfer_from(
             agent,
             env.get_logger(),
-            spender_subaccount,
+            opts.spender_subaccount,
             from,
             to,
             amount,
@@ -89,9 +84,9 @@ pub async fn exec(env: &dyn Environment, opts: TransferOpts) -> DfxResult {
             agent,
             env.get_logger(),
             amount,
-            from_subaccount,
+            opts.from_subaccount,
             opts.to,
-            to_subaccount,
+            opts.to_subaccount,
             created_at_time,
             opts.memo,
         )


### PR DESCRIPTION
# Description

`dfx cycles` uses the ICP ledger `Subaccount` type instead of the `icrc1` variant, which is wrong

# How Has This Been Tested?

Should not produce any functional changes. Covered by e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
