### PR TITLE
refactor: remove output_idl_path from <type>CanisterInfo types

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - ens/poc-unify-output-idl-path
   pull_request:
 
 concurrency:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - ens/poc-unify-output-idl-path
   pull_request:
 
 concurrency:

--- a/src/dfx/src/lib/builders/custom.rs
+++ b/src/dfx/src/lib/builders/custom.rs
@@ -129,7 +129,7 @@ impl CanisterBuilder for CustomBuilder {
         Ok(BuildOutput {
             canister_id,
             wasm: WasmBuildOutput::File(wasm),
-            idl: IdlBuildOutput::File(info.get_output_idl_path().unwrap()),
+            idl: IdlBuildOutput::File(info.get_output_idl_path().to_path_buf()),
         })
     }
 
@@ -140,13 +140,12 @@ impl CanisterBuilder for CustomBuilder {
         _config: &BuildConfig,
     ) -> DfxResult<PathBuf> {
         // get the path to candid file
-        let candid = info.get_output_idl_path().unwrap();
-        Ok(candid)
+        Ok(info.get_output_idl_path().to_path_buf())
     }
 }
 
 pub async fn custom_download(info: &CanisterInfo, pool: &CanisterPool) -> DfxResult {
-    let candid = info.get_output_idl_path().unwrap();
+    let candid = info.get_output_idl_path();
     let CustomBuilderExtra {
         input_candid_url,
         input_wasm_url,
@@ -159,7 +158,7 @@ pub async fn custom_download(info: &CanisterInfo, pool: &CanisterPool) -> DfxRes
         download_file_to_path(&url, &wasm).await?;
     }
     if let Some(url) = input_candid_url {
-        download_file_to_path(&url, &candid).await?;
+        download_file_to_path(&url, candid).await?;
     }
 
     Ok(())

--- a/src/dfx/src/lib/builders/custom.rs
+++ b/src/dfx/src/lib/builders/custom.rs
@@ -27,7 +27,7 @@ struct CustomBuilderExtra {
     /// Where to download the candid from
     input_candid_url: Option<Url>,
     /// Where the candid output will be located.
-    candid: PathBuf,
+    candid: PathBuf, // todo remove
     /// A command to run to build this canister. This is optional if the canister
     /// only needs to exist.
     build: Vec<String>,
@@ -47,11 +47,11 @@ impl CustomBuilderExtra {
                     )
             })
             .collect::<DfxResult<Vec<CanisterId>>>().with_context( || format!("Failed to collect dependencies (canister ids) of canister {}.", info.get_name()))?;
+        let candid = info.get_output_idl_path().unwrap();
         let info = info.as_info::<CustomCanisterInfo>()?;
         let input_wasm_url = info.get_input_wasm_url().to_owned();
         let wasm = info.get_output_wasm_path().to_owned();
         let input_candid_url = info.get_input_candid_url().to_owned();
-        let candid = info.get_output_idl_path().to_owned();
         let build = info.get_build_tasks().to_owned();
 
         Ok(CustomBuilderExtra {
@@ -103,7 +103,7 @@ impl CanisterBuilder for CustomBuilder {
     ) -> DfxResult<BuildOutput> {
         let CustomBuilderExtra {
             input_candid_url: _,
-            candid,
+            candid: _,
             input_wasm_url: _,
             wasm,
             build,
@@ -134,7 +134,7 @@ impl CanisterBuilder for CustomBuilder {
         Ok(BuildOutput {
             canister_id,
             wasm: WasmBuildOutput::File(wasm),
-            idl: IdlBuildOutput::File(candid),
+            idl: IdlBuildOutput::File(info.get_output_idl_path().unwrap()),
         })
     }
 

--- a/src/dfx/src/lib/builders/custom.rs
+++ b/src/dfx/src/lib/builders/custom.rs
@@ -26,8 +26,6 @@ struct CustomBuilderExtra {
     wasm: PathBuf,
     /// Where to download the candid from
     input_candid_url: Option<Url>,
-    /// Where the candid output will be located.
-    candid: PathBuf, // todo remove
     /// A command to run to build this canister. This is optional if the canister
     /// only needs to exist.
     build: Vec<String>,
@@ -47,7 +45,6 @@ impl CustomBuilderExtra {
                     )
             })
             .collect::<DfxResult<Vec<CanisterId>>>().with_context( || format!("Failed to collect dependencies (canister ids) of canister {}.", info.get_name()))?;
-        let candid = info.get_output_idl_path().unwrap();
         let info = info.as_info::<CustomCanisterInfo>()?;
         let input_wasm_url = info.get_input_wasm_url().to_owned();
         let wasm = info.get_output_wasm_path().to_owned();
@@ -59,7 +56,6 @@ impl CustomBuilderExtra {
             input_wasm_url,
             wasm,
             input_candid_url,
-            candid,
             build,
         })
     }
@@ -103,7 +99,6 @@ impl CanisterBuilder for CustomBuilder {
     ) -> DfxResult<BuildOutput> {
         let CustomBuilderExtra {
             input_candid_url: _,
-            candid: _,
             input_wasm_url: _,
             wasm,
             build,
@@ -140,20 +135,20 @@ impl CanisterBuilder for CustomBuilder {
 
     fn get_candid_path(
         &self,
-        pool: &CanisterPool,
+        _pool: &CanisterPool,
         info: &CanisterInfo,
         _config: &BuildConfig,
     ) -> DfxResult<PathBuf> {
         // get the path to candid file
-        let CustomBuilderExtra { candid, .. } = CustomBuilderExtra::try_from(info, pool)?;
+        let candid = info.get_output_idl_path().unwrap();
         Ok(candid)
     }
 }
 
 pub async fn custom_download(info: &CanisterInfo, pool: &CanisterPool) -> DfxResult {
+    let candid = info.get_output_idl_path().unwrap();
     let CustomBuilderExtra {
         input_candid_url,
-        candid,
         input_wasm_url,
         wasm,
         build: _,

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -433,9 +433,10 @@ pub fn get_and_write_environment_variables<'a>(
     if let Ok(id) = info.get_canister_id() {
         vars.push((Borrowed("CANISTER_ID"), Owned(format!("{}", id).into())));
     }
-    if let Some(path) = info.get_output_idl_path() {
-        vars.push((Borrowed("CANISTER_CANDID_PATH"), Owned(path.into())))
-    }
+    vars.push((
+        Borrowed("CANISTER_CANDID_PATH"),
+        Owned(info.get_output_idl_path().into()),
+    ));
 
     if let Some(write_path) = write_path {
         write_environment_variables(&vars, write_path)?;

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -182,12 +182,14 @@ impl CanisterBuilder for MotokoBuilder {
         };
         motoko_compile(&self.logger, cache.as_ref(), &params)?;
 
+        // eprintln!("output idl path (motoko info): {}", motoko_info.get_output_idl_path().display());
+        // eprintln!("output idl path (canister info): {}", canister_info.get_output_idl_path().unwrap().display());
         Ok(BuildOutput {
             canister_id: canister_info
                 .get_canister_id()
                 .expect("Could not find canister ID."),
             wasm: WasmBuildOutput::File(motoko_info.get_output_wasm_path().to_path_buf()),
-            idl: IdlBuildOutput::File(motoko_info.get_output_idl_path().to_path_buf()),
+            idl: IdlBuildOutput::File(canister_info.get_output_idl_path().unwrap()),
         })
     }
 
@@ -200,7 +202,10 @@ impl CanisterBuilder for MotokoBuilder {
         // get the path to candid file from dfx build
         let motoko_info = info.as_info::<MotokoCanisterInfo>()?;
         let idl_from_build = motoko_info.get_output_idl_path().to_path_buf();
-        Ok(idl_from_build)
+        // eprintln!("get_candid_path:");
+        // eprintln!("idl_from_build: {}", idl_from_build.display());
+        // eprintln!("idl (canister info): {}", info.get_output_idl_path().unwrap().display());
+        Ok(info.get_output_idl_path().unwrap())
     }
 }
 

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -182,8 +182,6 @@ impl CanisterBuilder for MotokoBuilder {
         };
         motoko_compile(&self.logger, cache.as_ref(), &params)?;
 
-        // eprintln!("output idl path (motoko info): {}", motoko_info.get_output_idl_path().display());
-        // eprintln!("output idl path (canister info): {}", canister_info.get_output_idl_path().unwrap().display());
         Ok(BuildOutput {
             canister_id: canister_info
                 .get_canister_id()

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -200,11 +200,6 @@ impl CanisterBuilder for MotokoBuilder {
         _config: &BuildConfig,
     ) -> DfxResult<PathBuf> {
         // get the path to candid file from dfx build
-        let motoko_info = info.as_info::<MotokoCanisterInfo>()?;
-        let idl_from_build = motoko_info.get_output_idl_path().to_path_buf();
-        // eprintln!("get_candid_path:");
-        // eprintln!("idl_from_build: {}", idl_from_build.display());
-        // eprintln!("idl (canister info): {}", info.get_output_idl_path().unwrap().display());
         Ok(info.get_output_idl_path().unwrap())
     }
 }

--- a/src/dfx/src/lib/builders/motoko.rs
+++ b/src/dfx/src/lib/builders/motoko.rs
@@ -187,7 +187,7 @@ impl CanisterBuilder for MotokoBuilder {
                 .get_canister_id()
                 .expect("Could not find canister ID."),
             wasm: WasmBuildOutput::File(motoko_info.get_output_wasm_path().to_path_buf()),
-            idl: IdlBuildOutput::File(canister_info.get_output_idl_path().unwrap()),
+            idl: IdlBuildOutput::File(canister_info.get_output_idl_path().to_path_buf()),
         })
     }
 
@@ -198,7 +198,7 @@ impl CanisterBuilder for MotokoBuilder {
         _config: &BuildConfig,
     ) -> DfxResult<PathBuf> {
         // get the path to candid file from dfx build
-        Ok(info.get_output_idl_path().unwrap())
+        Ok(info.get_output_idl_path().to_path_buf())
     }
 }
 

--- a/src/dfx/src/lib/builders/pull.rs
+++ b/src/dfx/src/lib/builders/pull.rs
@@ -48,7 +48,7 @@ impl CanisterBuilder for PullBuilder {
             canister_id: *pull_info.get_canister_id(),
             // It's impossible to know if the downloaded wasm is gzip or not with only the info in `dfx.json`.
             wasm: WasmBuildOutput::None,
-            idl: IdlBuildOutput::File(pull_info.get_output_idl_path().to_path_buf()),
+            idl: IdlBuildOutput::File(canister_info.get_output_idl_path().unwrap()),
         })
     }
 
@@ -58,8 +58,7 @@ impl CanisterBuilder for PullBuilder {
         info: &CanisterInfo,
         _config: &BuildConfig,
     ) -> DfxResult<PathBuf> {
-        let pull_info = info.as_info::<PullCanisterInfo>()?;
-        let output_idl_path = pull_info.get_output_idl_path();
+        let output_idl_path = info.get_output_idl_path().unwrap();
         Ok(output_idl_path.to_path_buf())
     }
 }

--- a/src/dfx/src/lib/builders/pull.rs
+++ b/src/dfx/src/lib/builders/pull.rs
@@ -48,7 +48,7 @@ impl CanisterBuilder for PullBuilder {
             canister_id: *pull_info.get_canister_id(),
             // It's impossible to know if the downloaded wasm is gzip or not with only the info in `dfx.json`.
             wasm: WasmBuildOutput::None,
-            idl: IdlBuildOutput::File(canister_info.get_output_idl_path().unwrap()),
+            idl: IdlBuildOutput::File(canister_info.get_output_idl_path().to_path_buf()),
         })
     }
 
@@ -58,7 +58,6 @@ impl CanisterBuilder for PullBuilder {
         info: &CanisterInfo,
         _config: &BuildConfig,
     ) -> DfxResult<PathBuf> {
-        let output_idl_path = info.get_output_idl_path().unwrap();
-        Ok(output_idl_path.to_path_buf())
+        Ok(info.get_output_idl_path().to_path_buf())
     }
 }

--- a/src/dfx/src/lib/builders/rust.rs
+++ b/src/dfx/src/lib/builders/rust.rs
@@ -102,7 +102,7 @@ impl CanisterBuilder for RustBuilder {
         Ok(BuildOutput {
             canister_id,
             wasm: WasmBuildOutput::File(rust_info.get_output_wasm_path().to_path_buf()),
-            idl: IdlBuildOutput::File(rust_info.get_output_idl_path().to_path_buf()),
+            idl: IdlBuildOutput::File(canister_info.get_output_idl_path().unwrap()),
         })
     }
 
@@ -112,8 +112,7 @@ impl CanisterBuilder for RustBuilder {
         info: &CanisterInfo,
         _config: &BuildConfig,
     ) -> DfxResult<PathBuf> {
-        let rust_info = info.as_info::<RustCanisterInfo>()?;
-        let output_idl_path = rust_info.get_output_idl_path();
-        Ok(output_idl_path.to_path_buf())
+        let output_idl_path = info.get_output_idl_path().unwrap();
+        Ok(output_idl_path)
     }
 }

--- a/src/dfx/src/lib/builders/rust.rs
+++ b/src/dfx/src/lib/builders/rust.rs
@@ -102,7 +102,7 @@ impl CanisterBuilder for RustBuilder {
         Ok(BuildOutput {
             canister_id,
             wasm: WasmBuildOutput::File(rust_info.get_output_wasm_path().to_path_buf()),
-            idl: IdlBuildOutput::File(canister_info.get_output_idl_path().unwrap()),
+            idl: IdlBuildOutput::File(canister_info.get_output_idl_path().to_path_buf()),
         })
     }
 
@@ -112,7 +112,6 @@ impl CanisterBuilder for RustBuilder {
         info: &CanisterInfo,
         _config: &BuildConfig,
     ) -> DfxResult<PathBuf> {
-        let output_idl_path = info.get_output_idl_path().unwrap();
-        Ok(output_idl_path)
+        Ok(info.get_output_idl_path().to_path_buf())
     }
 }

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -120,6 +120,9 @@ impl CanisterInfo {
                 .as_ref()
                 .and_then(|candid| canonicalize(candid).ok())
         });
+        // if let Some(remote_candid) = &remote_candid {
+        //     eprintln!("remote_candid is {}", remote_candid.display());
+        // }
 
         // Fill the default config values if None provided
         let declarations_config = CanisterDeclarationsConfig {
@@ -154,16 +157,22 @@ impl CanisterInfo {
                 }
             }
             CanisterTypeProperties::Motoko => {
-                if let Some(remote_candid) = &remote_candid {
-                    workspace_root.join(remote_candid)
-                } else {
-                    output_root.join(name).with_extension("did")
+                match (&remote_id, &remote_candid) {
+                    (Some(remote_id), Some(remote_candid)) => {
+                        // eprintln!("using workspace root {} because remote candid is {}, remote_id is {:?}", workspace_root.display(), remote_candid.display(), remote_id);
+                        workspace_root.join(remote_candid)
+                    }
+                    _ => {
+                        // eprintln!("using output root {}", output_root.display());
+                        output_root.join(name).with_extension("did")
+                    }
                 }
             }
             CanisterTypeProperties::Pull { id } => {
                 get_candid_path_in_project(workspace_root, id)
             }
         };
+        // eprintln!("output idl path is {}", output_idl_path.display());
 
         let type_specific = canister_config.type_specific.clone();
 

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -142,10 +142,7 @@ impl CanisterInfo {
         } else {
             match &canister_config.type_specific {
                 CanisterTypeProperties::Rust { package: _, candid } => workspace_root.join(candid),
-                CanisterTypeProperties::Assets { .. } => {
-                    let output_wasm_path = output_root.join(Path::new("assetstorage.wasm.gz"));
-                    output_wasm_path.with_extension("").with_extension("did")
-                }
+                CanisterTypeProperties::Assets { .. } => output_root.join("assetstorage.did"),
                 CanisterTypeProperties::Custom {
                     wasm: _,
                     candid,
@@ -158,7 +155,6 @@ impl CanisterInfo {
                     }
                 }
                 CanisterTypeProperties::Motoko => output_root.join(name).with_extension("did"),
-
                 CanisterTypeProperties::Pull { id } => {
                     get_candid_path_in_project(workspace_root, id)
                 }

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -331,26 +331,6 @@ impl CanisterInfo {
     /// To be separated into service.did and init_args.
     pub fn get_output_idl_path(&self) -> Option<PathBuf> {
         Some(self.output_idl_path.clone())
-        // let x = match &self.type_specific {
-        //     CanisterTypeProperties::Motoko { .. } => self
-        //         .as_info::<MotokoCanisterInfo>()
-        //         .map(|x| x.get_output_idl_path().to_path_buf()),
-        //     CanisterTypeProperties::Custom { .. } => self
-        //         .as_info::<CustomCanisterInfo>()
-        //         .map(|x| x.get_output_idl_path().to_path_buf()),
-        //     CanisterTypeProperties::Assets { .. } => self
-        //         .as_info::<AssetsCanisterInfo>()
-        //         .map(|x| x.get_output_idl_path().to_path_buf()),
-        //     CanisterTypeProperties::Rust { .. } => self
-        //         .as_info::<RustCanisterInfo>()
-        //         .map(|x| x.get_output_idl_path().to_path_buf()),
-        //     CanisterTypeProperties::Pull { .. } => self
-        //         .as_info::<PullCanisterInfo>()
-        //         .map(|x| x.get_output_idl_path().to_path_buf()),
-        // };
-        // x
-        // .ok()
-        // .or_else(|| self.remote_candid.clone())
     }
 
     #[context("Failed to create <Type>CanisterInfo for canister '{}'.", self.name, )]

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -15,17 +15,14 @@ use dfx_core::network::provider::get_network_context;
 use dfx_core::util;
 use fn_error_context::context;
 use std::path::{Path, PathBuf};
+use url::Url;
 
 pub mod assets;
 pub mod custom;
 pub mod motoko;
 pub mod pull;
 pub mod rust;
-use self::pull::PullCanisterInfo;
-use assets::AssetsCanisterInfo;
-use custom::CustomCanisterInfo;
-use motoko::MotokoCanisterInfo;
-use rust::RustCanisterInfo;
+use crate::lib::deps::get_candid_path_in_project;
 
 pub trait CanisterInfoFactory {
     fn create(info: &CanisterInfo) -> DfxResult<Self>
@@ -63,6 +60,7 @@ pub struct CanisterInfo {
     gzip: bool,
     init_arg: Option<String>,
     init_arg_file: Option<String>,
+    output_idl_path: PathBuf,
 }
 
 impl CanisterInfo {
@@ -137,6 +135,36 @@ impl CanisterInfo {
 
         let output_root = build_root.join(name);
 
+        let output_idl_path: PathBuf = match &canister_config.type_specific {
+            CanisterTypeProperties::Rust { package: _, candid } => {
+                let candid = remote_candid.as_ref().unwrap_or(candid);
+                workspace_root.join(candid)
+            }
+            CanisterTypeProperties::Assets { .. } => {
+                let output_wasm_path = output_root.join(Path::new("assetstorage.wasm.gz"));
+                output_wasm_path.with_extension("").with_extension("did")
+            }
+            CanisterTypeProperties::Custom { wasm: _, candid, build: _ } => {
+                if Url::parse(candid).is_ok() {
+                    output_root
+                        .join(name)
+                        .with_extension("did")
+                } else {
+                    workspace_root.join(candid)
+                }
+            }
+            CanisterTypeProperties::Motoko => {
+                if let Some(remote_candid) = &remote_candid {
+                    workspace_root.join(remote_candid)
+                } else {
+                    output_root.join(name).with_extension("did")
+                }
+            }
+            CanisterTypeProperties::Pull { id } => {
+                get_candid_path_in_project(workspace_root, id)
+            }
+        };
+
         let type_specific = canister_config.type_specific.clone();
 
         let args = match &canister_config.args {
@@ -174,6 +202,7 @@ impl CanisterInfo {
             gzip,
             init_arg,
             init_arg_file,
+            output_idl_path,
         };
 
         Ok(canister_info)
@@ -301,25 +330,27 @@ impl CanisterInfo {
     ///
     /// To be separated into service.did and init_args.
     pub fn get_output_idl_path(&self) -> Option<PathBuf> {
-        match &self.type_specific {
-            CanisterTypeProperties::Motoko { .. } => self
-                .as_info::<MotokoCanisterInfo>()
-                .map(|x| x.get_output_idl_path().to_path_buf()),
-            CanisterTypeProperties::Custom { .. } => self
-                .as_info::<CustomCanisterInfo>()
-                .map(|x| x.get_output_idl_path().to_path_buf()),
-            CanisterTypeProperties::Assets { .. } => self
-                .as_info::<AssetsCanisterInfo>()
-                .map(|x| x.get_output_idl_path().to_path_buf()),
-            CanisterTypeProperties::Rust { .. } => self
-                .as_info::<RustCanisterInfo>()
-                .map(|x| x.get_output_idl_path().to_path_buf()),
-            CanisterTypeProperties::Pull { .. } => self
-                .as_info::<PullCanisterInfo>()
-                .map(|x| x.get_output_idl_path().to_path_buf()),
-        }
-        .ok()
-        .or_else(|| self.remote_candid.clone())
+        Some(self.output_idl_path.clone())
+        // let x = match &self.type_specific {
+        //     CanisterTypeProperties::Motoko { .. } => self
+        //         .as_info::<MotokoCanisterInfo>()
+        //         .map(|x| x.get_output_idl_path().to_path_buf()),
+        //     CanisterTypeProperties::Custom { .. } => self
+        //         .as_info::<CustomCanisterInfo>()
+        //         .map(|x| x.get_output_idl_path().to_path_buf()),
+        //     CanisterTypeProperties::Assets { .. } => self
+        //         .as_info::<AssetsCanisterInfo>()
+        //         .map(|x| x.get_output_idl_path().to_path_buf()),
+        //     CanisterTypeProperties::Rust { .. } => self
+        //         .as_info::<RustCanisterInfo>()
+        //         .map(|x| x.get_output_idl_path().to_path_buf()),
+        //     CanisterTypeProperties::Pull { .. } => self
+        //         .as_info::<PullCanisterInfo>()
+        //         .map(|x| x.get_output_idl_path().to_path_buf()),
+        // };
+        // x
+        // .ok()
+        // .or_else(|| self.remote_candid.clone())
     }
 
     #[context("Failed to create <Type>CanisterInfo for canister '{}'.", self.name, )]

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -120,9 +120,6 @@ impl CanisterInfo {
                 .as_ref()
                 .and_then(|candid| canonicalize(candid).ok())
         });
-        // if let Some(remote_candid) = &remote_candid {
-        //     eprintln!("remote_candid is {}", remote_candid.display());
-        // }
 
         // Fill the default config values if None provided
         let declarations_config = CanisterDeclarationsConfig {

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -147,32 +147,23 @@ impl CanisterInfo {
                 let output_wasm_path = output_root.join(Path::new("assetstorage.wasm.gz"));
                 output_wasm_path.with_extension("").with_extension("did")
             }
-            CanisterTypeProperties::Custom { wasm: _, candid, build: _ } => {
+            CanisterTypeProperties::Custom {
+                wasm: _,
+                candid,
+                build: _,
+            } => {
                 if Url::parse(candid).is_ok() {
-                    output_root
-                        .join(name)
-                        .with_extension("did")
+                    output_root.join(name).with_extension("did")
                 } else {
                     workspace_root.join(candid)
                 }
             }
-            CanisterTypeProperties::Motoko => {
-                match (&remote_id, &remote_candid) {
-                    (Some(remote_id), Some(remote_candid)) => {
-                        // eprintln!("using workspace root {} because remote candid is {}, remote_id is {:?}", workspace_root.display(), remote_candid.display(), remote_id);
-                        workspace_root.join(remote_candid)
-                    }
-                    _ => {
-                        // eprintln!("using output root {}", output_root.display());
-                        output_root.join(name).with_extension("did")
-                    }
-                }
-            }
-            CanisterTypeProperties::Pull { id } => {
-                get_candid_path_in_project(workspace_root, id)
-            }
+            CanisterTypeProperties::Motoko => match (&remote_id, &remote_candid) {
+                (Some(_remote_id), Some(remote_candid)) => workspace_root.join(remote_candid),
+                _ => output_root.join(name).with_extension("did"),
+            },
+            CanisterTypeProperties::Pull { id } => get_candid_path_in_project(workspace_root, id),
         };
-        // eprintln!("output idl path is {}", output_idl_path.display());
 
         let type_specific = canister_config.type_specific.clone();
 

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -325,8 +325,8 @@ impl CanisterInfo {
     /// Path to the candid file from canister builder which should contain init types.
     ///
     /// To be separated into service.did and init_args.
-    pub fn get_output_idl_path(&self) -> Option<PathBuf> {
-        Some(self.output_idl_path.clone())
+    pub fn get_output_idl_path(&self) -> &Path {
+        self.output_idl_path.as_path()
     }
 
     #[context("Failed to create <Type>CanisterInfo for canister '{}'.", self.name, )]

--- a/src/dfx/src/lib/canister_info/assets.rs
+++ b/src/dfx/src/lib/canister_info/assets.rs
@@ -10,7 +10,6 @@ pub struct AssetsCanisterInfo {
     source_paths: Vec<PathBuf>,
 
     output_wasm_path: PathBuf,
-    output_idl_path: PathBuf,
     build: Vec<String>,
     workspace: Option<String>,
 }
@@ -21,9 +20,6 @@ impl AssetsCanisterInfo {
             .iter()
             .map(|sp| self.input_root.join(sp))
             .collect::<_>()
-    }
-    pub fn get_output_idl_path(&self) -> &Path {
-        self.output_idl_path.as_path()
     }
     pub fn get_build_tasks(&self) -> &[String] {
         &self.build
@@ -76,13 +72,11 @@ impl CanisterInfoFactory for AssetsCanisterInfo {
         let output_root = info.get_output_root();
 
         let output_wasm_path = output_root.join(Path::new("assetstorage.wasm.gz"));
-        let output_idl_path = output_wasm_path.with_extension("").with_extension("did");
 
         Ok(AssetsCanisterInfo {
             input_root,
             source_paths,
             output_wasm_path,
-            output_idl_path,
             build,
             workspace,
         })

--- a/src/dfx/src/lib/canister_info/custom.rs
+++ b/src/dfx/src/lib/canister_info/custom.rs
@@ -14,7 +14,6 @@ pub struct CustomCanisterInfo {
     input_wasm_url: Option<Url>,
     output_wasm_path: PathBuf,
     input_candid_url: Option<Url>,
-    output_idl_path: PathBuf,
     build: Vec<String>,
 }
 
@@ -27,9 +26,6 @@ impl CustomCanisterInfo {
     }
     pub fn get_input_candid_url(&self) -> &Option<Url> {
         &self.input_candid_url
-    }
-    pub fn get_output_idl_path(&self) -> &Path {
-        self.output_idl_path.as_path()
     }
     pub fn get_build_tasks(&self) -> &[String] {
         &self.build
@@ -76,24 +72,18 @@ impl CanisterInfoFactory for CustomCanisterInfo {
             let output_wasm_path = workspace_root.join(wasm);
             (None, output_wasm_path)
         };
-        let (input_candid_url, output_idl_path) =
-            if let Some(remote_candid) = info.get_remote_candid_if_remote() {
-                (None, workspace_root.join(remote_candid))
-            } else if let Ok(input_candid_url) = Url::parse(&candid) {
-                let output_candid_path = info
-                    .get_output_root()
-                    .join(info.get_name())
-                    .with_extension("did");
-                (Some(input_candid_url), output_candid_path)
-            } else {
-                (None, workspace_root.join(candid))
-            };
+        let input_candid_url = if info.get_remote_candid_if_remote().is_some() {
+            None
+        } else if let Ok(input_candid_url) = Url::parse(&candid) {
+            Some(input_candid_url)
+        } else {
+            None
+        };
 
         Ok(Self {
             input_wasm_url,
             output_wasm_path,
             input_candid_url,
-            output_idl_path,
             build,
         })
     }

--- a/src/dfx/src/lib/canister_info/motoko.rs
+++ b/src/dfx/src/lib/canister_info/motoko.rs
@@ -63,7 +63,6 @@ impl CanisterInfoFactory for MotokoCanisterInfo {
         let input_path = workspace_root.join(main_path);
         let output_root = info.get_output_root().to_path_buf();
         let output_wasm_path = output_root.join(name).with_extension("wasm");
-        // eprintln!("MotokoCanisterInfo::create: output_idl_path: {:?}", output_idl_path);
         let output_stable_path = output_wasm_path.with_extension("most");
         let output_did_js_path = output_wasm_path.with_extension("did.js");
         let output_canister_js_path = output_wasm_path.with_extension("js");

--- a/src/dfx/src/lib/canister_info/motoko.rs
+++ b/src/dfx/src/lib/canister_info/motoko.rs
@@ -72,6 +72,7 @@ impl CanisterInfoFactory for MotokoCanisterInfo {
         } else {
             output_wasm_path.with_extension("did")
         };
+        // eprintln!("MotokoCanisterInfo::create: output_idl_path: {:?}", output_idl_path);
         let output_stable_path = output_wasm_path.with_extension("most");
         let output_did_js_path = output_wasm_path.with_extension("did.js");
         let output_canister_js_path = output_wasm_path.with_extension("js");

--- a/src/dfx/src/lib/canister_info/motoko.rs
+++ b/src/dfx/src/lib/canister_info/motoko.rs
@@ -9,7 +9,6 @@ pub struct MotokoCanisterInfo {
     output_root: PathBuf,
 
     output_wasm_path: PathBuf,
-    output_idl_path: PathBuf,
     output_stable_path: PathBuf,
     output_did_js_path: PathBuf,
     output_canister_js_path: PathBuf,
@@ -25,9 +24,6 @@ impl MotokoCanisterInfo {
     }
     pub fn get_output_wasm_path(&self) -> &Path {
         self.output_wasm_path.as_path()
-    }
-    pub fn get_output_idl_path(&self) -> &Path {
-        self.output_idl_path.as_path()
     }
     pub fn get_output_stable_path(&self) -> &Path {
         self.output_stable_path.as_path()
@@ -67,11 +63,6 @@ impl CanisterInfoFactory for MotokoCanisterInfo {
         let input_path = workspace_root.join(main_path);
         let output_root = info.get_output_root().to_path_buf();
         let output_wasm_path = output_root.join(name).with_extension("wasm");
-        let output_idl_path = if let Some(remote_candid) = info.get_remote_candid_if_remote() {
-            workspace_root.join(remote_candid)
-        } else {
-            output_wasm_path.with_extension("did")
-        };
         // eprintln!("MotokoCanisterInfo::create: output_idl_path: {:?}", output_idl_path);
         let output_stable_path = output_wasm_path.with_extension("most");
         let output_did_js_path = output_wasm_path.with_extension("did.js");
@@ -82,7 +73,6 @@ impl CanisterInfoFactory for MotokoCanisterInfo {
             input_path,
             output_root,
             output_wasm_path,
-            output_idl_path,
             output_stable_path,
             output_did_js_path,
             output_canister_js_path,

--- a/src/dfx/src/lib/canister_info/pull.rs
+++ b/src/dfx/src/lib/canister_info/pull.rs
@@ -1,15 +1,12 @@
 use crate::lib::canister_info::{CanisterInfo, CanisterInfoFactory};
-use crate::lib::deps::get_candid_path_in_project;
 use crate::lib::error::DfxResult;
 use anyhow::bail;
 use candid::Principal;
 use dfx_core::config::model::dfinity::CanisterTypeProperties;
-use std::path::{Path, PathBuf};
 
 pub struct PullCanisterInfo {
     name: String,
     canister_id: Principal,
-    output_idl_path: PathBuf,
 }
 
 impl PullCanisterInfo {
@@ -19,10 +16,6 @@ impl PullCanisterInfo {
 
     pub fn get_canister_id(&self) -> &Principal {
         &self.canister_id
-    }
-
-    pub fn get_output_idl_path(&self) -> &Path {
-        self.output_idl_path.as_path()
     }
 }
 
@@ -40,13 +33,6 @@ impl CanisterInfoFactory for PullCanisterInfo {
             }
         };
 
-        let workspace_root = info.get_workspace_root().to_path_buf();
-        let output_idl_path = get_candid_path_in_project(&workspace_root, &canister_id);
-
-        Ok(Self {
-            name,
-            canister_id,
-            output_idl_path,
-        })
+        Ok(Self { name, canister_id })
     }
 }

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -366,7 +366,7 @@ pub fn get_canister_id_and_candid_path(
     };
     let config = env.get_config_or_anyhow()?;
     let candid_path = match CanisterInfo::load(&config, &canister_name, Some(canister_id)) {
-        Ok(info) => info.get_output_idl_path(),
+        Ok(info) => Some(info.get_output_idl_path().to_path_buf()),
         // In a rare case that the canister was deployed and then removed from dfx.json,
         // the canister_id_store can still resolve the canister id from the canister name.
         // In such case, technically, we are still able to call the canister.


### PR DESCRIPTION
# Description

Add `CanisterInfo.output_idl_path` and remove it from MotokoCanisterInfo, RustCanisterInfo, and so forth, and remove `CustomBuilderExtra.candid`.

Changed the return type of `CanisterInfo.get_output_idl_path()` from `Option<PathBuf>` to `&Path` since it is guaranteed to be set.

The motivation is to move in the direction of removing all of the *CanisterInfo types, instead having properties on CanisterInfo.

# How Has This Been Tested?

Covered by existing e2e tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
