### PR TITLE
Update the help messages of `dfx wallet send`

### DIFF
--- a/src/dfx/src/commands/wallet/send.rs
+++ b/src/dfx/src/commands/wallet/send.rs
@@ -7,10 +7,10 @@ use candid::CandidType;
 use candid::Principal;
 use clap::Parser;
 
-/// Send cycles to another cycles wallet.
+/// Send cycles to a canister.
 #[derive(Parser)]
 pub struct SendOpts {
-    /// Canister ID of the destination cycles wallet.
+    /// Canister ID of the destination canister.
     destination: String,
 
     /// Specifies the amount of cycles to send.


### PR DESCRIPTION
# Description

This is a supplement pr to https://github.com/dfinity/sdk/pull/3560. A customer reported that `dfx wallet send -h` still shows that this command can `only` be used to send cycles to a cycle wallet, which is not incorrect.

Fixes [SDK-1675](https://dfinity.atlassian.net/browse/SDK-1675)

# How Has This Been Tested?

Help message change only.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
