### PR TITLE
test: disable bitcoin testnet tests

### DIFF
--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -252,6 +252,8 @@ If you want to get reliable result, you can make an update call to the secure al
   # shellcheck disable=SC2154
   assert_contains "bitcoin_get_balance_query $WARNING bitcoin_get_balance" "$stderr"
 
+  # TODO: re-enable when testnet back to normal, tracking at https://dfinity.atlassian.net/browse/SDKTG-323
+
 #   ## bitcoin testnet
 #   assert_command dfx canister call --network ic --query aaaaa-aa bitcoin_get_balance_query '(
 #   record {

--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -251,15 +251,16 @@ If you want to get reliable result, you can make an update call to the secure al
 )'
   # shellcheck disable=SC2154
   assert_contains "bitcoin_get_balance_query $WARNING bitcoin_get_balance" "$stderr"
-  ## bitcoin testnet
-  assert_command dfx canister call --network ic --query aaaaa-aa bitcoin_get_balance_query '(
-  record {
-    network = variant { testnet };
-    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
-  }
-)'
-  # shellcheck disable=SC2154
-  assert_contains "bitcoin_get_balance_query $WARNING bitcoin_get_balance" "$stderr"
+
+#   ## bitcoin testnet
+#   assert_command dfx canister call --network ic --query aaaaa-aa bitcoin_get_balance_query '(
+#   record {
+#     network = variant { testnet };
+#     address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
+#   }
+# )'
+#   # shellcheck disable=SC2154
+#   assert_contains "bitcoin_get_balance_query $WARNING bitcoin_get_balance" "$stderr"
 
   # bitcoin_get_utxos_query
   ## bitcoin mainnet
@@ -272,13 +273,13 @@ If you want to get reliable result, you can make an update call to the secure al
   # shellcheck disable=SC2154
   assert_contains "bitcoin_get_utxos_query $WARNING bitcoin_get_utxos" "$stderr"
 
-  ## bitcoin testnet
-  assert_command dfx canister call --network ic --query aaaaa-aa bitcoin_get_utxos_query '(
-  record {
-    network = variant { testnet };
-    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
-  }
-)'
-  # shellcheck disable=SC2154
-  assert_contains "bitcoin_get_utxos_query $WARNING bitcoin_get_utxos" "$stderr"
+#   ## bitcoin testnet
+#   assert_command dfx canister call --network ic --query aaaaa-aa bitcoin_get_utxos_query '(
+#   record {
+#     network = variant { testnet };
+#     address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
+#   }
+# )'
+#   # shellcheck disable=SC2154
+#   assert_contains "bitcoin_get_utxos_query $WARNING bitcoin_get_utxos" "$stderr"
 }


### PR DESCRIPTION
# Description

The Bitcoin testnet has some abnormal performance recently which caused the Bitcoin Canister for testnet keep returning 
an error of "Canister state is not fully synced.".

This PR disable the Bitcoin testnet tests.
The Bitcoin mainnet tests are kept.

A TODO comment was added to tracking with https://dfinity.atlassian.net/browse/SDKTG-323.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
