### PR TITLE
refactor: convert extension install to async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,6 +1626,7 @@ version = "0.0.1"
 dependencies = [
  "aes-gcm",
  "argon2",
+ "backoff",
  "bip32",
  "byte-unit",
  "bytes",

--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 [dependencies]
 aes-gcm.workspace = true
 argon2.workspace = true
+backoff.workspace = true
 bip32 = "0.4.0"
 byte-unit = { workspace = true, features = ["serde"] }
 bytes.workspace = true

--- a/src/dfx-core/src/error/extension.rs
+++ b/src/dfx-core/src/error/extension.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+use crate::error::reqwest::WrappedReqwestError;
 use crate::error::structured_file::StructuredFileError;
 use thiserror::Error;
 
@@ -82,8 +83,8 @@ pub enum NewExtensionManagerError {
 
 #[derive(Error, Debug)]
 pub enum DownloadAndInstallExtensionToTempdirError {
-    #[error("Downloading extension from '{0}' failed")]
-    ExtensionDownloadFailed(url::Url, #[source] reqwest::Error),
+    #[error(transparent)]
+    ExtensionDownloadFailed(WrappedReqwestError),
 
     #[error("Cannot get extensions directory")]
     EnsureExtensionDirExistsFailed(#[source] crate::error::fs::FsError),

--- a/src/dfx-core/src/error/mod.rs
+++ b/src/dfx-core/src/error/mod.rs
@@ -17,6 +17,7 @@ pub mod load_dfx_config;
 pub mod load_networks_config;
 pub mod network_config;
 pub mod process;
+pub mod reqwest;
 pub mod root_key;
 pub mod socket_addr_conversion;
 pub mod structured_file;

--- a/src/dfx-core/src/error/reqwest.rs
+++ b/src/dfx-core/src/error/reqwest.rs
@@ -1,0 +1,28 @@
+use crate::http::retryable::Retryable;
+use reqwest::StatusCode;
+use thiserror::Error;
+
+// reqwest::Error's fmt::Display appends the error descriptions of all sources.
+// For this reason, it is not marked as #[source] here, so that we don't
+// display the error descriptions of all sources repeatedly.
+#[derive(Error, Debug)]
+#[error("{}", .0)]
+pub struct WrappedReqwestError(pub reqwest::Error);
+
+impl Retryable for WrappedReqwestError {
+    fn is_retryable(&self) -> bool {
+        let err = &self.0;
+        err.is_timeout()
+            || err.is_connect()
+            || matches!(
+                err.status(),
+                Some(
+                    StatusCode::INTERNAL_SERVER_ERROR
+                        | StatusCode::BAD_GATEWAY
+                        | StatusCode::SERVICE_UNAVAILABLE
+                        | StatusCode::GATEWAY_TIMEOUT
+                        | StatusCode::TOO_MANY_REQUESTS
+                )
+            )
+    }
+}

--- a/src/dfx-core/src/extension/manifest/compatibility_matrix.rs
+++ b/src/dfx-core/src/extension/manifest/compatibility_matrix.rs
@@ -31,12 +31,14 @@ pub struct ExtensionCompatibleVersions {
 }
 
 impl ExtensionCompatibilityMatrix {
-    pub fn fetch() -> Result<Self, FetchExtensionCompatibilityMatrixError> {
-        let resp = reqwest::blocking::get(COMMON_EXTENSIONS_MANIFEST_LOCATION).map_err(|e| {
-            CompatibilityMatrixFetchError(COMMON_EXTENSIONS_MANIFEST_LOCATION.to_string(), e)
-        })?;
+    pub async fn fetch() -> Result<Self, FetchExtensionCompatibilityMatrixError> {
+        let resp = reqwest::get(COMMON_EXTENSIONS_MANIFEST_LOCATION)
+            .await
+            .map_err(|e| {
+                CompatibilityMatrixFetchError(COMMON_EXTENSIONS_MANIFEST_LOCATION.to_string(), e)
+            })?;
 
-        resp.json().map_err(MalformedCompatibilityMatrix)
+        resp.json().await.map_err(MalformedCompatibilityMatrix)
     }
 
     pub fn find_latest_compatible_extension_version(

--- a/src/dfx-core/src/http/get.rs
+++ b/src/dfx-core/src/http/get.rs
@@ -1,0 +1,25 @@
+use crate::error::reqwest::WrappedReqwestError;
+use crate::http::retryable::Retryable;
+use backoff::exponential::ExponentialBackoff;
+use backoff::future::retry;
+use backoff::SystemClock;
+use reqwest::Response;
+use url::Url;
+
+pub async fn get_with_retries(
+    url: Url,
+    retry_policy: ExponentialBackoff<SystemClock>,
+) -> Result<Response, WrappedReqwestError> {
+    let operation = || async {
+        let response = reqwest::get(url.clone())
+            .await
+            .and_then(|resp| resp.error_for_status())
+            .map_err(WrappedReqwestError);
+        match response {
+            Ok(doc) => Ok(doc),
+            Err(e) if e.is_retryable() => Err(backoff::Error::transient(e)),
+            Err(e) => Err(backoff::Error::permanent(e)),
+        }
+    };
+    retry(retry_policy, operation).await
+}

--- a/src/dfx-core/src/http/mod.rs
+++ b/src/dfx-core/src/http/mod.rs
@@ -1,0 +1,2 @@
+pub mod get;
+pub mod retryable;

--- a/src/dfx-core/src/http/retryable.rs
+++ b/src/dfx-core/src/http/retryable.rs
@@ -1,0 +1,3 @@
+pub trait Retryable {
+    fn is_retryable(&self) -> bool;
+}

--- a/src/dfx-core/src/lib.rs
+++ b/src/dfx-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod extension;
 pub mod foundation;
 pub mod fs;
+pub mod http;
 pub mod identity;
 pub mod interface;
 pub mod json;


### PR DESCRIPTION
# Description

Upcoming changes to extension dependency management use retries and async.  This PR updates existing code to use async.  It makes minimal changes to compatibility_matrix.rs since it will soon be deleted.

# How Has This Been Tested?

Covered by CI, and also ran `cargo build && dfx cache delete && dfx cache install && dfx extension install nns` (fails as expected due to no entry in compatibility matrix) and then `dfx extension install --version 0.3.1`

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
