### PR TITLE
fix: Fix cdylib crate name logic

### DIFF
--- a/src/dfx/src/lib/canister_info/rust.rs
+++ b/src/dfx/src/lib/canister_info/rust.rs
@@ -63,7 +63,10 @@ impl CanisterInfoFactory for RustCanisterInfo {
             (format!("crate `{package}`"), package.clone())
         };
         let mut candidate_targets = package_info.targets.iter().filter(|x| {
-            x.name == crate_name && x.crate_types.iter().any(|c| c == "cdylib" || c == "bin")
+            x.crate_types.iter().any(|c| {
+                (c == "cdylib" && x.name == crate_name.replace('-', "_"))
+                    || (c == "bin" && x.name == crate_name)
+            })
         });
         let Some(target) = candidate_targets.next() else {
             if let Some(wrong_type_crate) =


### PR DESCRIPTION
The current crate selection logic assumes crate name == package name. This is only true for bins, not libs.

Fixes #3919