### PR TITLE
fix: bumps sveltekit starter dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 # 0.24.0
 
+### fix: bumps sveltekit starter dependency versions to prevent typescript config error
+
 ### feat: expose canister upgrade options in CLI
 
 `dfx canister install` and `dfx deploy` takes options `--skip-pre-upgrade` and `--wasm-memory-persistence`.

--- a/src/dfx/assets/project_templates/react_tests/src/__frontend_name__/package.json-patch
+++ b/src/dfx/assets/project_templates/react_tests/src/__frontend_name__/package.json-patch
@@ -17,7 +17,7 @@
     {
         "op": "add",
         "path": "/devDependencies/vitest",
-        "value": "^0.32.2"
+        "value": "^2.0.5"
     },
     {
         "op": "add",

--- a/src/dfx/assets/project_templates/react_tests/src/__frontend_name__/src/tests/App.test.jsx
+++ b/src/dfx/assets/project_templates/react_tests/src/__frontend_name__/src/tests/App.test.jsx
@@ -10,7 +10,7 @@ describe('App', () => {
         <App />
       </StrictMode>,
     );
-    expect(document.body.innerHTML).toMatchInlineSnapshot('"<div><main><img src=\\"/logo2.svg\\" alt=\\"DFINITY logo\\"><br><br><form action=\\"#\\"><label for=\\"name\\">Enter your name: &nbsp;</label><input id=\\"name\\" alt=\\"Name\\" type=\\"text\\"><button type=\\"submit\\">Click Me!</button></form><section id=\\"greeting\\"></section></main></div>"');
+    expect(document.body.innerHTML).toMatchInlineSnapshot('"<div><main><img src="/logo2.svg" alt="DFINITY logo"><br><br><form action="#"><label for="name">Enter your name: &nbsp;</label><input id="name" alt="Name" type="text"><button type="submit">Click Me!</button></form><section id="greeting"></section></main></div>"');
     expect(1).toEqual(1);
   });
 });

--- a/src/dfx/assets/project_templates/svelte/src/__frontend_name__/package.json
+++ b/src/dfx/assets/project_templates/svelte/src/__frontend_name__/package.json
@@ -16,15 +16,15 @@
     "@dfinity/principal": "^1.4.0"
   },
   "devDependencies": {
-    "@sveltejs/adapter-static": "^2.0.0",
-    "@sveltejs/kit": "^1.21.0",
-    "@sveltejs/vite-plugin-svelte": "^2.4.2",
+    "@sveltejs/adapter-static": "^3.0.4",
+    "@sveltejs/kit": "^2.5.26",
+    "@sveltejs/vite-plugin-svelte": "^3.1.2",
     "dotenv": "^16.3.1",
     "sass": "^1.63.6",
-    "svelte": "^4.0.1",
-    "svelte-check": "^3.4.4",
-    "typescript": "^5.1.3",
-    "vite": "^4.3.9",
+    "svelte": "^4.2.19",
+    "svelte-check": "^4.0.1",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.3",
     "vite-plugin-environment": "^1.1.3"
   }
 }

--- a/src/dfx/assets/project_templates/svelte_tests/src/__frontend_name__/package.json-patch
+++ b/src/dfx/assets/project_templates/svelte_tests/src/__frontend_name__/package.json-patch
@@ -1,8 +1,18 @@
 [
     {
         "op": "add",
+        "path": "/devDependencies/@testing-library~1jest-dom",
+        "value": "^5.16.5"
+    },
+    {
+        "op": "add",
         "path": "/devDependencies/cross-fetch",
         "value": "^3.1.6"
+    },
+    {
+        "op": "add",
+        "path": "/devDependencies/jsdom",
+        "value": "^22.1.0"
     },
     {
         "op": "add",

--- a/src/dfx/assets/project_templates/svelte_tests/src/__frontend_name__/package.json-patch
+++ b/src/dfx/assets/project_templates/svelte_tests/src/__frontend_name__/package.json-patch
@@ -1,23 +1,13 @@
 [
     {
         "op": "add",
-        "path": "/devDependencies/@testing-library~1jest-dom",
-        "value": "^5.16.5"
-    },
-    {
-        "op": "add",
         "path": "/devDependencies/cross-fetch",
         "value": "^3.1.6"
     },
     {
         "op": "add",
-        "path": "/devDependencies/jsdom",
-        "value": "^22.1.0"
-    },
-    {
-        "op": "add",
         "path": "/devDependencies/vitest",
-        "value": "^0.32.2"
+        "value": "^2.0.5"
     },
     {
         "op": "add",

--- a/src/dfx/assets/project_templates/svelte_tests/src/__frontend_name__/src/tests/App.test.js
+++ b/src/dfx/assets/project_templates/svelte_tests/src/__frontend_name__/src/tests/App.test.js
@@ -14,6 +14,6 @@ test('mount component', async () => {
   const instance = new App({ target: host, props: {} });
   expect(instance).toBeTruthy();
   expect(host.innerHTML).toMatchInlineSnapshot(
-    '"<main><img src=\\"/logo2.svg\\" alt=\\"DFINITY logo\\"> <br> <br> <form action=\\"#\\"><label for=\\"name\\">Enter your name: &nbsp;</label> <input id=\\"name\\" alt=\\"Name\\" type=\\"text\\"> <button type=\\"submit\\">Click Me!</button></form> <section id=\\"greeting\\"></section></main><!--<+page>-->"',
+    '"<main><img src=\\"/logo2.svg\\" alt=\\"DFINITY logo\\"> <br> <br> <form action=\\"#\\"><label for=\\"name\\">Enter your name: &nbsp;</label> <input id=\\"name\\" alt=\\"Name\\" type=\\"text\\"> <button type=\\"submit\\">Click Me!</button></form> <section id=\\"greeting\\"></section></main>"'
   );
 });

--- a/src/dfx/assets/project_templates/svelte_tests/src/__frontend_name__/src/tests/App.test.js
+++ b/src/dfx/assets/project_templates/svelte_tests/src/__frontend_name__/src/tests/App.test.js
@@ -14,6 +14,6 @@ test('mount component', async () => {
   const instance = new App({ target: host, props: {} });
   expect(instance).toBeTruthy();
   expect(host.innerHTML).toMatchInlineSnapshot(
-    '"<main><img src=\\"/logo2.svg\\" alt=\\"DFINITY logo\\"> <br> <br> <form action=\\"#\\"><label for=\\"name\\">Enter your name: &nbsp;</label> <input id=\\"name\\" alt=\\"Name\\" type=\\"text\\"> <button type=\\"submit\\">Click Me!</button></form> <section id=\\"greeting\\"></section></main>"'
+    '"<main><img src="/logo2.svg" alt="DFINITY logo"> <br> <br> <form action="#"><label for="name">Enter your name: &nbsp;</label> <input id="name" alt="Name" type="text"> <button type="submit">Click Me!</button></form> <section id="greeting"></section></main>"'
   );
 });

--- a/src/dfx/assets/project_templates/vanilla_js/src/__frontend_name__/package.json
+++ b/src/dfx/assets/project_templates/vanilla_js/src/__frontend_name__/package.json
@@ -18,7 +18,7 @@
     "typescript": "^5.1.3",
     "vite": "^4.3.9",
     "vite-plugin-environment": "^1.1.3",
-    "vitest": "^0.32.2"
+    "vitest": "^2.0.5"
   },
   "dependencies": {
     "@dfinity/agent": "^1.4.0",

--- a/src/dfx/assets/project_templates/vanilla_js_tests/src/__frontend_name__/package.json-patch
+++ b/src/dfx/assets/project_templates/vanilla_js_tests/src/__frontend_name__/package.json-patch
@@ -17,7 +17,7 @@
     {
         "op": "add",
         "path": "/devDependencies/vitest",
-        "value": "^0.32.2"
+        "value": "^2.0.5"
     },
     {
         "op": "add",

--- a/src/dfx/assets/project_templates/vue_tests/src/__frontend_name__/package.json-patch
+++ b/src/dfx/assets/project_templates/vue_tests/src/__frontend_name__/package.json-patch
@@ -22,7 +22,7 @@
     {
         "op": "add",
         "path": "/devDependencies/vitest",
-        "value": "^0.32.2"
+        "value": "^2.0.5"
     },
     {
         "op": "add",


### PR DESCRIPTION
to prevent typescript config error

# Checklist:

- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
