### PR TITLE
feat: add fn load_settings_digest to load_settings_digest

### DIFF
--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -42,7 +42,10 @@ tar.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tiny-bip39 = "1.0.0"
-time.workspace = true
+time = { workspace = true, features = [
+    "serde",
+    "serde-human-readable",
+] }
 url.workspace = true
 
 [dev-dependencies]

--- a/src/dfx-core/src/config/model/local_server_descriptor.rs
+++ b/src/dfx-core/src/config/model/local_server_descriptor.rs
@@ -10,7 +10,6 @@ use crate::error::network_config::{
     NetworkConfigError, NetworkConfigError::ParseBindAddressFailed,
 };
 use crate::error::structured_file::StructuredFileError;
-use crate::error::structured_file::StructuredFileError::DeserializeJsonFileFailed;
 use crate::json::load_json_file;
 use crate::json::structure::SerdeVec;
 use serde::{Deserialize, Serialize};
@@ -185,9 +184,7 @@ impl LocalServerDescriptor {
     pub fn load_settings_digest(&mut self) -> Result<(), StructuredFileError> {
         if self.settings_digest.is_none() {
             let network_id_path = self.data_directory.join("network-id");
-            let network_id_contents = crate::fs::read(&network_id_path)?;
-            let network_metadata: NetworkMetadata = serde_json::from_slice(&network_id_contents)
-                .map_err(|e| DeserializeJsonFileFailed(Box::new(network_id_path), e))?;
+            let network_metadata: NetworkMetadata = load_json_file(&network_id_path)?;
             self.settings_digest = Some(network_metadata.settings_digest);
         }
         Ok(())

--- a/src/dfx/src/lib/network/id.rs
+++ b/src/dfx/src/lib/network/id.rs
@@ -1,15 +1,8 @@
 use crate::lib::error::DfxResult;
 use anyhow::Context;
-use dfx_core::config::model::local_server_descriptor::LocalServerDescriptor;
+use dfx_core::config::model::local_server_descriptor::{LocalServerDescriptor, NetworkMetadata};
 use fn_error_context::context;
-use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-
-#[derive(Deserialize, Serialize, Debug)]
-struct NetworkMetadata {
-    created: OffsetDateTime,
-    settings_digest: String,
-}
 
 #[context("Failed write network id to {}.", local_server_descriptor.network_id_path().display())]
 pub fn write_network_id(local_server_descriptor: &LocalServerDescriptor) -> DfxResult {


### PR DESCRIPTION
This PR adds a new function `load_settings_digest` to fetch the settings digest from the `network-id` file in the data directory if no settings digest is set in `LocalServerDescriptor`.

The fix has been tested manually against a development version of the NNS extension.