### PR TITLE
chore: remove the deprecated --use-old-metering flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 # UNRELEASED
 
-# fix: display error cause of some http-related errors
+### fix: display error cause of some http-related errors
 
 Some commands that download http resources, for example `dfx extension install`, will
 once again display any error cause.
+
+### chore: remove the deprecated --use-old-metering flag
 
 # 0.22.0
 

--- a/docs/cli-reference/dfx-start.mdx
+++ b/docs/cli-reference/dfx-start.mdx
@@ -24,7 +24,6 @@ You can use the following optional flags with the `dfx start` command.
 | `--clean`                | Starts the local canister execution environment and web server processes in a clean state by removing checkpoints from your project cache. You can use this flag to set your project cache to a new state when troubleshooting or debugging.            |
 | `--enable-bitcoin`       | Enables bitcoin integration.                                                                                                                                                                                                                            |
 | `--enable-canister-http` | Enables canister HTTP requests. (deprecated: now enabled by default)                                                                                                                                                                                    |
-| `--use-old-metering`     | Enables the old metering in the local canister execution environment. Please see the forum thread for more details or to report any issues: [forum.dfinity.org/t/new-wasm-instrumentation/](https://forum.dfinity.org/t/new-wasm-instrumentation/22080) |
 | `--pocketic`             | Runs [PocketIC](https://github.com/dfinity/pocketic) instead of the replica.                                                                                                                                                                            |
 
 ## Options

--- a/src/dfx-core/src/config/model/replica_config.rs
+++ b/src/dfx-core/src/config/model/replica_config.rs
@@ -54,7 +54,6 @@ pub struct ReplicaConfig {
     pub canister_http_adapter: CanisterHttpAdapterConfig,
     pub log_level: ReplicaLogLevel,
     pub artificial_delay: u32,
-    pub use_old_metering: bool,
 }
 
 impl ReplicaConfig {
@@ -63,7 +62,6 @@ impl ReplicaConfig {
         subnet_type: ReplicaSubnetType,
         log_level: ReplicaLogLevel,
         artificial_delay: u32,
-        use_old_metering: bool,
     ) -> Self {
         ReplicaConfig {
             http_handler: HttpHandlerConfig {
@@ -90,7 +88,6 @@ impl ReplicaConfig {
             },
             log_level,
             artificial_delay,
-            use_old_metering,
         }
     }
 

--- a/src/dfx-core/src/config/model/settings_digest.rs
+++ b/src/dfx-core/src/config/model/settings_digest.rs
@@ -38,7 +38,6 @@ struct ReplicaSettings {
     pub canister_http_adapter: CanisterHttpAdapterSettings,
     pub log_level: ReplicaLogLevel,
     pub artificial_delay: u32,
-    pub use_old_metering: bool,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq)]
@@ -58,14 +57,13 @@ struct Settings<'a> {
 pub fn get_settings_digest(
     ic_repo_commit: &str,
     local_server_descriptor: &LocalServerDescriptor,
-    use_old_metering: bool,
     artificial_delay: u32,
     pocketic: bool,
 ) -> String {
     let backend = if pocketic {
         BackendSettings::PocketIc
     } else {
-        get_replica_backend_settings(local_server_descriptor, use_old_metering, artificial_delay)
+        get_replica_backend_settings(local_server_descriptor, artificial_delay)
     };
     let settings = Settings {
         ic_repo_commit: ic_repo_commit.into(),
@@ -78,7 +76,6 @@ pub fn get_settings_digest(
 
 fn get_replica_backend_settings(
     local_server_descriptor: &LocalServerDescriptor,
-    use_old_metering: bool,
     artificial_delay: u32,
 ) -> BackendSettings {
     let http_handler = HttpHandlerSettings {
@@ -107,7 +104,6 @@ fn get_replica_backend_settings(
             .log_level
             .unwrap_or_default(),
         artificial_delay,
-        use_old_metering,
     };
     BackendSettings::Replica {
         settings: Cow::Owned(replica_settings),

--- a/src/dfx/src/actors/replica.rs
+++ b/src/dfx/src/actors/replica.rs
@@ -365,10 +365,6 @@ fn replica_start_thread(
             &format!("{artificial_delay}"),
         ]);
 
-        if config.use_old_metering {
-            cmd.args(["--use-old-metering"]);
-        }
-
         // This should agree with the value at
         // at https://gitlab.com/dfinity-lab/core/ic/-/blob/master/ic-os/guestos/rootfs/etc/systemd/system/ic-replica.service
         cmd.env("RUST_MIN_STACK", "8192000");

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -295,12 +295,8 @@ pub fn exec(
     let proxy_domains = local_server_descriptor.proxy.domain.clone().into_vec();
 
     let replica_config = {
-        let replica_config = ReplicaConfig::new(
-            &state_root,
-            subnet_type,
-            log_level,
-            artificial_delay,
-        );
+        let replica_config =
+            ReplicaConfig::new(&state_root, subnet_type, log_level, artificial_delay);
         let mut replica_config = if let Some(port) = local_server_descriptor.replica.port {
             replica_config.with_port(port)
         } else {

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -74,10 +74,6 @@ pub struct StartOpts {
     #[arg(long, conflicts_with = "pocketic")]
     force: bool,
 
-    /// Use old metering.
-    #[arg(long, conflicts_with = "pocketic")]
-    use_old_metering: bool,
-
     /// A list of domains that can be served. These are used for canister resolution [default: localhost]
     #[arg(long)]
     domain: Vec<String>,
@@ -149,7 +145,6 @@ pub fn exec(
         enable_bitcoin,
         enable_canister_http,
         artificial_delay,
-        use_old_metering,
         domain,
         pocketic,
     }: StartOpts,
@@ -186,7 +181,6 @@ pub fn exec(
         bitcoin_node,
         enable_canister_http,
         domain,
-        use_old_metering,
         artificial_delay,
         pocketic,
     )?;
@@ -306,7 +300,6 @@ pub fn exec(
             subnet_type,
             log_level,
             artificial_delay,
-            use_old_metering,
         );
         let mut replica_config = if let Some(port) = local_server_descriptor.replica.port {
             replica_config.with_port(port)
@@ -489,7 +482,6 @@ pub fn apply_command_line_parameters(
     bitcoin_nodes: Vec<SocketAddr>,
     enable_canister_http: bool,
     domain: Vec<String>,
-    use_old_metering: bool,
     artificial_delay: u32,
     pocketic: bool,
 ) -> DfxResult<NetworkDescriptor> {
@@ -531,7 +523,6 @@ pub fn apply_command_line_parameters(
     let settings_digest = get_settings_digest(
         replica_rev(),
         &local_server_descriptor,
-        use_old_metering,
         artificial_delay,
         pocketic,
     );


### PR DESCRIPTION
Replica no longer support this flag