### PR TITLE
feat!: remove support for bitcoin query API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+### feat!: remove support for bitcoin query API
+
+`dfx call --query aaaaa-aa bitcoin_get_balance_query/bitcoin_get_utxos_query` will result in an error.
+
 ### fix: simplified log message when using the default shared network configuration
 
 Now displays `Using the default configuration for the local shared network.`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,8 +2649,7 @@ dependencies = [
 [[package]]
 name = "ic-agent"
 version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba85280257d8663adef20bf5c043b287b3a283d4f916073eb3ca9166a4a59d4b"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=be929fd7967249c879f48f2f494cbfc5805a7d98#be929fd7967249c879f48f2f494cbfc5805a7d98"
 dependencies = [
  "async-lock 3.3.0",
  "backoff",
@@ -3089,8 +3088,7 @@ dependencies = [
 [[package]]
 name = "ic-identity-hsm"
 version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163ac173f5fc62a4c082ecaa1467efe83fe8534fca9edbeef3895f6a3df9b13b"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=be929fd7967249c879f48f2f494cbfc5805a7d98#be929fd7967249c879f48f2f494cbfc5805a7d98"
 dependencies = [
  "hex",
  "ic-agent",
@@ -3190,8 +3188,7 @@ dependencies = [
 [[package]]
 name = "ic-transport-types"
 version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce14c068bd053c0f5ab525326f3f358f265cdfcae279fbf6461fb529e9682acd"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=be929fd7967249c879f48f2f494cbfc5805a7d98#be929fd7967249c879f48f2f494cbfc5805a7d98"
 dependencies = [
  "candid",
  "hex",
@@ -3260,8 +3257,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2e0da151b7fab7b977fbca381db15da51b0e9af896c97a17de567858df548f"
+source = "git+https://github.com/dfinity/agent-rs.git?rev=be929fd7967249c879f48f2f494cbfc5805a7d98#be929fd7967249c879f48f2f494cbfc5805a7d98"
 dependencies = [
  "async-trait",
  "candid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ license = "Apache-2.0"
 [workspace.dependencies]
 candid = "0.10.4"
 candid_parser = "0.1.4"
-ic-agent = "0.36.0"
+ic-agent = { git = "https://github.com/dfinity/agent-rs.git", rev = "be929fd7967249c879f48f2f494cbfc5805a7d98" }
 ic-asset = { path = "src/canisters/frontend/ic-asset" }
 ic-cdk = "0.13.1"
-ic-identity-hsm = "0.36.0"
-ic-utils = "0.36.0"
+ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs.git", rev = "be929fd7967249c879f48f2f494cbfc5805a7d98" }
+ic-utils = { git = "https://github.com/dfinity/agent-rs.git", rev = "be929fd7967249c879f48f2f494cbfc5805a7d98" }
 
 aes-gcm = "0.10.3"
 anyhow = "1.0.56"

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -196,27 +196,4 @@ set_local_network_bitcoin_enabled() {
   # The error message indicates that the argument is in correct format, only the inner transaction is malformed.
   assert_command_fail dfx canister call --wallet "$WALLET_ID" aaaaa-aa --candid bitcoin.did bitcoin_send_transaction '(record { transaction = vec {0:nat8}; network = variant { regtest } })'
   assert_contains "send_transaction failed: MalformedTransaction"
-
-  # the query Bitcoin API can be called directly
-
-  # bitcoin_get_balance_query
-  assert_command dfx canister call --query aaaaa-aa --candid bitcoin.did bitcoin_get_balance_query '(
-  record {
-    network = variant { regtest };
-    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
-    min_confirmations = opt (1 : nat32);
-  }
-)'
-  # shellcheck disable=SC2154
-  assert_eq "(0 : nat64)" "$stdout"
-
-  # bitcoin_get_balance_query
-  assert_command dfx canister call --query aaaaa-aa --candid bitcoin.did bitcoin_get_utxos_query '(
-  record {
-    network = variant { regtest };
-    filter = opt variant { min_confirmations = 1 : nat32 };
-    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
-  }
-)'
-  assert_contains "tip_height = 0 : nat32;"
 }

--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -237,55 +237,6 @@ teardown() {
   assert_match '("Hello, you!")'
 }
 
-@test "call management canister - bitcoin query API on the IC mainnet" {
-  WARNING="call to the management canister cannot be benefit from the \"Replica Signed Queries\" feature.
-The response might not be trustworthy.
-If you want to get reliable result, you can make an update call to the secure alternative:"
-  # bitcoin_get_balance_query
-  ## bitcoin mainnet
-  assert_command dfx canister call --network ic --query aaaaa-aa bitcoin_get_balance_query '(
-  record {
-    network = variant { mainnet };
-    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
-  }
-)'
-  # shellcheck disable=SC2154
-  assert_contains "bitcoin_get_balance_query $WARNING bitcoin_get_balance" "$stderr"
-
-  # TODO: re-enable when testnet back to normal, tracking at https://dfinity.atlassian.net/browse/SDKTG-323
-
-#   ## bitcoin testnet
-#   assert_command dfx canister call --network ic --query aaaaa-aa bitcoin_get_balance_query '(
-#   record {
-#     network = variant { testnet };
-#     address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
-#   }
-# )'
-#   # shellcheck disable=SC2154
-#   assert_contains "bitcoin_get_balance_query $WARNING bitcoin_get_balance" "$stderr"
-
-  # bitcoin_get_utxos_query
-  ## bitcoin mainnet
-  assert_command dfx canister call --network ic --query aaaaa-aa bitcoin_get_utxos_query '(
-  record {
-    network = variant { mainnet };
-    address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
-  }
-)'
-  # shellcheck disable=SC2154
-  assert_contains "bitcoin_get_utxos_query $WARNING bitcoin_get_utxos" "$stderr"
-
-#   ## bitcoin testnet
-#   assert_command dfx canister call --network ic --query aaaaa-aa bitcoin_get_utxos_query '(
-#   record {
-#     network = variant { testnet };
-#     address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
-#   }
-# )'
-#   # shellcheck disable=SC2154
-#   assert_contains "bitcoin_get_utxos_query $WARNING bitcoin_get_utxos" "$stderr"
-}
-
 @test "inter-canister calls" {
   dfx_new_rust inter
   install_asset inter

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -197,7 +197,7 @@ pub fn get_effective_canister_id(
         // TODO: SDKTG-347
         // BitcoinGetUtxosQuery and BitcoinGetBalanceQuery are to be removed.
         // We should remove this match arm when they are removed from `MgmtMethod` in ic-utils.
-        _ => Err(anyhow!(
+        MgmtMethod::BitcoinGetUtxosQuery | MgmtMethod::BitcoinGetBalanceQuery => Err(anyhow!(
             "Attempted to call an unsupported management canister method: {}",
             method_name
         )),

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -194,9 +194,13 @@ pub fn get_effective_canister_id(
                 Decode!(arg_value, In).context("Argument is not valid for InstallChunkedCode")?;
             Ok(in_args.target_canister)
         }
-        MgmtMethod::BitcoinGetUtxosQuery | MgmtMethod::BitcoinGetBalanceQuery => {
-            Ok(CanisterId::management_canister())
-        }
+        // TODO: SDKTG-347
+        // BitcoinGetUtxosQuery and BitcoinGetBalanceQuery are to be removed.
+        // We should remove this match arm when they are removed from `MgmtMethod` in ic-utils.
+        _ => Err(anyhow!(
+            "Attempted to call an unsupported management canister method: {}",
+            method_name
+        )),
     }
 }
 
@@ -250,7 +254,6 @@ pub async fn exec(
         opts.always_assist,
     )?;
 
-    let mut disable_verify_query_signatures = false;
     let effective_canister_id = if canister_id == CanisterId::management_canister() {
         let management_method = MgmtMethod::from_str(method_name).map_err(|_| {
             anyhow!(
@@ -258,39 +261,6 @@ pub async fn exec(
                 method_name
             )
         })?;
-
-        if matches!(
-            management_method,
-            MgmtMethod::BitcoinGetBalanceQuery | MgmtMethod::BitcoinGetUtxosQuery
-        ) {
-            match call_sender {
-                CallSender::SelectedId => {
-                    // Query calls to those two bitcoin query methods can not make a following read_state call.
-                    // We have to use a non-verify_query_signatures agent to make the call.
-                    // Rust's lifetime rule forces us to create the special env/agent outside this block.
-                    // agent = non_verify_query_signatures_agent;
-                    disable_verify_query_signatures = true;
-                    let secure_alt = match management_method {
-                        MgmtMethod::BitcoinGetBalanceQuery => "bitcoin_get_balance",
-                        MgmtMethod::BitcoinGetUtxosQuery => "bitcoin_get_utxos",
-                        _ => unreachable!(),
-                    };
-                    warn!(env.get_logger(), "{method_name} call to the management canister cannot be benefit from the \"Replica Signed Queries\" feature.
-The response might not be trustworthy.
-If you want to get reliable result, you can make an update call to the secure alternative: {secure_alt}");
-                }
-                CallSender::Wallet(_) => {
-                    return Err(DiagnosedError::new(
-                        format!(
-                            "{} can only be called directly without a wallet proxy.",
-                            method_name
-                        ),
-                        "Please remove the `--wallet <wallet id>` option.".to_string(),
-                    ))
-                    .context("Method only callable without wallet proxy.");
-                }
-            }
-        }
 
         if matches!(call_sender, CallSender::SelectedId)
             && matches!(
@@ -364,13 +334,7 @@ To figure out the id of your wallet, run 'dfx identity get-wallet (--network ic)
                     .query(&canister_id, method_name)
                     .with_effective_canister_id(effective_canister_id)
                     .with_arg(arg_value);
-                match disable_verify_query_signatures {
-                    true => query_builder
-                        .call_without_verification()
-                        .await
-                        .context("Failed query call.")?,
-                    false => query_builder.call().await.context("Failed query call.")?,
-                }
+                query_builder.call().await.context("Failed query call.")?
             }
             CallSender::Wallet(wallet_id) => {
                 let wallet = build_wallet_canister(*wallet_id, agent).await?;

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -194,13 +194,6 @@ pub fn get_effective_canister_id(
                 Decode!(arg_value, In).context("Argument is not valid for InstallChunkedCode")?;
             Ok(in_args.target_canister)
         }
-        // TODO: SDKTG-347
-        // BitcoinGetUtxosQuery and BitcoinGetBalanceQuery are to be removed.
-        // We should remove this match arm when they are removed from `MgmtMethod` in ic-utils.
-        MgmtMethod::BitcoinGetUtxosQuery | MgmtMethod::BitcoinGetBalanceQuery => Err(anyhow!(
-            "Attempted to call an unsupported management canister method: {}",
-            method_name
-        )),
     }
 }
 


### PR DESCRIPTION
SDK-1720

# Description

The bitcoin query API are to be removed from replica and spec.

`agent-rs` has already [removed](https://github.com/dfinity/agent-rs/pull/567) the query API. Updated the agent dependencies to `be929fd7967249c879f48f2f494cbfc5805a7d98`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
