### PR TITLE
fix: dfx only loads dfx.json for commands that need it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ source <(dfx completion)
 Previously, `dfx` would always create a `.dfx` directory in the project root if `dfx.json` was present.
 Now, it only does so if the command accesses the .dfx directory in some way.
 
+### fix: dfx only loads dfx.json for commands that need it
+
+For example, this will work now:
+```bash
+echo garbage >dfx.json && dfx identity get-principal
+```
+
 # 0.19.0
 
 ### fix: call management canister Bitcoin query API without replica-signed query

--- a/e2e/tests-dfx/usage.bash
+++ b/e2e/tests-dfx/usage.bash
@@ -46,5 +46,5 @@ teardown() {
 
 @test "does not unconditionally read dfx.json" {
   echo "garbage" >dfx.json
-  dfx identity get-principal
+  assert_command dfx identity get-principal
 }

--- a/e2e/tests-dfx/usage.bash
+++ b/e2e/tests-dfx/usage.bash
@@ -43,3 +43,8 @@ teardown() {
   dfx identity get-principal
   assert_directory_not_exists .dfx
 }
+
+@test "does not unconditionally read dfx.json" {
+  echo "garbage" >dfx.json
+  dfx identity get-principal
+}

--- a/src/dfx-core/src/error/canister_id_store.rs
+++ b/src/dfx-core/src/error/canister_id_store.rs
@@ -1,5 +1,6 @@
 use crate::error::{
-    config::GetTempPathError, dfx_config::GetPullCanistersError, fs::FsError,
+    config::GetTempPathError,
+    dfx_config::GetPullCanistersError, fs::FsError, load_dfx_config::LoadDfxConfigError,
     structured_file::StructuredFileError, unified_io::UnifiedIoError,
 };
 use thiserror::Error;
@@ -41,6 +42,9 @@ pub enum CanisterIdStoreError {
 
     #[error(transparent)]
     GetTempPath(#[from] GetTempPathError),
+
+    #[error(transparent)]
+    LoadDfxConfig(#[from] LoadDfxConfigError),
 }
 
 impl From<FsError> for CanisterIdStoreError {

--- a/src/dfx-core/src/error/canister_id_store.rs
+++ b/src/dfx-core/src/error/canister_id_store.rs
@@ -1,7 +1,7 @@
 use crate::error::{
-    config::GetTempPathError,
-    dfx_config::GetPullCanistersError, fs::FsError, load_dfx_config::LoadDfxConfigError,
-    structured_file::StructuredFileError, unified_io::UnifiedIoError,
+    config::GetTempPathError, dfx_config::GetPullCanistersError, fs::FsError,
+    load_dfx_config::LoadDfxConfigError, structured_file::StructuredFileError,
+    unified_io::UnifiedIoError,
 };
 use thiserror::Error;
 

--- a/src/dfx/src/commands/canister/id.rs
+++ b/src/dfx/src/commands/canister/id.rs
@@ -19,14 +19,14 @@ pub struct CanisterIdOpts {
 pub async fn exec(env: &dyn Environment, opts: CanisterIdOpts) -> DfxResult {
     env.get_config_or_anyhow()?;
     let network_descriptor = create_network_descriptor(
-        env.get_config(),
+        env.get_config()?,
         env.get_networks_config(),
         opts.network.to_network_name(),
         None,
         LocalBindDetermination::AsConfigured,
     )?;
     let canister_id_store =
-        CanisterIdStore::new(env.get_logger(), &network_descriptor, env.get_config())?;
+        CanisterIdStore::new(env.get_logger(), &network_descriptor, env.get_config()?)?;
 
     let canister_name = opts.canister.as_str();
     let canister_id =

--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -122,7 +122,7 @@ pub async fn exec(
     let canister_id_store = env.get_canister_id_store()?;
 
     if let Some(canister_name_or_id) = opts.canister.as_deref() {
-        let config = env.get_config();
+        let config = env.get_config()?;
         let config_interface = config.as_ref().map(|config| config.get_config());
         let mut controllers = controllers;
         let canister_id = CanisterId::from_text(canister_name_or_id)

--- a/src/dfx/src/commands/info/replica_port.rs
+++ b/src/dfx/src/commands/info/replica_port.rs
@@ -5,7 +5,7 @@ use dfx_core::network::provider::{create_network_descriptor, LocalBindDeterminat
 
 pub(crate) fn get_replica_port(env: &dyn Environment) -> DfxResult<String> {
     let network_descriptor = create_network_descriptor(
-        env.get_config(),
+        env.get_config()?,
         env.get_networks_config(),
         None,
         None,

--- a/src/dfx/src/commands/info/webserver_port.rs
+++ b/src/dfx/src/commands/info/webserver_port.rs
@@ -4,7 +4,7 @@ use dfx_core::network::provider::{create_network_descriptor, LocalBindDeterminat
 
 pub(crate) fn get_webserver_port(env: &dyn Environment) -> DfxResult<String> {
     let port = create_network_descriptor(
-        env.get_config(),
+        env.get_config()?,
         env.get_networks_config(),
         None,
         None,

--- a/src/dfx/src/commands/language_service.rs
+++ b/src/dfx/src/commands/language_service.rs
@@ -39,7 +39,7 @@ pub fn exec(env: &dyn Environment, opts: LanguageServiceOpts) -> DfxResult {
     // Are we being run from a terminal? That's most likely not what we want
     if stdout().is_terminal() && !force_tty {
         Err(anyhow!("The `_language-service` command is meant to be run by editors to start a language service. You probably don't want to run it from a terminal.\nIf you _really_ want to, you can pass the --force-tty flag."))
-    } else if let Some(config) = env.get_config() {
+    } else if let Some(config) = env.get_config()? {
         let main_path = get_main_path(config.get_config(), opts.canister)?;
         let packtool = &config
             .get_config()
@@ -54,14 +54,14 @@ pub fn exec(env: &dyn Environment, opts: LanguageServiceOpts) -> DfxResult {
             .get_config()
             .get_canister_names_with_dependencies(None)?;
         let network_descriptor = create_network_descriptor(
-            env.get_config(),
+            env.get_config()?,
             env.get_networks_config(),
             None,
             None,
             LocalBindDetermination::ApplyRunningWebserverPort,
         )?;
         let canister_id_store =
-            CanisterIdStore::new(env.get_logger(), &network_descriptor, env.get_config())?;
+            CanisterIdStore::new(env.get_logger(), &network_descriptor, env.get_config()?)?;
         for canister_name in canister_names {
             match canister_id_store.get(&canister_name) {
                 Ok(canister_id) => package_arguments.append(&mut vec![

--- a/src/dfx/src/commands/ping.rs
+++ b/src/dfx/src/commands/ping.rs
@@ -30,7 +30,7 @@ pub fn exec(env: &dyn Environment, opts: PingOpts) -> DfxResult {
     // For ping, "provider" could either be a URL or a network name.
     // If not passed, we default to the "local" network.
     let agent_url = create_network_descriptor(
-        env.get_config(),
+        env.get_config()?,
         env.get_networks_config(),
         opts.network,
         None,

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -155,7 +155,7 @@ pub fn exec(
             dfx_version_str()
         );
     }
-    let project_config = env.get_config();
+    let project_config = env.get_config()?;
 
     let network_descriptor_logger = if background {
         None // so we don't print it out twice

--- a/src/dfx/src/commands/stop.rs
+++ b/src/dfx/src/commands/stop.rs
@@ -57,7 +57,7 @@ fn wait_until_all_exited(mut system: System, mut pids: Vec<Pid>) -> DfxResult {
 
 pub fn exec(env: &dyn Environment, _opts: StopOpts) -> DfxResult {
     let network_descriptor = create_network_descriptor(
-        env.get_config(),
+        env.get_config()?,
         env.get_networks_config(),
         None,
         Some(env.get_logger().clone()),

--- a/src/dfx/src/lib/agent.rs
+++ b/src/dfx/src/lib/agent.rs
@@ -13,7 +13,7 @@ pub fn create_agent_environment<'a>(
     network: Option<String>,
 ) -> DfxResult<AgentEnvironment<'a>> {
     let network_descriptor = create_network_descriptor(
-        env.get_config(),
+        env.get_config()?,
         env.get_networks_config(),
         network,
         None,
@@ -28,7 +28,7 @@ pub fn create_anonymous_agent_environment<'a>(
     network: Option<String>,
 ) -> DfxResult<AgentEnvironment<'a>> {
     let network_descriptor = create_network_descriptor(
-        env.get_config(),
+        env.get_config()?,
         env.get_networks_config(),
         network,
         None,

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -434,7 +434,7 @@ impl CanisterPool {
     ) -> DfxResult<Self> {
         let logger = env.get_logger().new(slog::o!());
         let config = env
-            .get_config()
+            .get_config()?
             .ok_or_else(|| anyhow!("Cannot find dfx configuration file in the current working directory. Did you forget to create one?"))?;
 
         let mut canisters_map = Vec::new();

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -61,7 +61,7 @@ pub async fn deploy_canisters(
     let log = env.get_logger();
 
     let config = env
-        .get_config()
+        .get_config()?
         .ok_or_else(|| anyhow!("Cannot find dfx configuration file in the current working directory. Did you forget to create one?"))?;
     let initial_canister_id_store = env.get_canister_id_store()?;
 

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -256,7 +256,7 @@ The command line value will be used.",
         post_install_store_assets(canister_info, agent, log).await?;
     }
     if !canister_info.get_post_install().is_empty() {
-        let config = env.get_config();
+        let config = env.get_config()?;
         run_post_install_tasks(
             env,
             canister_info,


### PR DESCRIPTION
# Description

For example, this will work now:
```bash
echo garbage >dfx.json && dfx identity get-principal
```

This is meant to support reloading the config file in the future, which is why it uses RefCell and not OnceCell.

Fixes https://dfinity.atlassian.net/browse/SDK-1559

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
