### PR TITLE
refactor: fetch root key method names

### DIFF
--- a/src/dfx-core/src/error/root_key.rs
+++ b/src/dfx-core/src/error/root_key.rs
@@ -7,5 +7,5 @@ pub enum FetchRootKeyError {
     AgentError(#[from] ic_agent::AgentError),
 
     #[error("This command only runs on local instances. Cannot run this on the real IC.")]
-    NetworkMustBeLocal,
+    MustNotFetchRootKeyOnMainnet,
 }

--- a/src/dfx-core/src/network/root_key.rs
+++ b/src/dfx-core/src/network/root_key.rs
@@ -3,7 +3,15 @@ use crate::{
 };
 use ic_agent::Agent;
 
+#[deprecated(note = "use fetch_root_key_when_non_mainnet() instead")]
 pub async fn fetch_root_key_when_local(
+    agent: &Agent,
+    network: &NetworkDescriptor,
+) -> Result<(), FetchRootKeyError> {
+    fetch_root_key_when_non_mainnet(agent, network).await
+}
+
+pub async fn fetch_root_key_when_non_mainnet(
     agent: &Agent,
     network: &NetworkDescriptor,
 ) -> Result<(), FetchRootKeyError> {
@@ -16,7 +24,15 @@ pub async fn fetch_root_key_when_local(
     Ok(())
 }
 
+#[deprecated(note = "use fetch_root_key_when_non_mainnet_or_error() instead")]
 pub async fn fetch_root_key_when_local_or_error(
+    agent: &Agent,
+    network: &NetworkDescriptor,
+) -> Result<(), FetchRootKeyError> {
+    fetch_root_key_when_non_mainnet_or_error(agent, network).await
+}
+
+pub async fn fetch_root_key_when_non_mainnet_or_error(
     agent: &Agent,
     network: &NetworkDescriptor,
 ) -> Result<(), FetchRootKeyError> {
@@ -26,6 +42,6 @@ pub async fn fetch_root_key_when_local_or_error(
             .await
             .map_err(FetchRootKeyError::AgentError)
     } else {
-        Err(FetchRootKeyError::NetworkMustBeLocal)
+        Err(FetchRootKeyError::MustNotFetchRootKeyOnMainnet)
     }
 }

--- a/src/dfx/src/lib/root_key.rs
+++ b/src/dfx/src/lib/root_key.rs
@@ -5,7 +5,7 @@ use dfx_core::network::root_key;
 pub async fn fetch_root_key_if_needed(env: &dyn Environment) -> DfxResult {
     let agent = env.get_agent();
     let network = env.get_network_descriptor();
-    root_key::fetch_root_key_when_local(agent, network).await?;
+    root_key::fetch_root_key_when_non_mainnet(agent, network).await?;
     Ok(())
 }
 
@@ -14,6 +14,6 @@ pub async fn fetch_root_key_if_needed(env: &dyn Environment) -> DfxResult {
 pub async fn fetch_root_key_or_anyhow(env: &dyn Environment) -> DfxResult {
     let agent = env.get_agent();
     let network = env.get_network_descriptor();
-    root_key::fetch_root_key_when_local_or_error(agent, network).await?;
+    root_key::fetch_root_key_when_non_mainnet_or_error(agent, network).await?;
     Ok(())
 }


### PR DESCRIPTION
# Description

Renames (with deprecation0 two methods, since the criterion involved is whether the network is mainnet or not, rather than whether it is the local network or not, and the "local" setting also applies to testnets.
- fetch_root_key_when_local -> fetch_root_key_when_non_mainnet
- fetch_root_key_when_local_or_error -> fetch_root_key_when_non_mainnet_or_error

The motivation is an upcoming improvement to the interface used at https://github.com/dfinity/dfx-extensions/blob/main/extensions/nns/src/commands/install.rs#L70

# How Has This Been Tested?

Refactor covered by CI

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
