### PR TITLE
refactor: more idiomatic identity override

### DIFF
--- a/src/dfx-core/src/identity/identity_manager.rs
+++ b/src/dfx-core/src/identity/identity_manager.rs
@@ -206,7 +206,7 @@ pub struct IdentityManager {
 impl IdentityManager {
     pub fn new(
         logger: &Logger,
-        identity_override: &Option<String>,
+        identity_override: Option<&str>,
     ) -> Result<Self, NewIdentityManagerError> {
         let config_dfx_dir_path =
             get_user_dfx_config_dir().map_err(NewIdentityManagerError::GetConfigDirectoryFailed)?;
@@ -222,8 +222,9 @@ impl IdentityManager {
         };
 
         let selected_identity = identity_override
-            .clone()
-            .unwrap_or_else(|| configuration.default.clone());
+            .unwrap_or(&configuration.default)
+            .to_string();
+
         let file_locations = IdentityFileLocations::new(identity_root_path);
 
         let mgr = IdentityManager {

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -38,7 +38,7 @@ pub trait Environment {
 
     /// This is value of the name passed to dfx `--identity <name>`
     /// Notably, it is _not_ the name of the default identity or selected identity
-    fn get_identity_override(&self) -> &Option<String>;
+    fn get_identity_override(&self) -> Option<&str>;
 
     // Explicit lifetimes are actually needed for mockall to work properly.
     #[allow(clippy::needless_lifetimes)]
@@ -196,8 +196,8 @@ impl Environment for EnvironmentImpl {
         &self.version
     }
 
-    fn get_identity_override(&self) -> &Option<String> {
-        &self.identity_override
+    fn get_identity_override(&self) -> Option<&str> {
+        self.identity_override.as_deref()
     }
 
     fn get_agent(&self) -> &Agent {
@@ -317,7 +317,7 @@ impl<'a> Environment for AgentEnvironment<'a> {
         self.backend.get_version()
     }
 
-    fn get_identity_override(&self) -> &Option<String> {
+    fn get_identity_override(&self) -> Option<&str> {
         self.backend.get_identity_override()
     }
 


### PR DESCRIPTION
# Description

Changes the signature of `Environment::get_identity_override()` and `IdentityManager::new()` to be more idiomatic rust, using `Option<&str>` rather than `&Option<String>`.

The motivation is in consideration of another caller of `IdentityManager::new()`, which may pass `None` for the identity override.

# How Has This Been Tested?

Refactor covered by e2e

