### PR TITLE
feat: embedding well known canisters at build time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ pem = "1.0.2"
 proptest = "1.0.0"
 reqwest = { version = "0.12.4", default-features = false, features = [
     "rustls-tls",
+    "blocking",
 ] }
 ring = "0.16.11"
 schemars = "0.8"
@@ -72,7 +73,7 @@ tempfile = "3.3.0"
 thiserror = "1.0.24"
 time = "0.3.9"
 tokio = "1.35"
-url = {  version="2.1.0", features=["serde"] }
+url = { version = "2.1.0", features = ["serde"] }
 walkdir = "2.3.2"
 
 [profile.release]

--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 rust-version.workspace = true
+build = "src/build.rs"
+
+[build-dependencies]
+reqwest.workspace = true
 
 [dependencies]
 aes-gcm.workspace = true

--- a/src/dfx-core/src/build.rs
+++ b/src/dfx-core/src/build.rs
@@ -1,0 +1,35 @@
+use std::{env, fs::File, io::Write, path::Path};
+
+const CANISTER_IDS_URL: &str = "https://raw.githubusercontent.com/dfinity/ic/1402bf35308ec9bd87356c26f7c430f49b49423a/rs/nns/canister_ids.json";
+fn define_well_known_canisters() {
+    let well_known_canisters = reqwest::blocking::get(CANISTER_IDS_URL)
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .text()
+        .unwrap();
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let loader_path = Path::new(&out_dir).join("well_known_canisters.rs");
+    let mut f = File::create(loader_path).unwrap();
+    f.write_all(
+        format!(
+            "
+const WELL_KNOWN_CANISTERS: &str = r#\"
+{}
+\"#;
+
+pub fn map_wellknown_canisters() -> CanisterIds {{
+    serde_json::from_str(WELL_KNOWN_CANISTERS).unwrap_or(CanisterIds::new())
+}}
+",
+            well_known_canisters.replace("mainnet", "ic")
+        )
+        .as_bytes(),
+    )
+    .unwrap()
+}
+
+fn main() {
+    define_well_known_canisters();
+}

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -363,6 +363,11 @@ pub fn get_canister_id_and_candid_path(
             return Ok((id, None));
         }
     } else {
+        if env.get_network_descriptor().is_ic {
+            if let Some(id) = canister_id_store.find_in_ids(canister) {
+                return Ok((id, None));
+            }
+        }
         (canister.to_string(), canister_id_store.get(canister)?)
     };
     let config = env.get_config_or_anyhow()?;


### PR DESCRIPTION
# Description

DRE team would highly benefit if we could have a feature like this for well known canisters. Probably others as well. This PR adds a `build.rs`  for dfx-core which creates a file at build time for well known canisters.

Fixes # (issue)

# How Has This Been Tested?

TODO: will adapt if sdk team agrees to push for this. Also will add tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
