### PR TITLE
refactor: instantiate extension manager once

### DIFF
--- a/src/dfx/src/commands/extension/install.rs
+++ b/src/dfx/src/commands/extension/install.rs
@@ -24,7 +24,7 @@ pub fn exec(env: &dyn Environment, opts: InstallOpts) -> DfxResult<()> {
     // cause the cache to be considered "installed" and later commands would fail
     DiskBasedCache::install(&env.get_cache().version_str())?;
     let spinner = env.new_spinner(format!("Installing extension: {}", opts.name).into());
-    let mgr = env.new_extension_manager()?;
+    let mgr = env.get_extension_manager();
     let effective_extension_name = opts.install_as.clone().unwrap_or_else(|| opts.name.clone());
     if DfxCommand::has_subcommand(&effective_extension_name) {
         return Err(ExtensionError::CommandAlreadyExists(opts.name).into());

--- a/src/dfx/src/commands/extension/list.rs
+++ b/src/dfx/src/commands/extension/list.rs
@@ -3,7 +3,7 @@ use crate::lib::error::DfxResult;
 use std::io::Write;
 
 pub fn exec(env: &dyn Environment) -> DfxResult<()> {
-    let mgr = env.new_extension_manager()?;
+    let mgr = env.get_extension_manager();
     let extensions = mgr.list_installed_extensions()?;
 
     if extensions.is_empty() {

--- a/src/dfx/src/commands/extension/run.rs
+++ b/src/dfx/src/commands/extension/run.rs
@@ -23,7 +23,7 @@ impl From<Vec<OsString>> for RunOpts {
 }
 
 pub fn exec(env: &dyn Environment, opts: RunOpts) -> DfxResult<()> {
-    let mgr = env.new_extension_manager()?;
+    let mgr = env.get_extension_manager();
     mgr.run_extension(opts.name, opts.params)?;
     Ok(())
 }

--- a/src/dfx/src/commands/extension/uninstall.rs
+++ b/src/dfx/src/commands/extension/uninstall.rs
@@ -9,7 +9,7 @@ pub struct UninstallOpts {
 }
 
 pub fn exec(env: &dyn Environment, opts: UninstallOpts) -> DfxResult<()> {
-    let mgr = env.new_extension_manager()?;
+    let mgr = env.get_extension_manager();
     mgr.uninstall_extension(&opts.name)?;
     Ok(())
 }

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -120,9 +120,8 @@ fn print_error_and_diagnosis(err: Error, error_diagnosis: Diagnosis) {
     }
 }
 
-fn get_args_altered_for_extension_run() -> DfxResult<Vec<OsString>> {
+fn get_args_altered_for_extension_run(em: &ExtensionManager) -> DfxResult<Vec<OsString>> {
     let mut args = std::env::args_os().collect::<Vec<OsString>>();
-    let em = ExtensionManager::new(dfx_version())?;
 
     let installed_extensions = em.installed_extensions_as_clap_commands()?;
     if !installed_extensions.is_empty() {
@@ -141,7 +140,9 @@ fn get_args_altered_for_extension_run() -> DfxResult<Vec<OsString>> {
 }
 
 fn inner_main() -> DfxResult {
-    let args = get_args_altered_for_extension_run()?;
+    let em = ExtensionManager::new(dfx_version())?;
+
+    let args = get_args_altered_for_extension_run(&em)?;
 
     let cli_opts = CliOpts::parse_from(args);
 
@@ -153,7 +154,7 @@ fn inner_main() -> DfxResult {
     let identity = cli_opts.identity;
     let effective_canister_id = cli_opts.provisional_create_canister_effective_canister_id;
 
-    let env = EnvironmentImpl::new()?
+    let env = EnvironmentImpl::new(em)?
         .with_logger(log)
         .with_identity_override(identity)
         .with_verbose_level(verbose_level)


### PR DESCRIPTION
Since instantiating the ExtensionManager is literally the first thing to happen, keep it around.  We will also soon need it when loading the configuration.
