### PR TITLE
fix: skip serializing tech_stack null categories

### DIFF
--- a/e2e/tests-dfx/metadata.bash
+++ b/e2e/tests-dfx/metadata.bash
@@ -212,6 +212,8 @@ teardown() {
   assert_command dfx deploy b
   assert_command dfx canister metadata b dfx
   echo "$stdout" > b.json
+  assert_command jq -r '.tech_stack | keys[]' b.json
+  assert_eq "cdk" # only cdk is defined
   assert_command jq -r '.tech_stack.cdk | keys[]' b.json
   assert_eq "ic-cdk"
 

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -200,14 +200,19 @@ pub type TechStackCategoryMap = HashMap<String, HashMap<String, String>>;
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct TechStack {
     /// # cdk
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cdk: Option<TechStackCategoryMap>,
     /// # language
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<TechStackCategoryMap>,
     /// # lib
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lib: Option<TechStackCategoryMap>,
     /// # tool
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool: Option<TechStackCategoryMap>,
     /// # other
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub other: Option<TechStackCategoryMap>,
 }
 


### PR DESCRIPTION
# Description

When a canister defines not all 5 tech_stack categories, the generated metadata JSON contained the undefined categories as null object. For example:

```json
{
    "tech_stack": {
        "cdk": {
            "ic-cdk": {
                "version": "0.13.2"
            }
        },
        "language": null,
        "lib": null,
        "tool": null,
        "other": null
    }
}
```

This PR skip serializing such fields when they are None.

```json
{
    "tech_stack": {
        "cdk": {
            "ic-cdk": {
                "version": "0.13.2"
            }
        }
    }
}
```


# How Has This Been Tested?

In the metadat.bash e2e test, added a check:

```bash
assert_command jq -r '.tech_stack | keys[]' b.json
assert_eq "cdk" # only cdk is defined
```

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
