### PR TITLE
feat: require all PRs to update JSON schema if changed

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -33,7 +33,9 @@ jobs:
           cargo run -- schema --for dfx-metadata --outfile docs/dfx-metadata-schema.json
 
           echo "Schema changes:"
-          git diff --exit-code || echo "(None)"
+          if git diff --exit-code ; then
+            echo "(None)"
+          fi
 
           if [[ -n $(git status --porcelain) ]]; then
             git config user.name "GitHub Actions Bot"

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -23,7 +23,7 @@ jobs:
         run: cargo build
       - name: Show download worked
         run: cargo run -- --version
-      - name: Update any changed schema docs
+      - name: Check for changes
         run: |
           cargo run -- schema --outfile docs/dfx-json-schema.json
           cargo run -- schema --for networks --outfile docs/networks-json-schema.json

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -12,8 +12,8 @@ env:
   CURL_HOME: .
 
 jobs:
-  update_all_schema_docs:
-    name: schema-docs:required
+  update_all_json_schema_docs:
+    name: json-schema-docs:required
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,12 +29,13 @@ jobs:
           cargo run -- schema --for networks --outfile docs/networks-json-schema.json
           cargo run -- schema --for dfx-metadata --outfile docs/dfx-metadata-schema.json
 
-          echo "Schema changes:"
+          echo "JSON Schema changes:"
           if git diff --exit-code ; then
             echo "(None)"
           else
             echo
-            echo "There are code changes to the JSON schema in this PR, but the schema docs have not been updated."
+            echo "There are code changes in this PR that the JSON schema should reflect,"
+            echo "but the JSON schema docs have not been updated."
             echo
             echo "Run the above commands locally to update the JSON schema docs."
             exit 1

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,4 +1,4 @@
-name: Update Schema Docs
+name: Ensure any JSON schema changes applied
 on: pull_request
 
 concurrency:
@@ -12,8 +12,8 @@ env:
   CURL_HOME: .
 
 jobs:
-  update_all_json_schema_docs:
-    name: json-schema-docs:required
+  check:
+    name: update-json-schema-docs:required
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,4 +1,4 @@
-name: Ensure any JSON schema changes applied
+name: Ensure JSON schema docs are up-to-date
 on: pull_request
 
 concurrency:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,4 +1,4 @@
-name: Update Docs
+name: Update Schema Docs
 on: pull_request
 
 concurrency:
@@ -12,16 +12,13 @@ env:
   CURL_HOME: .
 
 jobs:
-  update_dfx_json_schema:
-    # Workflow breaks if it gets executed on an external PR
-    if: github.event.pull_request.head.repo.full_name == github.repository
+  update_all_schema_docs:
+    name: schema-docs:required
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Check cargo build
         run: cargo build
       - name: Show download worked
@@ -35,12 +32,9 @@ jobs:
           echo "Schema changes:"
           if git diff --exit-code ; then
             echo "(None)"
-          fi
-
-          if [[ -n $(git status --porcelain) ]]; then
-            git config user.name "GitHub Actions Bot"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add docs/*-schema.json
-            git commit -m "update schema docs" || true
-            git push
+          else
+            echo
+            echo "There are schema changes."
+            echo "Run the above commands locally to update the schema docs."
+            exit 1
           fi

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -34,7 +34,8 @@ jobs:
             echo "(None)"
           else
             echo
-            echo "There are schema changes."
-            echo "Run the above commands locally to update the schema docs."
+            echo "There are code changes to the JSON schema in this PR, but the schema docs have not been updated."
+            echo
+            echo "Run the above commands locally to update the JSON schema docs."
             exit 1
           fi

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -26,21 +26,19 @@ jobs:
         run: cargo build
       - name: Show download worked
         run: cargo run -- --version
-      - name: Update docs/dfx-json-schema.json
+      - name: Update any changed schema docs
         run: |
           cargo run -- schema --outfile docs/dfx-json-schema.json
           cargo run -- schema --for networks --outfile docs/networks-json-schema.json
           cargo run -- schema --for dfx-metadata --outfile docs/dfx-metadata-schema.json
-          echo "dfx.json schema:"
-          cat docs/dfx-json-schema.json
-          echo "networks.json schema:"
-          cat docs/networks-json-schema.json
-          echo "dfx-metadata schema:"
-          cat docs/dfx-metadata-schema.json
-          if [[ $(git status | wc -l) -eq 2 ]]; then
+
+          echo "Schema changes:"
+          git diff --exit-code || echo "(None)"
+
+          if [[ -n $(git status --porcelain) ]]; then
             git config user.name "GitHub Actions Bot"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add docs/dfx-json-schema.json docs/networks-json-schema.json docs/dfx-metadata-schema.json
-            git commit -m "update dfx-json-schema and networks-json-schema" || true
+            git add docs/*-schema.json
+            git commit -m "update schema docs" || true
             git push
           fi

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check:
-    name: update-json-schema-docs:required
+    name: json-schema-docs-up-to-date:required
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

The update-docs workflow doesn't work (skips itself) for external PRs.

Make it fail any PR if any of the schema command outputs changed and the changes are not included in the PR, rather than pushing a commit to update them.

This way it will work on external PRs too, and we can make it a required status.


# How Has This Been Tested?

The following PR makes a schema change: https://github.com/dfinity/sdk/pull/3805

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
