### PR TITLE
refactor: move wallet_canister_id to dfx-core

### DIFF
--- a/src/dfx-core/src/identity/mod.rs
+++ b/src/dfx-core/src/identity/mod.rs
@@ -41,6 +41,7 @@ pub mod identity_manager;
 pub mod keyring_mock;
 pub mod pem_safekeeping;
 pub mod pem_utils;
+pub mod wallet;
 
 pub const ANONYMOUS_IDENTITY_NAME: &str = "anonymous";
 pub const IDENTITY_JSON: &str = "identity.json";

--- a/src/dfx-core/src/identity/wallet.rs
+++ b/src/dfx-core/src/identity/wallet.rs
@@ -1,0 +1,48 @@
+use crate::config::directories::get_user_dfx_config_dir;
+use crate::config::model::network_descriptor::{NetworkDescriptor, NetworkTypeDescriptor};
+use crate::error::wallet_config::WalletConfigError;
+use crate::error::wallet_config::WalletConfigError::GetWalletConfigPathFailed;
+use crate::identity::{Identity, WALLET_CONFIG_FILENAME};
+use candid::Principal;
+use std::path::PathBuf;
+
+pub fn get_wallet_config_path(
+    network: &NetworkDescriptor,
+    name: &str,
+) -> Result<PathBuf, WalletConfigError> {
+    Ok(match &network.r#type {
+        NetworkTypeDescriptor::Persistent | NetworkTypeDescriptor::Playground { .. } => {
+            // Using the global
+            get_user_dfx_config_dir()
+                .map_err(|e| {
+                    GetWalletConfigPathFailed(
+                        Box::new(name.to_string()),
+                        Box::new(network.name.clone()),
+                        e,
+                    )
+                })?
+                .join("identity")
+                .join(name)
+                .join(WALLET_CONFIG_FILENAME)
+        }
+        NetworkTypeDescriptor::Ephemeral { wallet_config_path } => wallet_config_path.clone(),
+    })
+}
+
+pub fn wallet_canister_id(
+    network: &NetworkDescriptor,
+    name: &str,
+) -> Result<Option<Principal>, WalletConfigError> {
+    let wallet_path = get_wallet_config_path(network, name)?;
+    if !wallet_path.exists() {
+        return Ok(None);
+    }
+
+    let config = Identity::load_wallet_config(&wallet_path)?;
+
+    let maybe_wallet_principal = config
+        .identities
+        .get(name)
+        .and_then(|wallet_network| wallet_network.networks.get(&network.name).cloned());
+    Ok(maybe_wallet_principal)
+}

--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -1,7 +1,6 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::ic_attributes::CanisterSettings;
-use crate::lib::identity::wallet::wallet_canister_id;
 use crate::lib::operations::canister;
 use crate::lib::operations::canister::{
     deposit_cycles, start_canister, stop_canister, update_settings,
@@ -16,6 +15,7 @@ use candid::Principal;
 use clap::Parser;
 use dfx_core::canister::build_wallet_canister;
 use dfx_core::cli::ask_for_consent;
+use dfx_core::identity::wallet::wallet_canister_id;
 use dfx_core::identity::CallSender;
 use fn_error_context::context;
 use ic_utils::interfaces::management_canister::attributes::FreezingThreshold;

--- a/src/dfx/src/commands/quickstart.rs
+++ b/src/dfx/src/commands/quickstart.rs
@@ -7,7 +7,7 @@ use crate::{
         agent::create_agent_environment,
         environment::Environment,
         error::DfxResult,
-        identity::wallet::{set_wallet_id, wallet_canister_id},
+        identity::wallet::set_wallet_id,
         ledger_types::Memo,
         nns_types::{
             account_identifier::AccountIdentifier,
@@ -24,6 +24,7 @@ use crate::{
 use anyhow::{bail, Context};
 use candid::Principal;
 use clap::Parser;
+use dfx_core::identity::wallet::wallet_canister_id;
 use dialoguer::{Confirm, Input};
 use ic_agent::Agent;
 use ic_utils::interfaces::{

--- a/src/dfx/src/commands/wallet/upgrade.rs
+++ b/src/dfx/src/commands/wallet/upgrade.rs
@@ -1,11 +1,11 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
-use crate::lib::identity::wallet::wallet_canister_id;
 use crate::lib::operations::canister::install_canister::install_wallet;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::lib::state_tree::canister_info::read_state_tree_canister_module_hash;
 use anyhow::bail;
 use clap::Parser;
+use dfx_core::identity::wallet::wallet_canister_id;
 use ic_utils::interfaces::management_canister::builders::InstallMode;
 
 /// Upgrade the wallet's Wasm module to the current Wasm bundled with DFX.

--- a/src/dfx/src/lib/migrate.rs
+++ b/src/dfx/src/lib/migrate.rs
@@ -1,9 +1,9 @@
-use crate::lib::identity::wallet::wallet_canister_id;
 use crate::lib::operations::canister::install_wallet;
 use crate::lib::{environment::Environment, error::DfxResult, root_key::fetch_root_key_if_needed};
 use anyhow::{bail, Context, Error};
 use candid::{CandidType, Deserialize, Principal};
 use dfx_core::config::model::network_descriptor::NetworkDescriptor;
+use dfx_core::identity::wallet::wallet_canister_id;
 use dfx_core::identity::Identity;
 use ic_agent::{Agent, Identity as _};
 use ic_utils::{


### PR DESCRIPTION
# Description

Moves two methods from dfx/src/lib to dfx-core

Preparatory work for https://dfinity.atlassian.net/browse/SDK-1483

# How Has This Been Tested?

Covered by existing tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
