### PR TITLE
chore!: --with-cycles requires --wallet is enforced earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ To do this, the `@dfinity/agent` version was updated as well.
 
 ### fix: `dfx build` no longer requires a password for password-protected identities
 
+### chore!: enforce `--wallet` requirement for `dfx canister call --with-cycles` earlier
+
 ### feat: add `dfx schema` support for .json files related to extensions
 
 - `dfx schema --for extension-manifest` corresponds to extension.json

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -66,7 +66,7 @@ pub struct CanisterCallOpts {
     /// Specifies the amount of cycles to send on the call.
     /// Deducted from the wallet.
     /// Requires --wallet as a flag to `dfx canister`.
-    #[arg(long, value_parser = cycle_amount_parser, requires("wallet")]
+    #[arg(long, value_parser = cycle_amount_parser, requires("wallet"))]
     with_cycles: Option<u128>,
 
     /// Provide the .did file with which to decode the response.  Overrides value from dfx.json

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -66,7 +66,7 @@ pub struct CanisterCallOpts {
     /// Specifies the amount of cycles to send on the call.
     /// Deducted from the wallet.
     /// Requires --wallet as a flag to `dfx canister`.
-    #[arg(long, value_parser = cycle_amount_parser)]
+    #[arg(long, value_parser = cycle_amount_parser, requires("wallet")]
     with_cycles: Option<u128>,
 
     /// Provide the .did file with which to decode the response.  Overrides value from dfx.json


### PR DESCRIPTION
# Description

Internal [complaint](https://dfinity.slack.com/archives/CGA566TPV/p1719989491013429):
>If I pass arguments that won't work, such as --with-cycles without --wallet, it would be nice to get an error about that before walking though the entire interactive wizard.

With this change the user will see the error message instantly. The requirement is not new, just enforced at an earlier point in time.

# How Has This Been Tested?

Tested manually

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
