### PR TITLE
chore: Update CI to fail rustc lints

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Rust
         run: rustup show
       - name: Run Lint
-        run: cargo clippy --verbose --tests --benches --workspace -- -D clippy::all
+        run: cargo clippy --verbose --tests --benches --workspace -- -D warnings
         env:
           RUST_BACKTRACE: 1
 

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -100,18 +100,15 @@ pub fn set_permissions(path: &Path, permissions: Permissions) -> Result<(), FsEr
         .map_err(|err| FsError::new(WritePermissionsFailed(path.to_path_buf(), err)))
 }
 
+#[cfg_attr(not(unix), allow(unused_variables))]
 pub fn set_permissions_readwrite(path: &Path) -> Result<(), FsError> {
-    let mut permissions = read_permissions(path)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
+        let mut permissions = read_permissions(path)?;
         permissions.set_mode(permissions.mode() | 0o600);
+        set_permissions(path, permissions)?;
     }
-    #[cfg(not(unix))]
-    {
-        permissions.set_readonly(false);
-    }
-    set_permissions(path, permissions)?;
     Ok(())
 }
 

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -101,13 +101,17 @@ pub fn set_permissions(path: &Path, permissions: Permissions) -> Result<(), FsEr
 }
 
 pub fn set_permissions_readwrite(path: &Path) -> Result<(), FsError> {
+    let mut permissions = read_permissions(path)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut permissions = read_permissions(path)?;
         permissions.set_mode(permissions.mode() | 0o600);
-        set_permissions(path, permissions)?;
     }
+    #[cfg(not(unix))]
+    {
+        permissions.set_readonly(false);
+    }
+    set_permissions(path, permissions)?;
     Ok(())
 }
 


### PR DESCRIPTION
`clippy::all` is the lint group that clippy enables by default. `-Dclippy::all` does not error on lints from rustc, nor on explicitly `#[warn]`ed clippy lints. The flag to error on all warnings is `-Dwarnings`.