### PR TITLE
feat: upload br encoding to asset canister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,12 @@ Adds support for the `log_visibility` canister setting, which configures which u
 Valid options are `controllers` and `public`. The setting can be used with the `--log-visibility` flag in `dfx canister create`
 and `dfx canister update-settings`, or in `dfx.json` under `canisters[].initialization_values.log_visibility`.
 
+## Asset canister synchronization
+
+### feat: upload `br` encoding for `text`, `js`, and `html` MIME types
+
+Asset synchronization now not only uploads `identity` and `gzip` as encodings for MIME types `text`, `js`, and `html`, but also `br` encoding. 
+
 ## Dependencies
 
 ### Frontend canister

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,9 +96,12 @@ and `dfx canister update-settings`, or in `dfx.json` under `canisters[].initiali
 
 ## Asset canister synchronization
 
-### feat: upload `br` encoding for `text`, `js`, and `html` MIME types
+### feat: support `brotli` encoding
 
-Asset synchronization now not only uploads `identity` and `gzip` as encodings for MIME types `text`, `js`, and `html`, but also `br` encoding. 
+Asset synchronization now not only supports `identity` and `gzip`, but also `brotli` encoding.
+The default encodings are still
+- `identity` and `gzip` for MIME types `.txt`, `.html` and `.js`
+- `identity` for anything else
 
 ## Dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +653,27 @@ dependencies = [
  "quote",
  "syn 2.0.61",
  "syn_derive",
+]
+
+[[package]]
+name = "brotli"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -2691,6 +2727,7 @@ name = "ic-asset"
 version = "0.20.0"
 dependencies = [
  "backoff",
+ "brotli",
  "candid",
  "derivative",
  "dfx-core",

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -135,14 +135,14 @@ check_permission_failure() {
   dfx identity get-principal --identity prepare
   dfx canister call e2e_project_frontend list_permitted '(record { permission = variant { Commit }; })'
   assert_command dfx deploy e2e_project_frontend --by-proposal --identity prepare
-  assert_contains "Proposed commit of batch 2 with evidence 164fcc4d933ff9992ab6ab909a4bf350010fa0f4a3e1e247bfc679d3f45254e1.  Either commit it by proposal, or delete it."
+  assert_contains "Proposed commit of batch 2 with evidence 1eefb141d169b1b757a04bb3fc354c416d63d8ff925ed2f7606ea1a1407b6912.  Either commit it by proposal, or delete it."
 
   assert_command_fail dfx deploy e2e_project_frontend --by-proposal --identity prepare
   assert_contains "Batch 2 is already proposed.  Delete or execute it to propose another."
 
   assert_command dfx deploy e2e_project_frontend --compute-evidence --identity anonymous
   # shellcheck disable=SC2154
-  assert_eq "164fcc4d933ff9992ab6ab909a4bf350010fa0f4a3e1e247bfc679d3f45254e1" "$stdout"
+  assert_eq "1eefb141d169b1b757a04bb3fc354c416d63d8ff925ed2f7606ea1a1407b6912" "$stdout"
 
   ID=$(dfx canister id e2e_project_frontend)
   PORT=$(get_webserver_port)
@@ -162,9 +162,9 @@ check_permission_failure() {
   assert_command_fail dfx canister call e2e_project_frontend commit_proposed_batch "$wrong_commit_args" --identity commit
   assert_match "batch computed evidence .* does not match presented evidence"
 
-  commit_args='(record { batch_id = 2; evidence = blob "\16\4f\cc\4d\93\3f\f9\99\2a\b6\ab\90\9a\4b\f3\50\01\0f\a0\f4\a3\e1\e2\47\bf\c6\79\d3\f4\52\54\e1" } )'
+  commit_args='(record { batch_id = 2; evidence = blob "\1e\ef\b1\41\d1\69\b1\b7\57\a0\4b\b3\fc\35\4c\41\6d\63\d8\ff\92\5e\d2\f7\60\6e\a1\a1\40\7b\69\12" } )'
   assert_command dfx canister call e2e_project_frontend validate_commit_proposed_batch "$commit_args" --identity commit
-  assert_contains "commit proposed batch 2 with evidence 164f"
+  assert_contains "commit proposed batch 2 with evidence 1eef"
   assert_command dfx canister call e2e_project_frontend commit_proposed_batch "$commit_args" --identity commit
   assert_eq "()"
 

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -835,6 +835,35 @@ check_permission_failure() {
   diff encoded-compressed-2 src/e2e_project_frontend/assets/notreally.js
 }
 
+@test "generates brotli-compressed content encoding for .js files" {
+  install_asset assetscanister
+  for i in $(seq 1 400); do
+    echo "some easily duplicate text $i" >>src/e2e_project_frontend/assets/notreally.js
+  done
+
+  dfx_start
+  assert_command dfx deploy
+  dfx canister call --query e2e_project_frontend list '(record{})'
+
+  ID=$(dfx canister id e2e_project_frontend)
+  PORT=$(get_webserver_port)
+
+  assert_command curl -v --output not-compressed http://localhost:"$PORT"/notreally.js?canisterId="$ID"
+  assert_not_match "content-encoding:"
+  diff not-compressed src/e2e_project_frontend/assets/notreally.js
+
+  assert_command curl -v --output encoded-compressed-1.br -H "Accept-Encoding: br" http://localhost:"$PORT"/notreally.js?canisterId="$ID"
+  assert_match "content-encoding: br"
+  brotli --decompress encoded-compressed-1.br
+  diff encoded-compressed-1 src/e2e_project_frontend/assets/notreally.js
+
+  # should split up accept-encoding lines with more than one encoding
+  assert_command curl -v --output encoded-compressed-2.br -H "Accept-Encoding: br, deflate, gzip" http://localhost:"$PORT"/notreally.js?canisterId="$ID"
+  assert_match "content-encoding: br"
+  brotli --decompress encoded-compressed-2.br
+  diff encoded-compressed-2 src/e2e_project_frontend/assets/notreally.js
+}
+
 @test "leaves in place files that were already installed" {
   install_asset assetscanister
   dd if=/dev/urandom of=src/e2e_project_frontend/assets/asset1.bin bs=400000 count=1

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -135,14 +135,14 @@ check_permission_failure() {
   dfx identity get-principal --identity prepare
   dfx canister call e2e_project_frontend list_permitted '(record { permission = variant { Commit }; })'
   assert_command dfx deploy e2e_project_frontend --by-proposal --identity prepare
-  assert_contains "Proposed commit of batch 2 with evidence 1eefb141d169b1b757a04bb3fc354c416d63d8ff925ed2f7606ea1a1407b6912.  Either commit it by proposal, or delete it."
+  assert_contains "Proposed commit of batch 2 with evidence 164fcc4d933ff9992ab6ab909a4bf350010fa0f4a3e1e247bfc679d3f45254e1.  Either commit it by proposal, or delete it."
 
   assert_command_fail dfx deploy e2e_project_frontend --by-proposal --identity prepare
   assert_contains "Batch 2 is already proposed.  Delete or execute it to propose another."
 
   assert_command dfx deploy e2e_project_frontend --compute-evidence --identity anonymous
   # shellcheck disable=SC2154
-  assert_eq "1eefb141d169b1b757a04bb3fc354c416d63d8ff925ed2f7606ea1a1407b6912" "$stdout"
+  assert_eq "164fcc4d933ff9992ab6ab909a4bf350010fa0f4a3e1e247bfc679d3f45254e1" "$stdout"
 
   ID=$(dfx canister id e2e_project_frontend)
   PORT=$(get_webserver_port)
@@ -162,9 +162,9 @@ check_permission_failure() {
   assert_command_fail dfx canister call e2e_project_frontend commit_proposed_batch "$wrong_commit_args" --identity commit
   assert_match "batch computed evidence .* does not match presented evidence"
 
-  commit_args='(record { batch_id = 2; evidence = blob "\1e\ef\b1\41\d1\69\b1\b7\57\a0\4b\b3\fc\35\4c\41\6d\63\d8\ff\92\5e\d2\f7\60\6e\a1\a1\40\7b\69\12" } )'
+  commit_args='(record { batch_id = 2; evidence = blob "\16\4f\cc\4d\93\3f\f9\99\2a\b6\ab\90\9a\4b\f3\50\01\0f\a0\f4\a3\e1\e2\47\bf\c6\79\d3\f4\52\54\e1" } )'
   assert_command dfx canister call e2e_project_frontend validate_commit_proposed_batch "$commit_args" --identity commit
-  assert_contains "commit proposed batch 2 with evidence 1eef"
+  assert_contains "commit proposed batch 2 with evidence 164f"
   assert_command dfx canister call e2e_project_frontend commit_proposed_batch "$commit_args" --identity commit
   assert_eq "()"
 
@@ -835,7 +835,7 @@ check_permission_failure() {
   diff encoded-compressed-2 src/e2e_project_frontend/assets/notreally.js
 }
 
-@test "generates brotli-compressed content encoding for .js files" {
+@test "can use brotli compression" {
   install_asset assetscanister
   for i in $(seq 1 400); do
     echo "some easily duplicate text $i" >>src/e2e_project_frontend/assets/notreally.js

--- a/src/canisters/frontend/ic-asset/Cargo.toml
+++ b/src/canisters/frontend/ic-asset/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["internet-computer", "assets", "icp", "dfinity"]
 
 [dependencies]
 backoff.workspace = true
+brotli = "6.0.0"
 candid = { workspace = true }
 derivative = "2.2.0"
 dfx-core = { path = "../../../dfx-core" }

--- a/src/canisters/frontend/ic-asset/src/asset/content.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/content.rs
@@ -1,4 +1,5 @@
 use crate::asset::content_encoder::ContentEncoder;
+use brotli::CompressorWriter;
 use dfx_core::error::fs::FsError;
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -27,6 +28,7 @@ impl Content {
     pub fn encode(&self, encoder: &ContentEncoder) -> Result<Content, std::io::Error> {
         match encoder {
             ContentEncoder::Gzip => self.to_gzip(),
+            ContentEncoder::Brotli => self.to_brotli(),
         }
     }
 
@@ -36,6 +38,19 @@ impl Content {
         let data = e.finish()?;
         Ok(Content {
             data,
+            media_type: self.media_type.clone(),
+        })
+    }
+
+    pub fn to_brotli(&self) -> Result<Content, std::io::Error> {
+        let mut compressed_data = Vec::new();
+        {
+            let mut compressor = CompressorWriter::new(&mut compressed_data, 4096, 11, 22);
+            compressor.write_all(&self.data)?;
+            compressor.flush()?;
+        }
+        Ok(Content {
+            data: compressed_data,
             media_type: self.media_type.clone(),
         })
     }

--- a/src/canisters/frontend/ic-asset/src/asset/content_encoder.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/content_encoder.rs
@@ -1,12 +1,14 @@
 #[derive(Clone, Debug)]
 pub enum ContentEncoder {
     Gzip,
+    Brotli,
 }
 
 impl std::fmt::Display for ContentEncoder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
             ContentEncoder::Gzip => f.write_str("gzip"),
+            ContentEncoder::Brotli => f.write_str("br"),
         }
     }
 }

--- a/src/canisters/frontend/ic-asset/src/asset/content_encoder.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/content_encoder.rs
@@ -6,7 +6,6 @@ pub enum ContentEncoder {
     Gzip,
     #[serde(alias = "br")]
     Brotli,
-    #[serde(alias = "id")]
     Identity,
 }
 

--- a/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
+++ b/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
@@ -370,7 +370,9 @@ fn content_encoding_descriptive_suffix(content_encoding: &str) -> String {
 // todo: make this configurable https://github.com/dfinity/dx-triage/issues/152
 fn applicable_encoders(media_type: &Mime) -> Vec<ContentEncoder> {
     match (media_type.type_(), media_type.subtype()) {
-        (mime::TEXT, _) | (_, mime::JAVASCRIPT) | (_, mime::HTML) => vec![ContentEncoder::Gzip],
+        (mime::TEXT, _) | (_, mime::JAVASCRIPT) | (_, mime::HTML) => {
+            vec![ContentEncoder::Gzip, ContentEncoder::Brotli]
+        }
         _ => vec![],
     }
 }


### PR DESCRIPTION
# Description

Asset synchronization now not only uploads `identity` and `gzip` as encodings for MIME types `text`, `js`, and `html`, but also `br` encoding. 

Fixes [SDK-1604](https://dfinity.atlassian.net/browse/SDK-1604)

# How Has This Been Tested?

Added e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-1604]: https://dfinity.atlassian.net/browse/SDK-1604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ