### PR TITLE
refactor: simplify main and DRY error handling

### DIFF
--- a/src/dfx/src/commands/mod.rs
+++ b/src/dfx/src/commands/mod.rs
@@ -83,7 +83,7 @@ pub fn exec(env: &dyn Environment, cmd: DfxCommand) -> DfxResult {
         DfxCommand::Ping(v) => ping::exec(env, v),
         DfxCommand::Quickstart(v) => quickstart::exec(env, v),
         DfxCommand::Remote(v) => remote::exec(env, v),
-        DfxCommand::Schema(v) => schema::exec(v),
+        DfxCommand::Schema(_v) => unreachable!("called through exec_without_env"),
         DfxCommand::Start(v) => start::exec(env, v),
         DfxCommand::Stop(v) => stop::exec(env, v),
         DfxCommand::Toolchain(v) => toolchain::exec(env, v),

--- a/src/dfx/src/commands/mod.rs
+++ b/src/dfx/src/commands/mod.rs
@@ -83,7 +83,7 @@ pub fn exec(env: &dyn Environment, cmd: DfxCommand) -> DfxResult {
         DfxCommand::Ping(v) => ping::exec(env, v),
         DfxCommand::Quickstart(v) => quickstart::exec(env, v),
         DfxCommand::Remote(v) => remote::exec(env, v),
-        DfxCommand::Schema(_v) => unreachable!("called through exec_without_env"),
+        DfxCommand::Schema(v) => schema::exec(v),
         DfxCommand::Start(v) => start::exec(env, v),
         DfxCommand::Stop(v) => stop::exec(env, v),
         DfxCommand::Toolchain(v) => toolchain::exec(env, v),

--- a/src/dfx/src/lib/diagnosis.rs
+++ b/src/dfx/src/lib/diagnosis.rs
@@ -1,4 +1,3 @@
-use super::environment::Environment;
 use crate::lib::error_code;
 use anyhow::Error as AnyhowError;
 use ic_agent::agent::{RejectCode, RejectResponse};
@@ -37,7 +36,7 @@ impl DiagnosedError {
 }
 
 /// Attempts to give helpful suggestions on how to resolve errors.
-pub fn diagnose(_env: &dyn Environment, err: &AnyhowError) -> Diagnosis {
+pub fn diagnose(err: &AnyhowError) -> Diagnosis {
     if let Some(diagnosed_error) = err.downcast_ref::<DiagnosedError>() {
         return (
             diagnosed_error.error_explanation.clone(),

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -140,7 +140,7 @@ fn get_args_altered_for_extension_run() -> DfxResult<Vec<OsString>> {
     Ok(args)
 }
 
-fn inner_main() -> DfxResult<()> {
+fn inner_main() -> DfxResult {
     let args = get_args_altered_for_extension_run()?;
 
     let cli_opts = CliOpts::parse_from(args);

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -1,6 +1,6 @@
 #![allow(special_module_name)]
 use crate::config::{dfx_version, dfx_version_str};
-use crate::lib::diagnosis::{diagnose, Diagnosis, NULL_DIAGNOSIS};
+use crate::lib::diagnosis::{diagnose, Diagnosis};
 use crate::lib::environment::{Environment, EnvironmentImpl};
 use crate::lib::error::DfxResult;
 use crate::lib::logger::{create_root_logger, LoggingMode};
@@ -140,44 +140,36 @@ fn get_args_altered_for_extension_run() -> DfxResult<Vec<OsString>> {
     Ok(args)
 }
 
-fn main() {
-    let args = get_args_altered_for_extension_run().unwrap_or_else(|err| {
-        print_error_and_diagnosis(err, NULL_DIAGNOSIS);
-        std::process::exit(255);
-    });
-
-    let mut error_diagnosis: Diagnosis = NULL_DIAGNOSIS;
+fn inner_main() -> DfxResult<()> {
+    let args = get_args_altered_for_extension_run()?;
 
     let cli_opts = CliOpts::parse_from(args);
+
+    if matches!(cli_opts.command, commands::DfxCommand::Schema(_)) {
+        return commands::exec_without_env(cli_opts.command);
+    }
+
     let (verbose_level, log) = setup_logging(&cli_opts);
     let identity = cli_opts.identity;
     let effective_canister_id = cli_opts.provisional_create_canister_effective_canister_id;
-    let command = cli_opts.command;
-    let result = match EnvironmentImpl::new().map(|env| {
-        env.with_logger(log)
-            .with_identity_override(identity)
-            .with_verbose_level(verbose_level)
-            .with_effective_canister_id(effective_canister_id)
-    }) {
-        Ok(env) => {
-            slog::trace!(
-                env.get_logger(),
-                "Trace mode enabled. Lots of logs coming up."
-            );
-            match commands::exec(&env, command) {
-                Err(e) => {
-                    error_diagnosis = diagnose(&env, &e);
-                    Err(e)
-                }
-                ok => ok,
-            }
-        }
-        Err(e) => match command {
-            commands::DfxCommand::Schema(_) => commands::exec_without_env(command),
-            _ => Err(e),
-        },
-    };
+
+    let env = EnvironmentImpl::new()?
+        .with_logger(log)
+        .with_identity_override(identity)
+        .with_verbose_level(verbose_level)
+        .with_effective_canister_id(effective_canister_id);
+
+    slog::trace!(
+        env.get_logger(),
+        "Trace mode enabled. Lots of logs coming up."
+    );
+    commands::exec(&env, cli_opts.command)
+}
+
+fn main() {
+    let result = inner_main();
     if let Err(err) = result {
+        let error_diagnosis = diagnose(&err);
         print_error_and_diagnosis(err, error_diagnosis);
         std::process::exit(255);
     }


### PR DESCRIPTION
# Description

DRY error handling and simplify dfx's main function.

This supports upcoming work for extension-defined canister types, which will need the ExtensionManager when constructing the Environment.

# How Has This Been Tested?

Covered by e2e, in particular the test that `dfx schema` works even without a valid dfx.json
