### PR TITLE
fix: dfx only creates .dfx directory if it's going to access it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ In bash:
 source <(dfx completion)
 ```
 
+### fix: dfx no longer always creates .dfx directory if dfx.json is present
+
+Previously, `dfx` would always create a `.dfx` directory in the project root if `dfx.json` was present.
+Now, it only does so if the command accesses the .dfx directory in some way.
+
 # 0.19.0
 
 ### fix: call management canister Bitcoin query API without replica-signed query

--- a/e2e/tests-dfx/usage.bash
+++ b/e2e/tests-dfx/usage.bash
@@ -37,3 +37,9 @@ teardown() {
   dfx canister create --all
   assert_command dfx build
 }
+
+@test "does not create .dfx just by running dfx even if in a project" {
+  echo "{}" >dfx.json
+  dfx identity get-principal
+  assert_directory_not_exists .dfx
+}

--- a/src/dfx-core/src/config/model/canister_id_store.rs
+++ b/src/dfx-core/src/config/model/canister_id_store.rs
@@ -120,7 +120,7 @@ impl CanisterIdStore {
             NetworkDescriptor { name, .. } => match &config {
                 None => None,
                 Some(config) => {
-                    let dir = config.get_temp_path().join(name);
+                    let dir = config.get_temp_path()?.join(name);
                     ensure_cohesive_network_directory(network_descriptor, &dir).map_err(|e| {
                         CanisterIdStoreError::EnsureCohesiveNetworkDirectoryFailed {
                             network: network_descriptor.name.clone(),
@@ -138,7 +138,7 @@ impl CanisterIdStore {
                 ..
             } => {
                 if let Some(config) = config.as_ref() {
-                    let dir = config.get_temp_path().join(name);
+                    let dir = config.get_temp_path()?.join(name);
                     ensure_cohesive_network_directory(network_descriptor, &dir)?;
                     Some(dir.join("canister_timestamps.json"))
                 } else {

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -3,7 +3,7 @@
 use crate::config::directories::get_user_dfx_config_dir;
 use crate::config::model::bitcoin_adapter::BitcoinAdapterLogLevel;
 use crate::config::model::canister_http_adapter::HttpAdapterLogLevel;
-use crate::error::config::GetOutputEnvFileError;
+use crate::error::config::{GetOutputEnvFileError, GetTempPathError};
 use crate::error::dfx_config::AddDependenciesError::CanisterCircularDependency;
 use crate::error::dfx_config::GetCanisterNamesWithDependenciesError::AddDependenciesFailed;
 use crate::error::dfx_config::GetComputeAllocationError::GetComputeAllocationFailed;
@@ -35,6 +35,7 @@ use crate::error::structured_file::StructuredFileError;
 use crate::error::structured_file::StructuredFileError::{
     DeserializeJsonFileFailed, ReadJsonFileFailed,
 };
+use crate::fs::create_dir_all;
 use crate::json::save_json_file;
 use crate::json::structure::{PossiblyStr, SerdeVec};
 use byte_unit::Byte;
@@ -1040,8 +1041,10 @@ impl Config {
     pub fn get_path(&self) -> &PathBuf {
         &self.path
     }
-    pub fn get_temp_path(&self) -> PathBuf {
-        self.get_path().parent().unwrap().join(".dfx")
+    pub fn get_temp_path(&self) -> Result<PathBuf, GetTempPathError> {
+        let path = self.get_path().parent().unwrap().join(".dfx");
+        create_dir_all(&path)?;
+        Ok(path)
     }
     pub fn get_json(&self) -> &Value {
         &self.json

--- a/src/dfx-core/src/error/canister_id_store.rs
+++ b/src/dfx-core/src/error/canister_id_store.rs
@@ -1,6 +1,6 @@
 use crate::error::{
-    dfx_config::GetPullCanistersError, fs::FsError, structured_file::StructuredFileError,
-    unified_io::UnifiedIoError,
+    config::GetTempPathError, dfx_config::GetPullCanistersError, fs::FsError,
+    structured_file::StructuredFileError, unified_io::UnifiedIoError,
 };
 use thiserror::Error;
 
@@ -38,6 +38,9 @@ pub enum CanisterIdStoreError {
 
     #[error(transparent)]
     GetPullCanistersFailed(#[from] GetPullCanistersError),
+
+    #[error(transparent)]
+    GetTempPath(#[from] GetTempPathError),
 }
 
 impl From<FsError> for CanisterIdStoreError {

--- a/src/dfx-core/src/error/config.rs
+++ b/src/dfx-core/src/error/config.rs
@@ -29,3 +29,9 @@ pub enum GetOutputEnvFileError {
     #[error(transparent)]
     Parent(FsError),
 }
+
+#[derive(Error, Debug)]
+pub enum GetTempPathError {
+    #[error(transparent)]
+    CreateDirAll(#[from] FsError),
+}

--- a/src/dfx-core/src/error/network_config.rs
+++ b/src/dfx-core/src/error/network_config.rs
@@ -1,4 +1,4 @@
-use crate::error::config::ConfigError;
+use crate::error::config::{ConfigError, GetTempPathError};
 use crate::error::fs::FsError;
 use crate::error::socket_addr_conversion::SocketAddrConversionError;
 use crate::error::uri::UriError;
@@ -24,6 +24,9 @@ pub enum NetworkConfigError {
         network_name: String,
         cause: UriError,
     },
+
+    #[error(transparent)]
+    GetTempPath(#[from] GetTempPathError),
 
     #[error("Network '{0}' does not specify any network providers.")]
     NetworkHasNoProviders(String),

--- a/src/dfx-core/src/network/provider.rs
+++ b/src/dfx-core/src/network/provider.rs
@@ -355,12 +355,15 @@ fn create_project_network_descriptor(
                 config.get_path().display(),
             );
 
-            let data_directory = config.get_temp_path().join("network").join(network_name);
-            let legacy_pid_path = Some(config.get_temp_path().join("pid"));
-            let ephemeral_wallet_config_path = config
-                .get_temp_path()
-                .join("local")
-                .join(WALLET_CONFIG_FILENAME);
+            let temp_path = match config.get_temp_path() {
+                Ok(temp_path) => temp_path,
+                Err(e) => {
+                    return Some(Err(NetworkConfigError::GetTempPath(e)));
+                }
+            };
+            let data_directory = temp_path.join("network").join(network_name);
+            let legacy_pid_path = Some(temp_path.join("pid"));
+            let ephemeral_wallet_config_path = temp_path.join("local").join(WALLET_CONFIG_FILENAME);
             Some(config_network_to_network_descriptor(
                 network_name,
                 config_network,

--- a/src/dfx/src/commands/identity/rename.rs
+++ b/src/dfx/src/commands/identity/rename.rs
@@ -22,7 +22,7 @@ pub fn exec(env: &dyn Environment, opts: RenameOpts) -> DfxResult {
     let log = env.get_logger();
 
     let mut identity_manager = env.new_identity_manager()?;
-    let result = identity_manager.rename(log, env.get_project_temp_dir(), from, to);
+    let result = identity_manager.rename(log, env.get_project_temp_dir()?, from, to);
     if let Err(SwitchDefaultIdentitySettingsFailed(_)) = result {
         bail!("Failed to switch over default identity settings.  Please do this manually by running 'dfx identity use {}'", to);
     }

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -189,7 +189,7 @@ pub fn exec(
     // As we know no start process is running in this project, we can
     // clean up the state if it is necessary.
     if clean {
-        clean_state(local_server_descriptor, env.get_project_temp_dir())?;
+        clean_state(local_server_descriptor, env.get_project_temp_dir()?)?;
     }
 
     let (frontend_url, address_and_port) = frontend_address(local_server_descriptor, background)?;

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -470,7 +470,7 @@ impl BuildConfig {
     pub fn from_config(config: &Config, network_is_playground: bool) -> DfxResult<Self> {
         let config_intf = config.get_config();
         let network_name = util::network_to_pathcompat(&get_network_context()?);
-        let network_root = config.get_temp_path().join(&network_name);
+        let network_root = config.get_temp_path()?.join(&network_name);
         let canister_root = network_root.join("canisters");
 
         Ok(BuildConfig {

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -72,7 +72,7 @@ impl CanisterInfo {
         let build_defaults = config.get_config().get_defaults().get_build();
         let network_name = get_network_context()?;
         let build_root = config
-            .get_temp_path()
+            .get_temp_path()?
             .join(util::network_to_pathcompat(&network_name))
             .join("canisters");
         std::fs::create_dir_all(&build_root)


### PR DESCRIPTION
# Description

Make it so Environment::new doesn't create the .dfx directory; instead, create it when calling Config.get_temp_path().
The main motivation is to make it so Environment::new doesn't have to instantiate the Config at all, which is in turn in order to make it so dfx only loads dfx.json if it will use it.

Prep work for https://dfinity.atlassian.net/browse/SDK-1559

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
