### PR TITLE
fix: relax content security policy for sveltekit starter (#3902)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ Module hash: 3a533f511b3960b4186e76cf9abfbd8222a2c507456a66ec55671204ee70cae3
 
 # 0.23.0
 
+### fix: relax content security policy for sveltekit starter
+
+We had to roll back part of the increased default security policy for the sveltekit starter due to the framework's use of inline scripts
+
 ### feat: Add canister snapshots
 
 The new `dfx canister snapshot` command can be used to create, apply, and delete snapshots of stopped canisters.

--- a/src/dfx/assets/project_templates/svelte/src/__frontend_name__/static/.ic-assets.json5
+++ b/src/dfx/assets/project_templates/svelte/src/__frontend_name__/static/.ic-assets.json5
@@ -9,6 +9,10 @@
         // Options are: "hardened" | "standard" | "disabled".
         "security_policy": "standard",
 
+        "headers": {
+            "Content-Security-Policy": "default-src 'self';script-src 'self' 'unsafe-eval' 'unsafe-inline';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';style-src-elem * 'unsafe-inline';font-src *;object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;",
+        },
+
         // Uncomment to disable the warning about using the
         // standard security policy, if you understand the risk
         // "disable_security_policy_warning": true,


### PR DESCRIPTION
# Description

We had to roll back part of the increased default security policy for the sveltekit starter due to the framework's use of inline scripts

Part of the 0.23.0 release branch. Porting this over to `master`