### PR TITLE
test: bitcoin query on the mainnet

### DIFF
--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -218,4 +218,33 @@ set_local_network_bitcoin_enabled() {
   }
 )'
   assert_contains "tip_height = 0 : nat32;"
+
+  # check if the call can be routed on the mainnet
+  # bitcoin_get_balance_query
+  assert_command dfx canister call --network ic --query aaaaa-aa --candid bitcoin.did bitcoin_get_balance_query '(
+  record {
+    network = variant { mainnet };
+    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
+  }
+)'
+  assert_command dfx canister call --network ic --query aaaaa-aa --candid bitcoin.did bitcoin_get_balance_query '(
+  record {
+    network = variant { testnet };
+    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
+  }
+)'
+
+  # bitcoin_get_balance_query
+  assert_command dfx canister call --network ic --query aaaaa-aa --candid bitcoin.did bitcoin_get_utxos_query '(
+  record {
+    network = variant { mainnet };
+    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
+  }
+)'
+  assert_command dfx canister call --network ic --query aaaaa-aa --candid bitcoin.did bitcoin_get_utxos_query '(
+  record {
+    network = variant { testnet };
+    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
+  }
+)'
 }

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -202,7 +202,29 @@ pub fn get_effective_canister_id(
                 Ok(in_args.target_canister)
             }
             MgmtMethod::BitcoinGetUtxosQuery | MgmtMethod::BitcoinGetBalanceQuery => {
-                Ok(CanisterId::management_canister())
+                #[derive(CandidType, Deserialize)]
+                enum BitcoinNetwork {
+                    #[serde(rename = "mainnet")]
+                    Mainnet,
+                    #[serde(rename = "testnet")]
+                    Testnet,
+                    #[serde(rename = "regtest")]
+                    Regtest,
+                }
+                #[derive(CandidType, Deserialize)]
+                struct In {
+                    network: BitcoinNetwork,
+                }
+                let in_args = Decode!(arg_value, In)
+                    .with_context(|| format!("Argument is not valid for {method_name}"))?;
+                match in_args.network {
+                    BitcoinNetwork::Mainnet => Ok(Principal::from_text(
+                        "ghsi2-tqaaa-aaaan-aaaca-cai"
+                    )?),
+                    BitcoinNetwork::Testnet  | BitcoinNetwork::Regtest=> Ok(Principal::from_text(
+                        "g4xu7-jiaaa-aaaan-aaaaq-cai"
+                    )?),
+                }
             }
         }
     } else {


### PR DESCRIPTION
This PR aims to check how to call `bitcoin_get_balance_query` and `bitcoin_get_utxos_query` endpoints of the management canister on the mainnet. Especially, which `effective_canister_id` should be set?

This PR consists of two steps (commits):
1. add e2e tests which make the query calls to the IC mainnet
2. change the `effective_canister_id` to be the bitcoin integration canister ID

## Fail before step 2

This is the behavior of current master branch. The `effective_canister_id` was set with `aaaaa-aa` (management canister).

The bitcoin query APIs can be called on the local replica.
But when call on the mainnet, it failed with an error message like:
> The replica returned an HTTP Error: Http Error: status 400 Bad Request, content type "text/plain; charset=utf-8", content: subnet_not_found

Sample failure: https://github.com/dfinity/sdk/actions/runs/8303898149/job/22729314022?pr=3665#step:10:251

## Succeed after step 2

The `effective_canister_id` is changed to be the bitcoin integration canister ID (varies based on the network field of the call argument, mainnet/testnet/regtest).

Now the tests succeed.

Sample: https://github.com/dfinity/sdk/actions/runs/8304227809/job/22729766367?pr=3665#step:10:23