### PR TITLE
chore: add `--cask` in `provision-darwin.sh` when installing `mitmproxy`

### DIFF
--- a/scripts/workflows/provision-darwin.sh
+++ b/scripts/workflows/provision-darwin.sh
@@ -25,7 +25,7 @@ if [ "$E2E_TEST" = "tests-dfx/build_rust.bash" ]; then
 fi
 if [ "$E2E_TEST" = "tests-dfx/certificate.bash" ]; then
      brew fetch --retry --cask mitmproxy
-     brew install --cask mitmproxy
+     brew install --cask mitmproxy --no-quarantine
 fi
 if [ "$E2E_TEST" = "tests-dfx/deps.bash" ]; then
      cargo install cargo-binstall@1.6.9 --locked

--- a/scripts/workflows/provision-darwin.sh
+++ b/scripts/workflows/provision-darwin.sh
@@ -25,7 +25,7 @@ if [ "$E2E_TEST" = "tests-dfx/build_rust.bash" ]; then
 fi
 if [ "$E2E_TEST" = "tests-dfx/certificate.bash" ]; then
      brew fetch --retry mitmproxy
-     brew install mitmproxy
+     brew install --cask mitmproxy
 fi
 if [ "$E2E_TEST" = "tests-dfx/deps.bash" ]; then
      cargo install cargo-binstall@1.6.9 --locked

--- a/scripts/workflows/provision-darwin.sh
+++ b/scripts/workflows/provision-darwin.sh
@@ -24,7 +24,7 @@ if [ "$E2E_TEST" = "tests-dfx/build_rust.bash" ]; then
     cargo uninstall cargo-audit
 fi
 if [ "$E2E_TEST" = "tests-dfx/certificate.bash" ]; then
-     brew fetch --retry mitmproxy
+     brew fetch --retry --cask mitmproxy
      brew install --cask mitmproxy
 fi
 if [ "$E2E_TEST" = "tests-dfx/deps.bash" ]; then


### PR DESCRIPTION
add `--cask` to avoid CI warnings