### PR TITLE
chore: upgrade agent-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "ic-agent"
 version = "0.34.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=d76eb9869e981599eade1aafbbfad89048a1dc97#d76eb9869e981599eade1aafbbfad89048a1dc97"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=7840c34933fc509f443c3045c1c634201ad87e07#7840c34933fc509f443c3045c1c634201ad87e07"
 dependencies = [
  "backoff",
  "cached 0.46.1",
@@ -2941,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "ic-identity-hsm"
 version = "0.34.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=d76eb9869e981599eade1aafbbfad89048a1dc97#d76eb9869e981599eade1aafbbfad89048a1dc97"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=7840c34933fc509f443c3045c1c634201ad87e07#7840c34933fc509f443c3045c1c634201ad87e07"
 dependencies = [
  "hex",
  "ic-agent",
@@ -3041,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "ic-transport-types"
 version = "0.34.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=d76eb9869e981599eade1aafbbfad89048a1dc97#d76eb9869e981599eade1aafbbfad89048a1dc97"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=7840c34933fc509f443c3045c1c634201ad87e07#7840c34933fc509f443c3045c1c634201ad87e07"
 dependencies = [
  "candid",
  "hex",
@@ -3110,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.34.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=d76eb9869e981599eade1aafbbfad89048a1dc97#d76eb9869e981599eade1aafbbfad89048a1dc97"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=7840c34933fc509f443c3045c1c634201ad87e07#7840c34933fc509f443c3045c1c634201ad87e07"
 dependencies = [
  "async-trait",
  "candid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "ic-agent"
 version = "0.34.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=c3b7ad562f5d3baaead08e6439fd74018afb7e43#c3b7ad562f5d3baaead08e6439fd74018afb7e43"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=d76eb9869e981599eade1aafbbfad89048a1dc97#d76eb9869e981599eade1aafbbfad89048a1dc97"
 dependencies = [
  "backoff",
  "cached 0.46.1",
@@ -2941,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "ic-identity-hsm"
 version = "0.34.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=c3b7ad562f5d3baaead08e6439fd74018afb7e43#c3b7ad562f5d3baaead08e6439fd74018afb7e43"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=d76eb9869e981599eade1aafbbfad89048a1dc97#d76eb9869e981599eade1aafbbfad89048a1dc97"
 dependencies = [
  "hex",
  "ic-agent",
@@ -3041,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "ic-transport-types"
 version = "0.34.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=c3b7ad562f5d3baaead08e6439fd74018afb7e43#c3b7ad562f5d3baaead08e6439fd74018afb7e43"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=d76eb9869e981599eade1aafbbfad89048a1dc97#d76eb9869e981599eade1aafbbfad89048a1dc97"
 dependencies = [
  "candid",
  "hex",
@@ -3110,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.34.0"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=c3b7ad562f5d3baaead08e6439fd74018afb7e43#c3b7ad562f5d3baaead08e6439fd74018afb7e43"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=d76eb9869e981599eade1aafbbfad89048a1dc97#d76eb9869e981599eade1aafbbfad89048a1dc97"
 dependencies = [
  "async-trait",
  "candid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ license = "Apache-2.0"
 [workspace.dependencies]
 candid = "0.10.4"
 candid_parser = "0.1.4"
-ic-agent = { git = "https://github.com/dfinity/agent-rs.git", rev = "d76eb9869e981599eade1aafbbfad89048a1dc97" }
+ic-agent = { git = "https://github.com/dfinity/agent-rs.git", rev = "7840c34933fc509f443c3045c1c634201ad87e07" }
 ic-asset = { path = "src/canisters/frontend/ic-asset" }
 ic-cdk = "0.13.1"
-ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs.git", rev = "d76eb9869e981599eade1aafbbfad89048a1dc97" }
-ic-utils = { git = "https://github.com/dfinity/agent-rs.git", rev = "d76eb9869e981599eade1aafbbfad89048a1dc97" }
+ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs.git", rev = "7840c34933fc509f443c3045c1c634201ad87e07" }
+ic-utils = { git = "https://github.com/dfinity/agent-rs.git", rev = "7840c34933fc509f443c3045c1c634201ad87e07" }
 
 aes-gcm = "0.10.3"
 anyhow = "1.0.56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ license = "Apache-2.0"
 [workspace.dependencies]
 candid = "0.10.4"
 candid_parser = "0.1.4"
-ic-agent = { git = "https://github.com/dfinity/agent-rs.git", rev = "c3b7ad562f5d3baaead08e6439fd74018afb7e43" }
+ic-agent = { git = "https://github.com/dfinity/agent-rs.git", rev = "d76eb9869e981599eade1aafbbfad89048a1dc97" }
 ic-asset = { path = "src/canisters/frontend/ic-asset" }
 ic-cdk = "0.13.1"
-ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs.git", rev = "c3b7ad562f5d3baaead08e6439fd74018afb7e43" }
-ic-utils = { git = "https://github.com/dfinity/agent-rs.git", rev = "c3b7ad562f5d3baaead08e6439fd74018afb7e43" }
+ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs.git", rev = "d76eb9869e981599eade1aafbbfad89048a1dc97" }
+ic-utils = { git = "https://github.com/dfinity/agent-rs.git", rev = "d76eb9869e981599eade1aafbbfad89048a1dc97" }
 
 aes-gcm = "0.10.3"
 anyhow = "1.0.56"


### PR DESCRIPTION
SDK-1539

# Description

In agent-rs, we modified the types of the chunk store API to conform the specification.

Upgrading agent-rs dependencies changes the underlying call to the chunk store API when install large wasm.

There is no user visible changes in dfx.

# How Has This Been Tested?

The existing "can install >2MiB wasm" test in install.bash.

It also verifies the correctness of the [agent-rs PR](https://github.com/dfinity/agent-rs/pull/545).

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
