### PR TITLE
fix: file not found when installing an extension with no commands

### DIFF
--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -263,12 +263,6 @@ EOF
 }
 EOF
   cat www/arbitrary-2/foo/extension.json
-  cat > www/arbitrary-2/foo/foo <<EOF
-#!/usr/bin/env bash
-
-echo "the foo output"
-EOF
-  chmod +x www/arbitrary-2/foo/foo
 
   cat > www/arbitrary-2/foo/dependencies.json <<EOF
 {
@@ -290,7 +284,125 @@ EOF
 
   mkdir "$ARCHIVE_BASENAME"
   cp www/arbitrary-2/foo/extension.json "$ARCHIVE_BASENAME"
-  cp www/arbitrary-2/foo/foo "$ARCHIVE_BASENAME"
+  tar -czf "$ARCHIVE_BASENAME".tar.gz "$ARCHIVE_BASENAME"
+  rm -rf "$ARCHIVE_BASENAME"
+
+  mkdir -p www/arbitrary/downloads/foo-v0.1.0
+  mv "$ARCHIVE_BASENAME".tar.gz www/arbitrary/downloads/foo-v0.1.0/
+
+  assert_command dfx extension install foo --catalog-url "$CATALOG_URL"
+}
+
+@test "install extension with no subcommands" {
+  start_webserver --directory www
+
+  CATALOG_URL="http://localhost:$E2E_WEB_SERVER_PORT/arbitrary-1/catalog.json"
+  mkdir -p www/arbitrary-1
+  cat > www/arbitrary-1/catalog.json <<EOF
+{
+  "foo": "http://localhost:$E2E_WEB_SERVER_PORT/arbitrary-2/foo/extension.json",
+  "bar": "http://localhost:$E2E_WEB_SERVER_PORT/arbitrary-2/bar/extension.json"
+}
+EOF
+
+
+  EXTENSION_URL="http://localhost:$E2E_WEB_SERVER_PORT/arbitrary-2/foo/extension.json"
+  mkdir -p  www/arbitrary-2/foo/downloads
+
+  cat > www/arbitrary-2/foo/extension.json <<EOF
+{
+  "name": "foo",
+  "version": "0.1.0",
+  "homepage": "https://github.com/dfinity/dfx-extensions",
+  "authors": "DFINITY",
+  "summary": "Test extension for e2e purposes.",
+  "categories": [],
+  "keywords": [],
+  "download_url_template": "http://localhost:$E2E_WEB_SERVER_PORT/arbitrary/downloads/{{tag}}/{{basename}}.{{archive-format}}"
+}
+EOF
+  cat www/arbitrary-2/foo/extension.json
+
+  cat > www/arbitrary-2/foo/dependencies.json <<EOF
+{
+  "0.1.0": {
+    "dfx": {
+      "version": ">=0.8.0"
+    }
+  }
+}
+EOF
+
+  arch=$(get_extension_architecture)
+
+  if [ "$(uname)" == "Darwin" ]; then
+    ARCHIVE_BASENAME="foo-$arch-apple-darwin"
+  else
+    ARCHIVE_BASENAME="foo-$arch-unknown-linux-gnu"
+  fi
+
+  mkdir "$ARCHIVE_BASENAME"
+  cp www/arbitrary-2/foo/extension.json "$ARCHIVE_BASENAME"
+  tar -czf "$ARCHIVE_BASENAME".tar.gz "$ARCHIVE_BASENAME"
+  rm -rf "$ARCHIVE_BASENAME"
+
+  mkdir -p www/arbitrary/downloads/foo-v0.1.0
+  mv "$ARCHIVE_BASENAME".tar.gz www/arbitrary/downloads/foo-v0.1.0/
+
+  assert_command dfx extension install foo --catalog-url "$CATALOG_URL"
+}
+
+@test "install extension with empty subcommands" {
+  start_webserver --directory www
+
+  CATALOG_URL="http://localhost:$E2E_WEB_SERVER_PORT/arbitrary-1/catalog.json"
+  mkdir -p www/arbitrary-1
+  cat > www/arbitrary-1/catalog.json <<EOF
+{
+  "foo": "http://localhost:$E2E_WEB_SERVER_PORT/arbitrary-2/foo/extension.json",
+  "bar": "http://localhost:$E2E_WEB_SERVER_PORT/arbitrary-2/bar/extension.json"
+}
+EOF
+
+
+  EXTENSION_URL="http://localhost:$E2E_WEB_SERVER_PORT/arbitrary-2/foo/extension.json"
+  mkdir -p  www/arbitrary-2/foo/downloads
+
+  cat > www/arbitrary-2/foo/extension.json <<EOF
+{
+  "name": "foo",
+  "version": "0.1.0",
+  "homepage": "https://github.com/dfinity/dfx-extensions",
+  "authors": "DFINITY",
+  "summary": "Test extension for e2e purposes.",
+  "categories": [],
+  "keywords": [],
+  "subcommands": {},
+  "download_url_template": "http://localhost:$E2E_WEB_SERVER_PORT/arbitrary/downloads/{{tag}}/{{basename}}.{{archive-format}}"
+}
+EOF
+  cat www/arbitrary-2/foo/extension.json
+
+  cat > www/arbitrary-2/foo/dependencies.json <<EOF
+{
+  "0.1.0": {
+    "dfx": {
+      "version": ">=0.8.0"
+    }
+  }
+}
+EOF
+
+  arch=$(get_extension_architecture)
+
+  if [ "$(uname)" == "Darwin" ]; then
+    ARCHIVE_BASENAME="foo-$arch-apple-darwin"
+  else
+    ARCHIVE_BASENAME="foo-$arch-unknown-linux-gnu"
+  fi
+
+  mkdir "$ARCHIVE_BASENAME"
+  cp www/arbitrary-2/foo/extension.json "$ARCHIVE_BASENAME"
   tar -czf "$ARCHIVE_BASENAME".tar.gz "$ARCHIVE_BASENAME"
   rm -rf "$ARCHIVE_BASENAME"
 

--- a/src/dfx-core/src/error/extension.rs
+++ b/src/dfx-core/src/error/extension.rs
@@ -204,6 +204,9 @@ pub enum FinalizeInstallationError {
     GetTopLevelDirectory(#[from] GetTopLevelDirectoryError),
 
     #[error(transparent)]
+    LoadExtensionManifest(#[from] LoadExtensionManifestError),
+
+    #[error(transparent)]
     Rename(#[from] RenameError),
 
     #[error(transparent)]

--- a/src/dfx-core/src/extension/manager/install.rs
+++ b/src/dfx-core/src/extension/manager/install.rs
@@ -164,6 +164,7 @@ impl ExtensionManager {
         Ok(temp_dir)
     }
 
+    #[allow(clippy::collapsible-if)]
     fn finalize_installation(
         &self,
         extension_name: &str,

--- a/src/dfx-core/src/extension/manager/install.rs
+++ b/src/dfx-core/src/extension/manager/install.rs
@@ -173,17 +173,23 @@ impl ExtensionManager {
         let effective_extension_dir = &self.get_extension_directory(effective_extension_name);
         let top_level_dir = get_top_level_directory(temp_dir.path())?;
         crate::fs::rename(&top_level_dir, effective_extension_dir)?;
-        if extension_name != effective_extension_name {
-            // rename the binary
-            crate::fs::rename(
-                &effective_extension_dir.join(extension_name),
-                &effective_extension_dir.join(effective_extension_name),
-            )?;
-        }
-        #[cfg(unix)]
+
+        let installed_manifest = ExtensionManifest::load(effective_extension_name, &self.dir)?;
+
+        if matches!(installed_manifest.subcommands, Some(subcommands) if !subcommands.0.is_empty())
         {
-            let bin = effective_extension_dir.join(effective_extension_name);
-            crate::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o500))?;
+            if extension_name != effective_extension_name {
+                // rename the binary
+                crate::fs::rename(
+                    &effective_extension_dir.join(extension_name),
+                    &effective_extension_dir.join(effective_extension_name),
+                )?;
+            }
+            #[cfg(unix)]
+            {
+                let bin = effective_extension_dir.join(effective_extension_name);
+                crate::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o500))?;
+            }
         }
         Ok(())
     }

--- a/src/dfx-core/src/extension/manager/install.rs
+++ b/src/dfx-core/src/extension/manager/install.rs
@@ -164,7 +164,7 @@ impl ExtensionManager {
         Ok(temp_dir)
     }
 
-    #[allow(clippy::collapsible-if)]
+    #[allow(clippy::collapsible_if)]
     fn finalize_installation(
         &self,
         extension_name: &str,


### PR DESCRIPTION
# Description

`dfx extension install` no longer reports `file not found` if installing an extension that does not have any subcommands.

No extensions exist like this yet, so there is nothing to note in the changelog

# How Has This Been Tested?

Added e2e tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
