### PR TITLE
feat: accept --wallet <identity name> in addition to --wallet <principal>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ It is now possible to specify a particular crate within a Rust package to use fo
 This enables specifying crates with different names than the package. In a few cases these were previously auto-detected
 by dfx, you will need to add this field if you were using such a setup.
 
+### feat: the `--wallet` parameter now accepts an identity name
+
+The `--wallet` parameter can now be either a principal or the name of an identity.
+
+If the name of an identity, dfx looks up the associated wallet's principal.
+
+This means `--wallet <name>` is the equivalent of `--wallet $(dfx identity get-wallet --identity <name>)`.
+
 ### fix: display error cause of some http-related errors
 
 Some commands that download http resources, for example `dfx extension install`, will

--- a/docs/cli-reference/dfx-canister.mdx
+++ b/docs/cli-reference/dfx-canister.mdx
@@ -81,8 +81,12 @@ dfx canister call counter get --network http://192.168.3.1:5678
 By default, most `dfx canister` commands to the Internet Computer are signed by and sent from your own principal. (
 Exceptions are commands that require cycles: `dfx canister create` and `dfx canister deposit-cycles`. Those
 automatically go through the wallet.) Occasionally, you may want to make a call from your wallet, e.g. when only your
-wallet is allowed to call a certain function. To send a call through your wallet, you can use the `--wallet` option like
-this:
+wallet is allowed to call a certain function. To send a call through your wallet, you can use the `--wallet` option.
+You will either specify the wallet's principal, or the name of an identity associated with a wallet.
+
+### Specifying a wallet by principal
+
+To specify a wallet by principal, pass the principal directly.
 
 ``` bash
 dfx canister status <canister name> --wallet <wallet id>
@@ -100,6 +104,26 @@ you can then query the status of the canister (let's assume the canister is call
 
 ``` bash
 dfx canister status --network ic --wallet 22ayq-aiaaa-aaaai-qgmma-cai
+```
+
+### Specifying a wallet by identity name
+
+In the previous example, we first looked up the principal of the currently
+selected wallet. We can avoid this step by specifying the name of an identity,
+in which case dfx will look up the wallet's principal for us.
+
+For example, the following command will query the status of a canister,
+using the wallet associated with the default identity on the ic network:
+
+``` bash
+dfx canister status --network ic --wallet default
+```
+
+As another example, the following commands are equivalent:
+
+``` bash
+dfx canister status --network ic --wallet $(dfx identity get-wallet --network ic --identity alice)
+dfx canister status --network ic --wallet alice
 ```
 
 ## dfx canister call

--- a/e2e/tests-dfx/basic-project.bash
+++ b/e2e/tests-dfx/basic-project.bash
@@ -40,7 +40,7 @@ teardown() {
   assert_eq '("Hello, Blueberry!")'
 
   # Call using the wallet's call forwarding
-  assert_command dfx canister call --async hello_backend greet Blueberry --wallet="$(dfx identity get-wallet)"
+  assert_command dfx canister call --async hello_backend greet Blueberry --wallet=default
   # At this point $output is the request ID.
   # shellcheck disable=SC2154
   assert_command dfx canister request-status "$stdout" "$(dfx identity get-wallet)"
@@ -100,7 +100,7 @@ teardown() {
   assert_eq "(1_337 : nat)"
 
   # Call using the wallet's call forwarding
-  assert_command dfx canister call hello_backend read --async --wallet="$(dfx identity get-wallet)"
+  assert_command dfx canister call hello_backend read --async --wallet=default
   assert_command dfx canister request-status "$stdout" "$(dfx identity get-wallet)"
   assert_eq \
 '(

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -163,13 +163,13 @@ set_local_network_bitcoin_enabled() {
 @test "can call bitcoin API of the management canister" {
   install_asset bitcoin
   dfx_start --enable-bitcoin
+  dfx identity get-wallet
 
   # the non-query Bitcoin API can only be called by a canister not an agent
   # we need to proxy the call through the wallet canister
-  WALLET_ID=$(dfx identity get-wallet)
 
   # bitcoin_get_balance
-  assert_command dfx canister call --wallet "$WALLET_ID" aaaaa-aa --candid bitcoin.did bitcoin_get_balance '(
+  assert_command dfx canister call --wallet default aaaaa-aa --candid bitcoin.did bitcoin_get_balance '(
   record {
     network = variant { regtest };
     address = "bcrt1qu58aj62urda83c00eylc6w34yl2s6e5rkzqet7";
@@ -179,7 +179,7 @@ set_local_network_bitcoin_enabled() {
   assert_eq "(0 : nat64)"
 
   # bitcoin_get_utxos
-  assert_command dfx canister call --wallet "$WALLET_ID" aaaaa-aa --candid bitcoin.did bitcoin_get_utxos '(
+  assert_command dfx canister call --wallet default aaaaa-aa --candid bitcoin.did bitcoin_get_utxos '(
   record {
     network = variant { regtest };
     filter = opt variant { min_confirmations = 1 : nat32 };
@@ -189,11 +189,11 @@ set_local_network_bitcoin_enabled() {
   assert_contains "tip_height = 0 : nat32;"
 
   # bitcoin_get_current_fee_percentiles
-  assert_command dfx canister call --wallet "$WALLET_ID" aaaaa-aa --candid bitcoin.did bitcoin_get_current_fee_percentiles '(record { network = variant { regtest } })'
+  assert_command dfx canister call --wallet default aaaaa-aa --candid bitcoin.did bitcoin_get_current_fee_percentiles '(record { network = variant { regtest } })'
 
   # bitcoin_send_transaction
   # It's hard to test this without a real transaction, but we can at least check that the call fails.
   # The error message indicates that the argument is in correct format, only the inner transaction is malformed.
-  assert_command_fail dfx canister call --wallet "$WALLET_ID" aaaaa-aa --candid bitcoin.did bitcoin_send_transaction '(record { transaction = vec {0:nat8}; network = variant { regtest } })'
+  assert_command_fail dfx canister call --wallet default aaaaa-aa --candid bitcoin.did bitcoin_send_transaction '(record { transaction = vec {0:nat8}; network = variant { regtest } })'
   assert_contains "send_transaction failed: MalformedTransaction"
 }

--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -207,7 +207,18 @@ teardown() {
   dfx deploy
   assert_command_fail dfx canister call hello_backend greet '' --with-cycles 100
   assert_command dfx canister call hello_backend greet '' --with-cycles 100 --wallet "$(dfx identity get-wallet)"
+  dfx identity whoami
 }
+
+@test "call with cycles with wallet by name or by principal" {
+  dfx_start
+  dfx deploy
+  assert_command_fail dfx canister call hello_backend greet '' --with-cycles 100
+
+  assert_command dfx canister call hello_backend greet '' --with-cycles 100 --wallet "$(dfx identity get-wallet)"
+  assert_command dfx canister call hello_backend greet '' --with-cycles 100 --wallet default
+}
+
 
 @test "call by canister id outside of a project" {
   install_asset greet

--- a/e2e/tests-dfx/create.bash
+++ b/e2e/tests-dfx/create.bash
@@ -208,7 +208,7 @@ teardown() {
 
   assert_command_fail dfx deploy
   assert_command_fail dfx deploy --identity alice
-  assert_command dfx deploy --identity alice --wallet "${ALICE_WALLET}"
+  assert_command dfx deploy --identity alice --wallet alice
 }
 
 @test "create accepts --controller <controller> named parameter, with controller by name of selected identity" {

--- a/e2e/tests-dfx/update_settings.bash
+++ b/e2e/tests-dfx/update_settings.bash
@@ -139,46 +139,46 @@ teardown() {
   ALICE_WALLET=$(dfx identity get-wallet --identity alice)
   BOB_WALLET=$(dfx identity get-wallet --identity bob)
 
-  dfx canister create hello_backend --wallet "${ALICE_WALLET}"
+  dfx canister create hello_backend --wallet alice
   dfx build hello_backend
-  dfx canister install hello_backend --wallet "${ALICE_WALLET}"
+  dfx canister install hello_backend --wallet alice
   ID=$(dfx canister id hello_backend)
 
   # Set controller using canister name and identity name
-  assert_command dfx canister update-settings hello_backend --set-controller "${BOB_WALLET}" --wallet "${ALICE_WALLET}" --yes
+  assert_command dfx canister update-settings hello_backend --set-controller "${BOB_WALLET}" --wallet alice --yes
   assert_match "Set controller of \"hello_backend\" to: ${BOB_WALLET}"
 
   # Bob is controller, Alice cannot reinstall
-  echo "yes" | assert_command_fail dfx canister install hello_backend -m reinstall --wallet "${ALICE_WALLET}"
+  echo "yes" | assert_command_fail dfx canister install hello_backend -m reinstall --wallet alice
 
   # Bob can reinstall
-  echo "yes" | assert_command dfx canister install hello_backend -m reinstall --identity bob --wallet "${BOB_WALLET}"
+  echo "yes" | assert_command dfx canister install hello_backend -m reinstall --identity bob --wallet bob
 
   assert_command dfx identity use bob
   # Set controller using canister id and principal
-  assert_command dfx canister update-settings "${ID}" --set-controller "${ALICE_WALLET}" --wallet "${BOB_WALLET}" --yes
+  assert_command dfx canister update-settings "${ID}" --set-controller "${ALICE_WALLET}" --wallet bob --yes
   assert_match "Set controller of \"${ID}\" to: ${ALICE_WALLET}"
-  echo "yes" | assert_command_fail dfx canister install hello_backend -m reinstall --wallet "${BOB_WALLET}"
+  echo "yes" | assert_command_fail dfx canister install hello_backend -m reinstall --wallet bob
 
   # Set controller using combination of name/id and identity/principal
-  assert_command dfx canister update-settings hello_backend --set-controller "${BOB_WALLET}" --identity alice --wallet "${ALICE_WALLET}" --yes
+  assert_command dfx canister update-settings hello_backend --set-controller "${BOB_WALLET}" --identity alice --wallet alice --yes
   assert_match "Set controller of \"hello_backend\" to: ${BOB_WALLET}"
 
-  assert_command dfx canister update-settings "${ID}" --set-controller "${ALICE_WALLET}" --identity bob --wallet "${BOB_WALLET}" --yes
+  assert_command dfx canister update-settings "${ID}" --set-controller "${ALICE_WALLET}" --identity bob --wallet bob --yes
   assert_match "Set controller of \"${ID}\" to: ${ALICE_WALLET}"
 
   # Set controller using invalid principal/identity fails
-  assert_command_fail dfx canister update-settings hello_backend --set-controller charlie --identity alice --wallet "${ALICE_WALLET}" --yes
+  assert_command_fail dfx canister update-settings hello_backend --set-controller charlie --identity alice --wallet alice --yes
   assert_match "Identity charlie does not exist"
 
   # Set controller using invalid canister name/id fails
-  assert_command_fail dfx canister update-settings hello_assets --set-controller bob --identity alice --wallet "${ALICE_WALLET}" --yes
+  assert_command_fail dfx canister update-settings hello_assets --set-controller bob --identity alice --wallet alice --yes
   assert_match "Cannot find canister id. Please issue 'dfx canister create hello_assets'."
 
   # Fails if no consent is given
-  echo "no" | assert_command_fail dfx canister update-settings "${ID}" --set-controller "${BOB_WALLET}" --identity alice --wallet "${ALICE_WALLET}"
+  echo "no" | assert_command_fail dfx canister update-settings "${ID}" --set-controller "${BOB_WALLET}" --identity alice --wallet alice
   # But works with typing "yes"
-  echo "yes" | assert_command dfx canister update-settings "${ID}" --set-controller "${BOB_WALLET}" --identity alice --wallet "${ALICE_WALLET}"
+  echo "yes" | assert_command dfx canister update-settings "${ID}" --set-controller "${BOB_WALLET}" --identity alice --wallet alice
 }
 
 @test "set controller with wallet 0.7.2" {
@@ -194,32 +194,32 @@ teardown() {
   ALICE_WALLET=$(dfx identity get-wallet --identity alice)
   BOB_WALLET=$(dfx identity get-wallet --identity bob)
 
-  dfx canister create hello_backend --wallet "${ALICE_WALLET}"
+  dfx canister create hello_backend --wallet alice
   dfx build hello_backend
-  dfx canister install hello_backend --wallet "${ALICE_WALLET}"
+  dfx canister install hello_backend --wallet alice
   ID=$(dfx canister id hello_backend)
 
   # Set controller using canister name and identity name
-  assert_command dfx canister update-settings hello_backend --set-controller "${BOB_WALLET}" --wallet "${ALICE_WALLET}" --yes
+  assert_command dfx canister update-settings hello_backend --set-controller "${BOB_WALLET}" --wallet alice --yes
   assert_match "Set controller of \"hello_backend\" to: ${BOB_WALLET}"
 
   # Bob is controller, Alice cannot reinstall
-  echo "yes" | assert_command_fail dfx canister install hello_backend -m reinstall --wallet "${ALICE_WALLET}"
+  echo "yes" | assert_command_fail dfx canister install hello_backend -m reinstall --wallet alice
 
   # Bob can reinstall
-  echo "yes" | assert_command dfx canister install hello_backend -m reinstall --identity bob --wallet "${BOB_WALLET}"
+  echo "yes" | assert_command dfx canister install hello_backend -m reinstall --identity bob --wallet bob
 
   assert_command dfx identity use bob
   # Set controller using canister id and principal
-  assert_command dfx canister update-settings "${ID}" --set-controller "${ALICE_WALLET}" --wallet "${BOB_WALLET}" --yes
+  assert_command dfx canister update-settings "${ID}" --set-controller "${ALICE_WALLET}" --wallet bob --yes
   assert_match "Set controller of \"${ID}\" to: ${ALICE_WALLET}"
-  echo "yes" | assert_command_fail dfx canister install hello_backend -m reinstall --wallet "${BOB_WALLET}"
+  echo "yes" | assert_command_fail dfx canister install hello_backend -m reinstall --wallet bob
 
   # Set controller using combination of name/id and identity/principal
-  assert_command dfx canister update-settings hello_backend --set-controller "${BOB_WALLET}" --identity alice --wallet "${ALICE_WALLET}" --yes
+  assert_command dfx canister update-settings hello_backend --set-controller "${BOB_WALLET}" --identity alice --wallet alice --yes
   assert_match "Set controller of \"hello_backend\" to: ${BOB_WALLET}"
 
-  assert_command dfx canister update-settings "${ID}" --set-controller "${ALICE_WALLET}" --identity bob --wallet "${BOB_WALLET}" --yes
+  assert_command dfx canister update-settings "${ID}" --set-controller "${ALICE_WALLET}" --identity bob --wallet bob --yes
   assert_match "Set controller of \"${ID}\" to: ${ALICE_WALLET}"
 
   # Set controller using invalid principal/identity fails
@@ -231,9 +231,9 @@ teardown() {
   assert_match "Cannot find canister id. Please issue 'dfx canister create hello_assets'."
 
   # Fails if no consent is given
-  echo "no" | assert_command_fail dfx canister update-settings "${ID}" --set-controller "${BOB_WALLET}" --identity alice --wallet "${ALICE_WALLET}"
+  echo "no" | assert_command_fail dfx canister update-settings "${ID}" --set-controller "${BOB_WALLET}" --identity alice --wallet alice
   # But works with typing "yes"
-  echo "yes" | assert_command dfx canister update-settings "${ID}" --set-controller "${BOB_WALLET}" --identity alice --wallet "${ALICE_WALLET}"
+  echo "yes" | assert_command dfx canister update-settings "${ID}" --set-controller "${BOB_WALLET}" --identity alice --wallet alice
 }
 
 @test "set controller without wallet but using wallet 0.7.2" {
@@ -344,8 +344,8 @@ teardown() {
   assert_match "Set controllers of \"hello_backend\" to: ${WALLETS_SORTED}"
 
   # Both can reinstall
-  echo "yes" | assert_command dfx canister install hello_backend -m reinstall --identity alice --wallet "${ALICE_WALLET}"
-  echo "yes" | assert_command dfx canister install hello_backend -m reinstall --identity bob --wallet "${BOB_WALLET}"
+  echo "yes" | assert_command dfx canister install hello_backend -m reinstall --identity alice --wallet alice
+  echo "yes" | assert_command dfx canister install hello_backend -m reinstall --identity bob --wallet bob
 
   assert_command dfx canister info hello_backend
   assert_match "Controllers: ${WALLETS_SORTED}"
@@ -371,12 +371,12 @@ teardown() {
   ID=$(dfx canister id hello_backend)
 
   # Set controller using canister name and identity name
-  assert_command dfx canister update-settings hello_backend --set-controller "${ALICE_WALLET}" --set-controller "${BOB_WALLET}" --wallet "${ALICE_WALLET}"
+  assert_command dfx canister update-settings hello_backend --set-controller "${ALICE_WALLET}" --set-controller "${BOB_WALLET}" --wallet alice
   assert_match "Set controllers of \"hello_backend\" to: $WALLETS_SORTED"
 
   # Both can reinstall
-  echo "yes" | assert_command dfx canister install hello_backend -m reinstall --identity alice --wallet "${ALICE_WALLET}"
-  echo "yes" | assert_command dfx canister install hello_backend -m reinstall --identity bob --wallet "${BOB_WALLET}"
+  echo "yes" | assert_command dfx canister install hello_backend -m reinstall --identity alice --wallet alice
+  echo "yes" | assert_command dfx canister install hello_backend -m reinstall --identity bob --wallet bob
 
   assert_command dfx canister info hello_backend
   assert_match "Controllers: ${WALLETS_SORTED}"
@@ -397,7 +397,7 @@ teardown() {
   PRINCIPALS_SORTED=$(echo "$ALICE_PRINCIPAL" "$BOB_PRINCIPAL" | tr " " "\n" | sort | tr "\n" " " | awk '{printf "%s %s",$1,$2}' )
 
   dfx canister create hello_backend
-  dfx canister update-settings hello_backend --add-controller "$ALICE_PRINCIPAL" --wallet "$(dfx identity get-wallet)"
+  dfx canister update-settings hello_backend --add-controller "$ALICE_PRINCIPAL" --wallet alice
   dfx build hello_backend
   dfx canister install hello_backend
   ID=$(dfx canister id hello_backend)
@@ -527,10 +527,10 @@ teardown() {
   assert_not_contains "${ALICE_PRINCIPAL}"
 
   # Cannot remove wallet controller without extra consent
-  echo "no" | assert_command_fail dfx canister update-settings hello_backend --remove-controller "${WALLET_PRINCIPAL}" --wallet "${WALLET_PRINCIPAL}"
+  echo "no" | assert_command_fail dfx canister update-settings hello_backend --remove-controller "${WALLET_PRINCIPAL}" --wallet alice
   assert_command dfx canister info hello_backend
   assert_contains "${WALLET_PRINCIPAL}"
-  echo "yes" | assert_command dfx canister update-settings hello_backend --remove-controller "${WALLET_PRINCIPAL}" --wallet "${WALLET_PRINCIPAL}"
+  echo "yes" | assert_command dfx canister update-settings hello_backend --remove-controller "${WALLET_PRINCIPAL}" --wallet alice
   assert_command dfx canister info hello_backend
   assert_not_contains "${WALLET_PRINCIPAL}"
 

--- a/src/dfx-core/src/error/identity/call_sender_from_wallet.rs
+++ b/src/dfx-core/src/error/identity/call_sender_from_wallet.rs
@@ -1,8 +1,17 @@
+use crate::error::wallet_config::WalletConfigError;
 use candid::types::principal::PrincipalError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum CallSenderFromWalletError {
-    #[error("Failed to read principal from id '{0}'")]
-    ParsePrincipalFromIdFailed(String, #[source] PrincipalError),
+    #[error("Failed to read principal from id '{0}', and did not find a wallet for that identity")]
+    ParsePrincipalFromIdFailedAndNoWallet(String, #[source] PrincipalError),
+
+    #[error("Failed to read principal from id '{0}' ({1}), and failed to load the wallet for that identity"
+    )]
+    ParsePrincipalFromIdFailedAndGetWalletCanisterIdFailed(
+        String,
+        PrincipalError,
+        #[source] WalletConfigError,
+    ),
 }

--- a/src/dfx-core/src/identity/mod.rs
+++ b/src/dfx-core/src/identity/mod.rs
@@ -3,8 +3,11 @@
 //! Wallets are a map of network-identity, but don't have their own types or manager
 //! type.
 use crate::config::directories::{get_shared_network_data_directory, get_user_dfx_config_dir};
+use crate::config::model::network_descriptor::NetworkDescriptor;
 use crate::error::identity::call_sender_from_wallet::CallSenderFromWalletError;
-use crate::error::identity::call_sender_from_wallet::CallSenderFromWalletError::ParsePrincipalFromIdFailed;
+use crate::error::identity::call_sender_from_wallet::CallSenderFromWalletError::{
+    ParsePrincipalFromIdFailedAndGetWalletCanisterIdFailed, ParsePrincipalFromIdFailedAndNoWallet,
+};
 use crate::error::identity::load_pem_identity::LoadPemIdentityError;
 use crate::error::identity::load_pem_identity::LoadPemIdentityError::ReadIdentityFileFailed;
 use crate::error::identity::map_wallets_to_renamed_identity::MapWalletsToRenamedIdentityError;
@@ -19,6 +22,7 @@ use crate::error::wallet_config::WalletConfigError::{
     EnsureWalletConfigDirFailed, LoadWalletConfigFailed, SaveWalletConfigFailed,
 };
 use crate::identity::identity_file_locations::IdentityFileLocations;
+use crate::identity::wallet::wallet_canister_id;
 use crate::json::{load_json_file, save_json_file};
 use candid::Principal;
 use ic_agent::agent::EnvelopeContent;
@@ -303,14 +307,33 @@ pub enum CallSender {
     Wallet(Principal),
 }
 
-// Determine whether the selected Identity
-// or the provided wallet canister ID should be the Sender of the call.
+// Determine whether the selected Identity or a wallet should be the sender of the call.
+// If a wallet, the principal can be selected directly, or looked up from an identity name.
 impl CallSender {
-    pub fn from(wallet: &Option<String>) -> Result<Self, CallSenderFromWalletError> {
-        let sender = if let Some(id) = wallet {
-            CallSender::Wallet(
-                Principal::from_text(id).map_err(|e| ParsePrincipalFromIdFailed(id.clone(), e))?,
-            )
+    pub fn from(
+        wallet_principal_or_identity_name: &Option<String>,
+        network: &NetworkDescriptor,
+    ) -> Result<Self, CallSenderFromWalletError> {
+        let sender = if let Some(s) = wallet_principal_or_identity_name {
+            match Principal::from_text(s) {
+                Ok(principal) => CallSender::Wallet(principal),
+                Err(principal_err) => match wallet_canister_id(network, s) {
+                    Ok(Some(principal)) => CallSender::Wallet(principal),
+                    Ok(None) => {
+                        return Err(ParsePrincipalFromIdFailedAndNoWallet(
+                            s.clone(),
+                            principal_err,
+                        ));
+                    }
+                    Err(wallet_err) => {
+                        return Err(ParsePrincipalFromIdFailedAndGetWalletCanisterIdFailed(
+                            s.clone(),
+                            principal_err,
+                            wallet_err,
+                        ));
+                    }
+                },
+            }
         } else {
             CallSender::SelectedId
         };

--- a/src/dfx/src/commands/canister/mod.rs
+++ b/src/dfx/src/commands/canister/mod.rs
@@ -2,7 +2,6 @@ use crate::lib::agent::create_agent_environment;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::network::network_opt::NetworkOpt;
-use anyhow::anyhow;
 use clap::{Parser, Subcommand};
 use dfx_core::identity::CallSender;
 use tokio::runtime::Runtime;
@@ -75,26 +74,26 @@ pub fn exec(env: &dyn Environment, opts: CanisterOpts) -> DfxResult {
     let runtime = Runtime::new().expect("Unable to create a runtime");
 
     runtime.block_on(async {
-        let call_sender = CallSender::from(&opts.wallet)
-            .map_err(|e| anyhow!("Failed to determine call sender: {}", e))?;
+        let call_sender =
+            || CallSender::from(&opts.wallet, env.get_network_descriptor());
         match opts.subcmd {
-            SubCommand::Call(v) => call::exec(env, v, &call_sender).await,
-            SubCommand::Create(v) => create::exec(env, v, &call_sender).await,
-            SubCommand::Delete(v) => delete::exec(env, v, &call_sender).await,
-            SubCommand::DepositCycles(v) => deposit_cycles::exec(env, v, &call_sender).await,
+            SubCommand::Call(v) => call::exec(env, v, &call_sender()?).await,
+            SubCommand::Create(v) => create::exec(env, v, &call_sender()?).await,
+            SubCommand::Delete(v) => delete::exec(env, v, &call_sender()?).await,
+            SubCommand::DepositCycles(v) => deposit_cycles::exec(env, v, &call_sender()?).await,
             SubCommand::Id(v) => id::exec(env, v).await,
-            SubCommand::Install(v) => install::exec(env, v, &call_sender).await,
+            SubCommand::Install(v) => install::exec(env, v, &call_sender()?).await,
             SubCommand::Info(v) => info::exec(env, v).await,
             SubCommand::Metadata(v) => metadata::exec(env, v).await,
             SubCommand::RequestStatus(v) => request_status::exec(env, v).await,
-            SubCommand::Send(v) => send::exec(env, v, &call_sender).await,
-            SubCommand::Sign(v) => sign::exec(env, v, &call_sender).await,
-            SubCommand::Start(v) => start::exec(env, v, &call_sender).await,
-            SubCommand::Status(v) => status::exec(env, v, &call_sender).await,
-            SubCommand::Stop(v) => stop::exec(env, v, &call_sender).await,
-            SubCommand::UninstallCode(v) => uninstall_code::exec(env, v, &call_sender).await,
-            SubCommand::UpdateSettings(v) => update_settings::exec(env, v, &call_sender).await,
-            SubCommand::Logs(v) => logs::exec(env, v, &call_sender).await,
+            SubCommand::Send(v) => send::exec(env, v, &call_sender()?).await,
+            SubCommand::Sign(v) => sign::exec(env, v, &call_sender()?).await,
+            SubCommand::Start(v) => start::exec(env, v, &call_sender()?).await,
+            SubCommand::Status(v) => status::exec(env, v, &call_sender()?).await,
+            SubCommand::Stop(v) => stop::exec(env, v, &call_sender()?).await,
+            SubCommand::UninstallCode(v) => uninstall_code::exec(env, v, &call_sender()?).await,
+            SubCommand::UpdateSettings(v) => update_settings::exec(env, v, &call_sender()?).await,
+            SubCommand::Logs(v) => logs::exec(env, v, &call_sender()?).await,
             SubCommand::Url(v) => url::exec(env, v).await,
         }
     })

--- a/src/dfx/src/commands/canister/mod.rs
+++ b/src/dfx/src/commands/canister/mod.rs
@@ -74,8 +74,7 @@ pub fn exec(env: &dyn Environment, opts: CanisterOpts) -> DfxResult {
     let runtime = Runtime::new().expect("Unable to create a runtime");
 
     runtime.block_on(async {
-        let call_sender =
-            || CallSender::from(&opts.wallet, env.get_network_descriptor());
+        let call_sender = || CallSender::from(&opts.wallet, env.get_network_descriptor());
         match opts.subcmd {
             SubCommand::Call(v) => call::exec(env, v, &call_sender()?).await,
             SubCommand::Create(v) => create::exec(env, v, &call_sender()?).await,

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -173,7 +173,7 @@ pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
         (None, _) => NormalDeploy,
     };
 
-    let call_sender = CallSender::from(&opts.wallet)
+    let call_sender = CallSender::from(&opts.wallet, env.get_network_descriptor())
         .map_err(|e| anyhow!("Failed to determine call sender: {}", e))?;
 
     runtime.block_on(fetch_root_key_if_needed(&env))?;


### PR DESCRIPTION
# Description

The `--wallet` parameter can now be either the principal of a wallet or the name of an identity.

If the name of an identity, dfx looks up the associated wallet's principal.

This means `--wallet <name>` is the equivalent of `--wallet $(dfx identity get-wallet --identity <name>)`.

Fixes https://dfinity.atlassian.net/browse/SDK-1483

# How Has This Been Tested?

Added e2e tests and updated existing e2e tests to use the new (shorter) form.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
