### PR TITLE
fix: add context to dfx cache installation message

### DIFF
--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -151,12 +151,12 @@ pub fn install_version(v: &str, force: bool) -> Result<PathBuf, CacheError> {
 
         if dfx_core::fs::rename(temp_p.as_path(), &p).is_ok() {
             if let Some(b) = b {
-                b.finish_with_message(format!("Version v{} installed successfully.", v));
+                b.finish_with_message(format!("Installed dfx {} to cache.", v));
             }
         } else {
             dfx_core::fs::remove_dir_all(temp_p.as_path()).map_err(UnifiedIoError::from)?;
             if let Some(b) = b {
-                b.finish_with_message(format!("Version v{} was already installed.", v));
+                b.finish_with_message(format!("dfx {} was already installed in cache.", v));
             }
         }
         Ok(p)


### PR DESCRIPTION
# Description

When dfx runs for the first time, it installs binaries, including itself, to the dfx cache. It also displays a message that it has done so. Without context, this message can be confusing.

Changed the final message to include context about what (dfx) it's installing and where (the cache)

# How Has This Been Tested?

before
```
$ dfx extension install nns --version 0.3.1
  Version v0.21.0-beta.0+rev12.ecf712721 installed successfully.
  Extension 'nns' installed successfully
```

after
```
$ dfx extension install nns --version 0.3.1
  Installed dfx 0.21.0-beta.0+rev12.ecf712721 to cache.
  Extension 'nns' installed successfully
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
