### PR TITLE
docs: remove reference to obsolete warning

### DIFF
--- a/docs/cli-reference/dfx-envars.mdx
+++ b/docs/cli-reference/dfx-envars.mdx
@@ -54,17 +54,13 @@ Use the `DFX_MOC_PATH` environment variable to use a different version of the Mo
 
 Use the `DFX_WARNING` environment variable to disable one or more warnings that dfx may display. The value is a comma-separated list of warning names, each prefixed with a "-" to disable. The following warning names are currently supported:
 
-- `version_check`: Disables the warning message that is displayed when you use an older version of the SDK.
 - `mainnet_plaintext_identity`: Disables the warning message that is displayed when you use an insecure identity on the Internet Computer mainnet.
 
 ```bash
-export DFX_WARNING="-version_check"
-DFX_VERSION=0.13.1 dfx deploy --network ic
-
 export DFX_WARNING="-mainnet_plaintext_identity"
 dfx deploy --network ic
 
-# disable multiple warnings, though dfx 0.13.1 does not know about the mainnet_plaintext_identity warning
+# disable multiple warnings, though dfx 0.13.1 does not know about the mainnet_plaintext_identity warning and version_check no longer exists
 export DFX_WARNING="-version_check,-mainnet_plaintext_identity"
 DFX_VERSION=0.13.1 dfx deploy --network ic
 ```


### PR DESCRIPTION
Remove reference in docs to a warning removed in https://github.com/dfinity/sdk/pull/3624
