### PR TITLE
feat: choose asset encodings that are synced to asset canister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ It doesn't apply to `--pocketic` because PocketIC does not yet persist any data.
 
 When uploading assets to an asset canister, `dfx` by default uploads `.txt`, `.html` and `.js` files in `identity` encoding but also in `gzip` encoding to the frontend canister if encoding saves bytes.
 It is now possible to specify in `.ic-assets.json` which encodings are used besides `identity`.
-Note that encodings are only used if either `identity` is not a specified encoding or if the encoding saves bytes compared to `identity`.
+Note that encodings are only used if the encoding saves bytes compared to `identity` or if `identity` is not a specified encoding.
 
 Example: To turn off `gzip` for `.js` files and to turn on `gzip` for `.jpg` files, use this in `.ic-assets.json`:
 ``` json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,18 +62,19 @@ It doesn't apply to `--pocketic` because PocketIC does not yet persist any data.
 
 ### feat: allow specifying encodings in `.ic-assets.json`
 
-When uploading assets to an asset canister, `dfx` by default uploads `.txt`, `.html` and `.js` files in `identity` encoding but also in `gzip` encoding to the frontend canister if compression saves bytes.
+When uploading assets to an asset canister, `dfx` by default uploads `.txt`, `.html` and `.js` files in `identity` encoding but also in `gzip` encoding to the frontend canister if encoding saves bytes.
 It is now possible to specify in `.ic-assets.json` which encodings are used besides `identity`.
+Note that encodings are only used if either `identity` is not a specified encoding or if the encoding saves bytes compared to `identity`.
 
 Example: To turn off `gzip` for `.js` files and to turn on `gzip` for `.jpg` files, use this in `.ic-assets.json`:
 ``` json
 {
   "match": "**/*.js",
-  "encodings": []
+  "encodings": ["identity"]
 },
 {
   "match": "**/*.jpg",
-  "encodings": ["gzip"]
+  "encodings": ["identity", "gzip"]
 }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,23 @@ different replica version or different replica options.
 
 It doesn't apply to `--pocketic` because PocketIC does not yet persist any data.
 
+### feat: allow specifying encodings in `.ic-assets.json`
+
+When uploading assets to an asset canister, `dfx` by default uploads `.txt`, `.html` and `.js` files in `identity` encoding but also in `gzip` encoding to the frontend canister if compression saves bytes.
+It is now possible to specify in `.ic-assets.json` which encodings are used besides `identity`.
+
+Example: To turn off `gzip` for `.js` files and to turn on `gzip` for `.jpg` files, use this in `.ic-assets.json`:
+``` json
+{
+  "match": "**/*.js",
+  "encodings": []
+},
+{
+  "match": "**/*.jpg",
+  "encodings": ["gzip"]
+}
+```
+
 ### feat: `dfx canister url`
 
 Add `dfx canister url` subcommand to display the url of a given canister. Basic usage as below:

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -1304,6 +1304,40 @@ EOF
   assert_match "etag: my-custom-etag"
 }
 
+@test "asset configuration via .ic-assets.json5 - overwriting default encodings" {
+  dfx_new_frontend
+
+  dfx_start
+
+  echo '[
+    {
+      "match": "favicon.ico",
+      "encodings": ["gzip"]
+    },
+    {
+      "match": "index.html",
+      "encodings": []
+    }
+  ]' > src/e2e_project_frontend/assets/.ic-assets.json5
+
+  dfx deploy
+
+  ID=$(dfx canister id e2e_project_frontend)
+  PORT=$(get_webserver_port)
+
+  dfx canister call e2e_project_frontend list '(record{})'
+
+  # favicon.ico is not available in gzip format by default but was configured to be
+  assert_command curl -vv -H "Accept-Encoding: gzip" "http://localhost:$PORT/favicon.ico?canisterId=$ID"
+  assert_match "content-encoding: gzip"
+
+  # index.html is available in gzip format by default but was configured not to be
+  # The asset canister would serve the gzip encoding if it was available, but can't.
+  # Therefore it falls back to the identity encoding, meaning there is no `content-encoding` header present
+  assert_command curl -vv -H "Accept-Encoding: gzip" "http://localhost:$PORT/index.html?canisterId=$ID"
+  assert_not_match "content-encoding"
+}
+
 @test "aliasing rules: <filename> to <filename>.html or <filename>/index.html" {
   echo "test alias file" >'src/e2e_project_frontend/assets/test_alias_file.html'
   mkdir 'src/e2e_project_frontend/assets/index_test'

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -1316,7 +1316,7 @@ EOF
     },
     {
       "match": "index.html",
-      "encodings": []
+      "encodings": ["identity"]
     }
   ]' > src/e2e_project_frontend/assets/.ic-assets.json5
 

--- a/src/canisters/frontend/ic-asset/src/asset/content.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/content.rs
@@ -7,6 +7,7 @@ use sha2::{Digest, Sha256};
 use std::io::Write;
 use std::path::Path;
 
+#[derive(Clone)]
 pub(crate) struct Content {
     pub data: Vec<u8>,
     pub media_type: Mime,
@@ -27,6 +28,7 @@ impl Content {
     pub fn encode(&self, encoder: &ContentEncoder) -> Result<Content, std::io::Error> {
         match encoder {
             ContentEncoder::Gzip => self.to_gzip(),
+            ContentEncoder::Identity => Ok(self.clone()),
         }
     }
 

--- a/src/canisters/frontend/ic-asset/src/asset/content_encoder.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/content_encoder.rs
@@ -1,4 +1,7 @@
-#[derive(Clone, Debug)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Copy, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
 pub enum ContentEncoder {
     Gzip,
 }

--- a/src/canisters/frontend/ic-asset/src/asset/content_encoder.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/content_encoder.rs
@@ -4,12 +4,14 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "lowercase")]
 pub enum ContentEncoder {
     Gzip,
+    Identity,
 }
 
 impl std::fmt::Display for ContentEncoder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
             ContentEncoder::Gzip => f.write_str("gzip"),
+            ContentEncoder::Identity => f.write_str("identity"),
         }
     }
 }

--- a/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
+++ b/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
@@ -181,7 +181,7 @@ async fn make_encoding(
         }
         encoder => {
             let encoded = content.encode(encoder).map_err(|e| {
-                EncodeContentFailed(asset_descriptor.key.clone(), encoder.clone(), e)
+                EncodeContentFailed(asset_descriptor.key.clone(), encoder.to_owned(), e)
             })?;
             if make_even_if_identity_is_smaller || encoded.data.len() < content.data.len() {
                 let content_encoding = format!("{}", encoder);

--- a/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
+++ b/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
@@ -212,7 +212,12 @@ async fn make_encodings(
     logger: &Logger,
 ) -> Result<HashMap<String, ProjectAssetEncoding>, CreateEncodingError> {
     let mut encoders = vec![None];
-    for encoder in applicable_encoders(&content.media_type) {
+    let additional_encoders = asset_descriptor
+        .config
+        .encodings
+        .clone()
+        .unwrap_or_else(|| default_encoders(&content.media_type));
+    for encoder in additional_encoders {
         encoders.push(Some(encoder));
     }
 
@@ -367,8 +372,7 @@ fn content_encoding_descriptive_suffix(content_encoding: &str) -> String {
     }
 }
 
-// todo: make this configurable https://github.com/dfinity/dx-triage/issues/152
-fn applicable_encoders(media_type: &Mime) -> Vec<ContentEncoder> {
+fn default_encoders(media_type: &Mime) -> Vec<ContentEncoder> {
     match (media_type.type_(), media_type.subtype()) {
         (mime::TEXT, _) | (_, mime::JAVASCRIPT) | (_, mime::HTML) => vec![ContentEncoder::Gzip],
         _ => vec![],


### PR DESCRIPTION
# Description

Allows configuring which encodings are uploaded to the asset canister in `.ic-assets.json`

Fixes [SDK-1721](https://dfinity.atlassian.net/browse/SDK-1721)

# How Has This Been Tested?

added e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-1721]: https://dfinity.atlassian.net/browse/SDK-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ