### PR TITLE
test: improve a flacky start e2e test

### DIFF
--- a/e2e/tests-dfx/start.bash
+++ b/e2e/tests-dfx/start.bash
@@ -435,17 +435,17 @@ teardown() {
 }
 
 @test "flags count as configuration modification and require --clean" {
-  dfx_start
+  dfx start --background
   dfx stop
-  assert_command_fail dfx_start --enable-bitcoin
+  assert_command_fail dfx start --artificial-delay 100 --background
   assert_contains "The network configuration was changed. Rerun with \`--clean\`."
-  assert_command dfx_start --enable-bitcoin --clean
+  assert_command dfx start --artificial-delay 100 --clean --background
   dfx stop
-  assert_command dfx_start --enable-bitcoin
+  assert_command dfx start --artificial-delay 100 --background
   dfx stop
-  assert_command_fail dfx_start
+  assert_command_fail dfx start --background
   assert_contains "The network configuration was changed. Rerun with \`--clean\`."
-  assert_command dfx_start --force
+  assert_command dfx start --force --background
 }
 
 @test "dfx start then ctrl-c won't hang and panic but stop actors quickly" {


### PR DESCRIPTION
# Description

Sample failures:

https://github.com/dfinity/sdk/actions/runs/8143004480/job/22254823042#step:10:67
https://github.com/dfinity/sdk/actions/runs/8120382844/job/22197858666#step:10:139

The test involved `--enable-bitcoin` which introduced out-of-control factors and made the test flacky.

# How Has This Been Tested?

Before the change, the test had a high failure probability.
With the change, my three consecutive runs succeed locally.
We should also monitor the CI in the next few days to see if the flacky errors show again.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
