### PR TITLE
chore: update markdown content for pass mdx v3 parser

### DIFF
--- a/docs/cli-reference/dfx-deploy.mdx
+++ b/docs/cli-reference/dfx-deploy.mdx
@@ -2,15 +2,17 @@ import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 # dfx deploy
 
-<MarkdownChipRow labels={["Reference"]} />
+<MarkdownChipRow labels={["Reference"]}/>
 
 Use the `dfx deploy` command to register, build, and deploy a dapp on the local canister execution environment, on the IC or on a specified testnet. By default, all canisters defined in the project `dfx.json` configuration file are deployed.
 
 This command simplifies the developer workflow by enabling you to run one command instead of running the following commands as separate steps:
 
-    dfx canister create --all
-    dfx build
-    dfx canister install --all
+```shell
+dfx canister create --all
+dfx build
+dfx canister install --all
+```
 
 Note that you can only run this command from within the project directory structure. For example, if your project name is `hello_world`, your current working directory must be the `hello_world` top-level project directory or one of its subdirectories.
 
@@ -71,12 +73,13 @@ dfx deploy hello_actor_class --argument '("from DFINITY")'
 ```
 
 Note that currently you must use an actor class in your Motoko dapp. In this example, the `dfx deploy` command specifies an argument to pass to the `hello_actor_class` canister. The main program for the `hello_actor_class` canister looks like this:
-
-    actor class Greet(name: Text) {
-        public query func greet() : async Text {
-            return "Hello, " # name # "!";
-        };
+```motoko
+actor class Greet(name: Text) {
+    public query func greet() : async Text {
+        return "Hello, " # name # "!";
     };
+};
+```
 
 You can use the `dfx deploy` command with the `--with-cycles` option to specify the initial balance of a canister created by your wallet. If you don’t specify a canister, the number of cycles you specify will be added to all canisters by default. To avoid this, specify a specific canister by name. For example, to add an initial balance of 8000000000000 cycles to a canister called "hello-assets", run the following command:
 

--- a/docs/cli-reference/dfx-envars.mdx
+++ b/docs/cli-reference/dfx-envars.mdx
@@ -8,9 +8,11 @@ You can configure certain properties for your SDK execution environment using en
 
 This section lists the environment variables that are currently supported with examples of how to use them. In most cases, you can set environment variables for a session by executing an command in the terminal or by adding a line similar to the following to your `.profile` file:
 
-    export DFX_NETWORK=ic
+```shell
+export DFX_NETWORK=ic
+```
 
-## CANISTER_CANDID_PATH\_{canister.name}
+## CANISTER_CANDID_PATH\_\{canister.name\}
 
 Use environment variables with the `CANISTER_CANDID_PATH` prefix to reference the path to the Candid description file for the canisters that are listed as dependencies in the `dfx.json` file for your project.
 
@@ -18,7 +20,7 @@ For example, if you have a `whoami_frontend` canister that lists `whoami` under 
 
     $PROJECT_ROOT/.dfx/local/canisters/whoami/whoami.did
 
-## CANISTER_ID\_{canister.name}
+## CANISTER_ID\_\{canister.name\}
 
 Use environment variables with the `CANISTER_ID` prefix to reference the canister identifier for each canister in the `dfx.json` file for your project. Hyphens are invalid in environment variables and are replaced by underscores.  Lowercase characters are replaced by uppercase characters.
 

--- a/docs/cli-reference/dfx-identity.mdx
+++ b/docs/cli-reference/dfx-identity.mdx
@@ -332,8 +332,10 @@ If you use more than one principal for your identity, you might have access to m
 
 For example, you might store the wallet canister identifier in an environment variable, then invoke the `dfx identity set-wallet` command to use that wallet canister for additional operations by running the following:
 
-    export WALLET_CANISTER_ID=$(dfx identity get-wallet)
-    dfx identity set-wallet --canister-name ${WALLET_CANISTER_ID} --network=https://192.168.74.4
+```shell
+export WALLET_CANISTER_ID=$(dfx identity get-wallet)
+dfx identity set-wallet --canister-name ${WALLET_CANISTER_ID} --network=https://192.168.74.4
+```
 
 ## dfx identity use
 

--- a/docs/cli-reference/dfx-ping.mdx
+++ b/docs/cli-reference/dfx-ping.mdx
@@ -2,7 +2,7 @@ import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 # dfx ping
 
-<MarkdownChipRow labels={["Reference"]} />
+<MarkdownChipRow labels={["Reference"]}/>
 
 Use the `dfx ping` command to check connectivity to the IC or a testnet. This command enables you to verify that you can connect to the environment where you want to deploy to.
 
@@ -34,6 +34,8 @@ dfx ping https://testgw.dfinity.network
 
 If the IC is running on the specified network provider address, the command returns output similar to the following:
 
-    {
-      "ic_api_version": "0.8"
-    }
+```json
+{
+  "ic_api_version": "0.8"
+}
+```


### PR DESCRIPTION
In order to update [Docusaurus to v3](https://docusaurus.io/blog/preparing-your-site-for-docusaurus-v3#preparing-content-for-mdx-v3), we must ensure the mdx files read by the portal can be parsed by version 3 of the mdx parser engine.