### PR TITLE
feat: init_arg_file in dfx.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 Please see [extension-defined-canister-types](docs/concepts/extension-defined-canister-types.md) for details.
 
+### feat: init_arg_file in dfx.json
+
+In addition to setting `init_arg` in `dfx.json`, `init_arg_file` can be set in `dfx.json`.
+- Please set a relative path to the directory where the the `dfx.json` is located.
+- `init_arg` and `init_arg_file` cannot be set simultaneously.
+- If `--argument` or `--argument-file` are provided, the argument from the command line takes precedence over the one in dfx.json.
+
 ### Cycles wallet
 
 Updated cycles wallet to a gzipped version of `20240410` release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ Please see [extension-defined-canister-types](docs/concepts/extension-defined-ca
 
 ### feat: init_arg_file in dfx.json
 
-In addition to setting `init_arg` in `dfx.json`, `init_arg_file` can be set in `dfx.json`.
-- Please set a relative path to the directory where the the `dfx.json` is located.
-- `init_arg` and `init_arg_file` cannot be set simultaneously.
-- If `--argument` or `--argument-file` are provided, the argument from the command line takes precedence over the one in dfx.json.
+Introduces support for the `init_arg_file` field in `dfx.json`, providing an alternative method to specify initialization arguments.
+
+This field accepts a relative path, from the directory containing the `dfx.json` file.
+
+**Note**
+
+- Only one of `init_arg` and `init_arg_file` can be defined at a time.
+- If `--argument` or `--argument-file` are set, the argument from the command line takes precedence over the one in dfx.json.
 
 ### Cycles wallet
 

--- a/docs/dfx-json-schema.json
+++ b/docs/dfx-json-schema.json
@@ -382,6 +382,14 @@
             "null"
           ]
         },
+        "init_arg_file": {
+          "title": "Init Arg File",
+          "description": "The Candid initialization argument file for installing the canister. If the `--argument` or `--argument-file` argument is also provided, this `init_arg_file` field will be ignored.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "initialization_values": {
           "title": "Resource Allocation Settings",
           "description": "Defines initial values for resource allocation settings.",

--- a/e2e/tests-dfx/deploy.bash
+++ b/e2e/tests-dfx/deploy.bash
@@ -118,7 +118,7 @@ teardown() {
   assert_match "Hello, dfx!"
 
   assert_command dfx deploy dependency --mode reinstall --yes --argument '("icp")'
-  assert_contains "Canister 'dependency' has init_arg in dfx.json: (\"dfx\"),"
+  assert_contains "Canister 'dependency' has init_arg/init_arg_file in dfx.json: (\"dfx\"),"
   assert_contains "which is different from the one specified in the command line: (\"icp\")."
   assert_contains "The command line value will be used."
   assert_command dfx canister call dependency greet

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -277,8 +277,8 @@ teardown() {
 @test "install succeeds if init_arg_file is defined in dfx.json" {
   install_asset deploy_deps
   dfx_start
-  echo 'dfx' >> args.txt
-  jq '.canisters.dependency.init_arg_file="(\"args.txt\")"' dfx.json | sponge dfx.json
+  echo '("dfx")' >> args.txt
+  jq '.canisters.dependency.init_arg_file="args.txt"' dfx.json | sponge dfx.json
 
   dfx canister create dependency
   dfx build dependency
@@ -287,12 +287,12 @@ teardown() {
   assert_match "Hello, dfx!"
 }
 
-@test "install failed if both init_arg and init_arg_file are defined in dfx.json" {
+@test "install fails if both init_arg and init_arg_file are defined in dfx.json" {
   install_asset deploy_deps
   dfx_start
-  echo 'dfx' >> args.txt
+  echo '("dfx")' >> args.txt
   jq '.canisters.dependency.init_arg="(\"dfx\")"' dfx.json | sponge dfx.json
-  jq '.canisters.dependency.init_arg_file="(\"args.txt\")"' dfx.json | sponge dfx.json
+  jq '.canisters.dependency.init_arg_file="args.txt"' dfx.json | sponge dfx.json
 
   dfx canister create dependency
   dfx build dependency

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -274,6 +274,32 @@ teardown() {
   assert_match "Hello, icp!"
 }
 
+@test "install succeeds if init_arg_file is defined in dfx.json" {
+  install_asset deploy_deps
+  dfx_start
+  echo 'dfx' >> args.txt
+  jq '.canisters.dependency.init_arg_file="(\"args.txt\")"' dfx.json | sponge dfx.json
+
+  dfx canister create dependency
+  dfx build dependency
+  assert_command dfx canister install dependency
+  assert_command dfx canister call dependency greet
+  assert_match "Hello, dfx!"
+}
+
+@test "install failed if both init_arg and init_arg_file are defined in dfx.json" {
+  install_asset deploy_deps
+  dfx_start
+  echo 'dfx' >> args.txt
+  jq '.canisters.dependency.init_arg="(\"dfx\")"' dfx.json | sponge dfx.json
+  jq '.canisters.dependency.init_arg_file="(\"args.txt\")"' dfx.json | sponge dfx.json
+
+  dfx canister create dependency
+  dfx build dependency
+  assert_command_fail dfx canister install dependency
+  assert_contains "Cannot provide both 'init_arg' and 'init_arg_file' in dfx.json."
+}
+
 @test "install succeeds when specify canister id and wasm, in dir without dfx.json" {
   dfx_start
 

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -301,7 +301,8 @@ teardown() {
   dfx canister create dependency
   dfx build dependency
   assert_command_fail dfx canister install dependency
-  assert_contains "Cannot provide both 'init_arg' and 'init_arg_file' in dfx.json."
+  assert_contains "At most one of the fields 'init_arg' and 'init_arg_file' should be defined in \`dfx.json\`.
+Please remove one of them or leave both undefined."
 }
 
 @test "install succeeds when specify canister id and wasm, in dir without dfx.json" {

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -277,11 +277,13 @@ teardown() {
 @test "install succeeds if init_arg_file is defined in dfx.json" {
   install_asset deploy_deps
   dfx_start
-  echo '("dfx")' >> args.txt
-  jq '.canisters.dependency.init_arg_file="args.txt"' dfx.json | sponge dfx.json
+  mkdir arg-files
+  echo '("dfx")' >> arg-files/args.txt
+  jq '.canisters.dependency.init_arg_file="arg-files/args.txt"' dfx.json | sponge dfx.json
 
   dfx canister create dependency
   dfx build dependency
+  cd arg-files
   assert_command dfx canister install dependency
   assert_command dfx canister call dependency greet
   assert_match "Hello, dfx!"

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -267,7 +267,7 @@ teardown() {
   assert_match "Hello, dfx!"
 
   assert_command dfx canister install dependency --mode reinstall --yes --argument '("icp")'
-  assert_contains "Canister 'dependency' has init_arg in dfx.json: (\"dfx\"),"
+  assert_contains "Canister 'dependency' has init_arg/init_arg_file in dfx.json: (\"dfx\"),"
   assert_contains "which is different from the one specified in the command line: (\"icp\")."
   assert_contains "The command line value will be used."
   assert_command dfx canister call dependency greet
@@ -283,6 +283,8 @@ teardown() {
 
   dfx canister create dependency
   dfx build dependency
+
+  # The following commands will be run in this sub-directory, it verifies that the init_arg_file is relative to the dfx.json file
   cd arg-files
   assert_command dfx canister install dependency
   assert_command dfx canister call dependency greet

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -318,6 +318,11 @@ pub struct ConfigCanistersCanister {
     /// The Candid initialization argument for installing the canister.
     /// If the `--argument` or `--argument-file` argument is also provided, this `init_arg` field will be ignored.
     pub init_arg: Option<String>,
+
+    /// # Init Arg File
+    /// The Candid initialization argument file for installing the canister.
+    /// If the `--argument` or `--argument-file` argument is also provided, this `init_arg_file` field will be ignored.
+    pub init_arg_file: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, JsonSchema)]

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -376,7 +376,7 @@ impl CanisterInfo {
     }
 
     /// Get the init arg from the dfx.json configuration.
-    /// 
+    ///
     /// If the `init_arg` field is defined, it will be returned.
     /// If the `init_arg_file` field is defined, the content of the file will be returned.
     /// If both fields are defined, an error will be returned.

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -383,8 +383,8 @@ impl CanisterInfo {
             }
             (Some(arg), None) => Some(arg.clone()),
             (None, Some(arg_file)) => {
-                // TODO: read the file with the right path.
-                Some(arguments_from_file(Path::new(arg_file))?)
+                // Trim the end of line that's read from the file.
+                Some(arguments_from_file(Path::new(arg_file))?.trim().into())
             }
             (None, None) => None
         };

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
+use crate::error_invalid_config;
 use crate::lib::error::DfxResult;
 use crate::lib::metadata::config::CanisterMetadataConfig;
-use crate::{error_invalid_config};
 use anyhow::{anyhow, Context};
 use candid::Principal as CanisterId;
 use candid::Principal;
@@ -379,7 +379,9 @@ impl CanisterInfo {
         let init_arg_value = match (&self.init_arg, &self.init_arg_file) {
             (Some(_), Some(_)) => {
                 // Return with error if `init_arg` and `init_arg_file` are defined in dfx.json.
-                return Err(anyhow!("Cannot provide both 'init_arg' and 'init_arg_file' in dfx.json."))
+                return Err(anyhow!(
+                    "Cannot provide both 'init_arg' and 'init_arg_file' in dfx.json."
+                ));
             }
             (Some(arg), None) => Some(arg.clone()),
             (None, Some(arg_file)) => {
@@ -387,10 +389,16 @@ impl CanisterInfo {
                 let absolute_path = self.get_workspace_root().join(arg_file);
                 match std::fs::read_to_string(absolute_path) {
                     Ok(value) => Some(value),
-                    Err(e) => return Err(error_invalid_config!("Could not read init arg file `{}` to string: {}", arg_file, e)),
+                    Err(e) => {
+                        return Err(error_invalid_config!(
+                            "Could not read init arg file '{}' to string: {}",
+                            arg_file,
+                            e
+                        ))
+                    }
                 }
             }
-            (None, None) => None
+            (None, None) => None,
         };
 
         Ok(init_arg_value)

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -375,6 +375,12 @@ impl CanisterInfo {
         self.gzip
     }
 
+    /// Get the init arg from the dfx.json configuration.
+    /// 
+    /// If the `init_arg` field is defined, it will be returned.
+    /// If the `init_arg_file` field is defined, the content of the file will be returned.
+    /// If both fields are defined, an error will be returned.
+    /// If neither field is defined, `None` will be returned.
     pub fn get_init_arg(&self) -> DfxResult<Option<String>> {
         let init_arg_value = match (&self.init_arg, &self.init_arg_file) {
             (Some(_), Some(_)) => {

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -141,7 +141,7 @@ pub async fn install_canister(
             get_candid_init_type(&idl_path)
         };
 
-        // The argument and argument_type from the CLI take precedence over the `init_arg` or `init_arg_file` fields in dfx.json.
+        // The argument and argument_type from the CLI take precedence over the dfx.json configuration.
         let argument_from_json = canister_info.get_init_arg()?;
         let (argument, argument_type) = match (argument_from_cli, &argument_from_json) {
             (Some(a_cli), Some(a_json)) => {

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -152,7 +152,7 @@ pub async fn install_canister(
                 if argument_type_from_cli == Some("raw") || a_cli != a_json {
                     warn!(
                         log,
-                        "Canister '{0}' has init_arg in dfx.json: {1},
+                        "Canister '{0}' has init_arg/init_arg_file in dfx.json: {1},
 which is different from the one specified in the command line: {2}.
 The command line value will be used.",
                         canister_info.get_name(),

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -141,9 +141,9 @@ pub async fn install_canister(
             get_candid_init_type(&idl_path)
         };
 
-        // The argument and argument_type from the CLI take precedence over the `init_arg` field in dfx.json
-        let argument_from_json = canister_info.get_init_arg();
-        let (argument, argument_type) = match (argument_from_cli, argument_from_json) {
+        // The argument and argument_type from the CLI take precedence over the `init_arg` or `init_arg_file` fields in dfx.json.
+        let argument_from_json = canister_info.get_init_arg()?;
+        let (argument, argument_type) = match (argument_from_cli, &argument_from_json) {
             (Some(a_cli), Some(a_json)) => {
                 // We want to warn the user when the argument from CLI and json are different.
                 // There are two cases to consider:
@@ -163,7 +163,7 @@ The command line value will be used.",
                 (argument_from_cli, argument_type_from_cli)
             }
             (Some(_), None) => (argument_from_cli, argument_type_from_cli),
-            (None, Some(_)) => (argument_from_json, Some("idl")), // `init_arg` in dfx.json is always in Candid format
+            (None, Some(a_json)) => (Some(a_json.as_str()), Some("idl")), // `init_arg` in dfx.json is always in Candid format
             (None, None) => (None, None),
         };
         let install_args = blob_from_arguments(


### PR DESCRIPTION
# Description

In addition to setting `init_arg` in `dfx.json`, `init_arg_file` can be set in `dfx.json`.
- Please set a relative path to the directory where the the `dfx.json` is located.
- `init_arg` and `init_arg_file` cannot be set simultaneously.
- If `--argument` or `--argument-file` are provided, the argument from the command line takes precedence over the one in dfx.json.

Fixes [SDK-1455](https://dfinity.atlassian.net/browse/SDK-1455)

# How Has This Been Tested?

e2e: install.bash

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-1455]: https://dfinity.atlassian.net/browse/SDK-1455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ