### PR TITLE
chore: unpin mops

### DIFF
--- a/e2e/tests-dfx/playground.bash
+++ b/e2e/tests-dfx/playground.bash
@@ -16,7 +16,7 @@ teardown() {
 setup_playground() {
   if ! command -v ic-mops &> /dev/null
   then
-    npm i -g ic-mops@0.43.0
+    npm i -g ic-mops
   fi
   dfx_new hello
   create_networks_json


### PR DESCRIPTION
# Description

The issue for which we pinned mops was fixed in 0.44.1

https://cli.mops.one/

> 0.44.1
2024-04-24
•
678 KiB
•
b10db8562b5cc2e4ab77bef7dae95912c34ba1dfe5bc96c43932e2dbcef5af8d
Fixed fallback to dfx moc if there is no mops.toml

# How Has This Been Tested?

Playground e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
