### PR TITLE
fix: Rust crate names are underscore in metadata

### DIFF
--- a/src/dfx/src/lib/canister_info/rust.rs
+++ b/src/dfx/src/lib/canister_info/rust.rs
@@ -63,7 +63,8 @@ impl CanisterInfoFactory for RustCanisterInfo {
             (format!("crate `{package}`"), package.clone())
         };
         let mut candidate_targets = package_info.targets.iter().filter(|x| {
-            x.name == crate_name && x.crate_types.iter().any(|c| c == "cdylib" || c == "bin")
+            x.name == crate_name.replace("-", "_")
+                && x.crate_types.iter().any(|c| c == "cdylib" || c == "bin")
         });
         let Some(target) = candidate_targets.next() else {
             if let Some(wrong_type_crate) =


### PR DESCRIPTION
# Description
Rust expresses crate names with both hyphens and underscores but the metadata uses only underscores.  For example, `ic-cdk` is a dependency of the sdk repo, but in `cargo metadata` it appears as `ic_cdk`.  The match rule in `canister_info::rust` doesn't take this into account, causing spurious errors for canisters with hyphens in their name.


Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
