### PR TITLE
fix: limit download_file max retry time to 60s

### DIFF
--- a/e2e/assets/deps/onchain/dfx.json
+++ b/e2e/assets/deps/onchain/dfx.json
@@ -4,7 +4,7 @@
             "type": "motoko",
             "main": "src/a.mo",
             "pullable": {
-                "wasm_url": "http://example.com/a.wasm",
+                "wasm_url": "http://httpbin.org/status/404",
                 "dependencies": [],
                 "init_guide": "A natural number, e.g. 10."
             }
@@ -16,7 +16,7 @@
                 "a"
             ],
             "pullable": {
-                "wasm_url": "http://example.com/b.wasm.gz",
+                "wasm_url": "http://httpbin.org/status/404",
                 "dependencies": [
                     "yofga-2qaaa-aaaaa-aabsq-cai"
                 ],
@@ -31,7 +31,7 @@
                 "a"
             ],
             "pullable": {
-                "wasm_url": "http://example.com/c.wasm",
+                "wasm_url": "http://httpbin.org/status/404",
                 "dependencies": [
                     "yofga-2qaaa-aaaaa-aabsq-cai"
                 ],

--- a/e2e/tests-dfx/deps.bash
+++ b/e2e/tests-dfx/deps.bash
@@ -120,13 +120,13 @@ $CANISTER_ID_C"
   assert_occurs 1 "Fetching dependencies of canister $CANISTER_ID_A..." # common dependency onchain_a is pulled only once
   assert_contains "Pulling canister $CANISTER_ID_A...
 ERROR: Failed to pull canister $CANISTER_ID_A.
-Failed to download from url: http://example.com/a.wasm."
+Failed to download from url: http://httpbin.org/status/404."
   assert_contains "Pulling canister $CANISTER_ID_B...
 ERROR: Failed to pull canister $CANISTER_ID_B.
-Failed to download from url: http://example.com/b.wasm.gz."
+Failed to download from url: http://httpbin.org/status/404."
   assert_contains "Pulling canister $CANISTER_ID_C...
 ERROR: Failed to pull canister $CANISTER_ID_C.
-Failed to download from url: http://example.com/c.wasm."
+Failed to download from url: http://httpbin.org/status/404."
 
   # 3. sad path: if the canister is not present on-chain
   cd ../onchain

--- a/e2e/tests-dfx/deps.bash
+++ b/e2e/tests-dfx/deps.bash
@@ -73,7 +73,7 @@ cleanup_onchain() {
 
   ic-wasm .dfx/local/canisters/c/c.wasm metadata dfx > c_dfx.json
   assert_command jq -r '.pullable.wasm_url' c_dfx.json
-  assert_eq "http://example.com/c.wasm" "$output"
+  assert_eq "http://httpbin.org/status/404" "$output"
   assert_command jq -r '.pullable.dependencies | length' c_dfx.json
   assert_eq 1 "$output"
   assert_command jq -r '.pullable.dependencies | first' c_dfx.json

--- a/src/dfx/src/util/mod.rs
+++ b/src/dfx/src/util/mod.rs
@@ -393,6 +393,11 @@ pub async fn download_file(from: &Url) -> DfxResult<Vec<u8>> {
         .context("Could not create HTTP client.")?;
 
     let mut retry_policy = ExponentialBackoff::default();
+    // Retry at most 60 seconds
+    // When the server responds with errors not "404 not found" (e.g. "500 internal server error"),
+    // this function retries indefinitely.
+    // We arbitrarily set the maximum elapsed time to 60 seconds to avoid infinite retries.
+    retry_policy.max_elapsed_time = Some(Duration::from_secs(60));
 
     let body = loop {
         match attempt_download(&client, from).await {


### PR DESCRIPTION
# Description

In recent few CI run of the deps e2e test, it took abnormally longer time than usual (over 30mins v.s. around 5 mins).
A sample: https://github.com/dfinity/sdk/actions/runs/8256057849/job/22585991303

The test hanged when trying to download from "http://example.com/b.wasm.gz". That URL was believed to always return 404 which will terminate the download without retry. For some unknown reason, the URL may returns "500 internal server error" which makes the `download_file` retries indefinitely.

This PR not only fix the e2e test to use a "always 404" URL, but also limit the retry logic inside `download_file` to at most 60s.

# How Has This Been Tested?

A unit test was added to check if `download_file` retries at most 60s. This will make the "[Check cargo (unit) test](https://github.com/dfinity/sdk/actions/workflows/unit.yml)" job last 1 minute longer. This should be fine since it is still much faster than the e2e job.

The deps e2e test should not hang anymore.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
