### PR TITLE
feat: subaccount can be derived from principal in dfx ledger account-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+### feat: subaccount can be derived from principal in `dfx ledger account-id`
+
 ### feat: `dfx info candid-ui-url`
 
 `dfx info candid-ui-url` displays the URL to the Candid UI canister for an explicitly specified `--network <network name>` (or `local` by default).

--- a/docs/cli-reference/dfx-ledger.mdx
+++ b/docs/cli-reference/dfx-ledger.mdx
@@ -33,7 +33,7 @@ To view usage information for a specific subcommand, specify the subcommand and 
 
 ## dfx ledger account-id
 
-Use the `dfx ledger account-id` command to display the account identifier associated with the currently-active identity. Like the textual representation of your developer identity principal, the account identifier is derived from your private key and used to represent your identity in the ledger canister. The command can also be used to compute and display the account ids of other principals, canister aliases and subaccounts of your account.
+Use the `dfx ledger account-id` command to display the account identifier associated with the currently-active identity. Like the textual representation of your developer identity principal, the account identifier is derived from your private key and used to represent your identity in the ledger canister. The command can also be used to compute and display the account ids of other principals, canister aliases and subaccounts of your account (also subaccounts derived from principals).
 
 ### Basic usage
 
@@ -52,6 +52,7 @@ You can use the following optional flags with the `dfx ledger account-id` comman
 | `--of-canister <ALIAS>`      | Alias or principal of the canister controlling the account  |
 | `--of-principal <PRINCIPAL>` | Principal controlling the account                      |
 | `--subaccount <SUBACCOUNT>`   | Subaccount identifier (64 character long hex string)   |
+| `--subaccount-of-principal <PRINCIPAL>`   | Principal from which the subaccount identifier is derived.   |
 
 ### Examples
 
@@ -61,7 +62,13 @@ If you have created more than one identity, check the identity you are currently
 dfx ledger account-id
 ```
 
-The command displays output similar to the following:
+The following command computes the account identifier controlled by the Subnet Rental Canister and for the subaccount derived from Alice's principal:
+
+``` bash
+dfx ledger account-id --of-canister qvhpv-4qaaa-aaaaa-aaagq-cai --subaccount-from-principal fdsgv-62ihb-nbiqv-xgic5-iefsv-3cscz-tmbzv-63qd5-vh43v-dqfrt-pae
+```
+
+The commands display output similar to the following:
 
     03e3d86f29a069c6f2c5c48e01bc084e4ea18ad02b0eec8fccadf4487183c223
 

--- a/e2e/tests-dfx/ledger.bash
+++ b/e2e/tests-dfx/ledger.bash
@@ -34,6 +34,11 @@ current_time_nanoseconds() {
   assert_command dfx ledger account-id --of-principal fg7gi-vyaaa-aaaal-qadca-cai
   assert_match a014842f64a22e59887162a79c7ca7eb02553250704780ec4d954f12d0ea0b18
 
+  ALICE_PRINCIPAL="$(dfx identity get-principal)"
+  assert_command dfx ledger account-id --of-canister qvhpv-4qaaa-aaaaa-aaagq-cai --subaccount-from-principal ${ALICE_PRINCIPAL}
+  # value obtained by running `dfx --identity alice canister call --ic qvhpv-4qaaa-aaaaa-aaagq-cai get_payment_subaccount`
+  assert_match 7afe37275178a26c463a6609825748ba3ed3572f7f308917f96f9f7be20e9d01
+
   # --of-canister accepts both canister alias and canister principal
   assert_command dfx canister create dummy_canister
   assert_command dfx ledger account-id --of-canister "$(dfx canister id dummy_canister)"

--- a/e2e/tests-dfx/ledger.bash
+++ b/e2e/tests-dfx/ledger.bash
@@ -35,7 +35,7 @@ current_time_nanoseconds() {
   assert_match a014842f64a22e59887162a79c7ca7eb02553250704780ec4d954f12d0ea0b18
 
   ALICE_PRINCIPAL="$(dfx identity get-principal)"
-  assert_command dfx ledger account-id --of-canister qvhpv-4qaaa-aaaaa-aaagq-cai --subaccount-from-principal ${ALICE_PRINCIPAL}
+  assert_command dfx ledger account-id --of-canister qvhpv-4qaaa-aaaaa-aaagq-cai --subaccount-from-principal "${ALICE_PRINCIPAL}"
   # value obtained by running `dfx --identity alice canister call --ic qvhpv-4qaaa-aaaaa-aaagq-cai get_payment_subaccount`
   assert_match 7afe37275178a26c463a6609825748ba3ed3572f7f308917f96f9f7be20e9d01
 

--- a/src/dfx/src/commands/ledger/account_id.rs
+++ b/src/dfx/src/commands/ledger/account_id.rs
@@ -1,7 +1,7 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::nns_types::account_identifier::{AccountIdentifier, Subaccount};
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use candid::Principal;
 use clap::Parser;
 
@@ -12,7 +12,7 @@ pub struct AccountIdOpts {
     /// Principal controlling the account.
     pub of_principal: Option<Principal>,
 
-    #[arg(long, value_name = "ALIAS")]
+    #[arg(long, value_name = "ALIAS", conflicts_with("of_principal"))]
     /// Alias or principal of the canister controlling the account.
     pub of_canister: Option<String>,
 
@@ -20,18 +20,17 @@ pub struct AccountIdOpts {
     /// Subaccount identifier (64 character long hex string).
     pub subaccount: Option<Subaccount>,
 
-    #[arg(long, value_name = "SUBACCOUNT_FROM_PRINCIPAL")]
+    #[arg(
+        long,
+        value_name = "SUBACCOUNT_FROM_PRINCIPAL",
+        conflicts_with("subaccount")
+    )]
     /// Principal from which the subaccount identifier is derived.
     pub subaccount_from_principal: Option<Principal>,
 }
 
 pub async fn exec(env: &dyn Environment, opts: AccountIdOpts) -> DfxResult {
     let principal = if let Some(principal) = opts.of_principal {
-        if opts.of_canister.is_some() {
-            return Err(anyhow!(
-                "You can specify at most one of of-principal and of-canister arguments."
-            ));
-        }
         principal
     } else if let Some(alias) = opts.of_canister {
         let canister_id_store = env.get_canister_id_store()?;
@@ -41,11 +40,6 @@ pub async fn exec(env: &dyn Environment, opts: AccountIdOpts) -> DfxResult {
             .context("No identity is selected")?
     };
     let subaccount = if let Some(subaccount) = opts.subaccount {
-        if opts.subaccount_from_principal.is_some() {
-            return Err(anyhow!(
-                "You can specify at most one of subaccount and subaccount-from-principal arguments."
-            ));
-        }
         Some(subaccount)
     } else {
         opts.subaccount_from_principal

--- a/src/dfx/src/commands/ledger/account_id.rs
+++ b/src/dfx/src/commands/ledger/account_id.rs
@@ -47,11 +47,10 @@ pub async fn exec(env: &dyn Environment, opts: AccountIdOpts) -> DfxResult {
             ));
         }
         Some(subaccount)
-    } else if let Some(principal) = opts.subaccount_from_principal {
-        Some(Subaccount::from(&principal))
     } else {
-        None
+        opts.subaccount_from_principal
+            .map(|principal| Subaccount::from(&principal))
     };
-    println!("{}", AccountIdentifier::new(principal, opts.subaccount));
+    println!("{}", AccountIdentifier::new(principal, subaccount));
     Ok(())
 }


### PR DESCRIPTION
# Description

This PR makes it possible to derive the subaccount from a principal in the `dfx ledger account-id` command.
This is useful for NNS voters to validate NNS subnet rental request proposals by deriving the ledger account (controlled by the subnet rental canister's principal and using the proposer's principal as the subaccount) to which the proposer should have transfered the deposit.

# How Has This Been Tested?

A new e2e test has been added comparing the account ID returned by DFX against the account ID computed by the SRC for the caller.