### PR TITLE
refactor: data-driven backend project templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,7 @@ dependencies = [
  "ic-agent",
  "ic-identity-hsm",
  "ic-utils 0.37.1",
+ "itertools 0.10.5",
  "k256 0.11.6",
  "keyring",
  "lazy_static",

--- a/e2e/tests-dfx/new.bash
+++ b/e2e/tests-dfx/new.bash
@@ -35,6 +35,22 @@ teardown() {
   assert_command_fail dfx new 'a:b'
 }
 
+@test "dfx new --help shows possible backend template names" {
+  assert_command dfx new --help
+  assert_match "\[possible values.*motoko.*\]"
+  assert_match "\[possible values.*rust.*\]"
+  assert_match "\[possible values.*kybra.*\]"
+  assert_match "\[possible values.*azle.*\]"
+}
+
+@test "dfx new --type <bad type> shows possible values" {
+  assert_command_fail dfx new --type bad_type
+  assert_match "\[possible values.*motoko.*\]"
+  assert_match "\[possible values.*rust.*\]"
+  assert_match "\[possible values.*kybra.*\]"
+  assert_match "\[possible values.*azle.*\]"
+}
+
 @test "dfx new readmes contain appropriate links" {
   assert_command dfx new --type rust e2e_rust --no-frontend
   assert_command grep "https://docs.rs/ic-cdk" e2e_rust/README.md

--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -26,6 +26,7 @@ humantime-serde = "1.1.1"
 ic-agent.workspace = true
 ic-utils.workspace = true
 ic-identity-hsm.workspace = true
+itertools.workspace = true
 k256 = { version = "0.11.4", features = ["pem"] }
 keyring.workspace = true
 lazy_static.workspace = true

--- a/src/dfx-core/src/config/mod.rs
+++ b/src/dfx-core/src/config/mod.rs
@@ -1,3 +1,4 @@
 pub mod cache;
 pub mod directories;
 pub mod model;
+pub mod project_templates;

--- a/src/dfx-core/src/config/project_templates.rs
+++ b/src/dfx-core/src/config/project_templates.rs
@@ -25,6 +25,9 @@ pub struct ProjectTemplate {
     pub resource_location: ResourceLocation,
     pub category: Category,
     pub sort_order: u32,
+
+    pub update_cargo_lockfile: bool,
+    pub has_js: bool,
 }
 
 type ProjectTemplates = BTreeMap<ProjectTemplateName, ProjectTemplate>;

--- a/src/dfx-core/src/config/project_templates.rs
+++ b/src/dfx-core/src/config/project_templates.rs
@@ -7,6 +7,7 @@ type GetArchiveFn = fn() -> Result<tar::Archive<flate2::read::GzDecoder<&'static
 
 #[derive(Debug, Clone)]
 pub enum ResourceLocation {
+    /// The template's assets are compiled into the dfx binary
     Bundled { get_archive_fn: GetArchiveFn },
 }
 
@@ -20,14 +21,28 @@ pub struct ProjectTemplateName(pub String);
 
 #[derive(Debug, Clone)]
 pub struct ProjectTemplate {
+    /// The name of the template as specified on the command line, for example `--type rust`
     pub name: ProjectTemplateName,
-    pub display: String,
-    pub resource_location: ResourceLocation,
-    pub category: Category,
-    pub sort_order: u32,
 
+    /// The name used for display and sorting
+    pub display: String,
+
+    /// How to obtain the template's files
+    pub resource_location: ResourceLocation,
+
+    /// Used to determine which CLI group (`--type`, `--backend`, `--frontend`)
+    /// as well as for interactive selection
+    pub category: Category,
+
+    /// If true, run `cargo update` after creating the project.
     pub update_cargo_lockfile: bool,
+
+    /// If true, patch in the any_js template files.
     pub has_js: bool,
+
+    /// The sort order of the template. This will be fixed (motoko=0, rust=1, everything else=2)
+    /// and not settable in properties
+    pub sort_order: u32,
 }
 
 type ProjectTemplates = BTreeMap<ProjectTemplateName, ProjectTemplate>;

--- a/src/dfx-core/src/config/project_templates.rs
+++ b/src/dfx-core/src/config/project_templates.rs
@@ -1,0 +1,70 @@
+use itertools::Itertools;
+use std::collections::BTreeMap;
+use std::io;
+use std::sync::OnceLock;
+
+type GetArchiveFn = fn() -> Result<tar::Archive<flate2::read::GzDecoder<&'static [u8]>>, io::Error>;
+
+#[derive(Debug, Clone)]
+pub enum ResourceLocation {
+    Bundled { get_archive_fn: GetArchiveFn },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Category {
+    Backend,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct ProjectTemplateName(pub String);
+
+#[derive(Debug, Clone)]
+pub struct ProjectTemplate {
+    pub name: ProjectTemplateName,
+    pub display: String,
+    pub resource_location: ResourceLocation,
+    pub category: Category,
+    pub sort_order: u32,
+}
+
+type ProjectTemplates = BTreeMap<ProjectTemplateName, ProjectTemplate>;
+
+static PROJECT_TEMPLATES: OnceLock<ProjectTemplates> = OnceLock::new();
+
+pub fn populate(builtin_templates: Vec<ProjectTemplate>) {
+    let templates = builtin_templates
+        .iter()
+        .map(|t| (t.name.clone(), t.clone()))
+        .collect();
+
+    PROJECT_TEMPLATES.set(templates).unwrap();
+}
+
+pub fn get_project_template(name: &ProjectTemplateName) -> ProjectTemplate {
+    PROJECT_TEMPLATES.get().unwrap().get(name).cloned().unwrap()
+}
+
+pub fn get_sorted_templates(category: Category) -> Vec<ProjectTemplate> {
+    PROJECT_TEMPLATES
+        .get()
+        .unwrap()
+        .values()
+        .filter(|t| t.category == category)
+        .cloned()
+        .sorted_by(|a, b| {
+            a.sort_order
+                .cmp(&b.sort_order)
+                .then_with(|| a.display.cmp(&b.display))
+        })
+        .collect()
+}
+
+pub fn project_template_cli_names(category: Category) -> Vec<String> {
+    PROJECT_TEMPLATES
+        .get()
+        .unwrap()
+        .values()
+        .filter(|t| t.category == category)
+        .map(|t| t.name.0.clone())
+        .collect()
+}

--- a/src/dfx-core/src/config/project_templates.rs
+++ b/src/dfx-core/src/config/project_templates.rs
@@ -21,7 +21,8 @@ pub struct ProjectTemplateName(pub String);
 
 #[derive(Debug, Clone)]
 pub struct ProjectTemplate {
-    /// The name of the template as specified on the command line, for example `--type rust`
+    /// The name of the template as specified on the command line,
+    /// for example `--type rust`
     pub name: ProjectTemplateName,
 
     /// The name used for display and sorting
@@ -34,14 +35,16 @@ pub struct ProjectTemplate {
     /// as well as for interactive selection
     pub category: Category,
 
-    /// If true, run `cargo update` after creating the project.
+    /// If true, run `cargo update` after creating the project
     pub update_cargo_lockfile: bool,
 
-    /// If true, patch in the any_js template files.
+    /// If true, patch in the any_js template files
     pub has_js: bool,
 
-    /// The sort order of the template. This will be fixed (motoko=0, rust=1, everything else=2)
-    /// and not settable in properties
+    /// The sort order is fixed rather than settable in properties:
+    /// - motoko=0
+    /// - rust=1
+    /// - everything else=2 (and then by display name)
     pub sort_order: u32,
 }
 

--- a/src/dfx/src/lib/project/mod.rs
+++ b/src/dfx/src/lib/project/mod.rs
@@ -1,2 +1,3 @@
 pub mod import;
 pub mod network_mappings;
+pub mod templates;

--- a/src/dfx/src/lib/project/templates.rs
+++ b/src/dfx/src/lib/project/templates.rs
@@ -1,0 +1,48 @@
+use crate::util::assets;
+use dfx_core::config::project_templates::{
+    Category, ProjectTemplate, ProjectTemplateName, ResourceLocation,
+};
+
+pub fn builtin_templates() -> Vec<ProjectTemplate> {
+    let motoko = ProjectTemplate {
+        name: ProjectTemplateName("motoko".to_string()),
+        display: "Motoko".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_motoko_files,
+        },
+        category: Category::Backend,
+        sort_order: 0,
+    };
+
+    let rust = ProjectTemplate {
+        name: ProjectTemplateName("rust".to_string()),
+        display: "Rust".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_rust_files,
+        },
+        category: Category::Backend,
+        sort_order: 1,
+    };
+
+    let azle = ProjectTemplate {
+        name: ProjectTemplateName("azle".to_string()),
+        display: "Typescript (Azle)".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_azle_files,
+        },
+        category: Category::Backend,
+        sort_order: 2,
+    };
+
+    let kybra = ProjectTemplate {
+        name: ProjectTemplateName("kybra".to_string()),
+        display: "Python (Kybra)".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_kybra_files,
+        },
+        category: Category::Backend,
+        sort_order: 2,
+    };
+
+    vec![motoko, rust, azle, kybra]
+}

--- a/src/dfx/src/lib/project/templates.rs
+++ b/src/dfx/src/lib/project/templates.rs
@@ -12,6 +12,8 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         },
         category: Category::Backend,
         sort_order: 0,
+        update_cargo_lockfile: false,
+        has_js: false,
     };
 
     let rust = ProjectTemplate {
@@ -22,6 +24,8 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         },
         category: Category::Backend,
         sort_order: 1,
+        update_cargo_lockfile: true,
+        has_js: false,
     };
 
     let azle = ProjectTemplate {
@@ -32,6 +36,8 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         },
         category: Category::Backend,
         sort_order: 2,
+        update_cargo_lockfile: false,
+        has_js: true,
     };
 
     let kybra = ProjectTemplate {
@@ -42,6 +48,8 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         },
         category: Category::Backend,
         sort_order: 2,
+        update_cargo_lockfile: false,
+        has_js: false,
     };
 
     vec![motoko, rust, azle, kybra]

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -4,8 +4,10 @@ use crate::lib::diagnosis::{diagnose, Diagnosis};
 use crate::lib::environment::{Environment, EnvironmentImpl};
 use crate::lib::error::DfxResult;
 use crate::lib::logger::{create_root_logger, LoggingMode};
+use crate::lib::project::templates::builtin_templates;
 use anyhow::Error;
 use clap::{ArgAction, CommandFactory, Parser};
+use dfx_core::config::project_templates;
 use dfx_core::extension::installed::InstalledExtensionManifests;
 use dfx_core::extension::manager::ExtensionManager;
 use std::collections::HashMap;
@@ -135,6 +137,7 @@ fn get_args_altered_for_extension_run(
 fn inner_main() -> DfxResult {
     let em = ExtensionManager::new(dfx_version())?;
     let installed_extension_manifests = em.load_installed_extension_manifests()?;
+    project_templates::populate(builtin_templates());
 
     let args = get_args_altered_for_extension_run(&installed_extension_manifests)?;
 

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -195,11 +195,14 @@ pub fn sort_clap_commands(cmd: &mut clap::Command) {
 #[cfg(test)]
 mod tests {
     use clap::CommandFactory;
-
+    use dfx_core::config::project_templates;
     use crate::CliOpts;
+    use crate::lib::project::templates::builtin_templates;
 
     #[test]
     fn validate_cli() {
+        project_templates::populate(builtin_templates());
+
         CliOpts::command().debug_assert();
     }
 }

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -194,10 +194,10 @@ pub fn sort_clap_commands(cmd: &mut clap::Command) {
 
 #[cfg(test)]
 mod tests {
+    use crate::lib::project::templates::builtin_templates;
+    use crate::CliOpts;
     use clap::CommandFactory;
     use dfx_core::config::project_templates;
-    use crate::CliOpts;
-    use crate::lib::project::templates::builtin_templates;
 
     #[test]
     fn validate_cli() {


### PR DESCRIPTION
# Description

Refactors the code that hands backend project templates to be data-driven rather than hardcoded as an enum.

Part of https://dfinity.atlassian.net/browse/SDK-1805

# How Has This Been Tested?

Most is covered by existing e2e.

I added two tests that show that the help and command error output still include the list of possible values. It might seem like these are just making sure that clap works, but an experiment in which I tried to make the `type` variable an `Option<ProjectTemplateName>` turned out to not show the possible values. 


# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
