### PR TITLE
fix: reword confusing log message about default shared network config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # UNRELEASED
 
+### fix: simplified log message when using the default shared network configuration
+
+Now displays `Using the default configuration for the local shared network.`
+instead of `Using the default definition for the 'local' shared network because ~/.config/dfx/networks.json does not define it.`
+
 ### feat: `dfx start` for the shared local network stores replica state files in unique directories by options
 
 The state files for different replica versions are often incompatible,

--- a/e2e/tests-dfx/describe_local_network.bash
+++ b/e2e/tests-dfx/describe_local_network.bash
@@ -51,7 +51,7 @@ teardown() {
   assert_command dfx start --host 127.0.0.1:0 --background --verbose
 
   assert_match "There is no project-specific network 'local' defined in .*/some-project/dfx.json."
-  assert_match "Using the default definition for the 'local' shared network because $DFX_CONFIG_ROOT/.config/dfx/networks.json does not exist."
+  assert_match "Using the default configuration for the local shared network"
 
   assert_match "Local server configuration:"
   assert_match "bind address: 127.0.0.1:0 \(default: 127.0.0.1:4943\)"
@@ -65,7 +65,7 @@ teardown() {
   assert_command dfx start --host 127.0.0.1:0 --background --verbose
 
   assert_match "There is no project-specific network 'local' because there is no project \(no dfx.json\)."
-  assert_match "Using the default definition for the 'local' shared network because $DFX_CONFIG_ROOT/.config/dfx/networks.json does not exist."
+  assert_match "Using the default configuration for the local shared network"
 }
 
 @test "dfx start outside of a project with a shared configuration file" {
@@ -74,7 +74,7 @@ teardown() {
   assert_command dfx start --background --verbose
 
   assert_match "There is no project-specific network 'local' because there is no project \(no dfx.json\)."
-  assert_match "Using the default definition for the 'local' shared network because $DFX_CONFIG_ROOT/.config/dfx/networks.json does not define it."
+  assert_match "Using the default configuration for the local shared network"
 }
 
 

--- a/src/dfx-core/src/network/provider.rs
+++ b/src/dfx-core/src/network/provider.rs
@@ -229,11 +229,7 @@ fn create_shared_network_descriptor(
     let network = shared_config.get_interface().get_network(network_name);
     let network = match (network_name, network) {
         ("local", None) => {
-            if shared_config_file_exists {
-                info!(logger, "Using the default definition for the 'local' shared network because {} does not define it.", shared_config_display_path);
-            } else {
-                info!(logger, "Using the default definition for the 'local' shared network because {} does not exist.", shared_config_display_path);
-            }
+            info!(logger, "Using the default configuration for the local shared network.");
 
             Some(ConfigNetwork::ConfigLocalProvider(ConfigLocalProvider {
                 bind: Some(String::from(DEFAULT_SHARED_LOCAL_BIND)),

--- a/src/dfx-core/src/network/provider.rs
+++ b/src/dfx-core/src/network/provider.rs
@@ -229,7 +229,10 @@ fn create_shared_network_descriptor(
     let network = shared_config.get_interface().get_network(network_name);
     let network = match (network_name, network) {
         ("local", None) => {
-            info!(logger, "Using the default configuration for the local shared network.");
+            info!(
+                logger,
+                "Using the default configuration for the local shared network."
+            );
 
             Some(ConfigNetwork::ConfigLocalProvider(ConfigLocalProvider {
                 bind: Some(String::from(DEFAULT_SHARED_LOCAL_BIND)),


### PR DESCRIPTION

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)

# How Has This Been Tested?

Changed the message
```
Using the default definition for the 'local' shared network because ~/.config/dfx/networks.json does not define it.
```

to

```
Using the default configuration for the local shared network.
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
