### PR TITLE
feat: add DfxInterface and builder for easier setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,7 @@ dependencies = [
  "directories-next",
  "dunce",
  "flate2",
+ "futures",
  "handlebars",
  "hex",
  "humantime-serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,7 @@ dependencies = [
  "thiserror",
  "time",
  "tiny-bip39",
+ "tokio",
  "url",
 ]
 

--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -46,3 +46,4 @@ url.workspace = true
 [dev-dependencies]
 proptest = "1.0"
 tempfile = "3.1.0"
+tokio = { workspace = true, features = ["full"] }

--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -44,6 +44,7 @@ time.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+futures.workspace = true
 proptest = "1.0"
 tempfile = "3.1.0"
 tokio = { workspace = true, features = ["full"] }

--- a/src/dfx-core/src/error/builder.rs
+++ b/src/dfx-core/src/error/builder.rs
@@ -13,6 +13,9 @@ pub enum BuildDfxInterfaceError {
     BuildAgent(#[from] BuildAgentError),
 
     #[error(transparent)]
+    BuildIdentity(#[from] BuildIdentityError),
+
+    #[error(transparent)]
     LoadNetworksConfig(#[from] LoadNetworksConfigError),
 
     #[error(transparent)]
@@ -36,9 +39,6 @@ pub enum BuildIdentityError {
 
 #[derive(Error, Debug)]
 pub enum BuildAgentError {
-    #[error(transparent)]
-    BuildIdentity(#[from] BuildIdentityError),
-
     #[error("failed to create http client")]
     CreateHttpClient(#[source] reqwest::Error),
 

--- a/src/dfx-core/src/error/builder.rs
+++ b/src/dfx-core/src/error/builder.rs
@@ -1,0 +1,53 @@
+use crate::error::{
+    identity::instantiate_identity_from_name::InstantiateIdentityFromNameError,
+    identity::new_identity_manager::NewIdentityManagerError, load_dfx_config::LoadDfxConfigError,
+    load_networks_config::LoadNetworksConfigError, network_config::NetworkConfigError,
+    root_key::FetchRootKeyError,
+};
+use ic_agent::AgentError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum BuildDfxInterfaceError {
+    #[error(transparent)]
+    BuildAgent(#[from] BuildAgentError),
+
+    #[error(transparent)]
+    LoadNetworksConfig(#[from] LoadNetworksConfigError),
+
+    #[error(transparent)]
+    LoadDfxConfig(#[from] LoadDfxConfigError),
+
+    #[error(transparent)]
+    NetworkConfig(#[from] NetworkConfigError),
+
+    #[error(transparent)]
+    FetchRootKey(#[from] FetchRootKeyError),
+}
+
+#[derive(Error, Debug)]
+pub enum BuildIdentityError {
+    #[error(transparent)]
+    NewIdentityManager(#[from] NewIdentityManagerError),
+
+    #[error(transparent)]
+    InstantiateIdentityFromName(#[from] InstantiateIdentityFromNameError),
+}
+
+#[derive(Error, Debug)]
+pub enum BuildAgentError {
+    #[error(transparent)]
+    BuildIdentity(#[from] BuildIdentityError),
+
+    #[error("failed to create http client")]
+    CreateHttpClient(#[source] reqwest::Error),
+
+    #[error("failed to create route provider")]
+    CreateRouteProvider(#[source] AgentError),
+
+    #[error("failed to create transportr")]
+    CreateTransport(#[source] AgentError),
+
+    #[error("failed to create agent")]
+    CreateAgent(#[source] AgentError),
+}

--- a/src/dfx-core/src/error/identity/new_identity_manager.rs
+++ b/src/dfx-core/src/error/identity/new_identity_manager.rs
@@ -17,4 +17,7 @@ pub enum NewIdentityManagerError {
 
     #[error("The specified identity must exist")]
     OverrideIdentityMustExist(#[source] RequireIdentityExistsError),
+
+    #[error(r#"No identity configuration found.  Please run "dfx identity get-principal" or "dfx identity new <identity name> to create a new identity."#)]
+    NoIdentityConfigurationFound,
 }

--- a/src/dfx-core/src/error/identity/new_identity_manager.rs
+++ b/src/dfx-core/src/error/identity/new_identity_manager.rs
@@ -18,6 +18,6 @@ pub enum NewIdentityManagerError {
     #[error("The specified identity must exist")]
     OverrideIdentityMustExist(#[source] RequireIdentityExistsError),
 
-    #[error(r#"No identity configuration found.  Please run "dfx identity get-principal" or "dfx identity new <identity name> to create a new identity."#)]
+    #[error(r#"No identity configuration found.  Please run "dfx identity get-principal" or "dfx identity new <identity name>" to create a new identity."#)]
     NoIdentityConfigurationFound,
 }

--- a/src/dfx-core/src/error/mod.rs
+++ b/src/dfx-core/src/error/mod.rs
@@ -1,4 +1,5 @@
 pub mod archive;
+pub mod builder;
 pub mod cache;
 pub mod canister;
 pub mod canister_id_store;

--- a/src/dfx-core/src/identity/identity_manager.rs
+++ b/src/dfx-core/src/identity/identity_manager.rs
@@ -203,10 +203,17 @@ pub struct IdentityManager {
     selected_identity_principal: Option<Principal>,
 }
 
+#[derive(PartialEq)]
+pub enum InitializeIdentity {
+    Allow,
+    Disallow,
+}
+
 impl IdentityManager {
     pub fn new(
         logger: &Logger,
         identity_override: Option<&str>,
+        initialize_identity: InitializeIdentity,
     ) -> Result<Self, NewIdentityManagerError> {
         let config_dfx_dir_path =
             get_user_dfx_config_dir().map_err(NewIdentityManagerError::GetConfigDirectoryFailed)?;
@@ -216,6 +223,8 @@ impl IdentityManager {
         let configuration = if identity_json_path.exists() {
             load_configuration(&identity_json_path)
                 .map_err(LoadIdentityManagerConfigurationFailed)?
+        } else if initialize_identity == InitializeIdentity::Disallow {
+            return Err(NewIdentityManagerError::NoIdentityConfigurationFound);
         } else {
             initialize(logger, &identity_json_path, &identity_root_path)
                 .map_err(NewIdentityManagerError::InitializeFailed)?

--- a/src/dfx-core/src/interface/builder.rs
+++ b/src/dfx-core/src/interface/builder.rs
@@ -18,7 +18,7 @@ use ic_agent::{
     agent::http_transport::{
         reqwest_transport::ReqwestHttpReplicaV2Transport, route_provider::RoundRobinRouteProvider,
     },
-    Agent, Identity
+    Agent, Identity,
 };
 use reqwest::Client;
 use std::sync::Arc;

--- a/src/dfx-core/src/interface/builder.rs
+++ b/src/dfx-core/src/interface/builder.rs
@@ -1,0 +1,174 @@
+use crate::{
+    config::model::{
+        dfinity::{Config, NetworksConfig},
+        network_descriptor::NetworkDescriptor,
+    },
+    error::{
+        builder::{BuildAgentError, BuildDfxInterfaceError, BuildIdentityError},
+        network_config::NetworkConfigError,
+    },
+    identity::{identity_manager::InitializeIdentity, IdentityManager},
+    network::{
+        provider::{create_network_descriptor, LocalBindDetermination},
+        root_key::fetch_root_key_when_non_mainnet_or_error,
+    },
+    DfxInterface,
+};
+use ic_agent::{
+    agent::http_transport::{
+        reqwest_transport::ReqwestHttpReplicaV2Transport, route_provider::RoundRobinRouteProvider,
+    },
+    Agent, Identity
+};
+use reqwest::Client;
+use std::sync::Arc;
+
+#[derive(PartialEq)]
+pub enum IdentityPicker {
+    Anonymous,
+    Selected,
+    Named(String),
+}
+
+#[derive(PartialEq)]
+pub enum NetworkPicker {
+    Local,
+    Mainnet,
+    Named(String),
+}
+
+pub struct DfxInterfaceBuilder {
+    identity: IdentityPicker,
+
+    network: NetworkPicker,
+
+    /// Force fetching of the root key.
+    /// This is insecure and should only be set for non-mainnet networks.
+    /// There is no need to set this for the local network, where the root key is fetched by default.
+    /// This would typically be set for a testnet, or an alias for the local network.
+    force_fetch_root_key_insecure_non_mainnet_only: bool,
+}
+
+impl DfxInterfaceBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            identity: IdentityPicker::Selected,
+            network: NetworkPicker::Local,
+            force_fetch_root_key_insecure_non_mainnet_only: false,
+        }
+    }
+
+    pub fn anonymous(self) -> Self {
+        self.with_identity(IdentityPicker::Anonymous)
+    }
+
+    pub fn with_identity_named(self, name: &str) -> Self {
+        self.with_identity(IdentityPicker::Named(name.to_string()))
+    }
+
+    pub fn with_identity(self, identity: IdentityPicker) -> Self {
+        Self { identity, ..self }
+    }
+
+    pub fn mainnet(self) -> Self {
+        self.with_network(NetworkPicker::Mainnet)
+    }
+
+    pub fn with_network(self, network: NetworkPicker) -> Self {
+        Self { network, ..self }
+    }
+
+    pub fn with_force_fetch_root_key_insecure_non_mainnet_only(
+        self,
+        force_fetch_root_key_insecure_non_mainnet_only: bool,
+    ) -> Self {
+        Self {
+            force_fetch_root_key_insecure_non_mainnet_only,
+            ..self
+        }
+    }
+
+    pub async fn build(&self) -> Result<DfxInterface, BuildDfxInterfaceError> {
+        let fetch_root_key = self.network == NetworkPicker::Local
+            || self.force_fetch_root_key_insecure_non_mainnet_only;
+        let networks_config = NetworksConfig::new()?;
+        let config = Config::from_current_dir(None)?.map(Arc::new);
+        let network_descriptor = self.build_network_descriptor(config.clone(), &networks_config)?;
+        let agent = self.build_agent(&network_descriptor)?;
+
+        if fetch_root_key {
+            fetch_root_key_when_non_mainnet_or_error(&agent, &network_descriptor).await?;
+        }
+
+        Ok(DfxInterface {
+            config,
+            agent,
+            networks_config,
+            network_descriptor,
+        })
+    }
+
+    fn build_agent(
+        &self,
+        network_descriptor: &NetworkDescriptor,
+    ) -> Result<Agent, BuildAgentError> {
+        let identity = self.build_identity()?;
+        let route_provider = RoundRobinRouteProvider::new(network_descriptor.providers.clone())
+            .map_err(BuildAgentError::CreateRouteProvider)?;
+        let client = Client::builder()
+            .use_rustls_tls()
+            .build()
+            .map_err(BuildAgentError::CreateHttpClient)?;
+        let transport = ReqwestHttpReplicaV2Transport::create_with_client_route(
+            Arc::new(route_provider),
+            client,
+        )
+        .map_err(BuildAgentError::CreateTransport)?;
+        let agent = Agent::builder()
+            .with_transport(transport)
+            .with_arc_identity(identity)
+            .build()
+            .map_err(BuildAgentError::CreateAgent)?;
+        Ok(agent)
+    }
+
+    fn build_identity(&self) -> Result<Arc<dyn Identity>, BuildIdentityError> {
+        if self.identity == IdentityPicker::Anonymous {
+            return Ok(Arc::new(ic_agent::identity::AnonymousIdentity));
+        }
+
+        let logger = slog::Logger::root(slog::Discard, slog::o!());
+        let mut identity_manager =
+            IdentityManager::new(&logger, None, InitializeIdentity::Disallow)?;
+        let identity: Box<dyn Identity> =
+            identity_manager.instantiate_selected_identity(&logger)?;
+        Ok(Arc::from(identity))
+    }
+
+    fn build_network_descriptor(
+        &self,
+        config: Option<Arc<Config>>,
+        networks_config: &NetworksConfig,
+    ) -> Result<NetworkDescriptor, NetworkConfigError> {
+        let network = match &self.network {
+            NetworkPicker::Local => None,
+            NetworkPicker::Mainnet => Some("ic".to_string()),
+            NetworkPicker::Named(name) => Some(name.clone()),
+        }
+        .map(String::from);
+        let logger = None;
+        create_network_descriptor(
+            config,
+            Arc::new(networks_config.clone()),
+            network,
+            logger,
+            LocalBindDetermination::ApplyRunningWebserverPort,
+        )
+    }
+}
+
+impl Default for DfxInterfaceBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/dfx-core/src/interface/dfx.rs
+++ b/src/dfx-core/src/interface/dfx.rs
@@ -1,9 +1,9 @@
 use crate::config::model::dfinity::{Config, NetworksConfig};
 use crate::config::model::network_descriptor::NetworkDescriptor;
+use crate::error::builder::BuildDfxInterfaceError;
 use crate::DfxInterfaceBuilder;
 use ic_agent::Agent;
 use std::sync::Arc;
-use crate::error::builder::BuildDfxInterfaceError;
 
 pub struct DfxInterface {
     pub(crate) config: Option<Arc<Config>>,

--- a/src/dfx-core/src/interface/dfx.rs
+++ b/src/dfx-core/src/interface/dfx.rs
@@ -1,0 +1,34 @@
+use crate::config::model::dfinity::{Config, NetworksConfig};
+use crate::config::model::network_descriptor::NetworkDescriptor;
+use crate::DfxInterfaceBuilder;
+use ic_agent::Agent;
+use std::sync::Arc;
+
+pub struct DfxInterface {
+    pub(crate) config: Option<Arc<Config>>,
+    pub(crate) agent: Agent,
+    pub(crate) networks_config: NetworksConfig,
+    pub(crate) network_descriptor: NetworkDescriptor,
+}
+
+impl DfxInterface {
+    pub fn builder() -> DfxInterfaceBuilder {
+        DfxInterfaceBuilder::new()
+    }
+
+    pub fn config(&self) -> Option<Arc<Config>> {
+        self.config.clone()
+    }
+
+    pub fn agent(&self) -> &Agent {
+        &self.agent
+    }
+
+    pub fn networks_config(&self) -> &NetworksConfig {
+        &self.networks_config
+    }
+
+    pub fn network_descriptor(&self) -> &NetworkDescriptor {
+        &self.network_descriptor
+    }
+}

--- a/src/dfx-core/src/interface/dfx.rs
+++ b/src/dfx-core/src/interface/dfx.rs
@@ -2,12 +2,13 @@ use crate::config::model::dfinity::{Config, NetworksConfig};
 use crate::config::model::network_descriptor::NetworkDescriptor;
 use crate::error::builder::BuildDfxInterfaceError;
 use crate::DfxInterfaceBuilder;
-use ic_agent::Agent;
+use ic_agent::{Agent, Identity};
 use std::sync::Arc;
 
 pub struct DfxInterface {
     pub(crate) config: Option<Arc<Config>>,
     pub(crate) agent: Agent,
+    pub(crate) identity: Arc<dyn Identity>,
     pub(crate) networks_config: NetworksConfig,
     pub(crate) network_descriptor: NetworkDescriptor,
 }
@@ -27,6 +28,10 @@ impl DfxInterface {
 
     pub fn agent(&self) -> &Agent {
         &self.agent
+    }
+
+    pub fn identity(&self) -> Arc<dyn Identity> {
+        self.identity.clone()
     }
 
     pub fn networks_config(&self) -> &NetworksConfig {

--- a/src/dfx-core/src/interface/dfx.rs
+++ b/src/dfx-core/src/interface/dfx.rs
@@ -3,6 +3,7 @@ use crate::config::model::network_descriptor::NetworkDescriptor;
 use crate::DfxInterfaceBuilder;
 use ic_agent::Agent;
 use std::sync::Arc;
+use crate::error::builder::BuildDfxInterfaceError;
 
 pub struct DfxInterface {
     pub(crate) config: Option<Arc<Config>>,
@@ -14,6 +15,10 @@ pub struct DfxInterface {
 impl DfxInterface {
     pub fn builder() -> DfxInterfaceBuilder {
         DfxInterfaceBuilder::new()
+    }
+
+    pub async fn anonymous() -> Result<DfxInterface, BuildDfxInterfaceError> {
+        DfxInterfaceBuilder::new().anonymous().build().await
     }
 
     pub fn config(&self) -> Option<Arc<Config>> {

--- a/src/dfx-core/src/interface/mod.rs
+++ b/src/dfx-core/src/interface/mod.rs
@@ -1,0 +1,4 @@
+pub mod builder;
+pub mod dfx;
+
+pub use builder::DfxInterfaceBuilder;

--- a/src/dfx-core/src/lib.rs
+++ b/src/dfx-core/src/lib.rs
@@ -6,7 +6,11 @@ pub mod extension;
 pub mod foundation;
 pub mod fs;
 pub mod identity;
+pub mod interface;
 pub mod json;
 pub mod network;
 pub mod process;
 pub mod util;
+
+pub use interface::builder::DfxInterfaceBuilder;
+pub use interface::dfx::DfxInterface;

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -13,7 +13,7 @@ use dfx_core::error::canister_id_store::CanisterIdStoreError;
 use dfx_core::error::identity::new_identity_manager::NewIdentityManagerError;
 use dfx_core::error::load_dfx_config::LoadDfxConfigError;
 use dfx_core::extension::manager::ExtensionManager;
-use dfx_core::identity::identity_manager::IdentityManager;
+use dfx_core::identity::identity_manager::{IdentityManager, InitializeIdentity};
 use fn_error_context::context;
 use ic_agent::{Agent, Identity};
 use semver::Version;
@@ -53,7 +53,11 @@ pub trait Environment {
     fn new_progress(&self, message: &str) -> ProgressBar;
 
     fn new_identity_manager(&self) -> Result<IdentityManager, NewIdentityManagerError> {
-        IdentityManager::new(self.get_logger(), self.get_identity_override())
+        IdentityManager::new(
+            self.get_logger(),
+            self.get_identity_override(),
+            InitializeIdentity::Allow,
+        )
     }
 
     // Explicit lifetimes are actually needed for mockall to work properly.


### PR DESCRIPTION
# Description

Adds `DfxInterface` and `DfxInterfaceBuilder` to dfx-core, meant to make it easier to load the dfx configuration and create an agent.

For an example use see: https://github.com/dfinity/dfx-extensions/pull/104/files#diff-f5cfacf098ff19a8547e1a28f532da8dd3edb0fa0c51c0a82d54b237760af60aR33

Companion PR: https://github.com/dfinity/dfx-extensions/pull/104

# How Has This Been Tested?

Added unit tests, and also tested in https://github.com/dfinity/dfx-extensions/pull/104.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
