### PR TITLE
feat: install extension by url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 # UNRELEASED
 
+### feat: `dfx extension install <url to extension.json>`
+
+It's now possible for `dfx extension install` to install an extension from
+somewhere other than https://github.com/dfinity/dfx-extensions, by passing
+a URL to an extension.json file rather than an extension name.
+
+For example, these are equivalent:
+```bash
+dfx extension install nns
+dfx extension install https://raw.githubusercontent.com/dfinity/dfx-extensions/main/extensions/nns/extension.json
+```
+
+This update also adds the optional field `download_url_template` to extension.json,
+which dfx will use to locate an extension release archive.
+
 ### feat!: add `crate` field to dfx.json
 
 It is now possible to specify a particular crate within a Rust package to use for a canister module, using the `crate` field.

--- a/docs/extension-manifest-schema.json
+++ b/docs/extension-manifest-schema.json
@@ -48,7 +48,7 @@
       ]
     },
     "download_url_template": {
-      "description": "Components of the download url template are: - `{{tag}}`: the tag of the extension release, which must be \"<extension name>_v<extension version>\" - `{{basename}}`: The basename of the release filename, of the format \"<extension name>-<arch>-<platform>\", for example \"nns-x86_64-unknown-linux-gnu\" - `{{archive-format}}`: the format of the archive, for example \"tar.gz\"",
+      "description": "Components of the download url template are: - `{{tag}}`: the tag of the extension release, which will follow the form \"<extension name>_v<extension version>\" - `{{basename}}`: The basename of the release filename, which will follow the form \"<extension name>-<arch>-<platform>\", for example \"nns-x86_64-unknown-linux-gnu\" - `{{archive-format}}`: the format of the archive, for example \"tar.gz\"",
       "default": "https://github.com/dfinity/dfx-extensions/releases/download/{{tag}}/{{basename}}.{{archive-format}}",
       "type": [
         "string",

--- a/docs/extension-manifest-schema.json
+++ b/docs/extension-manifest-schema.json
@@ -48,7 +48,7 @@
       ]
     },
     "download_url_template": {
-      "description": "Components of the download url template are: - `{{tag}}`: the tag of the extension release, which will follow the form \"<extension name>_v<extension version>\" - `{{basename}}`: The basename of the release filename, which will follow the form \"<extension name>-<arch>-<platform>\", for example \"nns-x86_64-unknown-linux-gnu\" - `{{archive-format}}`: the format of the archive, for example \"tar.gz\"",
+      "description": "Components of the download url template are: - `{{tag}}`: the tag of the extension release, which will follow the form \"<extension name>-v<extension version>\" - `{{basename}}`: The basename of the release filename, which will follow the form \"<extension name>-<arch>-<platform>\", for example \"nns-x86_64-unknown-linux-gnu\" - `{{archive-format}}`: the format of the archive, for example \"tar.gz\"",
       "default": "https://github.com/dfinity/dfx-extensions/releases/download/{{tag}}/{{basename}}.{{archive-format}}",
       "type": [
         "string",

--- a/docs/extension-manifest-schema.json
+++ b/docs/extension-manifest-schema.json
@@ -47,6 +47,14 @@
         "null"
       ]
     },
+    "download_url_template": {
+      "description": "Components of the download url template are: - `{{tag}}`: the tag of the extension release, which must be \"<extension name>_v<extension version>\" - `{{basename}}`: The basename of the release filename, of the format \"<extension name>-<arch>-<platform>\", for example \"nns-x86_64-unknown-linux-gnu\" - `{{archive-format}}`: the format of the archive, for example \"tar.gz\"",
+      "default": "https://github.com/dfinity/dfx-extensions/releases/download/{{tag}}/{{basename}}.{{archive-format}}",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "homepage": {
       "type": "string"
     },

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -215,6 +215,26 @@ install_extension_from_official_registry() {
   install_extension_from_official_registry https://raw.githubusercontent.com/dfinity/dfx-extensions/main/extensions/sns/extension.json
 }
 
+get_extension_architecture() {
+  _cputype="$(uname -m)"
+  case "$_cputype" in
+
+    x86_64 | x86-64 | x64 | amd64)
+      _cputype=x86_64
+      ;;
+
+    arm64 | aarch64)
+      _cputype=aarch64
+      ;;
+
+    *)
+      err "unknown CPU type: $_cputype"
+      ;;
+
+  esac
+  echo "$_cputype"
+}
+
 @test "install extension by url from elsewhere" {
   start_webserver --directory www
   EXTENSION_URL="http://localhost:$E2E_WEB_SERVER_PORT/arbitrary/extension.json"
@@ -250,11 +270,12 @@ EOF
 }
 EOF
 
+  arch=$(get_extension_architecture)
 
   if [ "$(uname)" == "Darwin" ]; then
-    ARCHIVE_BASENAME="an-extension-aarch64-apple-darwin"
+    ARCHIVE_BASENAME="an-extension-$arch-apple-darwin"
   else
-    ARCHIVE_BASENAME="an-extension-x86_x86-unknown-linux"
+    ARCHIVE_BASENAME="an-extension-$arch-unknown-linux-gnu"
   fi
 
   mkdir "$ARCHIVE_BASENAME"

--- a/src/dfx-core/src/extension/manager/install.rs
+++ b/src/dfx-core/src/extension/manager/install.rs
@@ -1,10 +1,12 @@
 use crate::error::extension::{
     DownloadAndInstallExtensionToTempdirError, FinalizeInstallationError,
-    GetExtensionArchiveNameError, GetExtensionDownloadUrlError, GetHighestCompatibleVersionError,
-    InstallExtensionError,
+    GetExtensionArchiveNameError, GetExtensionDownloadUrlError, GetExtensionManifestError,
+    GetHighestCompatibleVersionError, GetTopLevelDirectoryError, InstallExtensionError,
 };
 use crate::extension::{
-    manager::ExtensionManager, manifest::ExtensionDependencies, url::ExtensionJsonUrl,
+    manager::ExtensionManager,
+    manifest::{ExtensionDependencies, ExtensionManifest},
+    url::ExtensionJsonUrl,
 };
 use crate::http::get::get_with_retries;
 use backoff::exponential::ExponentialBackoff;
@@ -14,21 +16,21 @@ use semver::{BuildMetadata, Prerelease, Version};
 use std::io::Cursor;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tar::Archive;
 use tempfile::{tempdir_in, TempDir};
 
-const DFINITY_DFX_EXTENSIONS_RELEASES_URL: &str =
-    "https://github.com/dfinity/dfx-extensions/releases/download";
-
 impl ExtensionManager {
     pub async fn install_extension(
         &self,
-        extension_name: &str,
         url: &ExtensionJsonUrl,
         install_as: Option<&str>,
         version: Option<&Version>,
     ) -> Result<Version, InstallExtensionError> {
+        let manifest = Self::get_extension_manifest(url).await?;
+        let extension_name: &str = &manifest.name;
+
         let effective_extension_name = install_as.unwrap_or(extension_name);
 
         if self
@@ -46,18 +48,17 @@ impl ExtensionManager {
         };
         let github_release_tag = get_git_release_tag(extension_name, &extension_version);
         let extension_archive = get_extension_archive_name(extension_name)?;
-        let archive_url = get_extension_download_url(&github_release_tag, &extension_archive)?;
+        let archive_url = get_extension_download_url(
+            &manifest.download_url_template(),
+            &github_release_tag,
+            &extension_archive,
+        )?;
 
         let temp_dir = self
             .download_and_unpack_extension_to_tempdir(archive_url)
             .await?;
 
-        self.finalize_installation(
-            extension_name,
-            effective_extension_name,
-            &extension_archive,
-            temp_dir,
-        )?;
+        self.finalize_installation(extension_name, effective_extension_name, temp_dir)?;
 
         Ok(extension_version)
     }
@@ -81,6 +82,22 @@ impl ExtensionManager {
         dependencies
             .find_highest_compatible_version(&dfx_version)?
             .ok_or(GetHighestCompatibleVersionError::NoCompatibleVersionFound())
+    }
+
+    async fn get_extension_manifest(
+        url: &ExtensionJsonUrl,
+    ) -> Result<ExtensionManifest, GetExtensionManifestError> {
+        let retry_policy = ExponentialBackoff {
+            max_elapsed_time: Some(Duration::from_secs(60)),
+            ..Default::default()
+        };
+        let resp = get_with_retries(url.as_url().clone(), retry_policy)
+            .await
+            .map_err(GetExtensionManifestError::Get)?;
+
+        resp.json()
+            .await
+            .map_err(GetExtensionManifestError::ParseJson)
     }
 
     async fn download_and_unpack_extension_to_tempdir(
@@ -122,14 +139,11 @@ impl ExtensionManager {
         &self,
         extension_name: &str,
         effective_extension_name: &str,
-        extension_unarchived_dir_name: &str,
         temp_dir: TempDir,
     ) -> Result<(), FinalizeInstallationError> {
         let effective_extension_dir = &self.get_extension_directory(effective_extension_name);
-        crate::fs::rename(
-            &temp_dir.path().join(extension_unarchived_dir_name),
-            effective_extension_dir,
-        )?;
+        let top_level_dir = get_top_level_directory(temp_dir.path())?;
+        crate::fs::rename(&top_level_dir, effective_extension_dir)?;
         if extension_name != effective_extension_name {
             // rename the binary
             crate::fs::rename(
@@ -146,11 +160,27 @@ impl ExtensionManager {
     }
 }
 
+fn get_top_level_directory(dir: &Path) -> Result<PathBuf, GetTopLevelDirectoryError> {
+    // the archive will have a single top-level subdirectory
+    // return that subdirectory
+    Ok(crate::fs::read_dir(dir)
+        .map_err(GetTopLevelDirectoryError::ReadDir)?
+        .next()
+        .ok_or(GetTopLevelDirectoryError::NoTopLevelDirectoryEntry)?
+        .map_err(GetTopLevelDirectoryError::ReadDirEntry)?
+        .path())
+}
+
 fn get_extension_download_url(
+    download_url_template: &str,
     github_release_tag: &str,
     extension_archive_name: &str,
 ) -> Result<Url, GetExtensionDownloadUrlError> {
-    let download_url = format!("{DFINITY_DFX_EXTENSIONS_RELEASES_URL}/{github_release_tag}/{extension_archive_name}.tar.gz",);
+    let download_url = download_url_template
+        .replace("{{tag}}", github_release_tag)
+        .replace("{{basename}}", extension_archive_name)
+        .replace("{{archive-format}}", "tar.gz");
+
     Url::parse(&download_url).map_err(|source| GetExtensionDownloadUrlError {
         url: download_url,
         source,

--- a/src/dfx-core/src/extension/manifest/extension.rs
+++ b/src/dfx-core/src/extension/manifest/extension.rs
@@ -35,7 +35,7 @@ pub struct ExtensionManifest {
     pub canister_type: Option<ExtensionCanisterType>,
 
     /// Components of the download url template are:
-    /// - `{{tag}}`: the tag of the extension release, which will follow the form "<extension name>_v<extension version>"
+    /// - `{{tag}}`: the tag of the extension release, which will follow the form "<extension name>-v<extension version>"
     /// - `{{basename}}`: The basename of the release filename, which will follow the form "<extension name>-<arch>-<platform>", for example "nns-x86_64-unknown-linux-gnu"
     /// - `{{archive-format}}`: the format of the archive, for example "tar.gz"
     #[serde(

--- a/src/dfx-core/src/extension/url.rs
+++ b/src/dfx-core/src/extension/url.rs
@@ -3,6 +3,10 @@ use url::Url;
 pub struct ExtensionJsonUrl(Url);
 
 impl ExtensionJsonUrl {
+    pub fn new(url: Url) -> Self {
+        ExtensionJsonUrl(url)
+    }
+
     pub fn registered(name: &str) -> Result<Self, url::ParseError> {
         let s = format!(
             "https://raw.githubusercontent.com/dfinity/dfx-extensions/main/extensions/{name}/extension.json"

--- a/src/dfx/src/commands/extension/install.rs
+++ b/src/dfx/src/commands/extension/install.rs
@@ -8,6 +8,7 @@ use clap::Subcommand;
 use dfx_core::extension::url::ExtensionJsonUrl;
 use semver::Version;
 use tokio::runtime::Runtime;
+use url::Url;
 
 #[derive(Parser)]
 pub struct InstallOpts {
@@ -32,18 +33,17 @@ pub fn exec(env: &dyn Environment, opts: InstallOpts) -> DfxResult<()> {
         bail!("Extension '{}' cannot be installed because it conflicts with an existing command. Consider using '--install-as' flag to install this extension under different name.", opts.name)
     }
 
-    let url = ExtensionJsonUrl::registered(&opts.name)?;
+    let url = if let Ok(url) = Url::parse(&opts.name) {
+        ExtensionJsonUrl::new(url)
+    } else {
+        ExtensionJsonUrl::registered(&opts.name)?
+    };
 
     let runtime = Runtime::new().expect("Unable to create a runtime");
 
     let installed_version = runtime.block_on(async {
-        mgr.install_extension(
-            &opts.name,
-            &url,
-            opts.install_as.as_deref(),
-            opts.version.as_ref(),
-        )
-        .await
+        mgr.install_extension(&url, opts.install_as.as_deref(), opts.version.as_ref())
+            .await
     })?;
     spinner.finish_with_message(
         format!(


### PR DESCRIPTION
# Description

dfx extension install <URL to extension.json>

Also adds download_url_template to extension.json

Fixes https://dfinity.atlassian.net/browse/SDK-1770

There is no document for `dfx extension` in https://github.com/dfinity/sdk/tree/master/docs/cli-reference, and this PR doesn't add one.

# How Has This Been Tested?

Added e2e tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
