### PR TITLE
fix: for dfx new failure if node is installed but npm is not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 Please see [extension-defined-canister-types](docs/concepts/extension-defined-canister-types.md) for details.
 
+### fix: dfx new failure when node is available but npm is not
+
+`dfx new` could fail with "Failed to scaffold frontend code" if node was installed but npm was not installed.
+
 ### Cycles wallet
 
 Updated cycles wallet to a gzipped version of `20240410` release:

--- a/e2e/tests-dfx/new.bash
+++ b/e2e/tests-dfx/new.bash
@@ -96,12 +96,8 @@ teardown() {
   which node || skip "node not installed"
   which npm || skip "npm not installed"
 
-  mkdir forward-to-node
-  cat > forward-to-node/node <<EOF
-#!/bin/bash
-$(dirname "$(which node)")/node "\$@"
-EOF
-  chmod +x forward-to-node/node
+  mkdir node-only
+  cp "$(which node)" node-only/node
 
   mkdir node-installable
   cat > node-installable/node <<EOF
@@ -124,7 +120,7 @@ EOF
   chmod +x npm-installable/npm
 
   DFX_BIN_DIR=$(dirname "$(which dfx)")
-  FORWARD_TO_NODE_DIR=$PWD/forward-to-node
+  NODE_ONLY_DIR=$PWD/node-only
   NODE_INSTALLABLE_DIR=$PWD/node-installable
   NPM_INSTALLABLE_DIR=$PWD/npm-installable
 
@@ -143,14 +139,14 @@ EOF
   assert_contains "You can bypass this check by using the --frontend flag."
 
   # node is installed, but there is no npm binary
-  PATH="/usr/bin:/bin:$DFX_BIN_DIR:$FORWARD_TO_NODE_DIR" \
+  PATH="/usr/bin:/bin:$DFX_BIN_DIR:$NODE_ONLY_DIR" \
     assert_command dfx new e2e_project3 --type motoko --frontend sveltekit
   assert_not_contains "Node could not be found"
   assert_contains "npm could not be found. Skipping installing the frontend example code."
   assert_contains "You can bypass this check by using the --frontend flag."
 
   # node is installed; npm is not, but a stub reports that it is installable
-  PATH="/usr/bin:/bin:$DFX_BIN_DIR:$FORWARD_TO_NODE_DIR:$NPM_INSTALLABLE_DIR" \
+  PATH="/usr/bin:/bin:$DFX_BIN_DIR:$NODE_ONLY_DIR:$NPM_INSTALLABLE_DIR" \
     assert_command dfx new e2e_project4 --type motoko --frontend sveltekit
   assert_not_contains "Node could not be found"
   assert_contains "npm could not be found. Skipping installing the frontend example code."

--- a/e2e/tests-dfx/new.bash
+++ b/e2e/tests-dfx/new.bash
@@ -128,6 +128,12 @@ EOF
   PATH="/usr/bin:/bin:$DFX_BIN_DIR" which node || true
   PATH="/usr/bin:/bin:$DFX_BIN_DIR" which npm || true
 
+  echo "with -a"
+  PATH="/usr/bin:/bin:$DFX_BIN_DIR" which -a node || true
+  PATH="/usr/bin:/bin:$DFX_BIN_DIR" which -a npm || true
+  which -a node || true
+  which -a npm || true
+
   # neither node nor npm are installed (no binaries)
   PATH="/usr/bin:/bin:$DFX_BIN_DIR" \
     assert_command dfx new e2e_project1 --type motoko --frontend sveltekit

--- a/e2e/tests-dfx/new.bash
+++ b/e2e/tests-dfx/new.bash
@@ -120,6 +120,7 @@ EOF
   chmod +x npm-installable/npm
 
   DFX_BIN_DIR=$(dirname "$(which dfx)")
+  echo "dfx is in $DFX_BIN_DIR"
   NODE_ONLY_DIR=$PWD/node-only
   NODE_INSTALLABLE_DIR=$PWD/node-installable
   NPM_INSTALLABLE_DIR=$PWD/npm-installable

--- a/e2e/tests-dfx/new.bash
+++ b/e2e/tests-dfx/new.bash
@@ -124,6 +124,9 @@ EOF
   NODE_INSTALLABLE_DIR=$PWD/node-installable
   NPM_INSTALLABLE_DIR=$PWD/npm-installable
 
+  PATH="/usr/bin:/bin:$DFX_BIN_DIR" which node || true
+  PATH="/usr/bin:/bin:$DFX_BIN_DIR" which npm || true
+
   # neither node nor npm are installed (no binaries)
   PATH="/usr/bin:/bin:$DFX_BIN_DIR" \
     assert_command dfx new e2e_project1 --type motoko --frontend sveltekit

--- a/e2e/tests-dfx/new.bash
+++ b/e2e/tests-dfx/new.bash
@@ -99,6 +99,9 @@ teardown() {
   mkdir node-only
   cp "$(which node)" node-only/node
 
+  mkdir dfx-only
+  cp "$(which dfx)" dfx-only/dfx
+
   mkdir node-installable
   cat > node-installable/node <<EOF
 #!/bin/bash
@@ -119,44 +122,34 @@ exit 127
 EOF
   chmod +x npm-installable/npm
 
-  DFX_BIN_DIR=$(dirname "$(which dfx)")
-  echo "dfx is in $DFX_BIN_DIR"
+  DFX_ONLY_DIR=$PWD/dfx-only
   NODE_ONLY_DIR=$PWD/node-only
   NODE_INSTALLABLE_DIR=$PWD/node-installable
   NPM_INSTALLABLE_DIR=$PWD/npm-installable
 
-  PATH="/usr/bin:/bin:$DFX_BIN_DIR" which node || true
-  PATH="/usr/bin:/bin:$DFX_BIN_DIR" which npm || true
-
-  echo "with -a"
-  PATH="/usr/bin:/bin:$DFX_BIN_DIR" which -a node || true
-  PATH="/usr/bin:/bin:$DFX_BIN_DIR" which -a npm || true
-  which -a node || true
-  which -a npm || true
-
   # neither node nor npm are installed (no binaries)
-  PATH="/usr/bin:/bin:$DFX_BIN_DIR" \
+  PATH="/usr/bin:/bin:$DFX_ONLY_DIR" \
     assert_command dfx new e2e_project1 --type motoko --frontend sveltekit
   assert_contains "Node could not be found. Skipping installing the frontend example code."
   assert_contains "npm could not be found. Skipping installing the frontend example code."
   assert_contains "You can bypass this check by using the --frontend flag."
 
   # node is installable, but not installed
-  PATH="/usr/bin:/bin:$DFX_BIN_DIR:$NODE_INSTALLABLE_DIR" \
+  PATH="/usr/bin:/bin:$DFX_ONLY_DIR:$NODE_INSTALLABLE_DIR" \
     assert_command dfx new e2e_project2 --type motoko --frontend sveltekit
   assert_contains "Node could not be found. Skipping installing the frontend example code."
   assert_contains "npm could not be found. Skipping installing the frontend example code."
   assert_contains "You can bypass this check by using the --frontend flag."
 
   # node is installed, but there is no npm binary
-  PATH="/usr/bin:/bin:$DFX_BIN_DIR:$NODE_ONLY_DIR" \
+  PATH="/usr/bin:/bin:$DFX_ONLY_DIR:$NODE_ONLY_DIR" \
     assert_command dfx new e2e_project3 --type motoko --frontend sveltekit
   assert_not_contains "Node could not be found"
   assert_contains "npm could not be found. Skipping installing the frontend example code."
   assert_contains "You can bypass this check by using the --frontend flag."
 
   # node is installed; npm is not, but a stub reports that it is installable
-  PATH="/usr/bin:/bin:$DFX_BIN_DIR:$NODE_ONLY_DIR:$NPM_INSTALLABLE_DIR" \
+  PATH="/usr/bin:/bin:$DFX_ONLY_DIR:$NODE_ONLY_DIR:$NPM_INSTALLABLE_DIR" \
     assert_command dfx new e2e_project4 --type motoko --frontend sveltekit
   assert_not_contains "Node could not be found"
   assert_contains "npm could not be found. Skipping installing the frontend example code."

--- a/e2e/tests-dfx/new.bash
+++ b/e2e/tests-dfx/new.bash
@@ -91,3 +91,68 @@ teardown() {
   assert_command dfx deploy
   assert_command npm test --workspaces
 }
+
+@test "variants of node and npm installed or not" {
+  which node || skip "node not installed"
+  which npm || skip "npm not installed"
+
+  mkdir forward-to-node
+  cat > forward-to-node/node <<EOF
+#!/bin/bash
+$(dirname "$(which node)")/node "\$@"
+EOF
+  chmod +x forward-to-node/node
+
+  mkdir node-installable
+  cat > node-installable/node <<EOF
+#!/bin/bash
+echo "Command 'node' not found, but can be installed with:" >&2
+echo "apt install npm" >&2
+echo "Please ask your administrator."
+exit 127
+EOF
+  chmod +x node-installable/node
+
+  mkdir npm-installable
+  cat > npm-installable/npm <<EOF
+#!/bin/bash
+echo "Command 'npm' not found, but can be installed with:" >&2
+echo "apt install npm" >&2
+echo "Please ask your administrator."
+exit 127
+EOF
+  chmod +x npm-installable/npm
+
+  DFX_BIN_DIR=$(dirname "$(which dfx)")
+  FORWARD_TO_NODE_DIR=$PWD/forward-to-node
+  NODE_INSTALLABLE_DIR=$PWD/node-installable
+  NPM_INSTALLABLE_DIR=$PWD/npm-installable
+
+  # neither node nor npm are installed (no binaries)
+  PATH="/usr/bin:/bin:$DFX_BIN_DIR" \
+    assert_command dfx new e2e_project1 --type motoko --frontend sveltekit
+  assert_contains "Node could not be found. Skipping installing the frontend example code."
+  assert_contains "npm could not be found. Skipping installing the frontend example code."
+  assert_contains "You can bypass this check by using the --frontend flag."
+
+  # node is installable, but not installed
+  PATH="/usr/bin:/bin:$DFX_BIN_DIR:$NODE_INSTALLABLE_DIR" \
+    assert_command dfx new e2e_project2 --type motoko --frontend sveltekit
+  assert_contains "Node could not be found. Skipping installing the frontend example code."
+  assert_contains "npm could not be found. Skipping installing the frontend example code."
+  assert_contains "You can bypass this check by using the --frontend flag."
+
+  # node is installed, but there is no npm binary
+  PATH="/usr/bin:/bin:$DFX_BIN_DIR:$FORWARD_TO_NODE_DIR" \
+    assert_command dfx new e2e_project3 --type motoko --frontend sveltekit
+  assert_not_contains "Node could not be found"
+  assert_contains "npm could not be found. Skipping installing the frontend example code."
+  assert_contains "You can bypass this check by using the --frontend flag."
+
+  # node is installed; npm is not, but a stub reports that it is installable
+  PATH="/usr/bin:/bin:$DFX_BIN_DIR:$FORWARD_TO_NODE_DIR:$NPM_INSTALLABLE_DIR" \
+    assert_command dfx new e2e_project4 --type motoko --frontend sveltekit
+  assert_not_contains "Node could not be found"
+  assert_contains "npm could not be found. Skipping installing the frontend example code."
+  assert_contains "You can bypass this check by using the --frontend flag."
+}


### PR DESCRIPTION
# Description

`dfx new` would fail with "Failed to scaffold frontend code" if node was installed, but npm was not installed.

Also, now checks the status code when calling node and npm to see if they are installed. This means if there is a script that outputs something like the below, dfx will no longer assume the program is installed.

```
$ npm
Command 'npm' not found, but can be installed with: apt install npm
Please ask your administrator.
```

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
