### PR TITLE
fix: dfx build no longer requires a password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 To do this, the `@dfinity/agent` version was updated as well.
 
+### fix: `dfx build` no longer requires a password
+
 ### feat: add `dfx schema` support for .json files related to extensions
 
 - `dfx schema --for extension-manifest` corresponds to extension.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 To do this, the `@dfinity/agent` version was updated as well.
 
-### fix: `dfx build` no longer requires a password
+### fix: `dfx build` no longer requires a password for password-protected identities
 
 ### feat: add `dfx schema` support for .json files related to extensions
 

--- a/e2e/tests-dfx/build.bash
+++ b/e2e/tests-dfx/build.bash
@@ -328,3 +328,10 @@ teardown() {
   assert_command ls .dfx/actuallylocal/canisters/e2e_project_backend/
   assert_command ls .dfx/actuallylocal/canisters/e2e_project_backend/e2e_project_backend.wasm
 }
+
+@test "dfx build does not require a password" {
+  assert_command "${BATS_TEST_DIRNAME}/../assets/expect_scripts/init_alice_with_pw.exp"
+  assert_command dfx identity use alice
+
+  assert_command timeout 30s dfx build --check
+}

--- a/scripts/workflows/provision-linux.sh
+++ b/scripts/workflows/provision-linux.sh
@@ -34,8 +34,8 @@ if [ "$E2E_TEST" = "tests-dfx/identity_encryption.bash" ] \
     || [ "$E2E_TEST" = "tests-dfx/generate.bash" ] \
     || [ "$E2E_TEST" = "tests-dfx/start.bash" ] \
     || [ "$E2E_TEST" = "tests-dfx/new.bash" ] \
-    || [ "$E2E_TEST" = "tests-dfx/call.bash" ]
-    || [ "$E2E_TEST" = "tests-dfx/build.bash" ] \
+    || [ "$E2E_TEST" = "tests-dfx/call.bash" ] \
+    || [ "$E2E_TEST" = "tests-dfx/build.bash" ]
 then
     sudo apt-get install --yes expect
 fi

--- a/scripts/workflows/provision-linux.sh
+++ b/scripts/workflows/provision-linux.sh
@@ -35,6 +35,7 @@ if [ "$E2E_TEST" = "tests-dfx/identity_encryption.bash" ] \
     || [ "$E2E_TEST" = "tests-dfx/start.bash" ] \
     || [ "$E2E_TEST" = "tests-dfx/new.bash" ] \
     || [ "$E2E_TEST" = "tests-dfx/call.bash" ]
+    || [ "$E2E_TEST" = "tests-dfx/build.bash" ] \
 then
     sudo apt-get install --yes expect
 fi

--- a/src/dfx/src/commands/build.rs
+++ b/src/dfx/src/commands/build.rs
@@ -1,5 +1,5 @@
 use crate::config::cache::DiskBasedCache;
-use crate::lib::agent::create_agent_environment;
+use crate::lib::agent::create_anonymous_agent_environment;
 use crate::lib::builders::BuildConfig;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
@@ -34,7 +34,7 @@ pub struct CanisterBuildOpts {
 }
 
 pub fn exec(env: &dyn Environment, opts: CanisterBuildOpts) -> DfxResult {
-    let env = create_agent_environment(env, opts.network.to_network_name())?;
+    let env = create_anonymous_agent_environment(env, opts.network.to_network_name())?;
 
     let logger = env.get_logger();
 


### PR DESCRIPTION
# Description

`dfx build` should not require a password as it does not depend on anything on-chain

Reported on the [forum](https://forum.dfinity.org/t/dfx-build-requires-password/32546)

# How Has This Been Tested?

added e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
