### PR TITLE
fix: flaky test due to panic in http gateway

### DIFF
--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -55,7 +55,7 @@ set_local_network_bitcoin_enabled() {
   assert_process_exits "$BTC_ADAPTER_PID" 15s
   assert_process_exits "$REPLICA_PID" 15s
 
-  timeout 15s sh -c \
+  timeout 30s sh -c \
     'until dfx ping; do echo waiting for replica to restart; sleep 1; done' \
     || (echo "replica did not restart" && ps aux && exit 1)
   wait_until_replica_healthy

--- a/e2e/tests-dfx/canister_http.bash
+++ b/e2e/tests-dfx/canister_http.bash
@@ -64,7 +64,7 @@ set_shared_local_network_canister_http_empty() {
   assert_process_exits "$CANISTER_HTTP_ADAPTER_PID" 15s
   assert_process_exits "$REPLICA_PID" 15s
 
-  timeout 15s sh -c \
+  timeout 30s sh -c \
     'until dfx ping; do echo waiting for replica to restart; sleep 1; done' \
     || (echo "replica did not restart" && ps aux && exit 1)
   wait_until_replica_healthy


### PR DESCRIPTION
# Description

The new http gateway has some unwrap() calls instead of error checking, and panics on connect failure.  This surfaces in the two tests that this PR updates.

The result is that dfx has to restart the http gateway more than once, until it finally comes up after the replica is healthy.  Sometimes this exceeds the 15 second timeout in these tests.

The panics are fixed in https://github.com/dfinity/ic/pull/1029 but that fix will take a while to land here.

# How Has This Been Tested?

See test failures and later successes in the commits on branch https://github.com/dfinity/sdk/commits/ens/check-flaky-test/

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
