### PR TITLE
fix: Fix PocketIC domain config

### DIFF
--- a/docs/dfx-json-schema.json
+++ b/docs/dfx-json-schema.json
@@ -730,15 +730,15 @@
     "ConfigDefaultsProxy": {
       "description": "Configuration for the HTTP gateway.",
       "type": "object",
-      "required": [
-        "domain"
-      ],
       "properties": {
         "domain": {
           "description": "A list of domains that can be served. These are used for canister resolution [default: localhost]",
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/SerdeVec_for_String"
+            },
+            {
+              "type": "null"
             }
           ]
         }

--- a/docs/networks-json-schema.json
+++ b/docs/networks-json-schema.json
@@ -107,15 +107,15 @@
     "ConfigDefaultsProxy": {
       "description": "Configuration for the HTTP gateway.",
       "type": "object",
-      "required": [
-        "domain"
-      ],
       "properties": {
         "domain": {
           "description": "A list of domains that can be served. These are used for canister resolution [default: localhost]",
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/SerdeVec_for_String"
+            },
+            {
+              "type": "null"
             }
           ]
         }

--- a/e2e/tests-dfx/frontend.bash
+++ b/e2e/tests-dfx/frontend.bash
@@ -65,6 +65,15 @@ teardown() {
   assert_match "Connection refused"
 }
 
+@test "dfx routes frontend based on subdomain" {
+  dfx_start
+  PORT=$(get_webserver_port)
+  dfx deploy
+  ID=$(dfx canister id e2e_project_frontend)
+  assert_command curl "http://$ID.localhost:$PORT/"
+  assert_match "<head>"
+}
+
 @test "dfx uses .ic-assets.json file provided in src/__project_name__frontend/assets" {
   echo '[{"match": "*", "headers": {"x-key": "x-value"}}]' > src/e2e_project_frontend/assets/.ic-assets.json5
 

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -673,7 +673,7 @@ pub struct ConfigDefaultsReplica {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ConfigDefaultsProxy {
     /// A list of domains that can be served. These are used for canister resolution [default: localhost]
-    pub domain: SerdeVec<String>,
+    pub domain: Option<SerdeVec<String>>,
 }
 
 // Schemars doesn't add the enum value's docstrings. Therefore the explanations have to be up here.

--- a/src/dfx-core/src/config/model/local_server_descriptor.rs
+++ b/src/dfx-core/src/config/model/local_server_descriptor.rs
@@ -265,7 +265,7 @@ impl LocalServerDescriptor {
 
     pub fn with_proxy_domains(self, domains: Vec<String>) -> LocalServerDescriptor {
         let proxy = ConfigDefaultsProxy {
-            domain: SerdeVec::Many(domains),
+            domain: Some(SerdeVec::Many(domains)),
         };
         Self { proxy, ..self }
     }

--- a/src/dfx/src/actors/pocketic_proxy.rs
+++ b/src/dfx/src/actors/pocketic_proxy.rs
@@ -380,6 +380,12 @@ async fn initialize_gateway(
 }
 
 #[cfg(not(unix))]
-async fn initialize_gateway(_: Url, _: Url, _: Vec<String>, _: SocketAddr, _: Logger) -> DfxResult {
+async fn initialize_gateway(
+    _: Url,
+    _: Url,
+    _: Option<Vec<String>>,
+    _: SocketAddr,
+    _: Logger,
+) -> DfxResult {
     bail!("PocketIC gateway not supported on this platform")
 }

--- a/src/dfx/src/actors/pocketic_proxy.rs
+++ b/src/dfx/src/actors/pocketic_proxy.rs
@@ -48,7 +48,7 @@ pub struct PocketIcProxyConfig {
     pub verbose: bool,
 
     /// list of domains that can be served (localhost if none specified)
-    pub domains: Vec<String>,
+    pub domains: Option<Vec<String>>,
 }
 
 /// The configuration for the pocketic_proxy actor.
@@ -226,7 +226,7 @@ fn pocketic_proxy_start_thread(
     pocketic_proxy_port_path: PathBuf,
     receiver: Receiver<()>,
     verbose: bool,
-    domains: Vec<String>,
+    domains: Option<Vec<String>>,
 ) -> DfxResult<std::thread::JoinHandle<()>> {
     let thread_handler = move || {
         loop {
@@ -328,7 +328,7 @@ fn pocketic_proxy_start_thread(
 fn block_on_initialize_gateway(
     pocketic_url: Url,
     replica_url: Url,
-    domains: Vec<String>,
+    domains: Option<Vec<String>>,
     addr: SocketAddr,
     logger: Logger,
 ) -> DfxResult {
@@ -349,7 +349,7 @@ fn block_on_initialize_gateway(
 async fn initialize_gateway(
     pocketic_url: Url,
     replica_url: Url,
-    domains: Vec<String>,
+    domains: Option<Vec<String>>,
     addr: SocketAddr,
     logger: Logger,
 ) -> DfxResult {
@@ -365,7 +365,7 @@ async fn initialize_gateway(
             forward_to: HttpGatewayBackend::Replica(replica_url.to_string()),
             ip_addr: Some(addr.ip().to_string()),
             port: Some(addr.port()),
-            domains: Some(domains),
+            domains,
             https_config: None,
         })
         .send()

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -293,7 +293,11 @@ pub fn exec(
         .log_level
         .unwrap_or_default();
 
-    let proxy_domains = local_server_descriptor.proxy.domain.clone().into_vec();
+    let proxy_domains = local_server_descriptor
+        .proxy
+        .domain
+        .clone()
+        .map(|v| v.into_vec());
 
     let replica_config = {
         let replica_config =


### PR DESCRIPTION
This sets the default domain to `localhost`, so `<canister>.localhost` resumes working.