### PR TITLE
docs: tech_stack - clarify metadata key and add reverse links

### DIFF
--- a/docs/concepts/pull-dependencies.md
+++ b/docs/concepts/pull-dependencies.md
@@ -35,7 +35,7 @@ Below is an example provider `dfx.json` which has a `pullable` "service" caniste
 }
 ```
 
-The `pullable` object will be serialized as a part of the `dfx` metadata and attached to the wasm.
+The `pullable` object will be serialized as a part of the [`dfx` metadata](canister-metadata.md#dfx) and attached to the wasm.
 
 Let's go through the properties of the `pullable` object.
 
@@ -78,6 +78,23 @@ A message to guide consumers how to initialize the canister.
 A default initialization argument for the canister that consumers can use.
 
 This field is optional.
+
+## Fetch the metadata
+
+To retrieve the metadata and validate the generated information, execute the following command:
+
+```sh
+> dfx canister metadata <canister_name> dfx
+```
+
+Please note that the `"pullable"` object is part of the public metadata under the key [`"dfx"`](canister-metadata.md#dfx).
+
+Given that the content is in JSON format, you can utilize tools such as `jq` to manipulate the output and extract the pertinent information.
+
+```sh
+> dfx canister metadata <canister_name> dfx | jq -r ".pullable.wasm_url"
+http://example.com/a.wasm
+```
 
 ## Canister Metadata Requirements
 

--- a/docs/concepts/tech-stack.md
+++ b/docs/concepts/tech-stack.md
@@ -18,6 +18,8 @@ Providing a standard format of such information makes it easier to build tools l
 
 Each category is a map keyed by the names of tech stack items, where each value is a map containing optional fields.
 
+The `"tech_stack"` object will be serialized as a part of the [`"dfx"` metadata](canister-metadata.md#dfx) and attached to the wasm.
+
 ### Example
 
 ```json
@@ -102,6 +104,23 @@ If the content of a custom field value begins with the prefix `$(` and ends with
 - The command will be executed in the workspace root directory, which contains the `dfx.json` file.
 - The stdout should be a valid UTF-8 string.
 - The field value will be obtained by trimming the stdout, removing any leading and trailing whitespace.
+
+## Fetch the metadata
+
+To retrieve the metadata and validate the generated information, execute the following command:
+
+```sh
+> dfx canister metadata <canister_name> dfx
+```
+
+Please note that the `"tech_stack"` object is part of the public metadata under the key [`"dfx"`](canister-metadata.md#dfx).
+
+Given that the content is in JSON format, you can utilize tools such as `jq` to manipulate the output and extract the pertinent information.
+
+```sh
+> dfx canister metadata <canister_name> dfx | jq -r ".tech_stack.language.rust.version"
+1.75.0
+```
 
 ## Q&A
 

--- a/src/dfx/assets/project_templates/azle/dfx.json-patch
+++ b/src/dfx/assets/project_templates/azle/dfx.json-patch
@@ -11,6 +11,7 @@
             "gzip": true,
             "tech_stack": {
                 "language": {
+                    "javascript": {},
                     "typescript": {}
                 },
                 "cdk": {


### PR DESCRIPTION
# Description

It was not clear that `"tech_stack"` is part of the metadata under the key of `"dfx"`.

This PR clarifies it in both `pull-dependencies.md` and `tech-stack.md`. Reverse links to `canister-metadata.md` are added.

Also added `javascript` to the Azle template `dfx.json`, as suggested by @lastmjs, the author of Azle.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
