### PR TITLE
fix: pin tsc in Svelte starter template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 # 0.24.0
 
+### fix: pin Typescript version in Svelte starter template
+
 ### feat: expose canister upgrade options in CLI
 
 `dfx canister install` and `dfx deploy` takes options `--skip-pre-upgrade` and `--wasm-memory-persistence`.

--- a/src/dfx/assets/project_templates/svelte/src/__frontend_name__/package.json
+++ b/src/dfx/assets/project_templates/svelte/src/__frontend_name__/package.json
@@ -23,7 +23,7 @@
     "sass": "^1.63.6",
     "svelte": "^4.0.1",
     "svelte-check": "^3.4.4",
-    "typescript": "^5.1.3",
+    "typescript": "5.5.4",
     "vite": "^4.3.9",
     "vite-plugin-environment": "^1.1.3"
   }


### PR DESCRIPTION
# Description

A deprecated field in tsconfig.json has been removed, and `dfx build` / `dfx deploy` now fails for these projects.

Fixes [SDKTG-379](https://dfinity.atlassian.net/browse/SDKTG-379)

# How Has This Been Tested?

covered by e2e, manually tested


[SDKTG-379]: https://dfinity.atlassian.net/browse/SDKTG-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ