### PR TITLE
chore: release ic(x)-asset v0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "ic-asset"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "backoff",
  "brotli",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "icx-asset"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
  "ic-asset",
  "ic-cdk",
  "ic-identity-hsm",
- "ic-utils 0.37.1",
+ "ic-utils 0.38.0",
  "ic-wasm",
  "icrc-ledger-types",
  "idl2json",
@@ -1628,7 +1628,7 @@ dependencies = [
  "humantime-serde",
  "ic-agent",
  "ic-identity-hsm",
- "ic-utils 0.37.1",
+ "ic-utils 0.38.0",
  "itertools 0.10.5",
  "k256 0.11.6",
  "keyring",
@@ -2675,8 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.37.1"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def8c34690d68caa452486af1fff4782d2f5a9d4c5b4e0e1afca648c616fa380"
 dependencies = [
  "async-lock 3.3.0",
  "backoff",
@@ -2728,7 +2729,7 @@ dependencies = [
  "globset",
  "hex",
  "ic-agent",
- "ic-utils 0.37.1",
+ "ic-utils 0.38.0",
  "itertools 0.10.5",
  "json5",
  "mime",
@@ -3115,8 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.37.1"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9975ba49e50ccf10d8268b168b9a35da165904f56725a333e8294d7e5f1d92"
 dependencies = [
  "hex",
  "ic-agent",
@@ -3215,8 +3217,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.37.1"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1834f2f91324b7263e0a05b95d385fd109b51efec991f053112d8cd2503d6e"
 dependencies = [
  "candid",
  "hex",
@@ -3284,8 +3287,9 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.37.1"
-source = "git+https://github.com/dfinity/agent-rs.git?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75135bc8838398f2b4a512b900ee1d58fbf34bdedb74aedc0ae772e785535814"
 dependencies = [
  "async-trait",
  "candid",
@@ -3414,7 +3418,7 @@ dependencies = [
  "humantime",
  "ic-agent",
  "ic-asset",
- "ic-utils 0.37.1",
+ "ic-utils 0.38.0",
  "libflate 1.4.0",
  "num-traits",
  "pem 1.1.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "dfx-core"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,9 @@ license = "Apache-2.0"
 [workspace.dependencies]
 candid = "0.10.4"
 candid_parser = "0.1.4"
+dfx-core = { path = "src/dfx-core", version = "0.1.0" }
 ic-agent = "0.38"
-ic-asset = { path = "src/canisters/frontend/ic-asset" }
+ic-asset = { path = "src/canisters/frontend/ic-asset", version = "0.21.0" }
 ic-cdk = "0.13.1"
 ic-identity-hsm = "0.38"
 ic-utils = "0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ license = "Apache-2.0"
 [workspace.dependencies]
 candid = "0.10.4"
 candid_parser = "0.1.4"
-ic-agent = { git = "https://github.com/dfinity/agent-rs.git", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
+ic-agent = "0.38"
 ic-asset = { path = "src/canisters/frontend/ic-asset" }
 ic-cdk = "0.13.1"
-ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs.git", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
-ic-utils = { git = "https://github.com/dfinity/agent-rs.git", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
+ic-identity-hsm = "0.38"
+ic-utils = "0.38"
 
 aes-gcm = "0.10.3"
 anyhow = "1.0.56"

--- a/e2e/tests-dfx/basic-project.bash
+++ b/e2e/tests-dfx/basic-project.bash
@@ -15,9 +15,9 @@ teardown() {
 @test "build + install + call + request-status -- greet_mo" {
   dfx_new hello
   install_asset greet
-  dfx_start
-  dfx canister create --all
-  dfx build
+  dfx_start --artificial-delay 10000
+  dfx canister create hello_backend
+  dfx build hello_backend
   # INSTALL_REQUEST_ID=$(dfx canister install hello_backend --async)
   # dfx canister request-status $INSTALL_REQUEST_ID
   dfx canister install hello_backend

--- a/e2e/tests-dfx/basic-project.bash
+++ b/e2e/tests-dfx/basic-project.bash
@@ -57,9 +57,9 @@ teardown() {
 @test "build + install + call + request-status -- counter_mo" {
   dfx_new hello
   install_asset counter
-  dfx_start
-  dfx canister create --all
-  dfx build
+  dfx_start --artificial-delay 10000
+  dfx canister create hello_backend
+  dfx build hello_backend
   dfx canister install hello_backend
 
   assert_command dfx canister call hello_backend read

--- a/e2e/tests-dfx/request_status.bash
+++ b/e2e/tests-dfx/request_status.bash
@@ -16,9 +16,9 @@ teardown() {
 
 @test "request-status output raw" {
   install_asset greet
-  dfx_start
-  dfx canister create --all
-  dfx build
+  dfx_start --artificial-delay 10000
+  dfx canister create hello_backend
+  dfx build hello_backend
 
   dfx canister install hello_backend
 

--- a/src/canisters/frontend/ic-asset/Cargo.toml
+++ b/src/canisters/frontend/ic-asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-asset"
-version = "0.20.0"
+version = "0.21.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/canisters/frontend/ic-asset/Cargo.toml
+++ b/src/canisters/frontend/ic-asset/Cargo.toml
@@ -16,7 +16,7 @@ backoff.workspace = true
 brotli = "6.0.0"
 candid = { workspace = true }
 derivative = "2.2.0"
-dfx-core = { path = "../../../dfx-core" }
+dfx-core.workspace = true
 flate2.workspace = true
 futures.workspace = true
 futures-intrusive = "0.4.0"

--- a/src/canisters/frontend/icx-asset/Cargo.toml
+++ b/src/canisters/frontend/icx-asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-asset"
-version = "0.20.0"
+version = "0.21.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfx-core"
-version = "0.0.1"
+version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 rust-version.workspace = true
+description = "dfx core library"
+documentation = "https://docs.rs/dfx-core"
+keywords = ["internet-computer", "icp", "dfinity"]
 
 [dependencies]
 aes-gcm.workspace = true

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -52,7 +52,7 @@ console = "0.15.0"
 crc32fast = "1.3.2"
 crossbeam = "0.8.1"
 ctrlc = { version = "3.2.1", features = ["termination"] }
-dfx-core = { path = "../dfx-core" }
+dfx-core.workspace = true
 dialoguer = { workspace = true, features = ["fuzzy-select"] }
 directories-next.workspace = true
 flate2 = { workspace = true, default-features = false, features = ["zlib-ng"] }

--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -285,7 +285,7 @@ pub async fn exec(
                 )
                 .with_context(|| format!("Failed to read Wasm memory limit of {canister_name}."))?;
                 let log_visibility = get_log_visibility(
-                    opts.log_visibility,
+                    opts.log_visibility.clone(),
                     Some(config_interface),
                     Some(canister_name),
                 )

--- a/src/dfx/src/commands/canister/status.rs
+++ b/src/dfx/src/commands/canister/status.rs
@@ -52,8 +52,13 @@ async fn canister_status(
         "Not Set".to_string()
     };
     let log_visibility = match status.settings.log_visibility {
-        LogVisibility::Controllers => "controllers",
-        LogVisibility::Public => "public",
+        LogVisibility::Controllers => "controllers".to_string(),
+        LogVisibility::Public => "public".to_string(),
+        LogVisibility::AllowedViewers(viewers) => {
+            let mut viewers: Vec<_> = viewers.iter().map(Principal::to_text).collect();
+            viewers.sort();
+            format!("allowed viewers: {}", viewers.join(", "))
+        }
     };
 
     println!("Canister status call result for {canister}.\nStatus: {status}\nControllers: {controllers}\nMemory allocation: {memory_allocation}\nCompute allocation: {compute_allocation}\nFreezing threshold: {freezing_threshold}\nMemory Size: {memory_size:?}\nBalance: {balance} Cycles\nReserved: {reserved} Cycles\nReserved cycles limit: {reserved_cycles_limit}\nWasm memory limit: {wasm_memory_limit}\nModule hash: {module_hash}\nNumber of queries: {queries_total}\nInstructions spent in queries: {query_instructions_total}\nTotal query request payload size (bytes): {query_req_payload_total}\nTotal query response payload size (bytes): {query_resp_payload_total}\nLog visibility: {log_visibility}",

--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -158,7 +158,7 @@ pub async fn exec(
         let wasm_memory_limit =
             get_wasm_memory_limit(opts.wasm_memory_limit, config_interface, canister_name)?;
         let log_visibility =
-            get_log_visibility(opts.log_visibility, config_interface, canister_name)?;
+            get_log_visibility(opts.log_visibility.clone(), config_interface, canister_name)?;
         if let Some(added) = &opts.add_controller {
             let status = get_canister_status(env, canister_id, call_sender).await?;
             let mut existing_controllers = status.settings.controllers;
@@ -241,7 +241,7 @@ pub async fn exec(
                 )
                 .with_context(|| format!("Failed to get Wasm memory limit for {canister_name}."))?;
                 let log_visibility = get_log_visibility(
-                    opts.log_visibility,
+                    opts.log_visibility.clone(),
                     Some(config_interface),
                     Some(canister_name),
                 )


### PR DESCRIPTION
Release `ic-asset` and `icx-asset` v0.21.0.

`dfx-core` is versioned and released. And `agent-rs` dependencies are specified with versions instead of git revs.