### PR TITLE
chore: Avoid using git hashes in cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ license = "Apache-2.0"
 [workspace.dependencies]
 candid = "0.10.4"
 candid_parser = "0.1.4"
-ic-agent = { git = "https://github.com/dfinity/agent-rs.git", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
+ic-agent = "0.37"
 ic-asset = { path = "src/canisters/frontend/ic-asset" }
 ic-cdk = "0.13.1"
 ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs.git", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
-ic-utils = { git = "https://github.com/dfinity/agent-rs.git", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
+ic-utils =  "0.37"
 
 aes-gcm = "0.10.3"
 anyhow = "1.0.56"


### PR DESCRIPTION
This makes it difficult for crates that build on the SDK, since they must also use those exact git hashes on pain of having weird incompatible types. The DFX SNS extension is in this boat. Unfortunately it is difficult for the DFX SNS extension to use that exact git hash since it depends on crates in the IC monorepo which also depend on and use ic-agent.
