### PR TITLE
[WIP] feat: rebuild only necessary canisters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # UNRELEASED
 
+### feat: rebuild only necessary canisters
+
+Don't compile canisters for which all dependencies are elder than the `.wasm` file.
+This results in big compilation speedups.
+
 ### feat: display schema for dfx metadata json
 
 `dfx schema --for dfx-metadata` to display JSON schema of the "dfx" metadata.

--- a/docs/cli-reference/dfx-build.mdx
+++ b/docs/cli-reference/dfx-build.mdx
@@ -10,6 +10,8 @@ Note that you can only run this command from within the project directory struct
 
 The `dfx build` command looks for the source code to compile using the information you have configured under the `canisters` section in the `dfx.json` configuration file.
 
+For compilation speed reasons, `dfx build` (and `dfx deploy`) don't recompile canisters, all dependencies of which are elder than the existing WebAssembly (from the previous compilation).
+
 ## Basic usage
 
 ``` bash

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -19,7 +19,6 @@ use slog::{info, o, trace, warn, Logger};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::fmt::Debug;
-use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::process::Output;
 use std::sync::Arc;

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -219,7 +219,6 @@ impl CanisterBuilder for MotokoBuilder {
                                 Some(Path::new(path2).to_owned())
                             } else {
                                 let path3 = pre_path.join(Path::new("lib.mo"));
-                                println!("path3: {}", &path3.to_string_lossy()); // FIXME
                                 if path3.exists() {
                                     Some(path3.to_owned())
                                 } else {

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -165,8 +165,10 @@ impl CanisterBuilder for MotokoBuilder {
                     MotokoImport::Canister(canisterName) => {
                         if let Some(canister) = pool.get_first_canister_with_name(canisterName) {
                             let canister = canister.clone(); // TODO: remove?
-                            if let Some(main_file) = *canister.get_info().get_main_file() {
-                                Some(main_file.clone())
+                            let main_file = canister.get_info().get_main_file().clone();
+                            if let Some(main_file) = main_file.clone() {
+                                let main_file = main_file.to_owned();
+                                Some(main_file)
                             } else {
                                 None
                             }
@@ -178,7 +180,7 @@ impl CanisterBuilder for MotokoBuilder {
                         if let Some(canisterName) = rev_id_map.get(canisterId) {
                             if let Some(canister) = pool.get_first_canister_with_name(canisterName) {
                                 if let Some(main_file) = canister.get_info().get_main_file() {
-                                    Some(main_file)
+                                    Some(main_file.to_owned())
                                 } else {
                                     None
                                 }
@@ -191,14 +193,14 @@ impl CanisterBuilder for MotokoBuilder {
                     }
                     MotokoImport::Lib(path) => {
                         // FIXME: `lib` in name
-                        Some(Path::new(path))
+                        Some(Path::new(path).to_owned())
                     }
                     MotokoImport::Relative(path) => {
-                        Some(Path::new(path))
+                        Some(Path::new(path).to_owned())
                     }
                 };
                 if let Some(imported_file) = imported_file {
-                    let imported_file_metadata = metadata(imported_file)?;
+                    let imported_file_metadata = metadata(imported_file.as_ref())?;
                     let imported_file_time = imported_file_metadata.modified()?;
                     if imported_file_time > wasm_file_time {
                         break;

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -164,11 +164,9 @@ impl CanisterBuilder for MotokoBuilder {
                 let imported_file = match import {
                     MotokoImport::Canister(canister_name) => {
                         if let Some(canister) = pool.get_first_canister_with_name(canister_name) {
-                            let canister = canister.clone(); // TODO: remove?
-                            let main_file = canister.get_info().get_main_file().clone();
-                            if let Some(main_file) = main_file.clone() {
-                                let main_file = main_file.to_owned();
-                                Some(main_file)
+                            let main_file = canister.get_info().get_main_file();
+                            if let Some(main_file) = main_file {
+                                Some(main_file.to_owned())
                             } else {
                                 None
                             }

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -93,7 +93,7 @@ impl CanisterBuilder for MotokoBuilder {
         info: &CanisterInfo,
     ) -> DfxResult<Vec<CanisterId>> {
         let motoko_info = info.as_info::<MotokoCanisterInfo>()?;
-        let imports = get_imports(self.cache.as_ref(), &motoko_info)?;
+        let imports = get_imports(self.cache.as_ref(), &motoko_info)?; // TODO: slow operation
 
         Ok(imports
             .iter()

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -163,7 +163,7 @@ impl CanisterBuilder for MotokoBuilder {
             if let Some(import) = import_iter.next() {
                 let imported_file = match import {
                     MotokoImport::Canister(canister_name) => {
-                        if let Some(canister) = pool.get_first_canister_with_name(canisterName) {
+                        if let Some(canister) = pool.get_first_canister_with_name(canister_name) {
                             let canister = canister.clone(); // TODO: remove?
                             let main_file = canister.get_info().get_main_file().clone();
                             if let Some(main_file) = main_file.clone() {
@@ -177,8 +177,8 @@ impl CanisterBuilder for MotokoBuilder {
                         }
                     }
                     MotokoImport::Ic(canister_id) => {
-                        if let Some(canister_name) = rev_id_map.get(canisterId) {
-                            if let Some(canister) = pool.get_first_canister_with_name(canisterName) {
+                        if let Some(canister_name) = rev_id_map.get(canister_id) {
+                            if let Some(canister) = pool.get_first_canister_with_name(canister_name) {
                                 if let Some(main_file) = canister.get_info().get_main_file() {
                                     Some(main_file.to_owned())
                                 } else {

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -144,7 +144,7 @@ impl CanisterBuilder for MotokoBuilder {
         std::fs::create_dir_all(idl_dir_path)
             .with_context(|| format!("Failed to create {}.", idl_dir_path.to_string_lossy()))?;
 
-        let imports = get_imports(cache.as_ref(), &motoko_info)?;
+        let imports = get_imports(cache.as_ref(), &motoko_info)?; // TODO: repeated slow operation
 
         // If the management canister is being imported, emit the candid file.
         if imports.contains(&MotokoImport::Ic("aaaaa-aa".to_string()))

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -162,7 +162,7 @@ impl CanisterBuilder for MotokoBuilder {
         loop {
             if let Some(import) = import_iter.next() {
                 let imported_file = match import {
-                    MotokoImport::Canister(canisterName) => {
+                    MotokoImport::Canister(canister_name) => {
                         if let Some(canister) = pool.get_first_canister_with_name(canisterName) {
                             let canister = canister.clone(); // TODO: remove?
                             let main_file = canister.get_info().get_main_file().clone();
@@ -176,8 +176,8 @@ impl CanisterBuilder for MotokoBuilder {
                             None
                         }
                     }
-                    MotokoImport::Ic(canisterId) => {
-                        if let Some(canisterName) = rev_id_map.get(canisterId) {
+                    MotokoImport::Ic(canister_id) => {
+                        if let Some(canister_name) = rev_id_map.get(canisterId) {
                             if let Some(canister) = pool.get_first_canister_with_name(canisterName) {
                                 if let Some(main_file) = canister.get_info().get_main_file() {
                                     Some(main_file.to_owned())

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -238,7 +238,15 @@ impl CanisterBuilder for MotokoBuilder {
                         };
                     };
                 } else {
-                    bail!("already compiled"); // FIXME: Ensure that `dfx` command doesn't return false because of this.
+                    // trace!(log, "Canister {} already compiled", canister_info.get_name()); // TODO
+                    return Ok(BuildOutput { // duplicate code
+                        canister_id: canister_info
+                            .get_canister_id()
+                            .expect("Could not find canister ID."),
+                        wasm: WasmBuildOutput::File(motoko_info.get_output_wasm_path().to_path_buf()),
+                        idl: IdlBuildOutput::File(motoko_info.get_output_idl_path().to_path_buf()),
+                    })
+            
                 }
             }
         };
@@ -279,7 +287,7 @@ impl CanisterBuilder for MotokoBuilder {
         };
         motoko_compile(&self.logger, cache.as_ref(), &params)?;
 
-        Ok(BuildOutput {
+        Ok(BuildOutput { // duplicate code
             canister_id: canister_info
                 .get_canister_id()
                 .expect("Could not find canister ID."),

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -691,6 +691,7 @@ impl CanisterPool {
         self.step_prebuild_all(log, build_config)
             .map_err(|e| DfxError::new(BuildError::PreBuildAllStepFailed(Box::new(e))))?;
 
+        trace!(log, "Building dependencies graph.");
         let graph = self.build_dependencies_graph()?;
         let nodes = petgraph::algo::toposort(&graph, None).map_err(|cycle| {
             let message = match graph.node_weight(cycle.node_id()) {

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -726,7 +726,13 @@ impl CanisterPool {
                         let wasm_file_time = wasm_file_metadata.modified()?;
                         let mut bfs = Bfs::new(&graph, idx);
                         loop {
-                            if let Some(node) = bfs.next(&graph) {
+                            if let Some(node_index) = bfs.next(&graph) {
+                                if let Some(node) = graph.node_weight(node_index) {
+                                    // FIXME: We need the graph of dependencies including `.mo` files, not only canisters.
+                                    // TODO
+                                } else {
+                                    panic!("cannot get canister");
+                                }
                             } else {
                                 break false;
                             }

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -726,10 +726,10 @@ impl CanisterPool {
                         let wasm_file_time = wasm_file_metadata.modified()?;
                         let mut bfs = Bfs::new(&graph, idx);
                         loop {
-                            // if let Some(&node) = bfs.next(graph) {
-                            // } else {
+                            if let Some(node) = bfs.next(&graph) {
+                            } else {
                                 break false;
-                            // }
+                            }
                         };
                         true
                     }

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -774,7 +774,7 @@ impl CanisterPool {
             }
         }
 
-        self.step_postbuild_all(build_config, &order.iter().map(|e| e.1).collect::<Vec<CanisterId>>())
+        self.step_postbuild_all(build_config, &order.into_iter().map(|e| e.1).collect::<Vec<CanisterId>>())
             .map_err(|e| DfxError::new(BuildError::PostBuildAllStepFailed(Box::new(e))))?;
 
         Ok(result)

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -719,13 +719,11 @@ impl CanisterPool {
                     .contains(&canister.get_name())
                     && {
                         use dfx_core::fs::metadata;
-                        let wasm_file_name = format!(
-                            "{}/{}/{}.wasm",
-                            canister.get_info().get_output_root().display(), canister.get_name(), canister.get_name()
-                        );
-                        let wasm_file_metadata = metadata(Path::new(&wasm_file_name))?;
+                        let wasm_file_name = canister.get_info().get_output_root()
+                            .join(Path::new(canister.get_name()))
+                            .join(Path::new(&format!("{}.wasm", canister.get_name())));
+                        let wasm_file_metadata = metadata(wasm_file_name.as_path())?;
                         let wasm_file_time = wasm_file_metadata.modified()?;
-                        let need_build = false;
                         let mut bfs = Bfs::new(&graph, idx);
                         loop {
                             // if let Some(&node) = bfs.next(graph) {


### PR DESCRIPTION
# Description

DFX doesn't compile canisters for which all dependencies are elder than the `.wasm` file. This results in big compilation speedups.

The PR also adds tracing and comments intended for future improvement of compilation speed.

This PR is a WIP. There is potential for further speedup and there is missing logging. More testing is necessary.

# How Has This Been Tested?

I run it before the `.wasm` file has been created and after it with a significant speedup. Also `dfx build -vv` correctly does not output any `moc` compilation logs, when invoking `dfx build` for the second time..

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
