### PR TITLE
chore: update filename for 0.22.1 migration notes

### DIFF
--- a/docs/migration/dfx-0.22.1-migration-guide.md
+++ b/docs/migration/dfx-0.22.1-migration-guide.md
@@ -1,4 +1,4 @@
-# dfx 0.23.0 Migration Guide
+# dfx 0.22.1 Migration Guide
 
 ## New frontend security header mechanism
 
@@ -7,7 +7,7 @@ Previously, the default projects provided by `dfx new` included a default set of
 While this is a solid default, it is likely that these headers will receive updates in the future and many projects will forget to update their security headers.
 Additionally, it is unlikely that many projects actually improve over the defaults with the individually defined headers.
 
-`dfx` version `0.23.0` introduces a new field `"security_policy"` to `.ic-assets.json5`,
+`dfx` version `0.22.1` introduces a new field `"security_policy"` to `.ic-assets.json5`,
 which can automatically provide all the default security headers and updates that will be shipped in future versions of `dfx`.
 You can check the default security headers with `dfx info security-policy`.
 

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -1,6 +1,6 @@
 # DFX Migration Guide
 
-- [dfx 0.23.0](./dfx-0.23.0-migration-guide.md)
+- [dfx 0.22.1](./dfx-0.22.1-migration-guide)
 - [dfx 0.18.0](./dfx-0.18.0-migration-guide.md)
 - [dfx 0.17.0](./dfx-0.17.0-migration-guide.md)
 - [dfx 0.15.0](./dfx-0.15.0-migration-guide.md)


### PR DESCRIPTION
# Description

dfx 0.22.1 has migration notes, even though the changes are not breaking.

# How Has This Been Tested?

Just updates docs

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
