### PR TITLE
fix: Capitalization of "Wasm"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### chore: Improve help text of `dfx identity new` to include which characters are valid in identity names
 
+### fix: Capitalization of "Wasm" in docs and messages
+
 ## Dependencies
 
 ### Updated to [agent-rs 0.35.0](https://github.com/dfinity/agent-rs/blob/main/CHANGELOG.md#0350---2024-05-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### fix: Capitalization of "Wasm" in docs and messages
 
+The output of `dfx canister status` has been also changed to use consistent capitalization of words.
+
 ## Dependencies
 
 ### Updated to [agent-rs 0.35.0](https://github.com/dfinity/agent-rs/blob/main/CHANGELOG.md#0350---2024-05-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Stderr:
 
 ### fix: "Failed to decrypt PEM file" errors messages will now include the cause
 
-### feat: WASM memory soft-limit
+### feat: Wasm memory soft-limit
 
 Adds support for the `wasm_memory_limit` canister setting, which limits the canister's heap during most calls but does not affect queries. As with other canister settings, it can be set in `dfx canister create` or `dfx canister update-settings` via the `--wasm-memory-limit` flag, as well as in `dfx.json` under `canisters[].initialization_values.wasm_memory_limit`.
 
@@ -555,7 +555,7 @@ Fix the HTTP header for deploying in remote environments
 
 ### feat: large canister modules now supported
 
-When using `dfx deploy` or `dfx canister install`, previously WASM modules larger than 2MiB would be rejected.
+When using `dfx deploy` or `dfx canister install`, previously Wasm modules larger than 2MiB would be rejected.
 They are now automatically submitted via the chunking API if they are large enough.
 From a user perspective the limitation will simply have been lifted.
 
@@ -1413,7 +1413,7 @@ The identity may be specified using the environment variable `DFX_IDENTITY`.
 
 ### feat: Add DFX_ASSETS_WASM
 
-Added the ability to configure the WASM module used for assets canisters through the environment variable `DFX_ASSETS_WASM`.
+Added the ability to configure the Wasm module used for assets canisters through the environment variable `DFX_ASSETS_WASM`.
 
 ### fix: dfx deploy and icx-asset no longer retry on permission failure
 
@@ -1529,7 +1529,7 @@ Added validate_grant_permission() and validate_revoke_permission() methods per S
 
 ### feat: Add dfx sns download
 
-This allows users to download SNS canister WASMs.
+This allows users to download SNS canister Wasm binaries.
 
 ### fix: fixed error text
 - `dfx nns install` had the wrong instructions for setting up the local replica type
@@ -2126,7 +2126,7 @@ It is now possible to inhibit automatic wallet creation by setting the `DFX_DISA
 
 ### feat: canister installation now waits for the replica
 
-When installing a new WASM module to a canister, DFX will now wait for the updated state (i.e. the new module hash) to be visible in the replica's certified state tree before proceeding with post-installation tasks or producing a success status.
+When installing a new Wasm module to a canister, DFX will now wait for the updated state (i.e. the new module hash) to be visible in the replica's certified state tree before proceeding with post-installation tasks or producing a success status.
 
 ### feat!: remove `dfx config`
 
@@ -2410,7 +2410,7 @@ can instead use `dfx canister metadata`.
 
 ### refactor: optimize from ic-wasm
 
-Optimize Rust canister WASM module via ic-wasm library instead of ic-cdk-optimizer. A separate installation of ic-cdk-optimizer is no longer needed.
+Optimize Rust canister Wasm module via ic-wasm library instead of ic-cdk-optimizer. A separate installation of ic-cdk-optimizer is no longer needed.
 
 The actual optimization was kept the same.
 
@@ -3707,7 +3707,7 @@ dfx deploy or dfx install will delete them.
 
 ### feat: get certified canister info from read state #1514
 
-Added `dfx canister info` command to get certified canister information. Currently this information is limited to the controller of the canister and the SHA256 hash of its WASM module. If there is no WASM module installed, the hash will be None.
+Added `dfx canister info` command to get certified canister information. Currently this information is limited to the controller of the canister and the SHA256 hash of its Wasm module. If there is no Wasm module installed, the hash will be None.
 
 ## Asset Canister
 
@@ -3850,18 +3850,18 @@ Please submit your Principal ("dfx identity get-principal") in the intake form t
 - feat: add deploy wallet subcommand to identity (#1414)
 
 This feature adds the deploy-wallet subcommand to the dfx identity.
-The User provides the ID of the canister onto which the wallet WASM is deployed.
+The User provides the ID of the canister onto which the wallet Wasm is deployed.
 
 ``` bash
 dfx identity deploy-wallet --help
 dfx-identity-deploy-wallet
-Installs the wallet WASM to the provided canister id
+Installs the wallet Wasm to the provided canister id
 
 USAGE:
     dfx identity deploy-wallet <canister-id>
 
 ARGS:
-    <canister-id>    The ID of the canister where the wallet WASM will be deployed
+    <canister-id>    The ID of the canister where the wallet Wasm will be deployed
 
 FLAGS:
     -h, --help       Prints help information

--- a/docs/cli-reference/dfx-canister.mdx
+++ b/docs/cli-reference/dfx-canister.mdx
@@ -32,7 +32,7 @@ For reference information and examples that illustrate using `dfx canister` comm
 | [`deposit-cycles`](#dfx-canister-deposit-cycles)   | Deposit cycles into the specified canister.                                                                                                            |
 | `help`                                             | Displays usage information message for a specified subcommand.                                                                                         |
 | [`id`](#dfx-canister-id)                           | Displays the identifier of a canister.                                                                                                                 |
-| [`info`](#dfx-canister-info)                       | Get the hash of a canister’s WASM module and its current controller.                                                                                   |
+| [`info`](#dfx-canister-info)                       | Get the hash of a canister’s Wasm module and its current controller.                                                                                   |
 | [`install`](#dfx-canister-install)                 | Installs compiled code in a canister.                                                                                                                  |
 | [`logs`](#dfx-canister-logs)                       | Returns the logs from a canister.                                                                                                                      |
 | [`metadata`](#dfx-canister-metadata)               | Displays metadata in a canister.                                                                                                                       |
@@ -459,7 +459,7 @@ The command displays output similar to the following:
 
 ## dfx canister info
 
-Use the `dfx canister info` command to output a canister's controller and installed WASM module hash.
+Use the `dfx canister info` command to output a canister's controller and installed Wasm module hash.
 
 ### Basic usage
 
@@ -477,7 +477,7 @@ You can use the following argument with the `dfx canister info` command.
 
 ### Examples
 
-You can use the `dfx canister info` command to display the canister controller and installed WASM module.
+You can use the `dfx canister info` command to display the canister controller and installed Wasm module.
 
 To the data about the `hello_world` canister, you can run the following command:
 
@@ -517,7 +517,7 @@ You can use the following options with the `dfx canister install` command.
 | `--no-wallet`                     | Performs the call with the user Identity as the Sender of messages. Bypasses the Wallet canister. Enabled by default.                                                                                                                                                 |
 | `--no-asset-upgrade`              | Skips upgrading the asset canister, to only install the assets themselves.                                                                                                                                                                                            |
 | `--upgrade-unchanged`             | Upgrade the canister even if the .wasm did not change.                                                                                                                                                                                                                |
-| `--wasm <file.wasm>`              | Specifies a particular WASM file to install, bypassing the dfx.json project settings.                                                                                                                                                                                 |
+| `--wasm <file.wasm>`              | Specifies a particular Wasm file to install, bypassing the dfx.json project settings.                                                                                                                                                                                 |
 
 #### Specifies the argument to pass to the init entrypoint
 
@@ -609,7 +609,7 @@ The command displays output similar to the following:
 
 ## dfx canister metadata
 
-Use the `dfx canister metadata` command to display metadata stored in a canister's WASM module.
+Use the `dfx canister metadata` command to display metadata stored in a canister's Wasm module.
 
 ### Basic usage
 

--- a/docs/cli-reference/dfx-identity.mdx
+++ b/docs/cli-reference/dfx-identity.mdx
@@ -22,7 +22,7 @@ For reference information and examples that illustrate using `dfx identity` comm
 
 | Command                                         | Description                                                                                                               |
 |-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| [`deploy-wallet`](#dfx-identity-deploy-wallet) | Installs the wallet WASM to the provided canister id.                                                                     |
+| [`deploy-wallet`](#dfx-identity-deploy-wallet) | Installs the wallet Wasm to the provided canister id.                                                                     |
 | [`get-principal`](#dfx-identity-get-principal) | Shows the textual representation of the principal associated with the current identity.                                   |
 | [`get-wallet`](#dfx-identity-get-wallet)       | Shows the canister identifier for the wallet associated with your current identity principal.                             |
 | `help`                                          | Displays this usage message or the help of the given subcommand(s).                                                       |
@@ -48,7 +48,7 @@ This command adds a private key for the `ic_admin` user identity in the `~/.conf
 
 ## dfx identity deploy-wallet
 
-Use the `dfx identity deploy-wallet` command to turn a canister into a wallet canister by installing the wallet WASM to it.
+Use the `dfx identity deploy-wallet` command to turn a canister into a wallet canister by installing the wallet Wasm to it.
 
 Note that you must be connected to the IC or the local canister execution environment to run this command. In addition, you must be a controller of the canister you want to deploy the wallet to.
 
@@ -64,7 +64,7 @@ You must specify the following argument for the `dfx identity deploy-wallet` com
 
 | Argument        | Description                                                    |
 |-----------------|----------------------------------------------------------------|
-| `<canister id>` | The ID of the canister where the wallet WASM will be deployed. |
+| `<canister id>` | The ID of the canister where the wallet Wasm will be deployed. |
 
 ## dfx identity get-principal
 

--- a/docs/dfx-json-schema.json
+++ b/docs/dfx-json-schema.json
@@ -209,7 +209,7 @@
             },
             "package": {
               "title": "Package Name",
-              "description": "Name of the rust package that compiles to this canister's WASM.",
+              "description": "Name of the rust package that compiles to this canister's Wasm binary.",
               "type": "string"
             },
             "type": {
@@ -273,7 +273,7 @@
           "properties": {
             "build": {
               "title": "Build Commands",
-              "description": "Commands that are executed in order to produce this canister's WASM module. Expected to produce the WASM in the path specified by the 'wasm' field. No build commands are allowed if the `wasm` field is a URL.",
+              "description": "Commands that are executed in order to produce this canister's Wasm module. Expected to produce the Wasm in the path specified by the 'wasm' field. No build commands are allowed if the `wasm` field is a URL.",
               "default": [],
               "allOf": [
                 {
@@ -293,8 +293,8 @@
               ]
             },
             "wasm": {
-              "title": "WASM Path",
-              "description": "Path to WASM to be installed. URLs to a WASM module are also acceptable. A canister that has a URL to a WASM module can not also have `build` steps.",
+              "title": "Wasm Path",
+              "description": "Path to Wasm to be installed. URLs to a Wasm module are also acceptable. A canister that has a URL to a Wasm module can not also have `build` steps.",
               "type": "string"
             }
           }
@@ -381,7 +381,7 @@
           }
         },
         "gzip": {
-          "title": "Gzip Canister WASM",
+          "title": "Gzip Canister Wasm",
           "description": "Disabled by default.",
           "type": [
             "boolean",
@@ -438,7 +438,7 @@
           }
         },
         "optimize": {
-          "title": "Optimize Canister WASM",
+          "title": "Optimize Canister Wasm",
           "description": "Invoke wasm level optimizations after building the canister. Optimization level can be set to \"cycles\" to optimize for cycle usage, \"size\" to optimize for binary size, or any of \"O4, O3, O2, O1, O0, Oz, Os\". Disabled by default. If this option is specified, the `shrink` option will be ignored.",
           "default": null,
           "anyOf": [
@@ -487,7 +487,7 @@
           ]
         },
         "shrink": {
-          "title": "Shrink Canister WASM",
+          "title": "Shrink Canister Wasm",
           "description": "Whether run `ic-wasm shrink` after building the Canister. Enabled by default for Rust/Motoko canisters. Disabled by default for custom canisters.",
           "type": [
             "boolean",
@@ -961,8 +961,8 @@
           "minimum": 0.0
         },
         "wasm_memory_limit": {
-          "title": "WASM Memory Limit",
-          "description": "Specifies a soft limit (in bytes) on the Wasm memory usage of the canister.\n\nUpdate calls, timers, heartbeats, installs, and post-upgrades fail if the WASM memory usage exceeds this limit. The main purpose of this setting is to protect against the case when the canister reaches the hard 4GiB limit.\n\nMust be a number of bytes between 0 and 2^48 (i.e. 256 TiB), inclusive. Can be specified as an integer, or as an SI unit string (e.g. \"4KB\", \"2 MiB\")",
+          "title": "Wasm Memory Limit",
+          "description": "Specifies a soft limit (in bytes) on the Wasm memory usage of the canister.\n\nUpdate calls, timers, heartbeats, installs, and post-upgrades fail if the Wasm memory usage exceeds this limit. The main purpose of this setting is to protect against the case when the canister reaches the hard 4GiB limit.\n\nMust be a number of bytes between 0 and 2^48 (i.e. 256 TiB), inclusive. Can be specified as an integer, or as an SI unit string (e.g. \"4KB\", \"2 MiB\")",
           "default": null,
           "anyOf": [
             {

--- a/e2e/assets/wasm/identity/README.adoc
+++ b/e2e/assets/wasm/identity/README.adoc
@@ -1,9 +1,9 @@
 = How to build the main.wasm
 
-The code for this WASM is in `/e2e/assets/identity/identity.mo`.
+The code for this Wasm is in `/e2e/assets/identity/identity.mo`.
 
 Follow the instructions there; create a new dfx project, overwrite the project's
 main.mo with the file above, and then rebuild it.
-Take the resulting WASM and DID and put them here.
+Take the resulting Wasm and DID and put them here.
 
 - [ ] TODO(#682)

--- a/e2e/tests-dfx/build.bash
+++ b/e2e/tests-dfx/build.bash
@@ -152,11 +152,11 @@ teardown() {
   dfx_start
   dfx canister create --all
   assert_command dfx build custom -vvv
-  assert_not_match "Shrinking WASM"
+  assert_not_match "Shrinking Wasm"
 
   jq '.canisters.custom.shrink=true' dfx.json | sponge dfx.json
   assert_command dfx build custom -vvv
-  assert_match "Shrinking WASM"
+  assert_match "Shrinking Wasm"
 }
 
 @test "build custom canister default no optimize" {
@@ -170,7 +170,7 @@ teardown() {
 
   jq '.canisters.custom.optimize="size"' dfx.json | sponge dfx.json
   assert_command dfx build custom -vvv
-  assert_match "Optimizing WASM at level"
+  assert_match "Optimizing Wasm at level"
 }
 
 @test "build succeeds if enable gzip" {

--- a/e2e/tests-dfx/create.bash
+++ b/e2e/tests-dfx/create.bash
@@ -23,11 +23,11 @@ teardown() {
 
     assert_command dfx canister create e2e_project_frontend --no-wallet
     assert_command dfx canister status e2e_project_frontend
-    assert_contains "Reserved Cycles Limit: 5_000_000_000_000 Cycles"
+    assert_contains "Reserved cycles limit: 5_000_000_000_000 Cycles"
 
     assert_command dfx canister create e2e_project_backend --reserved-cycles-limit 470000 --no-wallet
     assert_command dfx canister status e2e_project_backend
-    assert_contains "Reserved Cycles Limit: 470_000 Cycles"
+    assert_contains "Reserved cycles limit: 470_000 Cycles"
 }
 
 @test "create succeeds on default project" {
@@ -329,7 +329,7 @@ teardown() {
   assert_command dfx canister status e2e_project_backend
   assert_contains 'Memory allocation: 2_147_483_648'
   assert_contains 'Compute allocation: 5'
-  assert_contains 'Reserved Cycles Limit: 1_000_000_000_000'
-  assert_contains 'WASM Memory Limit: 1_073_741_824'
+  assert_contains 'Reserved cycles limit: 1_000_000_000_000'
+  assert_contains 'Wasm memory limit: 1_073_741_824'
   assert_contains 'Freezing threshold: 604_800'
 }

--- a/e2e/tests-dfx/deploy.bash
+++ b/e2e/tests-dfx/deploy.bash
@@ -25,7 +25,7 @@ teardown() {
     assert_command dfx deploy --no-wallet
 
     assert_command dfx canister status hello_backend
-    assert_contains "Reserved Cycles Limit: 860_000 Cycles"
+    assert_contains "Reserved cycles limit: 860_000 Cycles"
 }
 
 @test "deploy --upgrade-unchanged upgrades even if the .wasm did not change" {

--- a/e2e/tests-dfx/rust.bash
+++ b/e2e/tests-dfx/rust.bash
@@ -19,7 +19,7 @@ teardown() {
   dfx_start
   dfx canister create --all
   assert_command dfx build hello_backend -vvv
-  assert_match "Shrinking WASM"
+  assert_match "Shrinking Wasm"
   assert_command dfx canister install hello_backend
   assert_command dfx canister call hello_backend greet dfinity
   assert_match '("Hello, dfinity!")'

--- a/e2e/tests-dfx/update_settings.bash
+++ b/e2e/tests-dfx/update_settings.bash
@@ -18,11 +18,11 @@ teardown() {
     dfx_start
     assert_command dfx deploy hello_backend
     assert_command dfx canister status hello_backend
-    assert_contains "Reserved cycles Limit: 5_000_000_000_000 Cycles"
+    assert_contains "Reserved cycles limit: 5_000_000_000_000 Cycles"
 
     assert_command dfx canister update-settings hello_backend --reserved-cycles-limit 650000
     assert_command dfx canister status hello_backend
-    assert_contains "Reserved cycles Limit: 650_000 Cycles"
+    assert_contains "Reserved cycles limit: 650_000 Cycles"
 }
 
 @test "set freezing threshold" {

--- a/e2e/tests-dfx/update_settings.bash
+++ b/e2e/tests-dfx/update_settings.bash
@@ -18,11 +18,11 @@ teardown() {
     dfx_start
     assert_command dfx deploy hello_backend
     assert_command dfx canister status hello_backend
-    assert_contains "Reserved Cycles Limit: 5_000_000_000_000 Cycles"
+    assert_contains "Reserved cycles Limit: 5_000_000_000_000 Cycles"
 
     assert_command dfx canister update-settings hello_backend --reserved-cycles-limit 650000
     assert_command dfx canister status hello_backend
-    assert_contains "Reserved Cycles Limit: 650_000 Cycles"
+    assert_contains "Reserved cycles Limit: 650_000 Cycles"
 }
 
 @test "set freezing threshold" {
@@ -49,12 +49,12 @@ teardown() {
   assert_command dfx canister create e2e_project_backend --no-wallet --wasm-memory-limit 2MiB
   assert_command dfx deploy e2e_project_backend
   assert_command dfx canister status e2e_project_backend
-  assert_contains "WASM Memory Limit: 2_097_152 Bytes"
+  assert_contains "Wasm memory limit: 2_097_152 Bytes"
   # currently the limit is only checked when the memory grows. uncomment this line when that changes
   # assert_command dfx canister call e2e_project_backend greet_update '("alice")' 
   assert_command dfx canister update-settings e2e_project_backend --wasm-memory-limit 8b
   assert_command dfx canister status e2e_project_backend
-  assert_contains "WASM Memory Limit: 8 Bytes"
+  assert_contains "Wasm memory limit: 8 Bytes"
   assert_command dfx canister call e2e_project_backend greet '("alice")' --query
   assert_command dfx canister call e2e_project_backend greet '("alice")' --update
   assert_command_fail dfx canister call e2e_project_backend greet_update '("alice")'

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -277,13 +277,13 @@ pub struct ConfigCanistersCanister {
     /// Entry point for e.g. Motoko Compiler.
     pub main: Option<PathBuf>,
 
-    /// # Shrink Canister WASM
+    /// # Shrink Canister Wasm
     /// Whether run `ic-wasm shrink` after building the Canister.
     /// Enabled by default for Rust/Motoko canisters.
     /// Disabled by default for custom canisters.
     pub shrink: Option<bool>,
 
-    /// # Optimize Canister WASM
+    /// # Optimize Canister Wasm
     /// Invoke wasm level optimizations after building the canister. Optimization level can be set to "cycles" to optimize for cycle usage, "size" to optimize for binary size, or any of "O4, O3, O2, O1, O0, Oz, Os".
     /// Disabled by default.
     /// If this option is specified, the `shrink` option will be ignored.
@@ -305,7 +305,7 @@ pub struct ConfigCanistersCanister {
     #[serde(default)]
     pub tech_stack: Option<TechStack>,
 
-    /// # Gzip Canister WASM
+    /// # Gzip Canister Wasm
     /// Disabled by default.
     pub gzip: Option<bool>,
 
@@ -333,7 +333,7 @@ pub enum CanisterTypeProperties {
     /// # Rust-Specific Properties
     Rust {
         /// # Package Name
-        /// Name of the rust package that compiles to this canister's WASM.
+        /// Name of the rust package that compiles to this canister's Wasm.
         package: String,
 
         /// # Candid File
@@ -359,9 +359,9 @@ pub enum CanisterTypeProperties {
     },
     /// # Custom-Specific Properties
     Custom {
-        /// # WASM Path
-        /// Path to WASM to be installed. URLs to a WASM module are also acceptable.
-        /// A canister that has a URL to a WASM module can not also have `build` steps.
+        /// # Wasm Path
+        /// Path to Wasm to be installed. URLs to a Wasm module are also acceptable.
+        /// A canister that has a URL to a Wasm module can not also have `build` steps.
         wasm: String,
 
         /// # Candid File
@@ -369,8 +369,8 @@ pub enum CanisterTypeProperties {
         candid: String,
 
         /// # Build Commands
-        /// Commands that are executed in order to produce this canister's WASM module.
-        /// Expected to produce the WASM in the path specified by the 'wasm' field.
+        /// Commands that are executed in order to produce this canister's Wasm module.
+        /// Expected to produce the Wasm in the path specified by the 'wasm' field.
         /// No build commands are allowed if the `wasm` field is a URL.
         #[schemars(default)]
         build: SerdeVec<String>,
@@ -433,11 +433,11 @@ pub struct InitializationValues {
     #[schemars(with = "Option<u128>")]
     pub reserved_cycles_limit: Option<u128>,
 
-    /// # WASM Memory Limit
+    /// # Wasm Memory Limit
     /// Specifies a soft limit (in bytes) on the Wasm memory usage of the canister.
     ///
     /// Update calls, timers, heartbeats, installs, and post-upgrades fail if the
-    /// WASM memory usage exceeds this limit. The main purpose of this setting is
+    /// Wasm memory usage exceeds this limit. The main purpose of this setting is
     /// to protect against the case when the canister reaches the hard 4GiB
     /// limit.
     ///

--- a/src/dfx-core/src/error/dfx_config.rs
+++ b/src/dfx-core/src/error/dfx_config.rs
@@ -54,7 +54,7 @@ pub enum GetMemoryAllocationError {
 
 #[derive(Error, Debug)]
 pub enum GetWasmMemoryLimitError {
-    #[error("Failed to get WASM memory limit for canister '{0}': {1}")]
+    #[error("Failed to get Wasm memory limit for canister '{0}': {1}")]
     GetWasmMemoryLimitFailed(String, GetCanisterConfigError),
 }
 

--- a/src/dfx-core/src/extension/manifest/extension.rs
+++ b/src/dfx-core/src/extension/manifest/extension.rs
@@ -268,11 +268,11 @@ fn parse_test_file() {
       "about": "About for download command. You're looking at the output of parsing test extension.json.",
       "args": {
         "ic_commit": {
-          "about": "IC commit of SNS canister WASMs to download",
+          "about": "IC commit of SNS canister Wasm binaries to download",
           "long": "ic-commit"
         },
         "wasms_dir": {
-          "about": "Path to store downloaded SNS canister WASMs",
+          "about": "Path to store downloaded SNS canister Wasm binaries",
           "long": "wasms-dir"
         }
       }

--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -81,7 +81,7 @@ pub struct CanisterCreateOpts {
     /// Specifies a soft limit on the Wasm memory usage of the canister.
     ///
     /// Update calls, timers, heartbeats, installs, and post-upgrades fail if the
-    /// WASM memory usage exceeds this limit. The main purpose of this setting is
+    /// Wasm memory usage exceeds this limit. The main purpose of this setting is
     /// to protect against the case when the canister reaches the hard 4GiB
     /// limit.
     ///
@@ -194,7 +194,7 @@ pub async fn exec(
             Some(config_interface),
             Some(canister_name),
         )
-        .with_context(|| format!("Failed to read WASM memory limit of {canister_name}."))?;
+        .with_context(|| format!("Failed to read Wasm memory limit of {canister_name}."))?;
         create_canister(
             env,
             canister_name,
@@ -270,7 +270,7 @@ pub async fn exec(
                     Some(config_interface),
                     Some(canister_name),
                 )
-                .with_context(|| format!("Failed to read WASM memory limit of {canister_name}."))?;
+                .with_context(|| format!("Failed to read Wasm memory limit of {canister_name}."))?;
                 create_canister(
                     env,
                     canister_name,

--- a/src/dfx/src/commands/canister/info.rs
+++ b/src/dfx/src/commands/canister/info.rs
@@ -9,7 +9,7 @@ use candid::Principal;
 use clap::Parser;
 use itertools::Itertools;
 
-/// Get the hash of a canister’s WASM module and its current controllers.
+/// Get the hash of a canister’s Wasm module and its current controllers.
 #[derive(Parser)]
 pub struct InfoOpts {
     /// Specifies the name or id of the canister to get its canister information.

--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -49,7 +49,7 @@ pub struct CanisterInstallOpts {
     #[command(flatten)]
     argument_from_cli: ArgumentFromCliLongOpt,
 
-    /// Specifies a particular WASM file to install, bypassing the dfx.json project settings.
+    /// Specifies a particular Wasm file to install, bypassing the dfx.json project settings.
     #[arg(long, conflicts_with("all"))]
     wasm: Option<PathBuf>,
 

--- a/src/dfx/src/commands/canister/status.rs
+++ b/src/dfx/src/commands/canister/status.rs
@@ -51,7 +51,7 @@ async fn canister_status(
         "Not Set".to_string()
     };
 
-    println!("Canister status call result for {canister}.\nStatus: {status}\nControllers: {controllers}\nMemory allocation: {memory_allocation}\nCompute allocation: {compute_allocation}\nFreezing threshold: {freezing_threshold}\nMemory Size: {memory_size:?}\nBalance: {balance} Cycles\nReserved: {reserved} Cycles\nReserved Cycles Limit: {reserved_cycles_limit}\nWASM Memory Limit: {wasm_memory_limit}\nModule hash: {module_hash}\nNumber of queries: {queries_total}\nInstructions spent in queries: {query_instructions_total}\nTotal query request payload size (bytes): {query_req_payload_total}\nTotal query response payload size (bytes): {query_resp_payload_total}",
+    println!("Canister status call result for {canister}.\nStatus: {status}\nControllers: {controllers}\nMemory allocation: {memory_allocation}\nCompute allocation: {compute_allocation}\nFreezing threshold: {freezing_threshold}\nMemory Size: {memory_size:?}\nBalance: {balance} Cycles\nReserved: {reserved} Cycles\nReserved cycles limit: {reserved_cycles_limit}\nWasm memory limit: {wasm_memory_limit}\nModule hash: {module_hash}\nNumber of queries: {queries_total}\nInstructions spent in queries: {query_instructions_total}\nTotal query request payload size (bytes): {query_req_payload_total}\nTotal query response payload size (bytes): {query_resp_payload_total}",
         status = status.status,
         controllers = controllers.join(" "),
         memory_allocation = status.settings.memory_allocation,

--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -79,7 +79,7 @@ pub struct UpdateSettingsOpts {
     /// Sets a soft limit on the Wasm memory usage of the canister.
     ///
     /// Update calls, timers, heartbeats, installs, and post-upgrades fail if the
-    /// WASM memory usage exceeds this limit. The main purpose of this setting is
+    /// Wasm memory usage exceeds this limit. The main purpose of this setting is
     /// to protect against the case when the canister reaches the hard 4GiB
     /// limit.
     ///
@@ -230,7 +230,7 @@ pub async fn exec(
                     Some(config_interface),
                     Some(canister_name),
                 )
-                .with_context(|| format!("Failed to get WASM memory limit for {canister_name}."))?;
+                .with_context(|| format!("Failed to get Wasm memory limit for {canister_name}."))?;
                 if let Some(added) = &opts.add_controller {
                     let status = get_canister_status(env, canister_id, call_sender).await?;
                     let mut existing_controllers = status.settings.controllers;

--- a/src/dfx/src/commands/identity/deploy_wallet.rs
+++ b/src/dfx/src/commands/identity/deploy_wallet.rs
@@ -9,10 +9,10 @@ use candid::Principal as CanisterId;
 use clap::Parser;
 use tokio::runtime::Runtime;
 
-/// Installs the wallet WASM to the provided canister id.
+/// Installs the wallet Wasm to the provided canister id.
 #[derive(Parser)]
 pub struct DeployWalletOpts {
-    /// The ID of the canister where the wallet WASM will be deployed.
+    /// The ID of the canister where the wallet Wasm will be deployed.
     canister_id: String,
 }
 

--- a/src/dfx/src/lib/builders/custom.rs
+++ b/src/dfx/src/lib/builders/custom.rs
@@ -65,7 +65,7 @@ impl CustomBuilderExtra {
     }
 }
 
-/// A Builder for a WASM type canister, which has an optional build step.
+/// A Builder for a Wasm type canister, which has an optional build step.
 /// This will set environment variables for the external tool;
 ///   `CANISTER_ID`     => Its own canister ID (in textual format).
 ///   `CANDID_PATH`     => Its own candid path.

--- a/src/dfx/src/lib/ic_attributes/mod.rs
+++ b/src/dfx/src/lib/ic_attributes/mod.rs
@@ -99,7 +99,7 @@ impl TryFrom<ic_utils::interfaces::management_canister::builders::CanisterSettin
                 .and_then(|limit| limit.0.to_u64())
                 .map(|limit| {
                     WasmMemoryLimit::try_from(limit)
-                        .context("WASM memory limit must be between 0 and 2^48-1, inclusively.")
+                        .context("Wasm memory limit must be between 0 and 2^48-1, inclusively.")
                 })
                 .transpose()?,
         })
@@ -208,7 +208,7 @@ pub fn get_wasm_memory_limit(
             u64::try_from(arg.get_bytes())
                 .map_err(|e| anyhow!(e))
                 .and_then(|n| Ok(WasmMemoryLimit::try_from(n)?))
-                .context("WASM memory limit must be between 0 and 2^48 (i.e 256TB), inclusively.")
+                .context("Wasm memory limit must be between 0 and 2^48 (i.e 256TB), inclusively.")
         })
         .transpose()
 }

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -133,7 +133,7 @@ impl Canister {
 
         // optimize or shrink
         if let Some(level) = info.get_optimize() {
-            trace!(logger, "Optimizing WASM at level {}", level);
+            trace!(logger, "Optimizing Wasm at level {}", level);
             ic_wasm::optimize::optimize(
                 &mut m,
                 &wasm_opt_level_convert(level),
@@ -141,12 +141,12 @@ impl Canister {
                 &None,
                 false,
             )
-            .context("Failed to optimize the WASM module.")?;
+            .context("Failed to optimize the Wasm module.")?;
             modified = true;
         } else if info.get_shrink() == Some(true)
             || (info.get_shrink().is_none() && (info.is_rust() || info.is_motoko()))
         {
-            trace!(logger, "Shrinking WASM");
+            trace!(logger, "Shrinking Wasm");
             ic_wasm::shrink::shrink(&mut m);
             modified = true;
         }
@@ -295,7 +295,7 @@ impl Canister {
             // gzip
             // Unlike using gzip CLI, the compression below only takes the wasm bytes
             // So as long as the wasm bytes are the same, the gzip file will be the same on different platforms.
-            trace!(logger, "Compressing WASM");
+            trace!(logger, "Compressing Wasm");
             compress_bytes(&m.emit_wasm())?
         } else {
             m.emit_wasm()

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -255,7 +255,7 @@ async fn register_canisters(
                         .map_err(|e| anyhow!(e))
                         .and_then(|n| Ok(WasmMemoryLimit::try_from(n)?))
                         .context(
-                            "WASM memory limit must be between 0 and 2^48 (i.e 256TB), inclusively.",
+                            "Wasm memory limit must be between 0 and 2^48 (i.e 256TB), inclusively.",
                         )
                 },
             ).transpose()?;


### PR DESCRIPTION
This replaces incorrect capitalization of "WASM" with "Wasm", which is the official abbreviation of WebAssembly.

See: https://webassembly.org/

The reason why not all letters are capitalized is because "Wasm" is not an acronym, but rather an abbreviation.

This change also fixes capitalization of the canister status output to be consistent wih other fields.

