### PR TITLE
fix: playground e2e tests

### DIFF
--- a/e2e/assets/playground_backend/mops.toml
+++ b/e2e/assets/playground_backend/mops.toml
@@ -1,4 +1,6 @@
 [dependencies]
-base = "0.9.1"
+base = "0.10.4"
 splay = "0.1.0"
 
+[toolchain]
+moc = "0.10.4"

--- a/e2e/tests-dfx/playground.bash
+++ b/e2e/tests-dfx/playground.bash
@@ -21,6 +21,9 @@ setup_playground() {
   dfx_new hello
   create_networks_json
   install_asset playground_backend
+  touch "$HOME/.bashrc" # required by following mops command
+  mops toolchain init   # install the pinned moc version defined in mops.toml
+  export DFX_MOC_PATH=moc-wrapper # use the moc-wrapper installed by mops
   dfx_start
   dfx deploy backend
   dfx ledger fabricate-cycles --t 9999999 --canister backend


### PR DESCRIPTION
# Description

The local playground canister failed to compile with `moc` v0.11.0.

So I pinned the Motoko toolchain version to v0.10.4 in `mops.toml`. 
And in the `setup_playground`, I added `mops toolchain init` to use the pinned `moc`.

# How Has This Been Tested?

playground e2e tests
# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
