### PR TITLE
chore: update rust template with ic-cdk v0.16.0

### DIFF
--- a/e2e/assets/rust_complex/Cargo.toml
+++ b/e2e/assets/rust_complex/Cargo.toml
@@ -4,5 +4,5 @@ edition = 2021
 resolver = "2"
 
 [workspace.dependencies]
-ic-cdk = "0.15"
+ic-cdk = "0.16"
 candid = "0.10"

--- a/e2e/assets/rust_deps/src/rust_deps/Cargo.toml
+++ b/e2e/assets/rust_deps/src/rust_deps/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.10"
-ic-cdk = "0.12"
+ic-cdk = "0.16"
 
 [build-dependencies]
 ic-cdk-bindgen = "0.1"

--- a/src/dfx/assets/project_templates/rust/src/__backend_name__/Cargo.toml
+++ b/src/dfx/assets/project_templates/rust/src/__backend_name__/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.10"
-ic-cdk = "0.13"
-ic-cdk-timers = "0.7" # Feel free to remove this dependency if you don't need timers
+ic-cdk = "0.16"
+ic-cdk-timers = "0.10" # Feel free to remove this dependency if you don't need timers


### PR DESCRIPTION
Note that the `ic-cdk` dependency of the assets canister is not updated in this PR.