### PR TITLE
fix: retry certain http errors reported by replica during asset uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 # UNRELEASED
 
+### asset uploads: retry some HTTP errors returned by the replica
+
+Now retries the following, with exponential backoff as is already done for connect and transport errors:
+- 500 internal server error
+- 502 bad gateway
+- 503 service unavailable
+- 504 gateway timeout
+- 429 many requests
+
 ### fix: Allow canisters to be deployed even if unrelated canisters in dfx.json are malformed
 
 ### feat!: enable cycles ledger support unconditionally

--- a/src/canisters/frontend/ic-asset/src/batch_upload/retryable.rs
+++ b/src/canisters/frontend/ic-asset/src/batch_upload/retryable.rs
@@ -1,8 +1,17 @@
+use ic_agent::agent::http_transport::reqwest_transport::reqwest::StatusCode;
 use ic_agent::AgentError;
 
 pub(crate) fn retryable(agent_error: &AgentError) -> bool {
-    matches!(
-        agent_error,
-        AgentError::TimeoutWaitingForResponse() | AgentError::TransportError(_)
-    )
+    match agent_error {
+        AgentError::TimeoutWaitingForResponse() => true,
+        AgentError::TransportError(_) => true,
+        AgentError::HttpError(http_error) => {
+            http_error.status == StatusCode::INTERNAL_SERVER_ERROR
+                || http_error.status == StatusCode::BAD_GATEWAY
+                || http_error.status == StatusCode::SERVICE_UNAVAILABLE
+                || http_error.status == StatusCode::GATEWAY_TIMEOUT
+                || http_error.status == StatusCode::TOO_MANY_REQUESTS
+        }
+        _ => false,
+    }
 }


### PR DESCRIPTION
# Description

Fix for transient errors seen during asset upload as seen here: https://github.com/dfinity/portal/actions/runs/9838832207/job/27161262607

The status codes chosen correspond to the those checked for here: https://github.com/dfinity/sdk/pull/3815/files#diff-8d43d31fa855300ef66d8e25f19a7747fd49d36429a10f4fd2a9b077b568d832R12

# How Has This Been Tested?

Not tested specifically, but see above for a failed upload that may have succeeded with this change.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
