### PR TITLE
fix: [IC-272] make fetching canister logs grep- and tail- compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+### fix fetching canister logs to be grep & tail compatible
+
+Fix fetching canister logs so that the DFX output is `grep` and `tail` compatible.
+
 ### fix fetching canister logs
 
 The management canister method `fetch_canister_logs` can be called only as a query, not as an update call. Therefore, `dfx canister logs <canister_id>` now uses a query call for this purpose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### fix fetching canister logs to be grep & tail compatible
 
-Fix fetching canister logs so that the DFX output is `grep` and `tail` compatible.
+`dfx canister logs` now outputs to stdout, rather than stderr, so that its output is `grep` and `tail` compatible.
 
 ### fix fetching canister logs
 

--- a/e2e/tests-dfx/logs.bash
+++ b/e2e/tests-dfx/logs.bash
@@ -28,21 +28,11 @@ teardown() {
   assert_contains "Hello, Bob!"
 }
 
-@test "fetching canister logs is grepable" {
-  install_asset logs
-  dfx_start
-  dfx canister create --all
-  dfx build
-  dfx canister install e2e_project
-  dfx canister call e2e_project hello Alice
-  dfx canister call e2e_project hello Bob
-  sleep 2
-  assert_command dfx canister logs e2e_project | grep Alice
-  assert_contains "Hello, Alice!"
-  assert_not_contains "Hello, Bob!"
+dfx_canister_logs_grep_Alice() {
+  dfx canister logs e2e_project | grep Alice
 }
 
-@test "fetching canister logs is tailable" {
+@test "fetching canister logs output is grep-able" {
   install_asset logs
   dfx_start
   dfx canister create --all
@@ -51,7 +41,25 @@ teardown() {
   dfx canister call e2e_project hello Alice
   dfx canister call e2e_project hello Bob
   sleep 2
-  assert_command dfx canister logs e2e_project | tail -n 1
-  assert_not_contains "Hello, Alice!"
-  assert_contains "Hello, Bob!"
+  assert_command dfx_canister_logs_grep_Alice
+  assert_contains "Alice"
+  assert_not_contains "Bob"
+}
+
+dfx_canister_logs_tail_n_1() {
+  echo "$(dfx canister logs e2e_project)" | tail -n 1
+}
+
+@test "fetching canister logs output is tail-able" {
+  install_asset logs
+  dfx_start
+  dfx canister create --all
+  dfx build
+  dfx canister install e2e_project
+  dfx canister call e2e_project hello Alice
+  dfx canister call e2e_project hello Bob
+  sleep 2
+  assert_command dfx_canister_logs_tail_n_1
+  assert_not_contains "Alice"
+  assert_contains "Bob"
 }

--- a/e2e/tests-dfx/logs.bash
+++ b/e2e/tests-dfx/logs.bash
@@ -47,8 +47,8 @@ dfx_canister_logs_grep_Alice() {
 }
 
 dfx_canister_logs_tail_n_1() {
-  # shellcheck disable=SC2005
   # Extra echo is necessary to simulate file input for tail.
+  # shellcheck disable=SC2005
   echo "$(dfx canister logs e2e_project)" | tail -n 1
 }
 

--- a/e2e/tests-dfx/logs.bash
+++ b/e2e/tests-dfx/logs.bash
@@ -27,3 +27,31 @@ teardown() {
   assert_contains "Hello, Alice!"
   assert_contains "Hello, Bob!"
 }
+
+@test "fetching canister logs is grepable" {
+  install_asset logs
+  dfx_start
+  dfx canister create --all
+  dfx build
+  dfx canister install e2e_project
+  dfx canister call e2e_project hello Alice
+  dfx canister call e2e_project hello Bob
+  sleep 2
+  assert_command dfx canister logs e2e_project | grep Alice
+  assert_contains "Hello, Alice!"
+  assert_not_contains "Hello, Bob!"
+}
+
+@test "fetching canister logs is tailable" {
+  install_asset logs
+  dfx_start
+  dfx canister create --all
+  dfx build
+  dfx canister install e2e_project
+  dfx canister call e2e_project hello Alice
+  dfx canister call e2e_project hello Bob
+  sleep 2
+  assert_command dfx canister logs e2e_project | tail -n 1
+  assert_not_contains "Hello, Alice!"
+  assert_contains "Hello, Bob!"
+}

--- a/e2e/tests-dfx/logs.bash
+++ b/e2e/tests-dfx/logs.bash
@@ -47,6 +47,8 @@ dfx_canister_logs_grep_Alice() {
 }
 
 dfx_canister_logs_tail_n_1() {
+  # shellcheck disable=SC2005
+  # Extra echo is necessary to simulate file input for tail.
   echo "$(dfx canister logs e2e_project)" | tail -n 1
 }
 

--- a/src/dfx/src/commands/canister/logs.rs
+++ b/src/dfx/src/commands/canister/logs.rs
@@ -76,8 +76,6 @@ fn test_format_canister_logs() {
 }
 
 pub async fn exec(env: &dyn Environment, opts: LogsOpts, call_sender: &CallSender) -> DfxResult {
-    let log = env.get_logger();
-
     let callee_canister = opts.canister.as_str();
     let canister_id_store = env.get_canister_id_store()?;
 
@@ -88,7 +86,7 @@ pub async fn exec(env: &dyn Environment, opts: LogsOpts, call_sender: &CallSende
 
     let logs = canister::get_canister_logs(env, canister_id, call_sender).await?;
 
-    info!(log, "{}", format_canister_logs(logs).join("\n"));
+    println!("{}", format_canister_logs(logs).join("\n"));
 
     Ok(())
 }


### PR DESCRIPTION
# Description

`dfx canister logs` now outputs to stdout, rather than stderr, so that its output is `grep` and `tail` compatible.

# How Has This Been Tested?

Added corresponding tests to `e2e/tests-dfx/logs.bash`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] NO NEED in changes to the documentation.
