### PR TITLE
refactor: Split up FsError into method-specific error types (partial)

### DIFF
--- a/src/canisters/frontend/ic-asset/src/asset/config.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/config.rs
@@ -1,7 +1,7 @@
 use crate::error::AssetLoadConfigError;
 use crate::error::AssetLoadConfigError::{LoadRuleFailed, MalformedAssetConfigFile};
 use crate::error::GetAssetConfigError;
-use crate::error::GetAssetConfigError::{AssetConfigNotFound, InvalidPath};
+use crate::error::GetAssetConfigError::AssetConfigNotFound;
 use crate::security_policy::SecurityPolicy;
 use derivative::Derivative;
 use globset::GlobMatcher;
@@ -176,7 +176,7 @@ impl AssetSourceDirectoryConfiguration {
         &mut self,
         canonical_path: &Path,
     ) -> Result<AssetConfig, GetAssetConfigError> {
-        let parent_dir = dfx_core::fs::parent(canonical_path).map_err(InvalidPath)?;
+        let parent_dir = dfx_core::fs::parent(canonical_path)?;
         Ok(self
             .config_map
             .get(&parent_dir)

--- a/src/canisters/frontend/ic-asset/src/error/gather_asset_descriptors.rs
+++ b/src/canisters/frontend/ic-asset/src/error/gather_asset_descriptors.rs
@@ -1,6 +1,6 @@
 use crate::error::get_asset_config::GetAssetConfigError;
 use crate::error::load_config::AssetLoadConfigError;
-use dfx_core::error::fs::FsError;
+use dfx_core::error::fs::CanonicalizePathError;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -16,12 +16,12 @@ pub enum GatherAssetDescriptorsError {
     GetAssetConfigFailed(#[from] GetAssetConfigError),
 
     /// Failed to canonicalize a directory entry.
-    #[error("Invalid directory entry: {0}")]
-    InvalidDirectoryEntry(FsError),
+    #[error("invalid directory entry")]
+    InvalidDirectoryEntry(#[source] CanonicalizePathError),
 
     /// Failed to canonicalize a source directory.
-    #[error("Invalid source directory: {0}")]
-    InvalidSourceDirectory(FsError),
+    #[error("invalid source directory")]
+    InvalidSourceDirectory(#[source] CanonicalizePathError),
 
     /// Failed to load the asset configuration for a directory.
     #[error("Failed to load asset configuration: {0}")]

--- a/src/canisters/frontend/ic-asset/src/error/get_asset_config.rs
+++ b/src/canisters/frontend/ic-asset/src/error/get_asset_config.rs
@@ -1,4 +1,4 @@
-use dfx_core::error::fs::FsError;
+use dfx_core::error::fs::NoParentPathError;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -10,6 +10,6 @@ pub enum GetAssetConfigError {
     AssetConfigNotFound(PathBuf),
 
     /// The path to an asset was invalid.
-    #[error("Invalid asset path: {0}")]
-    InvalidPath(FsError),
+    #[error("invalid asset path")]
+    InvalidPath(#[from] NoParentPathError),
 }

--- a/src/dfx-core/src/config/model/canister_id_store.rs
+++ b/src/dfx-core/src/config/model/canister_id_store.rs
@@ -123,12 +123,7 @@ impl CanisterIdStore {
                 None => None,
                 Some(config) => {
                     let dir = config.get_temp_path()?.join(name);
-                    ensure_cohesive_network_directory(network_descriptor, &dir).map_err(|e| {
-                        CanisterIdStoreError::EnsureCohesiveNetworkDirectoryFailed {
-                            network: network_descriptor.name.clone(),
-                            source: e.into(),
-                        }
-                    })?;
+                    ensure_cohesive_network_directory(network_descriptor, &dir)?;
                     Some(dir.join("canister_ids.json"))
                 }
             },

--- a/src/dfx-core/src/config/model/canister_id_store.rs
+++ b/src/dfx-core/src/config/model/canister_id_store.rs
@@ -223,9 +223,8 @@ impl CanisterIdStore {
                 // the only callers of this method have already called Environment::get_config_or_anyhow
                 unreachable!("Must be in a project (call Environment::get_config_or_anyhow()) to save canister ids")
             });
-        crate::fs::composite::ensure_parent_dir_exists(path)
-            .map_err(SaveIdsError::EnsureParentDirExists)?;
-        crate::json::save_json_file(path, &self.ids).map_err(SaveIdsError::SaveJsonFile)?;
+        crate::fs::composite::ensure_parent_dir_exists(path)?;
+        crate::json::save_json_file(path, &self.ids)?;
         Ok(())
     }
 
@@ -237,10 +236,8 @@ impl CanisterIdStore {
                 // the only callers of this method have already called Environment::get_config_or_anyhow
                 unreachable!("Must be in a project (call Environment::get_config_or_anyhow()) to save canister timestamps")
             });
-        crate::fs::composite::ensure_parent_dir_exists(path)
-            .map_err(SaveTimestampsError::EnsureParentDirExists)?;
-        crate::json::save_json_file(path, &self.acquisition_timestamps)
-            .map_err(SaveTimestampsError::SaveJsonFile)?;
+        crate::fs::composite::ensure_parent_dir_exists(path)?;
+        crate::json::save_json_file(path, &self.acquisition_timestamps)?;
         Ok(())
     }
 

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -22,6 +22,7 @@ use crate::error::dfx_config::{
     GetMemoryAllocationError, GetPullCanistersError, GetRemoteCanisterIdError,
     GetReservedCyclesLimitError, GetSpecifiedIdError, GetWasmMemoryLimitError,
 };
+use crate::error::fs::CanonicalizePathError;
 use crate::error::load_dfx_config::LoadDfxConfigError;
 use crate::error::load_dfx_config::LoadDfxConfigError::{
     DetermineCurrentWorkingDirFailed, ResolveConfigPath,
@@ -1090,8 +1091,8 @@ pub struct Config {
 
 #[allow(dead_code)]
 impl Config {
-    fn resolve_config_path(working_dir: &Path) -> Result<Option<PathBuf>, LoadDfxConfigError> {
-        let mut curr = crate::fs::canonicalize(working_dir).map_err(ResolveConfigPath)?;
+    fn resolve_config_path(working_dir: &Path) -> Result<Option<PathBuf>, CanonicalizePathError> {
+        let mut curr = crate::fs::canonicalize(working_dir)?;
         while curr.parent().is_some() {
             if curr.join(CONFIG_FILE_NAME).is_file() {
                 return Ok(Some(curr.join(CONFIG_FILE_NAME)));
@@ -1120,7 +1121,7 @@ impl Config {
         working_dir: &Path,
         extension_manager: Option<&ExtensionManager>,
     ) -> Result<Option<Config>, LoadDfxConfigError> {
-        let path = Config::resolve_config_path(working_dir)?;
+        let path = Config::resolve_config_path(working_dir).map_err(ResolveConfigPath)?;
         path.map(|path| Config::from_file(&path, extension_manager))
             .transpose()
     }

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -1200,8 +1200,7 @@ impl Config {
                     let p = self.get_project_root().join(p);
 
                     // cannot canonicalize a path that doesn't exist, but the parent should exist
-                    let env_parent =
-                        crate::fs::parent(&p).map_err(GetOutputEnvFileError::Parent)?;
+                    let env_parent = crate::fs::parent(&p)?;
                     let env_parent = crate::fs::canonicalize(&env_parent)?;
                     if !env_parent.starts_with(self.get_project_root()) {
                         Err(GetOutputEnvFileError::OutputEnvFileMustBeInProjectRoot(p))

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -24,7 +24,7 @@ use crate::error::dfx_config::{
 };
 use crate::error::load_dfx_config::LoadDfxConfigError;
 use crate::error::load_dfx_config::LoadDfxConfigError::{
-    DetermineCurrentWorkingDirFailed, ResolveConfigPathFailed,
+    DetermineCurrentWorkingDirFailed, ResolveConfigPath,
 };
 use crate::error::load_networks_config::LoadNetworksConfigError;
 use crate::error::load_networks_config::LoadNetworksConfigError::{
@@ -1091,7 +1091,7 @@ pub struct Config {
 #[allow(dead_code)]
 impl Config {
     fn resolve_config_path(working_dir: &Path) -> Result<Option<PathBuf>, LoadDfxConfigError> {
-        let mut curr = crate::fs::canonicalize(working_dir).map_err(ResolveConfigPathFailed)?;
+        let mut curr = crate::fs::canonicalize(working_dir).map_err(ResolveConfigPath)?;
         while curr.parent().is_some() {
             if curr.join(CONFIG_FILE_NAME).is_file() {
                 return Ok(Some(curr.join(CONFIG_FILE_NAME)));
@@ -1202,8 +1202,7 @@ impl Config {
                     // cannot canonicalize a path that doesn't exist, but the parent should exist
                     let env_parent =
                         crate::fs::parent(&p).map_err(GetOutputEnvFileError::Parent)?;
-                    let env_parent = crate::fs::canonicalize(&env_parent)
-                        .map_err(GetOutputEnvFileError::Canonicalize)?;
+                    let env_parent = crate::fs::canonicalize(&env_parent)?;
                     if !env_parent.starts_with(self.get_project_root()) {
                         Err(GetOutputEnvFileError::OutputEnvFileMustBeInProjectRoot(p))
                     } else {

--- a/src/dfx-core/src/error/cache.rs
+++ b/src/dfx-core/src/error/cache.rs
@@ -2,12 +2,16 @@ use super::{
     archive::ArchiveError, fs::FsError, structured_file::StructuredFileError,
     unified_io::UnifiedIoError,
 };
+use crate::error::fs::CreateDirAllError;
 use crate::error::get_current_exe::GetCurrentExeError;
 use crate::error::get_user_home::GetUserHomeError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum CacheError {
+    #[error(transparent)]
+    CreateDirAll(#[from] CreateDirAllError),
+
     #[error(transparent)]
     GetCurrentExeError(#[from] GetCurrentExeError),
 
@@ -20,8 +24,8 @@ pub enum CacheError {
     #[error(transparent)]
     ProcessError(#[from] crate::error::process::ProcessError),
 
-    #[error("Cannot create cache directory")]
-    CreateCacheDirectoryFailed(#[source] crate::error::fs::FsError),
+    #[error("failed to create cache directory")]
+    CreateCacheDirectoryFailed(#[source] CreateDirAllError),
 
     #[error("Cannot find cache directory at '{0}'.")]
     FindCacheDirectoryFailed(std::path::PathBuf),

--- a/src/dfx-core/src/error/canister_id_store.rs
+++ b/src/dfx-core/src/error/canister_id_store.rs
@@ -1,6 +1,9 @@
 use crate::error::{
-    config::GetTempPathError, dfx_config::GetPullCanistersError, fs::FsError,
-    load_dfx_config::LoadDfxConfigError, structured_file::StructuredFileError,
+    config::GetTempPathError,
+    dfx_config::GetPullCanistersError,
+    fs::{CreateDirAllError, EnsureParentDirExistsError, FsError},
+    load_dfx_config::LoadDfxConfigError,
+    structured_file::StructuredFileError,
     unified_io::UnifiedIoError,
 };
 use thiserror::Error;
@@ -23,13 +26,6 @@ pub enum CanisterIdStoreError {
 
     #[error(transparent)]
     RemoveCanisterId(#[from] RemoveCanisterIdError),
-
-    #[error("Failed to add canister with name '{canister_name}' and id '{canister_id}' to canister id store")]
-    AddCanisterId {
-        canister_name: String,
-        canister_id: String,
-        source: AddCanisterIdError,
-    },
 
     #[error(transparent)]
     GetPullCanistersFailed(#[from] GetPullCanistersError),
@@ -57,7 +53,7 @@ pub enum AddCanisterIdError {
 #[derive(Error, Debug)]
 pub enum EnsureCohesiveNetworkDirectoryError {
     #[error(transparent)]
-    CreateDirAll(FsError),
+    CreateDirAll(CreateDirAllError),
 
     #[error(transparent)]
     ReadToString(FsError),
@@ -84,19 +80,19 @@ pub enum RemoveCanisterIdError {
 #[derive(Error, Debug)]
 pub enum SaveTimestampsError {
     #[error(transparent)]
-    EnsureParentDirExists(FsError),
+    EnsureParentDirExists(#[from] EnsureParentDirExistsError),
 
     #[error(transparent)]
-    SaveJsonFile(StructuredFileError),
+    SaveJsonFile(#[from] StructuredFileError),
 }
 
 #[derive(Error, Debug)]
 pub enum SaveIdsError {
     #[error(transparent)]
-    EnsureParentDirExists(FsError),
+    EnsureParentDirExists(#[from] EnsureParentDirExistsError),
 
     #[error(transparent)]
-    SaveJsonFile(StructuredFileError),
+    SaveJsonFile(#[from] StructuredFileError),
 }
 
 impl From<FsError> for CanisterIdStoreError {

--- a/src/dfx-core/src/error/canister_id_store.rs
+++ b/src/dfx-core/src/error/canister_id_store.rs
@@ -18,11 +18,8 @@ pub enum CanisterIdStoreError {
         network: String,
     },
 
-    #[error("Encountered error while loading canister id store for network '{network}' - ensuring cohesive network directory failed")]
-    EnsureCohesiveNetworkDirectoryFailed {
-        network: String,
-        source: UnifiedIoError,
-    },
+    #[error("failed to ensure cohesive network directory")]
+    EnsureCohesiveNetworkDirectoryFailed(#[from] EnsureCohesiveNetworkDirectoryError),
 
     #[error(transparent)]
     RemoveCanisterId(#[from] RemoveCanisterIdError),
@@ -55,6 +52,21 @@ pub enum AddCanisterIdError {
 
     #[error(transparent)]
     SaveTimestamps(#[from] SaveTimestampsError),
+}
+
+#[derive(Error, Debug)]
+pub enum EnsureCohesiveNetworkDirectoryError {
+    #[error(transparent)]
+    CreateDirAll(FsError),
+
+    #[error(transparent)]
+    ReadToString(FsError),
+
+    #[error(transparent)]
+    RemoveDirAll(FsError),
+
+    #[error(transparent)]
+    Write(FsError),
 }
 
 #[derive(Error, Debug)]

--- a/src/dfx-core/src/error/canister_id_store.rs
+++ b/src/dfx-core/src/error/canister_id_store.rs
@@ -24,17 +24,14 @@ pub enum CanisterIdStoreError {
         source: UnifiedIoError,
     },
 
-    #[error("Failed to remove canister '{canister_name}' from id store")]
-    RemoveCanisterId {
-        canister_name: String,
-        source: UnifiedIoError,
-    },
+    #[error(transparent)]
+    RemoveCanisterId(#[from] RemoveCanisterIdError),
 
     #[error("Failed to add canister with name '{canister_name}' and id '{canister_id}' to canister id store")]
     AddCanisterId {
         canister_name: String,
         canister_id: String,
-        source: UnifiedIoError,
+        source: AddCanisterIdError,
     },
 
     #[error(transparent)]
@@ -45,6 +42,49 @@ pub enum CanisterIdStoreError {
 
     #[error(transparent)]
     LoadDfxConfig(#[from] LoadDfxConfigError),
+}
+
+#[derive(Error, Debug)]
+pub enum AddCanisterIdError {
+    #[error("failed to add canister with name '{canister_name}' and id '{canister_id}' to canister id store")]
+    SaveIds {
+        canister_name: String,
+        canister_id: String,
+        source: SaveIdsError,
+    },
+
+    #[error(transparent)]
+    SaveTimestamps(#[from] SaveTimestampsError),
+}
+
+#[derive(Error, Debug)]
+pub enum RemoveCanisterIdError {
+    #[error("failed to remove canister '{canister_name}' from id store")]
+    SaveIds {
+        canister_name: String,
+        source: SaveIdsError,
+    },
+
+    #[error(transparent)]
+    SaveTimestamps(#[from] SaveTimestampsError),
+}
+
+#[derive(Error, Debug)]
+pub enum SaveTimestampsError {
+    #[error(transparent)]
+    EnsureParentDirExists(FsError),
+
+    #[error(transparent)]
+    SaveJsonFile(StructuredFileError),
+}
+
+#[derive(Error, Debug)]
+pub enum SaveIdsError {
+    #[error(transparent)]
+    EnsureParentDirExists(FsError),
+
+    #[error(transparent)]
+    SaveJsonFile(StructuredFileError),
 }
 
 impl From<FsError> for CanisterIdStoreError {

--- a/src/dfx-core/src/error/config.rs
+++ b/src/dfx-core/src/error/config.rs
@@ -21,7 +21,7 @@ pub enum ConfigError {
 
 #[derive(Error, Debug)]
 pub enum GetOutputEnvFileError {
-    #[error(transparent)]
+    #[error("failed to canonicalize output_env_file")]
     CanonicalizePath(#[from] CanonicalizePathError),
 
     #[error("The output_env_file must be within the project root, but is {}", .0.display())]

--- a/src/dfx-core/src/error/config.rs
+++ b/src/dfx-core/src/error/config.rs
@@ -1,5 +1,5 @@
 use crate::error::extension::LoadExtensionManifestError;
-use crate::error::fs::FsError;
+use crate::error::fs::{CanonicalizePathError, FsError};
 use crate::error::get_user_home::GetUserHomeError;
 use handlebars::RenderError;
 use std::path::PathBuf;
@@ -19,8 +19,8 @@ pub enum ConfigError {
 
 #[derive(Error, Debug)]
 pub enum GetOutputEnvFileError {
-    #[error("failed to canonicalize output_env_file")]
-    Canonicalize(#[source] FsError),
+    #[error(transparent)]
+    CanonicalizePath(#[from] CanonicalizePathError),
 
     #[error("The output_env_file must be within the project root, but is {}", .0.display())]
     OutputEnvFileMustBeInProjectRoot(PathBuf),

--- a/src/dfx-core/src/error/config.rs
+++ b/src/dfx-core/src/error/config.rs
@@ -1,5 +1,7 @@
 use crate::error::extension::LoadExtensionManifestError;
-use crate::error::fs::{CanonicalizePathError, FsError};
+use crate::error::fs::{
+    CanonicalizePathError, CreateDirAllError, EnsureDirExistsError, NoParentPathError,
+};
 use crate::error::get_user_home::GetUserHomeError;
 use handlebars::RenderError;
 use std::path::PathBuf;
@@ -7,8 +9,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ConfigError {
-    #[error("Failed to ensure config directory exists")]
-    EnsureConfigDirectoryExistsFailed(#[source] FsError),
+    #[error("failed to ensure config directory exists")]
+    EnsureConfigDirectoryExistsFailed(#[source] EnsureDirExistsError),
 
     #[error("Failed to determine config directory path")]
     DetermineConfigDirectoryFailed(#[source] GetUserHomeError),
@@ -29,13 +31,13 @@ pub enum GetOutputEnvFileError {
     OutputEnvFileMustBeRelative(PathBuf),
 
     #[error(transparent)]
-    Parent(FsError),
+    NoParentPath(#[from] NoParentPathError),
 }
 
 #[derive(Error, Debug)]
 pub enum GetTempPathError {
     #[error(transparent)]
-    CreateDirAll(#[from] FsError),
+    CreateDirAll(#[from] CreateDirAllError),
 }
 
 #[derive(Error, Debug)]

--- a/src/dfx-core/src/error/extension.rs
+++ b/src/dfx-core/src/error/extension.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::error::fs::FsError;
+use crate::error::fs::{EnsureDirExistsError, FsError};
 use crate::error::structured_file::StructuredFileError;
 use semver::Version;
 use thiserror::Error;
@@ -88,8 +88,8 @@ pub enum DownloadAndInstallExtensionToTempdirError {
     #[error(transparent)]
     ExtensionDownloadFailed(reqwest::Error),
 
-    #[error("Cannot get extensions directory")]
-    EnsureExtensionDirExistsFailed(#[source] crate::error::fs::FsError),
+    #[error(transparent)]
+    EnsureExtensionDirExistsFailed(#[from] EnsureDirExistsError),
 
     #[error("Cannot create temporary directory at '{0}'")]
     CreateTemporaryDirectoryFailed(std::path::PathBuf, #[source] std::io::Error),

--- a/src/dfx-core/src/error/fs.rs
+++ b/src/dfx-core/src/error/fs.rs
@@ -2,10 +2,14 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum FsErrorKind {
-    #[error("Failed to canonicalize {0}")]
-    CanonicalizePathFailed(PathBuf, #[source] std::io::Error),
+#[error("failed to canonicalize '{path}'")]
+pub struct CanonicalizePathError {
+    pub path: PathBuf,
+    pub source: std::io::Error,
+}
 
+#[derive(Error, Debug)]
+pub enum FsErrorKind {
     #[error("Failed to copy {0} to {1}")]
     CopyFileFailed(Box<PathBuf>, Box<PathBuf>, #[source] std::io::Error),
 

--- a/src/dfx-core/src/error/fs.rs
+++ b/src/dfx-core/src/error/fs.rs
@@ -17,16 +17,36 @@ pub struct CopyFileError {
 }
 
 #[derive(Error, Debug)]
-pub enum FsErrorKind {
-    #[error("Failed to create {0}")]
-    CreateDirectoryFailed(PathBuf, #[source] std::io::Error),
+#[error("failed to create directory {path} and parents")]
+pub struct CreateDirAllError {
+    pub path: PathBuf,
+    pub source: std::io::Error,
+}
 
-    #[error("Cannot determine parent folder for {0}")]
-    NoParent(PathBuf),
+#[derive(Error, Debug)]
+pub enum EnsureDirExistsError {
+    #[error(transparent)]
+    CreateDirAll(#[from] CreateDirAllError),
 
-    #[error("Path {0} is not a directory")]
+    #[error("path {0} is not a directory")]
     NotADirectory(PathBuf),
+}
 
+#[derive(Error, Debug)]
+pub enum EnsureParentDirExistsError {
+    #[error(transparent)]
+    EnsureDirExists(#[from] EnsureDirExistsError),
+
+    #[error(transparent)]
+    NoParentPath(#[from] NoParentPathError),
+}
+
+#[derive(Error, Debug)]
+#[error("failed to determine parent path for '{0}'")]
+pub struct NoParentPathError(pub PathBuf);
+
+#[derive(Error, Debug)]
+pub enum FsErrorKind {
     #[error("Failed to read directory {0}")]
     ReadDirFailed(PathBuf, #[source] std::io::Error),
 

--- a/src/dfx-core/src/error/fs.rs
+++ b/src/dfx-core/src/error/fs.rs
@@ -9,10 +9,15 @@ pub struct CanonicalizePathError {
 }
 
 #[derive(Error, Debug)]
-pub enum FsErrorKind {
-    #[error("Failed to copy {0} to {1}")]
-    CopyFileFailed(Box<PathBuf>, Box<PathBuf>, #[source] std::io::Error),
+#[error("failed to copy {from} to {to}")]
+pub struct CopyFileError {
+    pub from: PathBuf,
+    pub to: PathBuf,
+    pub source: std::io::Error,
+}
 
+#[derive(Error, Debug)]
+pub enum FsErrorKind {
     #[error("Failed to create {0}")]
     CreateDirectoryFailed(PathBuf, #[source] std::io::Error),
 

--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -376,10 +376,28 @@ pub enum WriteDefaultIdentityError {
 }
 
 #[derive(Error, Debug)]
+pub enum WritePemContentError {
+    #[error(transparent)]
+    CreateDirAll(FsError),
+
+    #[error(transparent)]
+    NoParent(FsError),
+
+    #[error(transparent)]
+    ReadPermissions(FsError),
+
+    #[error(transparent)]
+    SetPermissions(FsError),
+
+    #[error(transparent)]
+    Write(FsError),
+}
+
+#[derive(Error, Debug)]
 pub enum WritePemToFileError {
     #[error("Failed to encrypt PEM file")]
     EncryptPemFileFailed(PathBuf, #[source] EncryptionError),
 
-    #[error("Failed to write to PEM file")]
-    WritePemContentFailed(#[source] FsError),
+    #[error("failed to write PEM content")]
+    WritePemContentFailed(#[source] WritePemContentError),
 }

--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -1,7 +1,9 @@
 use crate::error::{
     config::ConfigError,
     encryption::EncryptionError,
-    fs::{CopyFileError, FsError},
+    fs::{
+        CopyFileError, CreateDirAllError, EnsureParentDirExistsError, FsError, NoParentPathError,
+    },
     get_user_home::GetUserHomeError,
     keyring::KeyringError,
     structured_file::StructuredFileError,
@@ -61,7 +63,7 @@ pub enum CreateNewIdentityError {
     CreateMnemonicFromPhraseFailed(String),
 
     #[error("Failed to create temporary identity directory")]
-    CreateTemporaryIdentityDirectoryFailed(#[source] FsError),
+    CreateTemporaryIdentityDirectoryFailed(#[source] CreateDirAllError),
 
     #[error("Failed to generate key")]
     GenerateKeyFailed(#[source] GenerateKeyError),
@@ -136,7 +138,7 @@ pub enum GetLegacyCredentialsPemPathError {
 #[derive(Error, Debug)]
 pub enum InitializeIdentityManagerError {
     #[error("Cannot create identity directory")]
-    CreateIdentityDirectoryFailed(#[source] FsError),
+    CreateIdentityDirectoryFailed(#[source] CreateDirAllError),
 
     #[error("Failed to generate key")]
     GenerateKeyFailed(#[source] GenerateKeyError),
@@ -330,8 +332,8 @@ pub enum RequireIdentityExistsError {
 
 #[derive(Error, Debug)]
 pub enum SaveIdentityConfigurationError {
-    #[error("Failed to ensure identity configuration directory exists")]
-    EnsureIdentityConfigurationDirExistsFailed(#[source] FsError),
+    #[error("failed to ensure identity configuration directory exists")]
+    EnsureIdentityConfigurationDirExistsFailed(#[source] EnsureParentDirExistsError),
 
     #[error("Failed to save identity configuration")]
     SaveIdentityConfigurationFailed(#[source] StructuredFileError),
@@ -381,10 +383,10 @@ pub enum WriteDefaultIdentityError {
 #[derive(Error, Debug)]
 pub enum WritePemContentError {
     #[error(transparent)]
-    CreateDirAll(FsError),
+    CreateDirAll(#[from] CreateDirAllError),
 
     #[error(transparent)]
-    NoParent(FsError),
+    NoParent(#[from] NoParentPathError),
 
     #[error(transparent)]
     ReadPermissions(FsError),

--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -1,6 +1,11 @@
 use crate::error::{
-    config::ConfigError, encryption::EncryptionError, fs::FsError, get_user_home::GetUserHomeError,
-    keyring::KeyringError, structured_file::StructuredFileError, wallet_config::WalletConfigError,
+    config::ConfigError,
+    encryption::EncryptionError,
+    fs::{CopyFileError, FsError},
+    get_user_home::GetUserHomeError,
+    keyring::KeyringError,
+    structured_file::StructuredFileError,
+    wallet_config::WalletConfigError,
 };
 use candid::types::principal::PrincipalError;
 use ic_agent::identity::PemError;
@@ -139,8 +144,8 @@ pub enum InitializeIdentityManagerError {
     #[error(transparent)]
     GetLegacyCredentialsPemPathFailed(#[from] GetLegacyCredentialsPemPathError),
 
-    #[error("Failed to migrate legacy identity")]
-    MigrateLegacyIdentityFailed(#[source] FsError),
+    #[error("failed to migrate legacy identity")]
+    MigrateLegacyIdentityFailed(#[source] CopyFileError),
 
     #[error("Failed to save configuration")]
     SaveConfigurationFailed(#[source] StructuredFileError),

--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -62,7 +62,7 @@ pub enum CreateNewIdentityError {
     #[error("Failed to create mnemonic from phrase: {0}")]
     CreateMnemonicFromPhraseFailed(String),
 
-    #[error("Failed to create temporary identity directory")]
+    #[error("failed to create temporary identity directory")]
     CreateTemporaryIdentityDirectoryFailed(#[source] CreateDirAllError),
 
     #[error("Failed to generate key")]

--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -5,7 +5,7 @@ use crate::error::{
     get_user_home::GetUserHomeError,
     keyring::KeyringError,
     structured_file::StructuredFileError,
-    wallet_config::WalletConfigError,
+    wallet_config::{SaveWalletConfigError, WalletConfigError},
 };
 use candid::types::principal::PrincipalError;
 use ic_agent::identity::PemError;
@@ -314,6 +314,9 @@ pub enum RenameIdentityError {
 pub enum RenameWalletGlobalConfigKeyError {
     #[error("Failed to rename '{0}' to '{1}' in the global wallet config")]
     RenameWalletFailed(Box<String>, Box<String>, #[source] WalletConfigError),
+
+    #[error(transparent)]
+    SaveWalletConfig(#[from] SaveWalletConfigError),
 }
 
 #[derive(Error, Debug)]

--- a/src/dfx-core/src/error/load_dfx_config.rs
+++ b/src/dfx-core/src/error/load_dfx_config.rs
@@ -1,5 +1,5 @@
 use crate::error::config::ApplyExtensionCanisterTypesError;
-use crate::error::fs::FsError;
+use crate::error::fs::{CanonicalizePathError, FsError};
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -11,8 +11,8 @@ pub enum LoadDfxConfigError {
     #[error("Failed to deserialize json from {0}")]
     DeserializeValueFailed(Box<PathBuf>, #[source] serde_json::Error),
 
-    #[error("Failed to resolve config path")]
-    ResolveConfigPathFailed(#[source] FsError),
+    #[error("failed to resolve config path")]
+    ResolveConfigPath(#[source] CanonicalizePathError),
 
     #[error("Failed to load dfx configuration")]
     ReadFile(#[source] FsError),

--- a/src/dfx-core/src/error/wallet_config.rs
+++ b/src/dfx-core/src/error/wallet_config.rs
@@ -15,7 +15,7 @@ pub enum WalletConfigError {
     LoadWalletConfigFailed(#[source] StructuredFileError),
 
     #[error("Failed to save wallet configuration")]
-    SaveWalletConfig(#[source] SaveWalletConfigError),
+    SaveWalletConfig(#[from] SaveWalletConfigError),
 }
 
 #[derive(Error, Debug)]

--- a/src/dfx-core/src/error/wallet_config.rs
+++ b/src/dfx-core/src/error/wallet_config.rs
@@ -15,5 +15,14 @@ pub enum WalletConfigError {
     LoadWalletConfigFailed(#[source] StructuredFileError),
 
     #[error("Failed to save wallet configuration")]
-    SaveWalletConfigFailed(#[source] StructuredFileError),
+    SaveWalletConfig(#[source] SaveWalletConfigError),
+}
+
+#[derive(Error, Debug)]
+pub enum SaveWalletConfigError {
+    #[error(transparent)]
+    EnsureParentDirExists(FsError),
+
+    #[error(transparent)]
+    SaveJsonFile(#[from] StructuredFileError),
 }

--- a/src/dfx-core/src/error/wallet_config.rs
+++ b/src/dfx-core/src/error/wallet_config.rs
@@ -1,12 +1,12 @@
 use crate::error::config::ConfigError;
-use crate::error::fs::FsError;
+use crate::error::fs::{CreateDirAllError, EnsureParentDirExistsError};
 use crate::error::structured_file::StructuredFileError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum WalletConfigError {
-    #[error("Failed to ensure existence of parent directory for wallet configuration")]
-    EnsureWalletConfigDirFailed(#[source] FsError),
+    #[error("failed to ensure existence of parent directory for wallet configuration")]
+    EnsureWalletConfigDirFailed(#[source] CreateDirAllError),
 
     #[error("Failed to get wallet configuration path")]
     GetWalletConfigPathFailed(Box<String>, Box<String>, #[source] ConfigError),
@@ -21,7 +21,7 @@ pub enum WalletConfigError {
 #[derive(Error, Debug)]
 pub enum SaveWalletConfigError {
     #[error(transparent)]
-    EnsureParentDirExists(FsError),
+    EnsureParentDirExists(#[from] EnsureParentDirExistsError),
 
     #[error(transparent)]
     SaveJsonFile(#[from] StructuredFileError),

--- a/src/dfx-core/src/fs/composite.rs
+++ b/src/dfx-core/src/fs/composite.rs
@@ -1,18 +1,20 @@
-use crate::error::fs::FsError;
-use crate::error::fs::FsErrorKind::NotADirectory;
+use crate::error::fs::EnsureDirExistsError::NotADirectory;
+use crate::error::fs::{EnsureDirExistsError, EnsureParentDirExistsError};
 use std::path::Path;
 
-pub fn ensure_dir_exists(p: &Path) -> Result<(), FsError> {
+pub fn ensure_dir_exists(p: &Path) -> Result<(), EnsureDirExistsError> {
     if !p.exists() {
-        crate::fs::create_dir_all(p)
+        crate::fs::create_dir_all(p)?;
+        Ok(())
     } else if !p.is_dir() {
-        Err(FsError::new(NotADirectory(p.to_path_buf())))
+        Err(NotADirectory(p.to_path_buf()))
     } else {
         Ok(())
     }
 }
 
-pub fn ensure_parent_dir_exists(d: &Path) -> Result<(), FsError> {
+pub fn ensure_parent_dir_exists(d: &Path) -> Result<(), EnsureParentDirExistsError> {
     let parent = crate::fs::parent(d)?;
-    ensure_dir_exists(&parent)
+    ensure_dir_exists(&parent)?;
+    Ok(())
 }

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -1,12 +1,12 @@
 pub mod composite;
 use crate::error::archive::ArchiveError;
 use crate::error::fs::FsErrorKind::{
-    CopyFileFailed, CreateDirectoryFailed, NoParent, ReadDirFailed, ReadFileFailed,
-    ReadMetadataFailed, ReadPermissionsFailed, ReadToStringFailed,
-    RemoveDirectoryAndContentsFailed, RemoveDirectoryFailed, RemoveFileFailed, RenameFailed,
-    UnpackingArchiveFailed, WriteFileFailed, WritePermissionsFailed,
+    CreateDirectoryFailed, NoParent, ReadDirFailed, ReadFileFailed, ReadMetadataFailed,
+    ReadPermissionsFailed, ReadToStringFailed, RemoveDirectoryAndContentsFailed,
+    RemoveDirectoryFailed, RemoveFileFailed, RenameFailed, UnpackingArchiveFailed, WriteFileFailed,
+    WritePermissionsFailed,
 };
-use crate::error::fs::{CanonicalizePathError, FsError};
+use crate::error::fs::{CanonicalizePathError, CopyFileError, FsError};
 use std::fs::{Metadata, Permissions, ReadDir};
 use std::path::{Path, PathBuf};
 
@@ -17,13 +17,11 @@ pub fn canonicalize(path: &Path) -> Result<PathBuf, CanonicalizePathError> {
     })
 }
 
-pub fn copy(from: &Path, to: &Path) -> Result<u64, FsError> {
-    std::fs::copy(from, to).map_err(|err| {
-        FsError::new(CopyFileFailed(
-            Box::new(from.to_path_buf()),
-            Box::new(to.to_path_buf()),
-            err,
-        ))
+pub fn copy(from: &Path, to: &Path) -> Result<u64, CopyFileError> {
+    std::fs::copy(from, to).map_err(|source| CopyFileError {
+        from: from.to_path_buf(),
+        to: to.to_path_buf(),
+        source,
     })
 }
 

--- a/src/dfx-core/src/fs/mod.rs
+++ b/src/dfx-core/src/fs/mod.rs
@@ -1,18 +1,20 @@
 pub mod composite;
 use crate::error::archive::ArchiveError;
-use crate::error::fs::FsError;
 use crate::error::fs::FsErrorKind::{
-    CanonicalizePathFailed, CopyFileFailed, CreateDirectoryFailed, NoParent, ReadDirFailed,
-    ReadFileFailed, ReadMetadataFailed, ReadPermissionsFailed, ReadToStringFailed,
+    CopyFileFailed, CreateDirectoryFailed, NoParent, ReadDirFailed, ReadFileFailed,
+    ReadMetadataFailed, ReadPermissionsFailed, ReadToStringFailed,
     RemoveDirectoryAndContentsFailed, RemoveDirectoryFailed, RemoveFileFailed, RenameFailed,
     UnpackingArchiveFailed, WriteFileFailed, WritePermissionsFailed,
 };
+use crate::error::fs::{CanonicalizePathError, FsError};
 use std::fs::{Metadata, Permissions, ReadDir};
 use std::path::{Path, PathBuf};
 
-pub fn canonicalize(path: &Path) -> Result<PathBuf, FsError> {
-    dunce::canonicalize(path)
-        .map_err(|err| FsError::new(CanonicalizePathFailed(path.to_path_buf(), err)))
+pub fn canonicalize(path: &Path) -> Result<PathBuf, CanonicalizePathError> {
+    dunce::canonicalize(path).map_err(|source| CanonicalizePathError {
+        path: path.to_path_buf(),
+        source,
+    })
 }
 
 pub fn copy(from: &Path, to: &Path) -> Result<u64, FsError> {

--- a/src/dfx-core/src/identity/mod.rs
+++ b/src/dfx-core/src/identity/mod.rs
@@ -195,9 +195,9 @@ impl Identity {
         path: &Path,
         config: &WalletGlobalConfig,
     ) -> Result<(), SaveWalletConfigError> {
-        ensure_parent_dir_exists(path).map_err(SaveWalletConfigError::EnsureParentDirExists)?;
+        ensure_parent_dir_exists(path)?;
 
-        save_json_file(path, &config).map_err(SaveWalletConfigError::SaveJsonFile)?;
+        save_json_file(path, &config)?;
         Ok(())
     }
 

--- a/src/dfx-core/src/identity/mod.rs
+++ b/src/dfx-core/src/identity/mod.rs
@@ -4,6 +4,7 @@
 //! type.
 use crate::config::directories::{get_shared_network_data_directory, get_user_dfx_config_dir};
 use crate::config::model::network_descriptor::NetworkDescriptor;
+use crate::error::wallet_config::SaveWalletConfigError;
 use crate::error::{
     identity::{
         CallSenderFromWalletError,
@@ -20,13 +21,9 @@ use crate::error::{
         NewIdentityError, RenameWalletGlobalConfigKeyError,
         RenameWalletGlobalConfigKeyError::RenameWalletFailed,
     },
-    wallet_config::{
-        WalletConfigError,
-        WalletConfigError::{
-            EnsureWalletConfigDirFailed, LoadWalletConfigFailed, SaveWalletConfigFailed,
-        },
-    },
+    wallet_config::{WalletConfigError, WalletConfigError::LoadWalletConfigFailed},
 };
+use crate::fs::composite::ensure_parent_dir_exists;
 use crate::identity::identity_file_locations::IdentityFileLocations;
 use crate::identity::wallet::wallet_canister_id;
 use crate::json::{load_json_file, save_json_file};
@@ -197,12 +194,11 @@ impl Identity {
     pub fn save_wallet_config(
         path: &Path,
         config: &WalletGlobalConfig,
-    ) -> Result<(), WalletConfigError> {
-        crate::fs::parent(path)
-            .and_then(|path| crate::fs::create_dir_all(&path))
-            .map_err(EnsureWalletConfigDirFailed)?;
+    ) -> Result<(), SaveWalletConfigError> {
+        ensure_parent_dir_exists(path).map_err(SaveWalletConfigError::EnsureParentDirExists)?;
 
-        save_json_file(path, &config).map_err(SaveWalletConfigFailed)
+        save_json_file(path, &config).map_err(SaveWalletConfigError::SaveJsonFile)?;
+        Ok(())
     }
 
     fn rename_wallet_global_config_key(
@@ -220,6 +216,7 @@ impl Identity {
                     });
                 identities.insert(renamed_identity.to_string(), v);
                 Identity::save_wallet_config(&wallet_path, &config)
+                    .map_err(WalletConfigError::SaveWalletConfig)
             })
             .map_err(|err| {
                 RenameWalletFailed(

--- a/src/dfx-core/src/identity/pem_safekeeping.rs
+++ b/src/dfx-core/src/identity/pem_safekeeping.rs
@@ -106,8 +106,8 @@ pub fn write_pem_to_file(
 }
 
 fn write_pem_content(path: &Path, pem_content: &[u8]) -> Result<(), WritePemContentError> {
-    let containing_folder = crate::fs::parent(path).map_err(WritePemContentError::NoParent)?;
-    crate::fs::create_dir_all(&containing_folder).map_err(WritePemContentError::CreateDirAll)?;
+    let containing_folder = crate::fs::parent(path)?;
+    crate::fs::create_dir_all(&containing_folder)?;
     crate::fs::write(path, pem_content).map_err(WritePemContentError::Write)?;
 
     let mut permissions =

--- a/src/dfx-core/src/identity/pem_safekeeping.rs
+++ b/src/dfx-core/src/identity/pem_safekeeping.rs
@@ -1,11 +1,11 @@
 use super::identity_manager::EncryptionConfiguration;
 use super::IdentityConfiguration;
+use crate::error::identity::WritePemContentError;
 use crate::error::{
     encryption::{
         EncryptionError,
         EncryptionError::{DecryptContentFailed, HashPasswordFailed},
     },
-    fs::FsError,
     identity::{
         LoadPemError,
         LoadPemError::LoadFromKeyringFailed,
@@ -105,12 +105,13 @@ pub fn write_pem_to_file(
     write_pem_content(path, &pem_content).map_err(WritePemContentFailed)
 }
 
-fn write_pem_content(path: &Path, pem_content: &[u8]) -> Result<(), FsError> {
-    let containing_folder = crate::fs::parent(path)?;
-    crate::fs::create_dir_all(&containing_folder)?;
-    crate::fs::write(path, pem_content)?;
+fn write_pem_content(path: &Path, pem_content: &[u8]) -> Result<(), WritePemContentError> {
+    let containing_folder = crate::fs::parent(path).map_err(WritePemContentError::NoParent)?;
+    crate::fs::create_dir_all(&containing_folder).map_err(WritePemContentError::CreateDirAll)?;
+    crate::fs::write(path, pem_content).map_err(WritePemContentError::Write)?;
 
-    let mut permissions = crate::fs::read_permissions(path)?;
+    let mut permissions =
+        crate::fs::read_permissions(path).map_err(WritePemContentError::ReadPermissions)?;
 
     permissions.set_readonly(true);
     // On *nix, set the read permission to owner-only.
@@ -120,7 +121,8 @@ fn write_pem_content(path: &Path, pem_content: &[u8]) -> Result<(), FsError> {
         permissions.set_mode(0o400);
     }
 
-    crate::fs::set_permissions(path, permissions)
+    crate::fs::set_permissions(path, permissions).map_err(WritePemContentError::SetPermissions)?;
+    Ok(())
 }
 
 /// If the IndentityConfiguration suggests that the content of the pem file should be encrypted,

--- a/src/dfx-core/src/network/directory.rs
+++ b/src/dfx-core/src/network/directory.rs
@@ -1,6 +1,6 @@
 use crate::config::model::local_server_descriptor::LocalNetworkScopeDescriptor;
 use crate::config::model::network_descriptor::NetworkDescriptor;
-use crate::error::fs::FsError;
+use crate::error::canister_id_store::EnsureCohesiveNetworkDirectoryError;
 use std::path::Path;
 
 /// A cohesive network directory is one in which the directory in question contains
@@ -10,7 +10,7 @@ use std::path::Path;
 pub fn ensure_cohesive_network_directory(
     network_descriptor: &NetworkDescriptor,
     directory: &Path,
-) -> Result<(), FsError> {
+) -> Result<(), EnsureCohesiveNetworkDirectoryError> {
     let scope = network_descriptor
         .local_server_descriptor
         .as_ref()
@@ -18,19 +18,25 @@ pub fn ensure_cohesive_network_directory(
 
     if let Some(LocalNetworkScopeDescriptor::Shared { network_id_path }) = &scope {
         if network_id_path.is_file() {
-            let network_id = crate::fs::read_to_string(network_id_path)?;
+            let network_id = crate::fs::read_to_string(network_id_path)
+                .map_err(EnsureCohesiveNetworkDirectoryError::ReadToString)?;
             let project_network_id_path = directory.join("network-id");
             let reset = directory.is_dir()
                 && (!project_network_id_path.exists()
-                    || crate::fs::read_to_string(&project_network_id_path)? != network_id);
+                    || crate::fs::read_to_string(&project_network_id_path)
+                        .map_err(EnsureCohesiveNetworkDirectoryError::ReadToString)?
+                        != network_id);
 
             if reset {
-                crate::fs::remove_dir_all(directory)?;
+                crate::fs::remove_dir_all(directory)
+                    .map_err(EnsureCohesiveNetworkDirectoryError::RemoveDirAll)?;
             };
 
             if !directory.exists() {
-                crate::fs::create_dir_all(directory)?;
-                crate::fs::write(&project_network_id_path, &network_id)?;
+                crate::fs::create_dir_all(directory)
+                    .map_err(EnsureCohesiveNetworkDirectoryError::CreateDirAll)?;
+                crate::fs::write(&project_network_id_path, &network_id)
+                    .map_err(EnsureCohesiveNetworkDirectoryError::Write)?;
             }
         }
     }

--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -94,7 +94,7 @@ pub fn install_version(v: &str, force: bool) -> Result<PathBuf, CacheError> {
             .map(|byte| byte as char)
             .collect();
         let temp_p = get_bin_cache(&format!("_{}_{}", v, rand_string))?;
-        dfx_core::fs::create_dir_all(&temp_p).map_err(UnifiedIoError::from)?;
+        dfx_core::fs::create_dir_all(&temp_p)?;
 
         let mut binary_cache_assets =
             util::assets::binary_cache().map_err(CacheError::ReadBinaryCacheStoreFailed)?;

--- a/src/dfx/src/lib/error/project.rs
+++ b/src/dfx/src/lib/error/project.rs
@@ -1,10 +1,13 @@
-use dfx_core::error::fs::CanonicalizePathError;
+use dfx_core::error::fs::{CanonicalizePathError, CreateDirAllError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ProjectError {
     #[error(transparent)]
     CanonicalizePath(#[from] CanonicalizePathError),
+
+    #[error(transparent)]
+    CreateDirAll(#[from] CreateDirAllError),
 
     #[error(transparent)]
     StructuredFileError(#[from] dfx_core::error::structured_file::StructuredFileError),

--- a/src/dfx/src/lib/error/project.rs
+++ b/src/dfx/src/lib/error/project.rs
@@ -1,7 +1,11 @@
+use dfx_core::error::fs::CanonicalizePathError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ProjectError {
+    #[error(transparent)]
+    CanonicalizePath(#[from] CanonicalizePathError),
+
     #[error(transparent)]
     StructuredFileError(#[from] dfx_core::error::structured_file::StructuredFileError),
 

--- a/src/dfx/src/lib/identity/wallet.rs
+++ b/src/dfx/src/lib/identity/wallet.rs
@@ -8,12 +8,8 @@ use dfx_core::canister::build_wallet_canister;
 use dfx_core::config::model::network_descriptor::NetworkDescriptor;
 use dfx_core::error::canister::CanisterBuilderError;
 use dfx_core::error::wallet_config::WalletConfigError;
-use dfx_core::error::wallet_config::WalletConfigError::{
-    EnsureWalletConfigDirFailed, SaveWalletConfigFailed,
-};
 use dfx_core::identity::wallet::{get_wallet_config_path, wallet_canister_id};
 use dfx_core::identity::{Identity, WalletGlobalConfig, WalletNetworkMap};
-use dfx_core::json::save_json_file;
 use ic_agent::agent::{RejectCode, RejectResponse};
 use ic_agent::AgentError;
 use ic_utils::interfaces::management_canister::builders::InstallMode;
@@ -170,26 +166,7 @@ pub fn set_wallet_id(
 
     network_map.networks.insert(network.name.clone(), id);
 
-    Identity::save_wallet_config(&wallet_path, &config)
-}
-
-#[allow(dead_code)]
-pub fn remove_wallet_id(network: &NetworkDescriptor, name: &str) -> Result<(), WalletConfigError> {
-    let (wallet_path, mut config) = wallet_config(network, name)?;
-    // Update the wallet map in it.
-    let identities = &mut config.identities;
-    let network_map = identities
-        .entry(name.to_string())
-        .or_insert(WalletNetworkMap {
-            networks: BTreeMap::new(),
-        });
-
-    network_map.networks.remove(&network.name);
-
-    dfx_core::fs::composite::ensure_parent_dir_exists(&wallet_path)
-        .map_err(EnsureWalletConfigDirFailed)?;
-
-    save_json_file(&wallet_path, &config).map_err(SaveWalletConfigFailed)
+    Identity::save_wallet_config(&wallet_path, &config).map_err(WalletConfigError::SaveWalletConfig)
 }
 
 fn wallet_config(

--- a/src/dfx/src/lib/identity/wallet.rs
+++ b/src/dfx/src/lib/identity/wallet.rs
@@ -166,7 +166,8 @@ pub fn set_wallet_id(
 
     network_map.networks.insert(network.name.clone(), id);
 
-    Identity::save_wallet_config(&wallet_path, &config).map_err(WalletConfigError::SaveWalletConfig)
+    Identity::save_wallet_config(&wallet_path, &config)?;
+    Ok(())
 }
 
 fn wallet_config(


### PR DESCRIPTION
# Description

Move some of the error types out of FsError into method-specific error types. The goal is to remove FsError altogether. 

# How Has This Been Tested?

Refactor covered by existing tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
