### PR TITLE
chore: pin binstall version so CI doent spontaneously break

### DIFF
--- a/scripts/workflows/provision-darwin.sh
+++ b/scripts/workflows/provision-darwin.sh
@@ -28,7 +28,7 @@ if [ "$E2E_TEST" = "tests-dfx/certificate.bash" ]; then
      brew install mitmproxy
 fi
 if [ "$E2E_TEST" = "tests-dfx/deps.bash" ]; then
-     cargo install cargo-binstall
+     cargo install cargo-binstall@1.6.9
      cargo binstall -y ic-wasm
 fi
 

--- a/scripts/workflows/provision-linux.sh
+++ b/scripts/workflows/provision-linux.sh
@@ -50,7 +50,7 @@ if [ "$E2E_TEST" = "tests-dfx/build_rust.bash" ]; then
 fi
 
 if [ "$E2E_TEST" = "tests-dfx/deps.bash" ]; then
-     cargo install cargo-binstall
+     cargo install cargo-binstall@1.6.9
      cargo binstall -y ic-wasm
 fi
 


### PR DESCRIPTION
# Description

CI is broken because binstall bumped the Rust required version in the latest version bump

# How Has This Been Tested?

CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
