### PR TITLE
test: pin mops to 0.43.0

### DIFF
--- a/e2e/tests-dfx/playground.bash
+++ b/e2e/tests-dfx/playground.bash
@@ -16,7 +16,7 @@ teardown() {
 setup_playground() {
   if ! command -v ic-mops &> /dev/null
   then
-    npm i -g ic-mops
+    npm i -g ic-mops@0.43.0
   fi
   dfx_new hello
   create_networks_json


### PR DESCRIPTION
# Description

The playground test is failing.

Examples:
- https://github.com/dfinity/sdk/actions/runs/8803187859/job/24161266261
- https://github.com/dfinity/sdk/actions/runs/8803438757/job/24162434193?pr=3722

Hypothesis: introduced in [mops](https://cli.mops.one/) 0.44.0, released 2024-04-22

# How Has This Been Tested?

Tested by existing playground test

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
