### PR TITLE
chore: downgrade Bitcoin Canister back to 2023-10-13 (revert #3593)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ target/
 
 # DB repo for cargo-audit
 advisory-db/
+
+# mops
+**/.mops/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ This incorporates the following executed proposals:
 - [128295](https://dashboard.internetcomputer.org/proposal/128295)
 - [128171](https://dashboard.internetcomputer.org/proposal/128171)
 
+### Bitcoin canister
+
+Downgraded Bitcoin canister to [release/2023-10-13](https://github.com/dfinity/bitcoin-canister/releases/tag/release%2F2023-10-13)
+
 # 0.18.0
 
 ### fix!: removed the `dfx upgrade` command
@@ -186,6 +190,10 @@ bump ic-cdk to 0.13.1
 Module hash: 1208093dcc5b31286a073f00f748ac6612dbae17b66c22332762705960a8aaad
 
 bump ic-cdk to 0.13.1
+
+### Bitcoin canister
+
+Updated Bitcoin canister to [release/2024-01-22](https://github.com/dfinity/bitcoin-canister/releases/tag/release%2F2024-01-22)
 
 # 0.17.0
 

--- a/e2e/assets/bitcoin/bitcoin.did
+++ b/e2e/assets/bitcoin/bitcoin.did
@@ -1,0 +1,75 @@
+type satoshi = nat64;
+type bitcoin_network = variant {
+    mainnet;
+    testnet;
+    regtest;
+};
+type bitcoin_address = text;
+type block_hash = blob;
+type outpoint = record {
+    txid : blob;
+    vout : nat32;
+};
+type utxo = record {
+    outpoint : outpoint;
+    value : satoshi;
+    height : nat32;
+};
+type bitcoin_get_utxos_args = record {
+    address : bitcoin_address;
+    network : bitcoin_network;
+    filter : opt variant {
+        min_confirmations : nat32;
+        page : blob;
+    };
+};
+type bitcoin_get_utxos_query_args = record {
+    address : bitcoin_address;
+    network : bitcoin_network;
+    filter : opt variant {
+        min_confirmations : nat32;
+        page : blob;
+    };
+};
+type bitcoin_get_current_fee_percentiles_args = record {
+    network : bitcoin_network;
+};
+type bitcoin_get_utxos_result = record {
+    utxos : vec utxo;
+    tip_block_hash : block_hash;
+    tip_height : nat32;
+    next_page : opt blob;
+};
+type bitcoin_get_utxos_query_result = record {
+    utxos : vec utxo;
+    tip_block_hash : block_hash;
+    tip_height : nat32;
+    next_page : opt blob;
+};
+type bitcoin_get_balance_args = record {
+    address : bitcoin_address;
+    network : bitcoin_network;
+    min_confirmations : opt nat32;
+};
+type bitcoin_get_balance_query_args = record {
+    address : bitcoin_address;
+    network : bitcoin_network;
+    min_confirmations : opt nat32;
+};
+type bitcoin_send_transaction_args = record {
+    transaction : blob;
+    network : bitcoin_network;
+};
+type millisatoshi_per_byte = nat64;
+type bitcoin_get_balance_result = satoshi;
+type bitcoin_get_balance_query_result = satoshi;
+type bitcoin_get_current_fee_percentiles_result = vec millisatoshi_per_byte;
+service ic : {
+    // bitcoin interface
+    bitcoin_get_balance : (bitcoin_get_balance_args) -> (bitcoin_get_balance_result);
+    bitcoin_get_balance_query : (bitcoin_get_balance_query_args) -> (bitcoin_get_balance_query_result) query;
+    bitcoin_get_utxos : (bitcoin_get_utxos_args) -> (bitcoin_get_utxos_result);
+    bitcoin_get_utxos_query : (bitcoin_get_utxos_query_args) -> (bitcoin_get_utxos_query_result) query;
+    bitcoin_send_transaction : (bitcoin_send_transaction_args) -> ();
+    bitcoin_get_current_fee_percentiles : (bitcoin_get_current_fee_percentiles_args) -> (bitcoin_get_current_fee_percentiles_result);
+};

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -163,7 +163,8 @@ set_local_network_bitcoin_enabled() {
 @test "can call bitcoin API of the management canister" {
   install_asset bitcoin
   dfx_start --enable-bitcoin
-  # the Bitcoin API can only be called by a canister not an agent
+
+  # the non-query Bitcoin API can only be called by a canister not an agent
   # we need to proxy the call through the wallet canister
   WALLET_ID=$(dfx identity get-wallet)
 
@@ -195,4 +196,26 @@ set_local_network_bitcoin_enabled() {
   # The error message indicates that the argument is in correct format, only the inner transaction is malformed.
   assert_command_fail dfx canister call --wallet "$WALLET_ID" aaaaa-aa --candid bitcoin.did bitcoin_send_transaction '(record { transaction = vec {0:nat8}; network = variant { regtest } })'
   assert_contains "send_transaction failed: MalformedTransaction"
+
+  # the query Bitcoin API can be called directly
+
+  # bitcoin_get_balance_query
+  assert_command dfx canister call --query aaaaa-aa --candid bitcoin.did bitcoin_get_balance_query '(
+  record {
+    network = variant { regtest };
+    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
+    min_confirmations = opt (1 : nat32);
+  }
+)'
+  assert_eq "(0 : nat64)"
+
+  # bitcoin_get_balance_query
+  assert_command dfx canister call --query aaaaa-aa --candid bitcoin.did bitcoin_get_utxos_query '(
+  record {
+    network = variant { regtest };
+    filter = opt variant { min_confirmations = 1 : nat32 };
+    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
+  }
+)'
+  assert_contains "tip_height = 0 : nat32;"
 }

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -152,3 +152,10 @@ set_local_network_bitcoin_enabled() {
   assert_eq '("Hello, Alpha!")'
 }
 
+
+@test "bitcoin canister has decent amount of cycles" {
+  dfx_start --enable-bitcoin
+  # The canister is created with default amount of cycles: 100T
+  cycles_balance=$( dfx --identity anonymous canister status "$BITCOIN_CANISTER_ID" 2>&1 | grep 'Balance:' | sed 's/[^0-9]//g' )
+  assert_command test "$cycles_balance" -gt 99000000000000 # 99T
+}

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -159,3 +159,40 @@ set_local_network_bitcoin_enabled() {
   cycles_balance=$( dfx --identity anonymous canister status "$BITCOIN_CANISTER_ID" 2>&1 | grep 'Balance:' | sed 's/[^0-9]//g' )
   assert_command test "$cycles_balance" -gt 99000000000000 # 99T
 }
+
+@test "can call bitcoin API of the management canister" {
+  install_asset bitcoin
+  dfx_start --enable-bitcoin
+  # the Bitcoin API can only be called by a canister not an agent
+  # we need to proxy the call through the wallet canister
+  WALLET_ID=$(dfx identity get-wallet)
+
+  # bitcoin_get_balance
+  assert_command dfx canister call --wallet "$WALLET_ID" aaaaa-aa --candid bitcoin.did bitcoin_get_balance '(
+  record {
+    network = variant { regtest };
+    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
+    min_confirmations = opt (1 : nat32);
+  }
+)'
+  assert_eq "(0 : nat64)"
+
+  # bitcoin_get_utxos
+  assert_command dfx canister call --wallet "$WALLET_ID" aaaaa-aa --candid bitcoin.did bitcoin_get_utxos '(
+  record {
+    network = variant { regtest };
+    filter = opt variant { min_confirmations = 1 : nat32 };
+    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
+  }
+)'
+  assert_contains "tip_height = 0 : nat32;"
+
+  # bitcoin_get_current_fee_percentiles
+  assert_command dfx canister call --wallet "$WALLET_ID" aaaaa-aa --candid bitcoin.did bitcoin_get_current_fee_percentiles '(record { network = variant { regtest } })'
+
+  # bitcoin_send_transaction
+  # It's hard to test this without a real transaction, but we can at least check that the call fails.
+  # The error message indicates that the argument is in correct format, only the inner transaction is malformed.
+  assert_command_fail dfx canister call --wallet "$WALLET_ID" aaaaa-aa --candid bitcoin.did bitcoin_send_transaction '(record { transaction = vec {0:nat8}; network = variant { regtest } })'
+  assert_contains "send_transaction failed: MalformedTransaction"
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -53,11 +53,11 @@
     },
     "ic-btc-canister": {
         "owner": "dfinity",
-        "sha256": "1hjc661rkb5qcsxdmags42lka994prpgcj5injvfmk741awx6c0q",
+        "sha256": "1b34jpxkk72h07ls0fspwrgmndmj7xhlivdhn82msvgz8mx69x89",
         "type": "file",
-        "url": "https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2024-01-22/ic-btc-canister.wasm.gz",
+        "url": "https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2023-10-13/ic-btc-canister.wasm.gz",
         "url_template": "https://github.com/dfinity/bitcoin-canister/releases/download/<version>/ic-btc-canister.wasm.gz",
-        "version": "release%2F2024-01-22"
+        "version": "release%2F2023-10-13"
     },
     "ic-https-outcalls-adapter-x86_64-darwin": {
         "builtin": false,

--- a/src/dfx/assets/dfx-asset-sources.toml
+++ b/src/dfx/assets/dfx-asset-sources.toml
@@ -52,8 +52,8 @@ url = 'https://github.com/dfinity/motoko/releases/download/0.11.0/motoko-base-li
 sha256 = '296130ab608a242facb9cb1249dda75e20d7a5b373f27455ac79cb45b17d0ea9'
 
 [x86_64-darwin.ic-btc-canister]
-url = 'https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2024-01-22/ic-btc-canister.wasm.gz'
-sha256 = '1830d3b90ae4cceab6b4b148f66ebe242535a920faa9daba66b8ac9983314cc2'
+url = 'https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2023-10-13/ic-btc-canister.wasm.gz'
+sha256 = '09f5647a45ff6d5d05b2b0ed48613fb2365b5fe6573ba0e901509c39fb9564ac'
 
 [x86_64-linux.icx-proxy]
 url = 'https://download.dfinity.systems/ic/69e1408347723dbaa7a6cd2faa9b65c42abbe861/openssl-static-binaries/x86_64-linux/icx-proxy-dev.gz'
@@ -106,5 +106,5 @@ url = 'https://github.com/dfinity/motoko/releases/download/0.11.0/motoko-base-li
 sha256 = '296130ab608a242facb9cb1249dda75e20d7a5b373f27455ac79cb45b17d0ea9'
 
 [x86_64-linux.ic-btc-canister]
-url = 'https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2024-01-22/ic-btc-canister.wasm.gz'
-sha256 = '1830d3b90ae4cceab6b4b148f66ebe242535a920faa9daba66b8ac9983314cc2'
+url = 'https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2023-10-13/ic-btc-canister.wasm.gz'
+sha256 = '09f5647a45ff6d5d05b2b0ed48613fb2365b5fe6573ba0e901509c39fb9564ac'

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -202,13 +202,14 @@ pub fn get_effective_canister_id(
                 Ok(in_args.target_canister)
             }
             MgmtMethod::BitcoinGetUtxosQuery | MgmtMethod::BitcoinGetBalanceQuery => {
-                #[derive(CandidType, Deserialize)]
-                struct In {
-                    network: BitcoinNetwork,
-                }
-                let in_args = Decode!(arg_value, In)
-                    .with_context(|| format!("Argument is not valid for {method_name}"))?;
-                Ok(in_args.network.effective_canister_id())
+                // #[derive(CandidType, Deserialize)]
+                // struct In {
+                //     network: BitcoinNetwork,
+                // }
+                // let in_args = Decode!(arg_value, In)
+                //     .with_context(|| format!("Argument is not valid for {method_name}"))?;
+                // Ok(in_args.network.effective_canister_id())
+                Ok(CanisterId::management_canister())
             }
         }
     } else {

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -16,7 +16,7 @@ use dfx_core::identity::CallSender;
 use fn_error_context::context;
 use ic_utils::canister::Argument;
 use ic_utils::interfaces::management_canister::builders::{CanisterInstall, CanisterSettings};
-use ic_utils::interfaces::management_canister::{BitcoinNetwork, MgmtMethod};
+use ic_utils::interfaces::management_canister::MgmtMethod;
 use ic_utils::interfaces::wallet::{CallForwarder, CallResult};
 use ic_utils::interfaces::WalletCanister;
 use slog::warn;
@@ -202,13 +202,6 @@ pub fn get_effective_canister_id(
                 Ok(in_args.target_canister)
             }
             MgmtMethod::BitcoinGetUtxosQuery | MgmtMethod::BitcoinGetBalanceQuery => {
-                // #[derive(CandidType, Deserialize)]
-                // struct In {
-                //     network: BitcoinNetwork,
-                // }
-                // let in_args = Decode!(arg_value, In)
-                //     .with_context(|| format!("Argument is not valid for {method_name}"))?;
-                // Ok(in_args.network.effective_canister_id())
                 Ok(CanisterId::management_canister())
             }
         }


### PR DESCRIPTION
Reverts dfinity/sdk#3593

Bitcoin Canister release/2024-01-22 doesn't work with application subnet. (It drains all the cycles on purpose which is fine only on the system subnet).

The bitcoin canister will be fixed in a few weeks.
Before that, we need to downgrade it to the previous version.

To detect such break in the future, I added two bitcoin.bash e2e tests:
* check if the canister has enough cycles balance.
* check if the management canister Bitcoin API can be called.
  * When testing the two query API, I found out that their effective_canister_id were set incorrectly. Fixed in this PR.
  * A `bitcoin.did` is added for the test. It was refined from the `ic.did` in the spec and added the `regtest` network variant.

Also filled the missing changelog entry in v0.18.0.