### PR TITLE
chore: add link to dfx reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repo contains the `IC SDK`: a Software Development Kit for creating and managing [canister smart contracts on the Internet Computer (ICP blockchain)](https://wiki.internetcomputer.org/wiki/Canister_smart_contract).
 
 For further reading:
+* [Reference documentation on internetcomputer.org](https://internetcomputer.org/docs/current/developer-docs/developer-tools/cli-tools/cli-reference/)
 * [Introduction to the ICP blockchain](https://wiki.internetcomputer.org/wiki/Introduction_to_ICP)
 * [Internet Computer dashboard](https://dashboard.internetcomputer.org/)
 * [Developer docs for ICP smart contracts](https://internetcomputer.org/docs/current/home)


### PR DESCRIPTION
Adds a link to the dfx reference on internetcomputer.org to the README.