### PR TITLE
fix: DFX sometimes omits a canister in .env

### DIFF
--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -253,6 +253,8 @@ The command line value will be used.",
         info!(log, "Uploading assets to asset canister...");
         post_install_store_assets(canister_info, agent, log).await?;
     }
+
+    // bad, untested code
     if !canister_info.get_post_install().is_empty() {
         let config = env.get_config()?;
         run_post_install_tasks(
@@ -262,6 +264,15 @@ The command line value will be used.",
             pool,
             env_file.or_else(|| config.as_ref()?.get_config().output_env_file.as_deref()),
         )?;
+    } else {
+        if let Some(pool) = pool {
+            let dependencies = pool
+                .get_canister_list()
+                .iter()
+                .map(|can| can.canister_id())
+                .collect_vec();
+            get_and_write_environment_variables(canister_info, &network.name, pool, dependencies.as_slice(), env_file)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
# Description

I changed the code and it now seems to work. However, this is unchecked and probably illogical code.

However, testing with the repository specified in #3833 does work. It creates `.env` file with `CANISTER_ID_REPOSITORYINDEX` variable as expected by both `dfx deploy RepositoryIndex` and `dfx deploy test` commands.

Probably, fixes #3833

# How Has This Been Tested?

See above.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
