### PR TITLE
fix: CI e2e:required status could skip even on failure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -239,7 +239,7 @@ jobs:
 
   aggregate:
     name: e2e:required
-    if: needs.changes.outputs.sources == 'true'
+    if: always() && needs.changes.outputs.sources == 'true'
     needs: [changes, test, smoke, ui_test]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -62,7 +62,7 @@ jobs:
 
   aggregate:
     name: fmt:required
-    if: needs.changes.outputs.sources == 'true'
+    if: always() && needs.changes.outputs.sources == 'true'
     needs: [changes, test]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,7 @@ jobs:
 
   aggregate:
     name: lint:required
-    if: needs.changes.outputs.sources == 'true'
+    if: always() && needs.changes.outputs.sources == 'true'
     needs: [changes, test]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -60,7 +60,7 @@ jobs:
 
   aggregate:
     name: unit:required
-    if: needs.changes.outputs.sources == 'true'
+    if: always() && needs.changes.outputs.sources == 'true'
     needs: [changes, test]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description

The always() check provides a "status check"
    https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
If a status check isn't present, a default status check of success() is automatically applied.

This meant that the e2e:required status could be skipped even on test failure, and when skipped, be marked as successful for purposes of required statuses.

Fixes https://dfinity.atlassian.net/browse/SDK-1474

# How Has This Been Tested?

Tested here: https://github.com/dfinity/sdk/actions/runs/8177422298/job/22359553279?pr=3644

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
