### PR TITLE
fix: dfx extension install no longer reports an error if extension already installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ dfx extension install https://raw.githubusercontent.com/dfinity/dfx-extensions/m
 This update also adds the optional field `download_url_template` to extension.json,
 which dfx will use to locate an extension release archive.
 
+### fix: `dfx extension install` no longer reports an error if the extension is already installed
+
+However, if a version is specified with `--version`, and the installed version is different,
+then `dfx extension install` will still report an error.
+
 ### feat: display replica port in `dfx start`
 
 This replaces the dashboard link, which is now shown only in verbose mode. This should hopefully be less confusing for new users.

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -25,7 +25,7 @@ teardown() {
 start_and_install_nns() {
   dfx_start_for_nns_install
 
-  dfx extension install nns --version 0.3.1 || true
+  dfx extension install nns --version 0.3.1
   dfx nns install --ledger-accounts "$(dfx ledger account-id --identity cycle-giver)"
 }
 

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -188,8 +188,7 @@ install_extension_from_official_registry() {
   assert_match 'No extensions installed'
 
   assert_command dfx extension install "$EXTENSION" --install-as snsx --version 0.2.1
-  # TODO: how to capture spinner message?
-  # assert_match 'Successfully installed extension'
+  assert_contains 'Successfully installed extension'
 
   assert_command dfx extension list
   assert_match 'snsx'
@@ -343,9 +342,31 @@ EOF
   assert_command_fail dfx nns --help
   assert_command dfx extension install nns --version 0.4.1
   assert_command dfx extension install nns --version 0.4.1
+  # shellcheck disable=SC2154
+  assert_eq "WARN: Extension 'nns' version 0.4.1 is already installed" "$stderr"
   assert_command dfx nns --help
 }
 
+@test "install is not an error if an older version is already installed and no version was specified" {
+  assert_command_fail dfx nns --help
+  assert_command dfx extension install nns --version 0.3.1
+  assert_command dfx extension install nns
+  # shellcheck disable=SC2154
+  assert_eq "WARN: Extension 'nns' version 0.3.1 is already installed" "$stderr"
+  assert_command dfx nns --help
+}
+
+@test "reports error if older version already installed and specific version requested" {
+  assert_command_fail dfx nns --help
+  assert_command dfx extension install nns --version 0.3.1
+  assert_command_fail dfx extension install nns --version 0.4.1
+  # shellcheck disable=SC2154
+  assert_contains "WARN: Extension 'nns' version 0.3.1 is already installed" "$stderr"
+  # shellcheck disable=SC2154
+  assert_contains "ERROR: Requested version 0.4.1 is different from installed version 0.3.1" "$stderr"
+  # shellcheck disable=SC2154
+  assert_contains 'ERROR: To upgrade, run "dfx extension uninstall nns" and then re-run the dfx extension install command' "$stderr"
+}
 @test "manually create extension" {
   assert_command dfx extension list
   assert_match 'No extensions installed'

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -339,6 +339,12 @@ EOF
   assert_command dfx extension install "$EXTENSION_URL"
 }
 
+@test "install is not an error if already installed" {
+  assert_command_fail dfx nns --help
+  assert_command dfx extension install nns --version 0.4.1
+  assert_command dfx extension install nns --version 0.4.1
+  assert_command dfx nns --help
+}
 
 @test "manually create extension" {
   assert_command dfx extension list

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -188,7 +188,7 @@ install_extension_from_official_registry() {
   assert_match 'No extensions installed'
 
   assert_command dfx extension install "$EXTENSION" --install-as snsx --version 0.2.1
-  assert_contains 'Successfully installed extension'
+  assert_contains "Extension 'sns' version 0.2.1 installed successfully, and is available as 'snsx'"
 
   assert_command dfx extension list
   assert_match 'snsx'

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -361,12 +361,11 @@ EOF
   assert_command dfx extension install nns --version 0.3.1
   assert_command_fail dfx extension install nns --version 0.4.1
   # shellcheck disable=SC2154
-  assert_contains "WARN: Extension 'nns' version 0.3.1 is already installed" "$stderr"
-  # shellcheck disable=SC2154
-  assert_contains "ERROR: Requested version 0.4.1 is different from installed version 0.3.1" "$stderr"
+  assert_contains "ERROR: Extension 'nns' is already installed at version 0.3.1" "$stderr"
   # shellcheck disable=SC2154
   assert_contains 'ERROR: To upgrade, run "dfx extension uninstall nns" and then re-run the dfx extension install command' "$stderr"
 }
+
 @test "manually create extension" {
   assert_command dfx extension list
   assert_match 'No extensions installed'

--- a/e2e/tests-dfx/ledger.bash
+++ b/e2e/tests-dfx/ledger.bash
@@ -12,7 +12,7 @@ setup() {
 
   dfx_start_for_nns_install
 
-  dfx extension install nns --version 0.2.1 || true
+  dfx extension install nns --version 0.2.1
   dfx nns install --ledger-accounts 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 22ca7edac648b814e81d7946e8bacea99280e07c5f51a04ba7a38009d8ad8e89 5a94fe181e9d411c58726cb87cbf2d016241b6c350bc3330e4869ca76e54ecbc
 }
 

--- a/src/dfx-core/src/error/extension.rs
+++ b/src/dfx-core/src/error/extension.rs
@@ -118,6 +118,9 @@ pub enum InstallExtensionError {
 
     #[error(transparent)]
     FinalizeInstallation(#[from] FinalizeInstallationError),
+
+    #[error(transparent)]
+    LoadManifest(#[from] LoadExtensionManifestError),
 }
 
 #[derive(Error, Debug)]

--- a/src/dfx-core/src/error/extension.rs
+++ b/src/dfx-core/src/error/extension.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
+
 use crate::error::fs::FsError;
 use crate::error::structured_file::StructuredFileError;
+use semver::Version;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -98,8 +100,8 @@ pub enum DownloadAndInstallExtensionToTempdirError {
 
 #[derive(Error, Debug)]
 pub enum InstallExtensionError {
-    #[error("Extension '{0}' is already installed.")]
-    ExtensionAlreadyInstalled(String),
+    #[error("Extension '{0}' is already installed at version {1}.")]
+    OtherVersionAlreadyInstalled(String, Version),
 
     #[error(transparent)]
     GetExtensionArchiveName(#[from] GetExtensionArchiveNameError),

--- a/src/dfx-core/src/extension/manager/install.rs
+++ b/src/dfx-core/src/extension/manager/install.rs
@@ -44,17 +44,17 @@ impl ExtensionManager {
         {
             let installed_manifest = ExtensionManifest::load(effective_extension_name, &self.dir)?;
 
-            if matches!(version, Some(v) if *v != *installed_manifest.version) {
-                return Err(InstallExtensionError::OtherVersionAlreadyInstalled(
+            return if matches!(version, Some(v) if *v != *installed_manifest.version) {
+                Err(InstallExtensionError::OtherVersionAlreadyInstalled(
                     extension_name.to_string(),
                     installed_manifest.version.clone(),
-                ));
+                ))
             } else {
-                return Ok(InstallOutcome::AlreadyInstalled(
+                Ok(InstallOutcome::AlreadyInstalled(
                     extension_name.to_string(),
                     installed_manifest.version.clone(),
-                ));
-            }
+                ))
+            };
         }
 
         let extension_version = match version {

--- a/src/dfx-core/src/extension/manager/install.rs
+++ b/src/dfx-core/src/extension/manager/install.rs
@@ -46,7 +46,7 @@ impl ExtensionManager {
 
             if matches!(version, Some(v) if *v != *installed_manifest.version) {
                 return Err(InstallExtensionError::OtherVersionAlreadyInstalled(
-                    effective_extension_name.to_string(),
+                    extension_name.to_string(),
                     installed_manifest.version.clone(),
                 ));
             } else {

--- a/src/dfx-core/src/extension/manager/mod.rs
+++ b/src/dfx-core/src/extension/manager/mod.rs
@@ -8,6 +8,8 @@ mod install;
 mod list;
 mod uninstall;
 
+pub use install::InstallOutcome;
+
 pub struct ExtensionManager {
     pub dir: PathBuf,
     pub dfx_version: Version,

--- a/src/dfx-core/src/extension/manifest/extension.rs
+++ b/src/dfx-core/src/extension/manifest/extension.rs
@@ -2,7 +2,7 @@ use crate::error::extension::{
     ConvertExtensionSubcommandIntoClapArgError, ConvertExtensionSubcommandIntoClapCommandError,
     LoadExtensionManifestError,
 };
-use crate::json::structure::VersionReqWithJsonSchema;
+use crate::json::structure::{VersionReqWithJsonSchema, VersionWithJsonSchema};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
@@ -23,7 +23,7 @@ type ArgName = String;
 #[serde(deny_unknown_fields)]
 pub struct ExtensionManifest {
     pub name: String,
-    pub version: String,
+    pub version: VersionWithJsonSchema,
     pub homepage: String,
     pub authors: Option<String>,
     pub summary: String,

--- a/src/dfx-core/src/json/structure.rs
+++ b/src/dfx-core/src/json/structure.rs
@@ -1,6 +1,6 @@
 use candid::Deserialize;
 use schemars::JsonSchema;
-use semver::VersionReq;
+use semver::{Version, VersionReq};
 use serde::Serialize;
 use std::fmt::Display;
 use std::ops::{Deref, DerefMut};
@@ -69,6 +69,24 @@ impl Deref for VersionReqWithJsonSchema {
 }
 
 impl DerefMut for VersionReqWithJsonSchema {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(transparent)]
+pub struct VersionWithJsonSchema(#[schemars(with = "String")] pub Version);
+
+impl Deref for VersionWithJsonSchema {
+    type Target = Version;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for VersionWithJsonSchema {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/src/dfx/src/commands/extension/install.rs
+++ b/src/dfx/src/commands/extension/install.rs
@@ -75,10 +75,9 @@ pub fn exec(env: &dyn Environment, opts: InstallOpts) -> DfxResult<()> {
                 logger,
                 "Extension '{name}' is already installed at version {version}"
             );
-            let uninstall = opts.install_as.unwrap_or(opts.name);
             error!(
                 logger,
-                r#"To upgrade, run "dfx extension uninstall {uninstall}" and then re-run the dfx extension install command"#
+                r#"To upgrade, run "dfx extension uninstall {name}" and then re-run the dfx extension install command"#
             );
             bail!("Different version already installed");
         }

--- a/src/dfx/src/lib/progress_bar.rs
+++ b/src/dfx/src/lib/progress_bar.rs
@@ -36,6 +36,7 @@ impl ProgressBar {
         }
     }
 
+    forward_fn_impl!(finish_and_clear);
     forward_fn_impl!(finish_with_message, message: Cow<'static, str>);
 
     pub fn discard() -> Self {


### PR DESCRIPTION
# Description

`dfx extension install` (without the `--version` parameter) reports success, with a warning log, if any version of the extension is already installed.

if `--version` is passed, and the version does not match, dfx still reports an error.

Fixes https://dfinity.atlassian.net/browse/SDK-1651

# How Has This Been Tested?

Added e2e tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
