### PR TITLE
chore: document valid identity names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+### chore: Improve help text of `dfx identity new` to include which characters are valid in identity names
+
 # 0.20.1
 
 ### feat: reformatted error output

--- a/docs/cli-reference/dfx-identity.mdx
+++ b/docs/cli-reference/dfx-identity.mdx
@@ -208,9 +208,9 @@ dfx identity new [options] _identity-name_
 
 You must specify the following argument for the `dfx identity new` command.
 
-| Argument          | Description                                                              |
-|-------------------|--------------------------------------------------------------------------|
-| `<identity_name>` | Specifies the name of the identity to create. This argument is required. |
+| Argument          | Description                                                                                                                             |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `<identity_name>` | Specifies the name of the identity to create. This argument is required. Valid characters are letters, numbers, and these symbols: .-_@ |
 
 ### Options
 

--- a/src/dfx/src/commands/identity/new.rs
+++ b/src/dfx/src/commands/identity/new.rs
@@ -16,7 +16,7 @@ use IdentityCreationParameters::{Hardware, Pem};
 #[derive(Parser)]
 pub struct NewIdentityOpts {
     #[arg(value_parser = identity_name_validator)]
-    /// The name of the identity to create.
+    /// The name of the identity to create. Valid characters are letters, numbers, and these symbols: .-_@
     new_identity: String,
 
     #[cfg_attr(


### PR DESCRIPTION
# Description

The `dfx identity new` help text and documentation don't state what a valid identity name looks like.

Fixes [SDK-1481](https://dfinity.atlassian.net/browse/SDK-1481)

# How Has This Been Tested?

Not tested

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.


[SDK-1481]: https://dfinity.atlassian.net/browse/SDK-1481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ