### PR TITLE
fix: dfx wallet set-name calls the wrong function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 The management canister method `fetch_canister_logs` can be called only as a query, not as an update call. Therefore, `dfx canister logs <canister_id>` now uses a query call for this purpose.
 
+### `dfx wallet set-name` now actually sets the name of the wallet
+
 ### feat: hyphenated project names
 
 DFX no longer forbids hyphens in project names. Anywhere they appear as the name of a variable, e.g. environment variables or generated JS variables, they will be replaced with underscores.

--- a/src/dfx/src/commands/wallet/set_name.rs
+++ b/src/dfx/src/commands/wallet/set_name.rs
@@ -11,7 +11,7 @@ pub struct SetNameOpts {
 }
 
 pub async fn exec(env: &dyn Environment, opts: SetNameOpts) -> DfxResult {
-    wallet_update(env, "name", opts.name.clone()).await?;
+    wallet_update(env, "set_name", opts.name.clone()).await?;
     println!("Set name to {}.", opts.name);
     Ok(())
 }


### PR DESCRIPTION
# Description

As [reported on the forum](https://forum.dfinity.org/t/wallet-set-name/28460) `dfx wallet set-name` does not work. It calls the [wrong function](https://github.com/dfinity/cycles-wallet/blob/main/wallet/src/lib.rs#L145-L154) of the cycles wallet.

# How Has This Been Tested?

Manually tested against my existing cycles wallet

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
