### PR TITLE
refactor: Split up CacheError into method-specific error types

### DIFF
--- a/src/dfx-core/src/config/cache.rs
+++ b/src/dfx-core/src/config/cache.rs
@@ -45,7 +45,7 @@ pub fn get_cache_root() -> Result<PathBuf, GetCacheRootError> {
 }
 
 /// Constructs and returns <cache root>/versions/<version> without creating any directories.
-pub fn get_existing_cache_path_for_version(v: &str) -> Result<PathBuf, GetCacheRootError> {
+pub fn get_cache_path_for_version(v: &str) -> Result<PathBuf, GetCacheRootError> {
     let p = get_cache_root()?.join("versions").join(v);
     Ok(p)
 }
@@ -60,13 +60,14 @@ pub fn ensure_cache_versions_dir() -> Result<PathBuf, EnsureCacheVersionsDirErro
     Ok(p)
 }
 
-pub fn join_cache_dir_for_version(v: &str) -> Result<PathBuf, EnsureCacheVersionsDirError> {
+/// Doesn't create the version dir, but does create everything up to it
+pub fn get_bin_cache(v: &str) -> Result<PathBuf, EnsureCacheVersionsDirError> {
     let root = ensure_cache_versions_dir()?;
     Ok(root.join(v))
 }
 
 pub fn is_version_installed(v: &str) -> Result<bool, IsCacheInstalledError> {
-    Ok(join_cache_dir_for_version(v)?.is_dir())
+    Ok(get_bin_cache(v)?.is_dir())
 }
 
 pub fn delete_version(v: &str) -> Result<bool, DeleteCacheError> {
@@ -74,7 +75,7 @@ pub fn delete_version(v: &str) -> Result<bool, DeleteCacheError> {
         return Ok(false);
     }
 
-    let root = join_cache_dir_for_version(v)?;
+    let root = get_bin_cache(v)?;
     crate::fs::remove_dir_all(&root)?;
 
     Ok(true)
@@ -90,7 +91,7 @@ pub fn get_binary_path_from_version(
         return Ok(PathBuf::from(path));
     }
 
-    Ok(join_cache_dir_for_version(version)?.join(binary_name))
+    Ok(get_bin_cache(version)?.join(binary_name))
 }
 
 pub fn binary_command_from_version(

--- a/src/dfx-core/src/config/cache.rs
+++ b/src/dfx-core/src/config/cache.rs
@@ -60,13 +60,13 @@ pub fn ensure_cache_versions_dir() -> Result<PathBuf, EnsureCacheVersionsDirErro
     Ok(p)
 }
 
-pub fn get_cache_dir_for_version(v: &str) -> Result<PathBuf, EnsureCacheVersionsDirError> {
+pub fn join_cache_dir_for_version(v: &str) -> Result<PathBuf, EnsureCacheVersionsDirError> {
     let root = ensure_cache_versions_dir()?;
     Ok(root.join(v))
 }
 
 pub fn is_version_installed(v: &str) -> Result<bool, IsCacheInstalledError> {
-    Ok(get_cache_dir_for_version(v)?.is_dir())
+    Ok(join_cache_dir_for_version(v)?.is_dir())
 }
 
 pub fn delete_version(v: &str) -> Result<bool, DeleteCacheError> {
@@ -74,7 +74,7 @@ pub fn delete_version(v: &str) -> Result<bool, DeleteCacheError> {
         return Ok(false);
     }
 
-    let root = get_cache_dir_for_version(v)?;
+    let root = join_cache_dir_for_version(v)?;
     crate::fs::remove_dir_all(&root)?;
 
     Ok(true)
@@ -90,7 +90,7 @@ pub fn get_binary_path_from_version(
         return Ok(PathBuf::from(path));
     }
 
-    Ok(get_cache_dir_for_version(version)?.join(binary_name))
+    Ok(join_cache_dir_for_version(version)?.join(binary_name))
 }
 
 pub fn binary_command_from_version(

--- a/src/dfx-core/src/config/cache.rs
+++ b/src/dfx-core/src/config/cache.rs
@@ -6,9 +6,9 @@ use crate::error::cache::{
 };
 #[cfg(not(windows))]
 use crate::foundation::get_user_home;
+use crate::fs::composite::ensure_dir_exists;
 use semver::Version;
 use std::path::PathBuf;
-use crate::fs::composite::ensure_dir_exists;
 
 pub trait Cache {
     fn version_str(&self) -> String;

--- a/src/dfx-core/src/config/cache.rs
+++ b/src/dfx-core/src/config/cache.rs
@@ -2,7 +2,7 @@
 use crate::config::directories::project_dirs;
 use crate::error::cache::{
     CacheError, DeleteCacheError, GetBinaryCommandPathError, GetBinaryPathFromVersionError,
-    ListCacheVersionsError,
+    IsCacheInstalledError, ListCacheVersionsError,
 };
 #[cfg(not(windows))]
 use crate::foundation::get_user_home;
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 pub trait Cache {
     fn version_str(&self) -> String;
-    fn is_installed(&self) -> Result<bool, CacheError>;
+    fn is_installed(&self) -> Result<bool, IsCacheInstalledError>;
     fn delete(&self) -> Result<(), DeleteCacheError>;
     fn get_binary_command_path(
         &self,
@@ -68,8 +68,8 @@ pub fn get_bin_cache(v: &str) -> Result<PathBuf, CacheError> {
     Ok(root.join(v))
 }
 
-pub fn is_version_installed(v: &str) -> Result<bool, CacheError> {
-    get_bin_cache(v).map(|c| c.is_dir())
+pub fn is_version_installed(v: &str) -> Result<bool, IsCacheInstalledError> {
+    Ok(get_bin_cache(v)?.is_dir())
 }
 
 pub fn delete_version(v: &str) -> Result<bool, DeleteCacheError> {

--- a/src/dfx-core/src/config/cache.rs
+++ b/src/dfx-core/src/config/cache.rs
@@ -1,7 +1,8 @@
 #[cfg(windows)]
 use crate::config::directories::project_dirs;
 use crate::error::cache::{
-    CacheError, GetBinaryCommandPathError, GetBinaryPathFromVersionError, ListCacheVersionsError,
+    CacheError, DeleteCacheError, GetBinaryCommandPathError, GetBinaryPathFromVersionError,
+    ListCacheVersionsError,
 };
 #[cfg(not(windows))]
 use crate::foundation::get_user_home;
@@ -11,7 +12,7 @@ use std::path::PathBuf;
 pub trait Cache {
     fn version_str(&self) -> String;
     fn is_installed(&self) -> Result<bool, CacheError>;
-    fn delete(&self) -> Result<(), CacheError>;
+    fn delete(&self) -> Result<(), DeleteCacheError>;
     fn get_binary_command_path(
         &self,
         binary_name: &str,
@@ -71,7 +72,7 @@ pub fn is_version_installed(v: &str) -> Result<bool, CacheError> {
     get_bin_cache(v).map(|c| c.is_dir())
 }
 
-pub fn delete_version(v: &str) -> Result<bool, CacheError> {
+pub fn delete_version(v: &str) -> Result<bool, DeleteCacheError> {
     if !is_version_installed(v).unwrap_or(false) {
         return Ok(false);
     }

--- a/src/dfx-core/src/error/cache.rs
+++ b/src/dfx-core/src/error/cache.rs
@@ -19,22 +19,43 @@ pub enum GetBinaryCommandPathError {
 #[derive(Error, Debug)]
 pub enum GetBinaryPathFromVersionError {
     #[error(transparent)]
-    GetBinCache(CacheError),
+    GetBinCache(GetBinCacheRootError),
 }
 
 #[derive(Error, Debug)]
 pub enum DeleteCacheError {
     #[error(transparent)]
-    GetBinCache(#[from] CacheError),
+    GetBinCache(#[from] GetBinCacheRootError),
 
     #[error(transparent)]
     RemoveDirectoryAndContents(#[from] RemoveDirectoryAndContentsError),
 }
 
 #[derive(Error, Debug)]
+pub enum GetBinCacheRootError {
+    #[error("failed to create cache directory")]
+    CreateCacheDirectoryFailed(#[source] CreateDirAllError),
+
+    #[error("Cannot find cache directory at '{0}'.")]
+    FindCacheDirectoryFailed(std::path::PathBuf),
+
+    #[error(transparent)]
+    GetCacheRoot(#[from] GetCacheRootError),
+}
+
+#[derive(Error, Debug)]
+pub enum GetCacheRootError {
+    #[error(transparent)]
+    GetUserHomeError(#[from] GetUserHomeError),
+
+    #[error("Cannot find cache directory at '{0}'.")]
+    FindCacheDirectoryFailed(std::path::PathBuf),
+}
+
+#[derive(Error, Debug)]
 pub enum IsCacheInstalledError {
     #[error(transparent)]
-    GetBinCache(#[from] CacheError),
+    GetBinCache(#[from] GetBinCacheRootError),
 }
 
 #[derive(Error, Debug)]
@@ -43,7 +64,7 @@ pub enum ListCacheVersionsError {
     ReadDir(#[from] ReadDirError),
 
     #[error(transparent)]
-    GetBinCacheRoot(CacheError),
+    GetBinCacheRoot(#[from] GetBinCacheRootError),
 
     #[error("failed to parse '{0}' as Semantic Version")]
     MalformedSemverString(String, #[source] semver::Error),
@@ -61,7 +82,7 @@ pub enum InstallCacheError {
     GetArchivePath(#[from] GetArchivePathError),
 
     #[error(transparent)]
-    GetBinCache(CacheError),
+    GetBinCache(#[from] GetBinCacheRootError),
 
     #[error(transparent)]
     GetCurrentExeError(#[from] GetCurrentExeError),
@@ -98,18 +119,4 @@ pub enum InstallCacheError {
 
     #[error(transparent)]
     WriteFile(#[from] WriteFileError),
-}
-
-#[derive(Error, Debug)]
-pub enum CacheError {
-    #[error(transparent)]
-    GetUserHomeError(#[from] GetUserHomeError),
-
-    // #[error(transparent)]
-    // RemoveDirectoryAndContents(#[from] RemoveDirectoryAndContentsError),
-    #[error("failed to create cache directory")]
-    CreateCacheDirectoryFailed(#[source] CreateDirAllError),
-
-    #[error("Cannot find cache directory at '{0}'.")]
-    FindCacheDirectoryFailed(std::path::PathBuf),
 }

--- a/src/dfx-core/src/error/cache.rs
+++ b/src/dfx-core/src/error/cache.rs
@@ -23,6 +23,15 @@ pub enum GetBinaryPathFromVersionError {
 }
 
 #[derive(Error, Debug)]
+pub enum DeleteCacheError {
+    #[error(transparent)]
+    GetBinCache(#[from] CacheError),
+
+    #[error(transparent)]
+    RemoveDirectoryAndContents(#[from] RemoveDirectoryAndContentsError),
+}
+
+#[derive(Error, Debug)]
 pub enum ListCacheVersionsError {
     #[error(transparent)]
     ReadDir(#[from] ReadDirError),
@@ -90,9 +99,8 @@ pub enum CacheError {
     #[error(transparent)]
     GetUserHomeError(#[from] GetUserHomeError),
 
-    #[error(transparent)]
-    RemoveDirectoryAndContents(#[from] RemoveDirectoryAndContentsError),
-
+    // #[error(transparent)]
+    // RemoveDirectoryAndContents(#[from] RemoveDirectoryAndContentsError),
     #[error("failed to create cache directory")]
     CreateCacheDirectoryFailed(#[source] CreateDirAllError),
 

--- a/src/dfx-core/src/error/cache.rs
+++ b/src/dfx-core/src/error/cache.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum GetBinaryCommandPathError {
     #[error(transparent)]
-    Install(#[from] CacheError),
+    Install(#[from] InstallCacheError),
 
     #[error(transparent)]
     GetBinaryPathFromVersion(#[from] GetBinaryPathFromVersionError),
@@ -38,21 +38,33 @@ pub enum ListCacheVersionsError {
 }
 
 #[derive(Error, Debug)]
-pub enum CacheError {
-    #[error(transparent)]
-    Archive(#[from] GetArchivePathError),
-
+pub enum InstallCacheError {
     #[error(transparent)]
     CreateDirAll(#[from] CreateDirAllError),
 
     #[error(transparent)]
+    GetArchivePath(#[from] GetArchivePathError),
+
+    #[error(transparent)]
+    GetBinCache(CacheError),
+
+    #[error(transparent)]
     GetCurrentExeError(#[from] GetCurrentExeError),
 
-    #[error(transparent)]
-    GetUserHomeError(#[from] GetUserHomeError),
+    #[error("invalid cache for version '{0}'.")]
+    InvalidCacheForDfxVersion(String),
 
-    #[error(transparent)]
-    UnpackingArchive(#[from] UnpackingArchiveError),
+    #[error("failed to parse '{0}' as Semantic Version")]
+    MalformedSemverString(String, #[source] semver::Error),
+
+    #[error("failed to iterate through binary cache")]
+    ReadBinaryCacheEntriesFailed(#[source] std::io::Error),
+
+    #[error("failed to read binary cache entry")]
+    ReadBinaryCacheEntryFailed(#[source] std::io::Error),
+
+    #[error("failed to read binary cache")]
+    ReadBinaryCacheStoreFailed(#[source] std::io::Error),
 
     #[error(transparent)]
     ReadFile(#[from] ReadFileError),
@@ -67,35 +79,23 @@ pub enum CacheError {
     SetPermissions(#[from] SetPermissionsError),
 
     #[error(transparent)]
-    WriteFile(#[from] WriteFileError),
+    UnpackingArchive(#[from] UnpackingArchiveError),
 
     #[error(transparent)]
-    ProcessError(#[from] crate::error::process::ProcessError),
+    WriteFile(#[from] WriteFileError),
+}
+
+#[derive(Error, Debug)]
+pub enum CacheError {
+    #[error(transparent)]
+    GetUserHomeError(#[from] GetUserHomeError),
+
+    #[error(transparent)]
+    RemoveDirectoryAndContents(#[from] RemoveDirectoryAndContentsError),
 
     #[error("failed to create cache directory")]
     CreateCacheDirectoryFailed(#[source] CreateDirAllError),
 
     #[error("Cannot find cache directory at '{0}'.")]
     FindCacheDirectoryFailed(std::path::PathBuf),
-
-    #[error("Invalid cache for version '{0}'.")]
-    InvalidCacheForDfxVersion(String),
-
-    #[error("Unable to parse '{0}' as Semantic Version")]
-    MalformedSemverString(String, #[source] semver::Error),
-
-    #[error("Failed to read binary cache")]
-    ReadBinaryCacheStoreFailed(#[source] std::io::Error),
-
-    #[error("Failed to iterate through binary cache")]
-    ReadBinaryCacheEntriesFailed(#[source] std::io::Error),
-
-    #[error("Failed to read binary cache entry")]
-    ReadBinaryCacheEntryFailed(#[source] std::io::Error),
-
-    #[error("Failed to read entry in cache directory")]
-    ReadCacheEntryFailed(#[source] std::io::Error),
-
-    #[error(transparent)]
-    ReadDir(#[from] ReadDirError),
 }

--- a/src/dfx-core/src/error/cache.rs
+++ b/src/dfx-core/src/error/cache.rs
@@ -23,6 +23,21 @@ pub enum GetBinaryPathFromVersionError {
 }
 
 #[derive(Error, Debug)]
+pub enum ListCacheVersionsError {
+    #[error(transparent)]
+    ReadDir(#[from] ReadDirError),
+
+    #[error(transparent)]
+    GetBinCacheRoot(CacheError),
+
+    #[error("failed to parse '{0}' as Semantic Version")]
+    MalformedSemverString(String, #[source] semver::Error),
+
+    #[error("failed to read entry in cache directory")]
+    ReadCacheEntryFailed(#[source] std::io::Error),
+}
+
+#[derive(Error, Debug)]
 pub enum CacheError {
     #[error(transparent)]
     Archive(#[from] GetArchivePathError),

--- a/src/dfx-core/src/error/cache.rs
+++ b/src/dfx-core/src/error/cache.rs
@@ -8,6 +8,21 @@ use crate::error::get_user_home::GetUserHomeError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+pub enum GetBinaryCommandPathError {
+    #[error(transparent)]
+    Install(#[from] CacheError),
+
+    #[error(transparent)]
+    GetBinaryPathFromVersion(#[from] GetBinaryPathFromVersionError),
+}
+
+#[derive(Error, Debug)]
+pub enum GetBinaryPathFromVersionError {
+    #[error(transparent)]
+    GetBinCache(CacheError),
+}
+
+#[derive(Error, Debug)]
 pub enum CacheError {
     #[error(transparent)]
     Archive(#[from] GetArchivePathError),

--- a/src/dfx-core/src/error/cache.rs
+++ b/src/dfx-core/src/error/cache.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum DeleteCacheError {
     #[error(transparent)]
-    GetBinCache(#[from] GetCacheVersionsRootError),
+    GetBinCache(#[from] EnsureCacheVersionsDirError),
 
     #[error(transparent)]
     RemoveDirectoryAndContents(#[from] RemoveDirectoryAndContentsError),
@@ -22,11 +22,11 @@ pub enum GetBinaryCommandPathError {
     Install(#[from] InstallCacheError),
 
     #[error(transparent)]
-    GetBinCacheRoot(#[from] GetCacheVersionsRootError),
+    GetBinCacheRoot(#[from] EnsureCacheVersionsDirError),
 }
 
 #[derive(Error, Debug)]
-pub enum GetCacheVersionsRootError {
+pub enum EnsureCacheVersionsDirError {
     #[error(transparent)]
     EnsureDirExists(#[from] EnsureDirExistsError),
 
@@ -52,7 +52,7 @@ pub enum InstallCacheError {
     GetArchivePath(#[from] GetArchivePathError),
 
     #[error(transparent)]
-    GetBinCache(#[from] GetCacheVersionsRootError),
+    GetBinCache(#[from] EnsureCacheVersionsDirError),
 
     #[error(transparent)]
     GetCurrentExeError(#[from] GetCurrentExeError),
@@ -94,7 +94,7 @@ pub enum InstallCacheError {
 #[derive(Error, Debug)]
 pub enum IsCacheInstalledError {
     #[error(transparent)]
-    GetBinCache(#[from] GetCacheVersionsRootError),
+    GetBinCache(#[from] EnsureCacheVersionsDirError),
 }
 
 #[derive(Error, Debug)]
@@ -103,7 +103,7 @@ pub enum ListCacheVersionsError {
     ReadDir(#[from] ReadDirError),
 
     #[error(transparent)]
-    GetBinCacheRoot(#[from] GetCacheVersionsRootError),
+    GetBinCacheRoot(#[from] EnsureCacheVersionsDirError),
 
     #[error("failed to parse '{0}' as Semantic Version")]
     MalformedSemverString(String, #[source] semver::Error),

--- a/src/dfx-core/src/error/cache.rs
+++ b/src/dfx-core/src/error/cache.rs
@@ -36,7 +36,7 @@ pub enum GetBinCacheRootError {
     #[error("failed to create cache directory")]
     CreateCacheDirectoryFailed(#[source] CreateDirAllError),
 
-    #[error("Cannot find cache directory at '{0}'.")]
+    #[error("failed to find cache directory at '{0}'.")]
     FindCacheDirectoryFailed(std::path::PathBuf),
 
     #[error(transparent)]
@@ -48,7 +48,7 @@ pub enum GetCacheRootError {
     #[error(transparent)]
     GetUserHomeError(#[from] GetUserHomeError),
 
-    #[error("Cannot find cache directory at '{0}'.")]
+    #[error("failed to find cache directory at '{0}'.")]
     FindCacheDirectoryFailed(std::path::PathBuf),
 }
 

--- a/src/dfx-core/src/error/cache.rs
+++ b/src/dfx-core/src/error/cache.rs
@@ -32,6 +32,12 @@ pub enum DeleteCacheError {
 }
 
 #[derive(Error, Debug)]
+pub enum IsCacheInstalledError {
+    #[error(transparent)]
+    GetBinCache(#[from] CacheError),
+}
+
+#[derive(Error, Debug)]
 pub enum ListCacheVersionsError {
     #[error(transparent)]
     ReadDir(#[from] ReadDirError),

--- a/src/dfx-core/src/error/cache.rs
+++ b/src/dfx-core/src/error/cache.rs
@@ -1,5 +1,8 @@
 use crate::error::archive::GetArchivePathError;
-use crate::error::fs::{CreateDirAllError, EnsureDirExistsError, ReadDirError, ReadFileError, ReadPermissionsError, RemoveDirectoryAndContentsError, SetPermissionsError, UnpackingArchiveError, WriteFileError};
+use crate::error::fs::{
+    CreateDirAllError, EnsureDirExistsError, ReadDirError, ReadFileError, ReadPermissionsError,
+    RemoveDirectoryAndContentsError, SetPermissionsError, UnpackingArchiveError, WriteFileError,
+};
 use crate::error::get_current_exe::GetCurrentExeError;
 use crate::error::get_user_home::GetUserHomeError;
 use thiserror::Error;

--- a/src/dfx-core/src/error/extension.rs
+++ b/src/dfx-core/src/error/extension.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::error::cache::{GetBinCacheRootError, GetCacheRootError};
 use crate::error::fs::{
     EnsureDirExistsError, ReadDirError, RemoveDirectoryAndContentsError, RenameError,
     SetPermissionsError,
@@ -50,7 +51,7 @@ pub enum RunExtensionError {
     InvalidExtensionName(std::ffi::OsString),
 
     #[error("Cannot find cache directory")]
-    FindCacheDirectoryFailed(#[source] crate::error::cache::CacheError),
+    FindCacheDirectoryFailed(#[from] GetBinCacheRootError),
 
     #[error("Failed to run extension '{0}'")]
     FailedToLaunchExtension(String, #[source] std::io::Error),
@@ -83,7 +84,7 @@ pub enum GetExtensionBinaryError {
 #[derive(Error, Debug)]
 pub enum NewExtensionManagerError {
     #[error("Cannot find cache directory")]
-    FindCacheDirectoryFailed(#[source] crate::error::cache::CacheError),
+    FindCacheDirectoryFailed(#[from] GetCacheRootError),
 }
 
 #[derive(Error, Debug)]

--- a/src/dfx-core/src/error/extension.rs
+++ b/src/dfx-core/src/error/extension.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::error::cache::{GetCacheRootError, GetCacheVersionsRootError};
+use crate::error::cache::{EnsureCacheVersionsDirError, GetCacheRootError};
 use crate::error::fs::{
     EnsureDirExistsError, ReadDirError, RemoveDirectoryAndContentsError, RenameError,
     SetPermissionsError,
@@ -51,7 +51,7 @@ pub enum RunExtensionError {
     InvalidExtensionName(std::ffi::OsString),
 
     #[error("Cannot find cache directory")]
-    FindCacheDirectoryFailed(#[from] GetCacheVersionsRootError),
+    FindCacheDirectoryFailed(#[from] EnsureCacheVersionsDirError),
 
     #[error("Failed to run extension '{0}'")]
     FailedToLaunchExtension(String, #[source] std::io::Error),

--- a/src/dfx-core/src/error/extension.rs
+++ b/src/dfx-core/src/error/extension.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::error::cache::{GetBinCacheRootError, GetCacheRootError};
+use crate::error::cache::{GetCacheRootError, GetCacheVersionsRootError};
 use crate::error::fs::{
     EnsureDirExistsError, ReadDirError, RemoveDirectoryAndContentsError, RenameError,
     SetPermissionsError,
@@ -51,7 +51,7 @@ pub enum RunExtensionError {
     InvalidExtensionName(std::ffi::OsString),
 
     #[error("Cannot find cache directory")]
-    FindCacheDirectoryFailed(#[from] GetBinCacheRootError),
+    FindCacheDirectoryFailed(#[from] GetCacheVersionsRootError),
 
     #[error("Failed to run extension '{0}'")]
     FailedToLaunchExtension(String, #[source] std::io::Error),

--- a/src/dfx-core/src/extension/manager/execute.rs
+++ b/src/dfx-core/src/extension/manager/execute.rs
@@ -14,8 +14,7 @@ impl ExtensionManager {
             .map_err(RunExtensionError::InvalidExtensionName)?;
 
         let mut extension_binary = self.get_extension_binary(&extension_name)?;
-        let dfx_cache = get_bin_cache(self.dfx_version.to_string().as_str())
-            .map_err(RunExtensionError::FindCacheDirectoryFailed)?;
+        let dfx_cache = get_bin_cache(self.dfx_version.to_string().as_str())?;
 
         params.extend(["--dfx-cache-path".into(), dfx_cache.into_os_string()]);
 

--- a/src/dfx-core/src/extension/manager/execute.rs
+++ b/src/dfx-core/src/extension/manager/execute.rs
@@ -1,5 +1,5 @@
 use super::ExtensionManager;
-use crate::config::cache::join_cache_dir_for_version;
+use crate::config::cache::get_bin_cache;
 use crate::error::extension::RunExtensionError;
 use std::ffi::OsString;
 
@@ -14,7 +14,7 @@ impl ExtensionManager {
             .map_err(RunExtensionError::InvalidExtensionName)?;
 
         let mut extension_binary = self.get_extension_binary(&extension_name)?;
-        let dfx_cache = join_cache_dir_for_version(self.dfx_version.to_string().as_str())?;
+        let dfx_cache = get_bin_cache(self.dfx_version.to_string().as_str())?;
 
         params.extend(["--dfx-cache-path".into(), dfx_cache.into_os_string()]);
 

--- a/src/dfx-core/src/extension/manager/execute.rs
+++ b/src/dfx-core/src/extension/manager/execute.rs
@@ -1,5 +1,5 @@
 use super::ExtensionManager;
-use crate::config::cache::get_cache_dir_for_version;
+use crate::config::cache::join_cache_dir_for_version;
 use crate::error::extension::RunExtensionError;
 use std::ffi::OsString;
 
@@ -14,7 +14,7 @@ impl ExtensionManager {
             .map_err(RunExtensionError::InvalidExtensionName)?;
 
         let mut extension_binary = self.get_extension_binary(&extension_name)?;
-        let dfx_cache = get_cache_dir_for_version(self.dfx_version.to_string().as_str())?;
+        let dfx_cache = join_cache_dir_for_version(self.dfx_version.to_string().as_str())?;
 
         params.extend(["--dfx-cache-path".into(), dfx_cache.into_os_string()]);
 

--- a/src/dfx-core/src/extension/manager/execute.rs
+++ b/src/dfx-core/src/extension/manager/execute.rs
@@ -1,5 +1,5 @@
 use super::ExtensionManager;
-use crate::config::cache::get_bin_cache;
+use crate::config::cache::get_cache_dir_for_version;
 use crate::error::extension::RunExtensionError;
 use std::ffi::OsString;
 
@@ -14,7 +14,7 @@ impl ExtensionManager {
             .map_err(RunExtensionError::InvalidExtensionName)?;
 
         let mut extension_binary = self.get_extension_binary(&extension_name)?;
-        let dfx_cache = get_bin_cache(self.dfx_version.to_string().as_str())?;
+        let dfx_cache = get_cache_dir_for_version(self.dfx_version.to_string().as_str())?;
 
         params.extend(["--dfx-cache-path".into(), dfx_cache.into_os_string()]);
 

--- a/src/dfx-core/src/extension/manager/mod.rs
+++ b/src/dfx-core/src/extension/manager/mod.rs
@@ -1,4 +1,4 @@
-use crate::config::cache::get_cache_path_for_version;
+use crate::config::cache::get_existing_cache_path_for_version;
 use crate::error::extension::{GetExtensionBinaryError, NewExtensionManagerError};
 use semver::Version;
 use std::path::PathBuf;
@@ -17,7 +17,7 @@ pub struct ExtensionManager {
 
 impl ExtensionManager {
     pub fn new(version: &Version) -> Result<Self, NewExtensionManagerError> {
-        let extensions_dir = get_cache_path_for_version(&version.to_string())?.join("extensions");
+        let extensions_dir = get_existing_cache_path_for_version(&version.to_string())?.join("extensions");
 
         Ok(Self {
             dir: extensions_dir,

--- a/src/dfx-core/src/extension/manager/mod.rs
+++ b/src/dfx-core/src/extension/manager/mod.rs
@@ -17,7 +17,8 @@ pub struct ExtensionManager {
 
 impl ExtensionManager {
     pub fn new(version: &Version) -> Result<Self, NewExtensionManagerError> {
-        let extensions_dir = get_existing_cache_path_for_version(&version.to_string())?.join("extensions");
+        let extensions_dir =
+            get_existing_cache_path_for_version(&version.to_string())?.join("extensions");
 
         Ok(Self {
             dir: extensions_dir,

--- a/src/dfx-core/src/extension/manager/mod.rs
+++ b/src/dfx-core/src/extension/manager/mod.rs
@@ -1,4 +1,4 @@
-use crate::config::cache::get_existing_cache_path_for_version;
+use crate::config::cache::get_cache_path_for_version;
 use crate::error::extension::{GetExtensionBinaryError, NewExtensionManagerError};
 use semver::Version;
 use std::path::PathBuf;
@@ -17,8 +17,7 @@ pub struct ExtensionManager {
 
 impl ExtensionManager {
     pub fn new(version: &Version) -> Result<Self, NewExtensionManagerError> {
-        let extensions_dir =
-            get_existing_cache_path_for_version(&version.to_string())?.join("extensions");
+        let extensions_dir = get_cache_path_for_version(&version.to_string())?.join("extensions");
 
         Ok(Self {
             dir: extensions_dir,

--- a/src/dfx-core/src/extension/manager/mod.rs
+++ b/src/dfx-core/src/extension/manager/mod.rs
@@ -17,9 +17,7 @@ pub struct ExtensionManager {
 
 impl ExtensionManager {
     pub fn new(version: &Version) -> Result<Self, NewExtensionManagerError> {
-        let extensions_dir = get_cache_path_for_version(&version.to_string())
-            .map_err(NewExtensionManagerError::FindCacheDirectoryFailed)?
-            .join("extensions");
+        let extensions_dir = get_cache_path_for_version(&version.to_string())?.join("extensions");
 
         Ok(Self {
             dir: extensions_dir,

--- a/src/dfx/src/commands/cache/show.rs
+++ b/src/dfx/src/commands/cache/show.rs
@@ -11,7 +11,7 @@ pub fn exec(env: &dyn Environment, _opts: CacheShowOpts) -> DfxResult {
     let v = format!("{}", env.get_version());
     println!(
         "{}",
-        dfx_core::config::cache::join_cache_dir_for_version(&v)?
+        dfx_core::config::cache::get_bin_cache(&v)?
             .as_path()
             .display()
     );

--- a/src/dfx/src/commands/cache/show.rs
+++ b/src/dfx/src/commands/cache/show.rs
@@ -11,7 +11,7 @@ pub fn exec(env: &dyn Environment, _opts: CacheShowOpts) -> DfxResult {
     let v = format!("{}", env.get_version());
     println!(
         "{}",
-        dfx_core::config::cache::get_bin_cache(&v)?
+        dfx_core::config::cache::get_cache_dir_for_version(&v)?
             .as_path()
             .display()
     );

--- a/src/dfx/src/commands/cache/show.rs
+++ b/src/dfx/src/commands/cache/show.rs
@@ -11,7 +11,7 @@ pub fn exec(env: &dyn Environment, _opts: CacheShowOpts) -> DfxResult {
     let v = format!("{}", env.get_version());
     println!(
         "{}",
-        dfx_core::config::cache::get_cache_dir_for_version(&v)?
+        dfx_core::config::cache::join_cache_dir_for_version(&v)?
             .as_path()
             .display()
     );

--- a/src/dfx/src/commands/killall.rs
+++ b/src/dfx/src/commands/killall.rs
@@ -2,7 +2,7 @@ use crate::lib::{environment::Environment, error::DfxResult};
 
 use anyhow::Error;
 use clap::Parser;
-use dfx_core::config::cache::get_bin_cache_root;
+use dfx_core::config::cache::get_or_create_cache_versions_root;
 use slog::info;
 use sysinfo::{ProcessExt, System, SystemExt};
 
@@ -24,7 +24,7 @@ pub fn exec(env: &dyn Environment, _: KillallOpts) -> DfxResult {
     }
     // then, kill anything that was installed alongside dfx
     info.refresh_processes();
-    let versions_dir = get_bin_cache_root()?;
+    let versions_dir = get_or_create_cache_versions_root()?;
     for (pid, proc) in info.processes() {
         if *pid != self_pid && proc.exe().starts_with(&versions_dir) {
             n += 1;

--- a/src/dfx/src/commands/killall.rs
+++ b/src/dfx/src/commands/killall.rs
@@ -2,7 +2,7 @@ use crate::lib::{environment::Environment, error::DfxResult};
 
 use anyhow::Error;
 use clap::Parser;
-use dfx_core::config::cache::get_or_create_cache_versions_root;
+use dfx_core::config::cache::ensure_cache_versions_dir;
 use slog::info;
 use sysinfo::{ProcessExt, System, SystemExt};
 
@@ -24,7 +24,7 @@ pub fn exec(env: &dyn Environment, _: KillallOpts) -> DfxResult {
     }
     // then, kill anything that was installed alongside dfx
     info.refresh_processes();
-    let versions_dir = get_or_create_cache_versions_root()?;
+    let versions_dir = ensure_cache_versions_dir()?;
     for (pid, proc) in info.processes() {
         if *pid != self_pid && proc.exe().starts_with(&versions_dir) {
             n += 1;

--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -2,8 +2,8 @@ use crate::config::dfx_version;
 use crate::util;
 use dfx_core;
 use dfx_core::config::cache::{
-    binary_command_from_version, delete_version, get_bin_cache, get_binary_path_from_version,
-    is_version_installed, Cache,
+    binary_command_from_version, delete_version, get_binary_path_from_version,
+    get_cache_dir_for_version, is_version_installed, Cache,
 };
 use dfx_core::error::cache::{
     DeleteCacheError, GetBinaryCommandPathError, InstallCacheError, IsCacheInstalledError,
@@ -75,7 +75,7 @@ impl Cache for DiskBasedCache {
 }
 
 pub fn install_version(v: &str, force: bool) -> Result<PathBuf, InstallCacheError> {
-    let p = get_bin_cache(v)?;
+    let p = get_cache_dir_for_version(v)?;
     if !force && is_version_installed(v).unwrap_or(false) {
         return Ok(p);
     }
@@ -102,7 +102,7 @@ pub fn install_version(v: &str, force: bool) -> Result<PathBuf, InstallCacheErro
             .take(12)
             .map(|byte| byte as char)
             .collect();
-        let temp_p = get_bin_cache(&format!("_{}_{}", v, rand_string))?;
+        let temp_p = get_cache_dir_for_version(&format!("_{}_{}", v, rand_string))?;
         dfx_core::fs::create_dir_all(&temp_p)?;
 
         let mut binary_cache_assets =

--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -75,7 +75,7 @@ impl Cache for DiskBasedCache {
 }
 
 pub fn install_version(v: &str, force: bool) -> Result<PathBuf, InstallCacheError> {
-    let p = get_bin_cache(v).map_err(InstallCacheError::GetBinCache)?;
+    let p = get_bin_cache(v)?;
     if !force && is_version_installed(v).unwrap_or(false) {
         return Ok(p);
     }
@@ -102,8 +102,7 @@ pub fn install_version(v: &str, force: bool) -> Result<PathBuf, InstallCacheErro
             .take(12)
             .map(|byte| byte as char)
             .collect();
-        let temp_p = get_bin_cache(&format!("_{}_{}", v, rand_string))
-            .map_err(InstallCacheError::GetBinCache)?;
+        let temp_p = get_bin_cache(&format!("_{}_{}", v, rand_string))?;
         dfx_core::fs::create_dir_all(&temp_p)?;
 
         let mut binary_cache_assets =

--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -5,7 +5,7 @@ use dfx_core::config::cache::{
     binary_command_from_version, delete_version, get_bin_cache, get_binary_path_from_version,
     is_version_installed, Cache,
 };
-use dfx_core::error::cache::CacheError;
+use dfx_core::error::cache::{CacheError, GetBinaryCommandPathError};
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
@@ -53,14 +53,22 @@ impl Cache for DiskBasedCache {
         delete_version(&self.version_str()).map(|_| {})
     }
 
-    fn get_binary_command_path(&self, binary_name: &str) -> Result<PathBuf, CacheError> {
+    fn get_binary_command_path(
+        &self,
+        binary_name: &str,
+    ) -> Result<PathBuf, GetBinaryCommandPathError> {
         Self::install(&self.version_str())?;
-        get_binary_path_from_version(&self.version_str(), binary_name)
+        let path = get_binary_path_from_version(&self.version_str(), binary_name)?;
+        Ok(path)
     }
 
-    fn get_binary_command(&self, binary_name: &str) -> Result<std::process::Command, CacheError> {
+    fn get_binary_command(
+        &self,
+        binary_name: &str,
+    ) -> Result<std::process::Command, GetBinaryCommandPathError> {
         Self::install(&self.version_str())?;
-        binary_command_from_version(&self.version_str(), binary_name)
+        let path = binary_command_from_version(&self.version_str(), binary_name)?;
+        Ok(path)
     }
 }
 

--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -6,7 +6,7 @@ use dfx_core::config::cache::{
     is_version_installed, Cache,
 };
 use dfx_core::error::cache::{
-    CacheError, DeleteCacheError, GetBinaryCommandPathError, InstallCacheError,
+    DeleteCacheError, GetBinaryCommandPathError, InstallCacheError, IsCacheInstalledError,
 };
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use rand::distributions::Alphanumeric;
@@ -47,7 +47,7 @@ impl Cache for DiskBasedCache {
         format!("{}", self.version)
     }
 
-    fn is_installed(&self) -> Result<bool, CacheError> {
+    fn is_installed(&self) -> Result<bool, IsCacheInstalledError> {
         is_version_installed(&self.version_str())
     }
 

--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -3,7 +3,7 @@ use crate::util;
 use dfx_core;
 use dfx_core::config::cache::{
     binary_command_from_version, delete_version, get_binary_path_from_version,
-    get_cache_dir_for_version, is_version_installed, Cache,
+    is_version_installed, join_cache_dir_for_version, Cache,
 };
 use dfx_core::error::cache::{
     DeleteCacheError, GetBinaryCommandPathError, InstallCacheError, IsCacheInstalledError,
@@ -75,7 +75,7 @@ impl Cache for DiskBasedCache {
 }
 
 pub fn install_version(v: &str, force: bool) -> Result<PathBuf, InstallCacheError> {
-    let p = get_cache_dir_for_version(v)?;
+    let p = join_cache_dir_for_version(v)?;
     if !force && is_version_installed(v).unwrap_or(false) {
         return Ok(p);
     }
@@ -102,7 +102,7 @@ pub fn install_version(v: &str, force: bool) -> Result<PathBuf, InstallCacheErro
             .take(12)
             .map(|byte| byte as char)
             .collect();
-        let temp_p = get_cache_dir_for_version(&format!("_{}_{}", v, rand_string))?;
+        let temp_p = join_cache_dir_for_version(&format!("_{}_{}", v, rand_string))?;
         dfx_core::fs::create_dir_all(&temp_p)?;
 
         let mut binary_cache_assets =

--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -5,7 +5,9 @@ use dfx_core::config::cache::{
     binary_command_from_version, delete_version, get_bin_cache, get_binary_path_from_version,
     is_version_installed, Cache,
 };
-use dfx_core::error::cache::{CacheError, GetBinaryCommandPathError, InstallCacheError};
+use dfx_core::error::cache::{
+    CacheError, DeleteCacheError, GetBinaryCommandPathError, InstallCacheError,
+};
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
@@ -49,7 +51,7 @@ impl Cache for DiskBasedCache {
         is_version_installed(&self.version_str())
     }
 
-    fn delete(&self) -> Result<(), CacheError> {
+    fn delete(&self) -> Result<(), DeleteCacheError> {
         delete_version(&self.version_str()).map(|_| {})
     }
 

--- a/src/dfx/src/config/cache.rs
+++ b/src/dfx/src/config/cache.rs
@@ -2,8 +2,8 @@ use crate::config::dfx_version;
 use crate::util;
 use dfx_core;
 use dfx_core::config::cache::{
-    binary_command_from_version, delete_version, get_binary_path_from_version,
-    is_version_installed, join_cache_dir_for_version, Cache,
+    binary_command_from_version, delete_version, get_bin_cache, get_binary_path_from_version,
+    is_version_installed, Cache,
 };
 use dfx_core::error::cache::{
     DeleteCacheError, GetBinaryCommandPathError, InstallCacheError, IsCacheInstalledError,
@@ -75,7 +75,7 @@ impl Cache for DiskBasedCache {
 }
 
 pub fn install_version(v: &str, force: bool) -> Result<PathBuf, InstallCacheError> {
-    let p = join_cache_dir_for_version(v)?;
+    let p = get_bin_cache(v)?;
     if !force && is_version_installed(v).unwrap_or(false) {
         return Ok(p);
     }
@@ -102,7 +102,7 @@ pub fn install_version(v: &str, force: bool) -> Result<PathBuf, InstallCacheErro
             .take(12)
             .map(|byte| byte as char)
             .collect();
-        let temp_p = join_cache_dir_for_version(&format!("_{}_{}", v, rand_string))?;
+        let temp_p = get_bin_cache(&format!("_{}_{}", v, rand_string))?;
         dfx_core::fs::create_dir_all(&temp_p)?;
 
         let mut binary_cache_assets =


### PR DESCRIPTION
# Description

Split up CacheError into method-specific error types.

Also uses `ensure_dir_exists` and renames `get_bin_cache_root` to `ensure_cache_versions_dir` because that is what it does.  I may follow up with another PR that renames some other methods that currently have similar names but subtle differences.

# How Has This Been Tested?

Covered by existing tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
