### PR TITLE
feat!: Change crate selection logic to use an explicit crate field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # UNRELEASED
 
+### feat!: add `crate` field to dfx.json
+
+It is now possible to specify a particular crate within a Rust package to use for a canister module, using the `crate` field.
+This enables specifying crates with different names than the package. In a few cases these were previously auto-detected
+by dfx, you will need to add this field if you were using such a setup.
+
 ### fix: display error cause of some http-related errors
 
 Some commands that download http resources, for example `dfx extension install`, will

--- a/docs/dfx-json-schema.json
+++ b/docs/dfx-json-schema.json
@@ -214,9 +214,17 @@
               "description": "Path of this canister's candid interface declaration.",
               "type": "string"
             },
+            "crate": {
+              "title": "Crate name",
+              "description": "Name of the Rust crate that compiles to this canister's Wasm. If left unspecified, defaults to the crate with the same name as the package.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "package": {
               "title": "Package Name",
-              "description": "Name of the rust package that compiles to this canister's Wasm.",
+              "description": "Name of the Rust package that compiles this canister's Wasm.",
               "type": "string"
             },
             "type": {

--- a/e2e/assets/rust_complex/Cargo.toml
+++ b/e2e/assets/rust_complex/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+members = ["can1", "can2"]
+edition = 2021
+resolver = "2"
+
+[workspace.dependencies]
+ic-cdk = "0.15"
+candid = "0.10"

--- a/e2e/assets/rust_complex/can1/Cargo.toml
+++ b/e2e/assets/rust_complex/can1/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "can1"
+version = "0.0.0"
+
+[dependencies]
+ic-cdk.workspace = true
+candid.workspace = true

--- a/e2e/assets/rust_complex/can1/src/main.rs
+++ b/e2e/assets/rust_complex/can1/src/main.rs
@@ -1,0 +1,6 @@
+#![no_main]
+
+#[ic_cdk::query]
+fn id() -> u32 {
+    1
+}

--- a/e2e/assets/rust_complex/can2/Cargo.toml
+++ b/e2e/assets/rust_complex/can2/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "can2"
+version = "0.0.0"
+
+[dependencies]
+ic-cdk.workspace = true
+candid.workspace = true
+
+[lib]
+crate-type = ["cdylib"]

--- a/e2e/assets/rust_complex/can2/src/bin/can3.rs
+++ b/e2e/assets/rust_complex/can2/src/bin/can3.rs
@@ -1,0 +1,6 @@
+#![no_main]
+
+#[ic_cdk::query]
+fn id() -> u32 {
+    3
+}

--- a/e2e/assets/rust_complex/can2/src/lib.rs
+++ b/e2e/assets/rust_complex/can2/src/lib.rs
@@ -1,0 +1,4 @@
+#[ic_cdk::query]
+fn id() -> u32 {
+    2
+}

--- a/e2e/assets/rust_complex/dfx.json
+++ b/e2e/assets/rust_complex/dfx.json
@@ -1,0 +1,21 @@
+{
+    "version": 1,
+    "canisters": {
+        "can1": {
+            "type": "rust",
+            "package": "can1",
+            "candid": "interface.did"
+        },
+        "can2": {
+            "type": "rust",
+            "package": "can2",
+            "candid": "interface.did"
+        },
+        "can3": {
+            "type": "rust",
+            "package": "can2",
+            "crate": "can3",
+            "candid": "interface.did"
+        }
+    }
+}

--- a/e2e/assets/rust_complex/interface.did
+++ b/e2e/assets/rust_complex/interface.did
@@ -1,0 +1,3 @@
+service : {
+    "id" : () -> (nat32) query;
+};

--- a/e2e/tests-dfx/rust.bash
+++ b/e2e/tests-dfx/rust.bash
@@ -62,3 +62,16 @@ teardown() {
   cargo update
   assert_command dfx deploy
 }
+
+@test "rust canisters support complex package layout" {
+  dfx_new_rust rust_complex
+  install_asset rust_complex
+  dfx_start
+  assert_command dfx deploy
+  assert_command dfx canister call can1 id
+  assert_contains '(1 : nat32)'
+  assert_command dfx canister call can2 id
+  assert_contains '(2 : nat32)'
+  assert_command dfx canister call can3 id
+  assert_contains '(3 : nat32)'
+}

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -335,8 +335,14 @@ pub enum CanisterTypeProperties {
     /// # Rust-Specific Properties
     Rust {
         /// # Package Name
-        /// Name of the rust package that compiles to this canister's Wasm.
+        /// Name of the Rust package that compiles this canister's Wasm.
         package: String,
+
+        /// # Crate name
+        /// Name of the Rust crate that compiles to this canister's Wasm.
+        /// If left unspecified, defaults to the crate with the same name as the package.
+        #[serde(rename = "crate")]
+        crate_name: Option<String>,
 
         /// # Candid File
         /// Path of this canister's candid interface declaration.
@@ -1240,6 +1246,7 @@ impl<'de> Visitor<'de> for PropertiesVisitor {
         let mut wasm = None;
         let mut candid = None;
         let mut package = None;
+        let mut crate_name = None;
         let mut source = None;
         let mut build = None;
         let mut r#type = None;
@@ -1248,6 +1255,7 @@ impl<'de> Visitor<'de> for PropertiesVisitor {
         while let Some(key) = map.next_key::<String>()? {
             match &*key {
                 "package" => package = Some(map.next_value()?),
+                "crate" => crate_name = Some(map.next_value()?),
                 "source" => source = Some(map.next_value()?),
                 "candid" => candid = Some(map.next_value()?),
                 "build" => build = Some(map.next_value()?),
@@ -1263,6 +1271,7 @@ impl<'de> Visitor<'de> for PropertiesVisitor {
             Some("rust") => CanisterTypeProperties::Rust {
                 candid: PathBuf::from(candid.ok_or_else(|| missing_field("candid"))?),
                 package: package.ok_or_else(|| missing_field("package"))?,
+                crate_name,
             },
             Some("assets") => CanisterTypeProperties::Assets {
                 source: source.ok_or_else(|| missing_field("source"))?,

--- a/src/dfx/src/lib/canister_info.rs
+++ b/src/dfx/src/lib/canister_info.rs
@@ -135,31 +135,34 @@ impl CanisterInfo {
 
         let output_root = build_root.join(name);
 
-        let output_idl_path: PathBuf = if let (Some(_id), Some(candid)) =
-            (&remote_id, &remote_candid)
-        {
-            workspace_root.join(candid)
-        } else {
-            match &canister_config.type_specific {
-                CanisterTypeProperties::Rust { package: _, candid } => workspace_root.join(candid),
-                CanisterTypeProperties::Assets { .. } => output_root.join("assetstorage.did"),
-                CanisterTypeProperties::Custom {
-                    wasm: _,
-                    candid,
-                    build: _,
-                } => {
-                    if Url::parse(candid).is_ok() {
-                        output_root.join(name).with_extension("did")
-                    } else {
-                        workspace_root.join(candid)
+        let output_idl_path: PathBuf =
+            if let (Some(_id), Some(candid)) = (&remote_id, &remote_candid) {
+                workspace_root.join(candid)
+            } else {
+                match &canister_config.type_specific {
+                    CanisterTypeProperties::Rust {
+                        package: _,
+                        crate_name: _,
+                        candid,
+                    } => workspace_root.join(candid),
+                    CanisterTypeProperties::Assets { .. } => output_root.join("assetstorage.did"),
+                    CanisterTypeProperties::Custom {
+                        wasm: _,
+                        candid,
+                        build: _,
+                    } => {
+                        if Url::parse(candid).is_ok() {
+                            output_root.join(name).with_extension("did")
+                        } else {
+                            workspace_root.join(candid)
+                        }
+                    }
+                    CanisterTypeProperties::Motoko => output_root.join(name).with_extension("did"),
+                    CanisterTypeProperties::Pull { id } => {
+                        get_candid_path_in_project(workspace_root, id)
                     }
                 }
-                CanisterTypeProperties::Motoko => output_root.join(name).with_extension("did"),
-                CanisterTypeProperties::Pull { id } => {
-                    get_candid_path_in_project(workspace_root, id)
-                }
-            }
-        };
+            };
 
         let type_specific = canister_config.type_specific.clone();
 

--- a/src/dfx/src/lib/canister_info/rust.rs
+++ b/src/dfx/src/lib/canister_info/rust.rs
@@ -3,6 +3,7 @@ use crate::lib::error::DfxResult;
 use anyhow::{bail, ensure, Context};
 use cargo_metadata::Metadata;
 use dfx_core::config::model::dfinity::CanisterTypeProperties;
+use itertools::Itertools;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -33,10 +34,13 @@ impl CanisterInfoFactory for RustCanisterInfo {
             bail!("`cargo metadata` was unsuccessful");
         }
 
-        let package = if let CanisterTypeProperties::Rust { package, candid: _ } =
-            info.type_specific.clone()
+        let (package, crate_name) = if let CanisterTypeProperties::Rust {
+            package,
+            crate_name,
+            candid: _,
+        } = info.type_specific.clone()
         {
-            package
+            (package, crate_name)
         } else {
             bail!(
                 "Attempted to construct a custom canister from a type:{} canister config",
@@ -50,31 +54,33 @@ impl CanisterInfoFactory for RustCanisterInfo {
             .iter()
             .find(|x| x.name == package)
             .with_context(|| format!("No package `{package}` found"))?;
-        let target = if let Some(exact_match_target) =
-            package_info.targets.iter().find(|x| x.name == package)
-        {
-            ensure!(
-                exact_match_target
-                    .crate_types
-                    .iter()
-                    .any(|c| c == "cdylib" || c == "bin"),
-                "Crate `{package}` is not a bin or cdylib",
-            );
-            exact_match_target
+        let (phrasing, crate_name) = if let Some(crate_name) = crate_name {
+            (
+                format!("crate `{crate_name}` in package `{package}`"),
+                crate_name,
+            )
         } else {
-            let mut candidate_targets = package_info
-                .targets
-                .iter()
-                .filter(|x| x.crate_types.iter().any(|c| c == "cdylib" || c == "bin"));
-            let target = candidate_targets
-                .next()
-                .with_context(|| format!("No bin or cdylib crates found in package `{package}`"))?;
-            ensure!(
-                candidate_targets.next().is_none(),
-                "More than one bin/cdylib crate was found in package `{package}`",
-            );
-            target
+            (format!("crate `{package}`"), package.clone())
         };
+        let mut candidate_targets = package_info.targets.iter().filter(|x| {
+            x.name == crate_name && x.crate_types.iter().any(|c| c == "cdylib" || c == "bin")
+        });
+        let Some(target) = candidate_targets.next() else {
+            if let Some(wrong_type_crate) =
+                package_info.targets.iter().find(|x| x.name == crate_name)
+            {
+                bail!(
+                    "The {phrasing} was of type {}, must be either bin or cdylib",
+                    wrong_type_crate.crate_types.iter().format("/")
+                )
+            } else {
+                bail!("No {phrasing} found")
+            }
+        };
+        ensure!(
+            candidate_targets.next().is_none(),
+            "More than one bin/cdylib {phrasing} found"
+        );
 
         let wasm_name = target.name.replace('-', "_");
         let output_wasm_path = metadata


### PR DESCRIPTION
Currently, dfx asks you to specify a package, and selects what it thinks is the default crate from that package. This misfires when a package contains multiple possible crates, as @sesi200 reported with the cycles ledger. This PR changes it to only assume that the default crate is the one with the same name as the package, and use a new `crate` field in dfx.json to explicitly specify non-default crates.