### PR TITLE
refactor: data-driven frontend, frontend test, and extra project templates

### DIFF
--- a/e2e/tests-dfx/completion.bash
+++ b/e2e/tests-dfx/completion.bash
@@ -94,3 +94,11 @@ teardown() {
   assert_contains "dfx;nns;install"
   assert_contains "dfx;help;sns;deploy"
 }
+
+@test "completion scripts include built-in project template names" {
+  assert_command dfx completion bash
+  assert_contains "motoko"
+  assert_contains "sveltekit"
+  assert_contains "bitcoin"
+  assert_contains "frontend-tests"
+}

--- a/src/dfx-core/src/config/project_templates.rs
+++ b/src/dfx-core/src/config/project_templates.rs
@@ -14,9 +14,12 @@ pub enum ResourceLocation {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Category {
     Backend,
+    Frontend,
+    FrontendTest,
+    Extra,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ProjectTemplateName(pub String);
 
 #[derive(Debug, Clone)]
@@ -41,10 +44,26 @@ pub struct ProjectTemplate {
     /// If true, patch in the any_js template files
     pub has_js: bool,
 
+    /// If true, run npm install
+    pub install_node_dependencies: bool,
+
     /// The sort order is fixed rather than settable in properties:
-    /// - motoko=0
-    /// - rust=1
-    /// - everything else=2 (and then by display name)
+    /// For backend:
+    ///   - motoko=0
+    ///   - rust=1
+    ///   - everything else=2 (and then by display name)
+    /// For frontend:
+    ///   - SvelteKit=0
+    ///   - React=1
+    ///   - Vue=2
+    ///   - Vanilla JS=3
+    ///   - No JS Template=4
+    ///   - everything else=5 (and then by display name)
+    /// For extras:
+    ///   - Internet Identity=0
+    ///   - Bitcoin=1
+    ///   - everything else=2 (and then by display name)
+    ///   - Frontend Tests
     pub sort_order: u32,
 }
 
@@ -63,6 +82,10 @@ pub fn populate(builtin_templates: Vec<ProjectTemplate>) {
 
 pub fn get_project_template(name: &ProjectTemplateName) -> ProjectTemplate {
     PROJECT_TEMPLATES.get().unwrap().get(name).cloned().unwrap()
+}
+
+pub fn find_project_template(name: &ProjectTemplateName) -> Option<ProjectTemplate> {
+    PROJECT_TEMPLATES.get().unwrap().get(name).cloned()
 }
 
 pub fn get_sorted_templates(category: Category) -> Vec<ProjectTemplate> {

--- a/src/dfx/src/lib/project/templates.rs
+++ b/src/dfx/src/lib/project/templates.rs
@@ -14,6 +14,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         sort_order: 0,
         update_cargo_lockfile: false,
         has_js: false,
+        install_node_dependencies: false,
     };
 
     let rust = ProjectTemplate {
@@ -26,6 +27,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         sort_order: 1,
         update_cargo_lockfile: true,
         has_js: false,
+        install_node_dependencies: false,
     };
 
     let azle = ProjectTemplate {
@@ -38,6 +40,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         sort_order: 2,
         update_cargo_lockfile: false,
         has_js: true,
+        install_node_dependencies: false,
     };
 
     let kybra = ProjectTemplate {
@@ -50,7 +53,167 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         sort_order: 2,
         update_cargo_lockfile: false,
         has_js: false,
+        install_node_dependencies: false,
     };
 
-    vec![motoko, rust, azle, kybra]
+    let sveltekit = ProjectTemplate {
+        name: ProjectTemplateName("sveltekit".to_string()),
+        display: "SvelteKit".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_svelte_files,
+        },
+        category: Category::Frontend,
+        sort_order: 0,
+        update_cargo_lockfile: false,
+        has_js: true,
+        install_node_dependencies: true,
+    };
+
+    let react = ProjectTemplate {
+        name: ProjectTemplateName("react".to_string()),
+        display: "React".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_react_files,
+        },
+        category: Category::Frontend,
+        sort_order: 1,
+        update_cargo_lockfile: false,
+        has_js: true,
+        install_node_dependencies: true,
+    };
+
+    let vue = ProjectTemplate {
+        name: ProjectTemplateName("vue".to_string()),
+        display: "Vue".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_vue_files,
+        },
+        category: Category::Frontend,
+        sort_order: 2,
+        update_cargo_lockfile: false,
+        has_js: true,
+        install_node_dependencies: true,
+    };
+
+    let vanilla = ProjectTemplate {
+        name: ProjectTemplateName("vanilla".to_string()),
+        display: "Vanilla JS".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_vanillajs_files,
+        },
+        category: Category::Frontend,
+        sort_order: 3,
+        update_cargo_lockfile: false,
+        has_js: true,
+        install_node_dependencies: true,
+    };
+
+    let simple_assets = ProjectTemplate {
+        name: ProjectTemplateName("simple-assets".to_string()),
+        display: "No JS template".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_assets_files,
+        },
+        category: Category::Frontend,
+        sort_order: 4,
+        update_cargo_lockfile: false,
+        has_js: false,
+        install_node_dependencies: false,
+    };
+
+    let sveltekit_tests = ProjectTemplate {
+        name: ProjectTemplateName("sveltekit-tests".to_string()),
+        display: "SvelteKit Test Files".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_svelte_test_files,
+        },
+        category: Category::FrontendTest,
+        sort_order: 0,
+        update_cargo_lockfile: false,
+        has_js: false,
+        install_node_dependencies: false,
+    };
+
+    let react_tests = ProjectTemplate {
+        name: ProjectTemplateName("react-tests".to_string()),
+        display: "React Test Files".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_react_test_files,
+        },
+        category: Category::FrontendTest,
+        sort_order: 0,
+        update_cargo_lockfile: false,
+        has_js: false,
+        install_node_dependencies: false,
+    };
+
+    let vue_tests = ProjectTemplate {
+        name: ProjectTemplateName("vue-tests".to_string()),
+        display: "Vue Test Files".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_vue_test_files,
+        },
+        category: Category::FrontendTest,
+        sort_order: 0,
+        update_cargo_lockfile: false,
+        has_js: false,
+        install_node_dependencies: false,
+    };
+
+    let vanillajs_tests = ProjectTemplate {
+        name: ProjectTemplateName("vanilla-tests".to_string()),
+        display: "Vanilla JS Test Files".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_vanillajs_test_files,
+        },
+        category: Category::FrontendTest,
+        sort_order: 0,
+        update_cargo_lockfile: false,
+        has_js: false,
+        install_node_dependencies: false,
+    };
+
+    let internet_identity = ProjectTemplate {
+        name: ProjectTemplateName("internet-identity".to_string()),
+        display: "Internet Identity".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_internet_identity_files,
+        },
+        category: Category::Extra,
+        sort_order: 0,
+        update_cargo_lockfile: false,
+        has_js: false,
+        install_node_dependencies: false,
+    };
+
+    let bitcoin = ProjectTemplate {
+        name: ProjectTemplateName("bitcoin".to_string()),
+        display: "Bitcoin (Regtest)".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_bitcoin_files,
+        },
+        category: Category::Extra,
+        sort_order: 1,
+        update_cargo_lockfile: false,
+        has_js: false,
+        install_node_dependencies: false,
+    };
+
+    vec![
+        motoko,
+        rust,
+        azle,
+        kybra,
+        vanilla,
+        sveltekit,
+        vue,
+        react,
+        simple_assets,
+        sveltekit_tests,
+        react_tests,
+        vue_tests,
+        vanillajs_tests,
+        internet_identity,
+        bitcoin,
+    ]
 }


### PR DESCRIPTION
# Description

Refactors the "frontend" and "extras" project templates to be data-driven rather than hardcoded.  This is in preparation for extensions to be able to provide project templates.

Part of https://dfinity.atlassian.net/browse/SDK-1805

# How Has This Been Tested?

Existing tests cover `dfx new` (cli and interactive).  I also tested the interactive flow manually.

Added an e2e test that verifies that the project template options show up in the completion scripts.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
