### PR TITLE
fix(ci): audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -27,4 +27,4 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/audit@v1
+      - uses: lwshang/audit@cargo_install_locked


### PR DESCRIPTION
# Description

The audit action doesn't build `cargo-audit` with `--locked` which caused our recent audit jobs failure.

I created the [PR](https://github.com/actions-rust-lang/audit/pull/72) to fix the action.

This PR on our side prove that the fix works.

# How Has This Been Tested?

The Audit CI job should pass now.


# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
