### PR TITLE
fix: .ic-assets.json configuration entries no longer overwrite the default for allow_raw_access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 # UNRELEASED
 
+# fix: .ic-assets.json configuration entries no longer overwrite the default for `allow_raw_access`
+
+Previously, any configuration element in .ic-assets.json functioned as if a setting of
+`"allow_raw_access": true` were present in the json object.
+
+For example, given the following configuration, all files would be configured
+with `allow_raw_access` set to `true`, as if the second entry specified
+`"allow_raw_access": true` (which is the default), even though it does not.
+
+```json
+[
+  {
+    "match": "**/*",
+    "allow_raw_access": false
+  },
+  {
+    "match": "**/*",
+    "headers": {
+      "X-Anything": "Something"
+    }
+  }
+]
+```
+
+Now, given the same configuration, all files would be configured with `allow_raw_access` set to false, as expected.
+
+Note that the default value of `allow_raw_access` is still `true`.
+
 # 0.18.0
 
 ### fix!: removed the `dfx upgrade` command

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -1538,29 +1538,25 @@ EOF
   "match": "nevermatchme",
   "cache": {
     "max_age": 2000
-  },
-  "allow_raw_access": true
+  }
 }'
   assert_match 'WARN: 4 unmatched configurations in .*/src/e2e_project_frontend/assets/somedir/.ic-assets.json config file:'
   assert_contains 'WARN: {
   "match": "nevermatchme",
   "headers": {},
-  "ignore": false,
-  "allow_raw_access": true
+  "ignore": false
 }
 WARN: {
   "match": "nevermatchmetoo",
   "headers": {},
-  "ignore": false,
-  "allow_raw_access": true
+  "ignore": false
 }
 WARN: {
   "match": "non-matcher",
   "headers": {
     "x-header": "x-value"
   },
-  "ignore": false,
-  "allow_raw_access": true
+  "ignore": false
 }'
   # splitting this up into two checks, because the order is different on macos vs ubuntu
   assert_contains 'WARN: {
@@ -1568,8 +1564,7 @@ WARN: {
   "headers": {
     "x-header": "x-value"
   },
-  "ignore": false,
-  "allow_raw_access": true
+  "ignore": false
 }'
 }
 

--- a/src/canisters/frontend/ic-asset/src/asset/config.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/config.rs
@@ -34,10 +34,6 @@ pub(crate) struct CacheConfig {
     pub(crate) max_age: Option<u64>,
 }
 
-fn default_raw_access() -> Option<bool> {
-    Some(true)
-}
-
 /// A single configuration object, from `.ic-assets.json` config file
 #[derive(Derivative, Clone, Serialize)]
 #[derivative(Debug, PartialEq)]
@@ -348,7 +344,6 @@ mod rule_utils {
         headers: Maybe<HeadersConfig>,
         ignore: Option<bool>,
         enable_aliasing: Option<bool>,
-        #[serde(default = "super::default_raw_access")]
         allow_raw_access: Option<bool>,
     }
 
@@ -426,6 +421,16 @@ mod rule_utils {
                 if let Some(ref max_age) = cache.max_age {
                     s.push_str(&format!("  - HTTP cache max-age: {}\n", max_age));
                 }
+            }
+            if let Some(allow_raw_access) = self.allow_raw_access {
+                s.push_str(&format!(
+                    "  - enable raw access: {}\n",
+                    if allow_raw_access {
+                        "enabled"
+                    } else {
+                        "disabled"
+                    }
+                ));
             }
             if let Some(aliasing) = self.enable_aliasing {
                 s.push_str(&format!(

--- a/src/canisters/frontend/ic-asset/src/asset/config.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/config.rs
@@ -936,4 +936,152 @@ mod with_tempdir {
             },
         );
     }
+
+    #[test]
+    fn the_order_does_not_matter() {
+        let cfg = Some(HashMap::from([(
+            "".to_string(),
+            r#"[
+                {
+                    "match": "**/deep/**/*",
+                    "allow_raw_access": false,
+                    "cache": {
+                      "max_age": 22
+                    },
+                    "enable_aliasing": true,
+                    "ignore": true
+                },
+                {
+                    "match": "**/*",
+                    "headers": {
+                        "X-Frame-Options": "DENY"
+                    }
+                }
+            ]
+"#
+                .to_string(),
+        )]));
+        let cfg2 = Some(HashMap::from([(
+            "".to_string(),
+            r#"[
+                {
+                    "match": "**/*",
+                    "headers": {
+                        "X-Frame-Options": "DENY"
+                    }
+                },
+                {
+                    "match": "**/deep/**/*",
+                    "allow_raw_access": false,
+                    "cache": {
+                      "max_age": 22
+                    },
+                    "enable_aliasing": true,
+                    "ignore": true
+                }
+            ]
+            "#
+                .to_string(),
+        )]));
+
+        let x = {
+            let assets_temp_dir = create_temporary_assets_directory(cfg, 0);
+            let assets_dir = assets_temp_dir.path().canonicalize().unwrap();
+            let mut assets_config = AssetSourceDirectoryConfiguration::load(&assets_dir).unwrap();
+            assets_config
+                .get_asset_config(assets_dir.join("nested/deep/the-next-thing.toml").as_path())
+                .unwrap()
+        };
+        let y = {
+            let assets_temp_dir = create_temporary_assets_directory(cfg2, 0);
+            let assets_dir = assets_temp_dir.path().canonicalize().unwrap();
+            let mut assets_config = AssetSourceDirectoryConfiguration::load(&assets_dir).unwrap();
+            assets_config
+                .get_asset_config(assets_dir.join("nested/deep/the-next-thing.toml").as_path())
+                .unwrap()
+        };
+
+        dbg!(&x, &y);
+        assert_eq!(x.allow_raw_access, Some(false));
+        assert_eq!(y.allow_raw_access, Some(false));
+        assert_eq!(x.enable_aliasing, Some(true));
+        assert_eq!(y.enable_aliasing, Some(true));
+        assert_eq!(x.ignore, Some(true));
+        assert_eq!(y.ignore, Some(true));
+        assert_eq!(x.cache.clone().unwrap().max_age, Some(22));
+        assert_eq!(y.cache.clone().unwrap().max_age, Some(22));
+
+        // same as above but with different values
+        let cfg = Some(HashMap::from([(
+            "".to_string(),
+            r#"[
+                {
+                    "match": "**/deep/**/*",
+                    "allow_raw_access": true,
+                    "enable_aliasing": false,
+                    "ignore": false,
+                    "headers": {
+                        "X-Frame-Options": "ALLOW"
+                    }
+                },
+                {
+                    "match": "**/*",
+                    "cache": {
+                      "max_age": 22
+                    }
+                }
+            ]
+"#
+                .to_string(),
+        )]));
+        let cfg2 = Some(HashMap::from([(
+            "".to_string(),
+            r#"[
+                {
+                    "match": "**/*",
+                    "cache": {
+                      "max_age": 22
+                    }
+                },
+                {
+                    "match": "**/deep/**/*",
+                    "allow_raw_access": true,
+                    "enable_aliasing": false,
+                    "ignore": false,
+                    "headers": {
+                        "X-Frame-Options": "ALLOW"
+                    }
+                }
+            ]
+            "#
+                .to_string(),
+        )]));
+
+        let x = {
+            let assets_temp_dir = create_temporary_assets_directory(cfg, 0);
+            let assets_dir = assets_temp_dir.path().canonicalize().unwrap();
+            let mut assets_config = AssetSourceDirectoryConfiguration::load(&assets_dir).unwrap();
+            assets_config
+                .get_asset_config(assets_dir.join("nested/deep/the-next-thing.toml").as_path())
+                .unwrap()
+        };
+        let y = {
+            let assets_temp_dir = create_temporary_assets_directory(cfg2, 0);
+            let assets_dir = assets_temp_dir.path().canonicalize().unwrap();
+            let mut assets_config = AssetSourceDirectoryConfiguration::load(&assets_dir).unwrap();
+            assets_config
+                .get_asset_config(assets_dir.join("nested/deep/the-next-thing.toml").as_path())
+                .unwrap()
+        };
+
+        dbg!(&x, &y);
+        assert_eq!(x.allow_raw_access, Some(true));
+        assert_eq!(y.allow_raw_access, Some(true));
+        assert_eq!(x.enable_aliasing, Some(false));
+        assert_eq!(y.enable_aliasing, Some(false));
+        assert_eq!(x.ignore, Some(false));
+        assert_eq!(y.ignore, Some(false));
+        assert_eq!(x.cache.clone().unwrap().max_age, Some(22));
+        assert_eq!(y.cache.clone().unwrap().max_age, Some(22));
+    }
 }

--- a/src/canisters/frontend/ic-asset/src/asset/config.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/config.rs
@@ -964,7 +964,7 @@ mod with_tempdir {
                 }
             ]
 "#
-                .to_string(),
+            .to_string(),
         )]));
         let cfg2 = Some(HashMap::from([(
             "".to_string(),
@@ -986,7 +986,7 @@ mod with_tempdir {
                 }
             ]
             "#
-                .to_string(),
+            .to_string(),
         )]));
 
         let x = {
@@ -1037,7 +1037,7 @@ mod with_tempdir {
                 }
             ]
 "#
-                .to_string(),
+            .to_string(),
         )]));
         let cfg2 = Some(HashMap::from([(
             "".to_string(),
@@ -1059,7 +1059,7 @@ mod with_tempdir {
                 }
             ]
             "#
-                .to_string(),
+            .to_string(),
         )]));
 
         let x = {


### PR DESCRIPTION
# Description

Previously, any configuration element in .ic-assets.json functioned as if a setting of
`"allow_raw_access": true` were present in the json object.

For example, given the following configuration, all files would be configured
with `allow_raw_access` set to `true`, as if the second entry specified
`"allow_raw_access": true` (which is the default), even though it does not.

```json
[
  {
    "match": "**/*",
    "allow_raw_access": false
  },
  {
    "match": "**/*",
    "headers": {
      "X-Anything": "Something"
    }
  }
]
```

Now, given the same configuration, all files would be configured with `allow_raw_access` set to false, as expected.

Note that the default value of `allow_raw_access` is still `true`.

Fixes https://dfinity.atlassian.net/browse/SDK-1238

Notes to reviewers:
- the default of `true` comes from here: https://github.com/dfinity/sdk/blob/master/src/canisters/frontend/ic-asset/src/asset/config.rs#L228
- the removal of the default value from the `"asset configuration via .ic-assets.json5 - detect unused config"` e2e test was a hint of the problem: the configuration file doesn't specify a value, but it showed up in the output as if it had.

# How Has This Been Tested?

Added e2e tests, as well as a unit test from https://github.com/dfinity/sdk/pull/3434

This PR is broken up into two commits.  The first adds the tests, two of which fail. The second

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
