### PR TITLE
chore: update h2 dependency in order to pass cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -2456,7 +2456,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",


### PR DESCRIPTION
See failed workflow run: https://github.com/dfinity/sdk/actions/runs/8546427855?pr=3694

https://rustsec.org/advisories/RUSTSEC-2024-0332.html
