### PR TITLE
refactor: project template properties

### DIFF
--- a/src/dfx-core/src/config/project_templates.rs
+++ b/src/dfx-core/src/config/project_templates.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 use std::collections::BTreeMap;
+use std::fmt::Display;
 use std::io;
 use std::sync::OnceLock;
 
@@ -17,10 +18,17 @@ pub enum Category {
     Frontend,
     FrontendTest,
     Extra,
+    Support,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ProjectTemplateName(pub String);
+
+impl Display for ProjectTemplateName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct ProjectTemplate {
@@ -38,14 +46,17 @@ pub struct ProjectTemplate {
     /// as well as for interactive selection
     pub category: Category,
 
-    /// If true, run `cargo update` after creating the project
-    pub update_cargo_lockfile: bool,
+    /// Other project templates to patch in alongside this one
+    pub requirements: Vec<ProjectTemplateName>,
 
-    /// If true, patch in the any_js template files
-    pub has_js: bool,
+    /// Run a command after adding the canister to dfx.json
+    pub post_create: Vec<String>,
 
-    /// If true, run npm install
-    pub install_node_dependencies: bool,
+    /// If set, display a spinner while this command runs
+    pub post_create_spinner_message: Option<String>,
+
+    /// If the post-create command fails, display this warning but don't fail
+    pub post_create_failure_warning: Option<String>,
 
     /// The sort order is fixed rather than settable in properties:
     /// For backend:

--- a/src/dfx/src/lib/builders/mod.rs
+++ b/src/dfx/src/lib/builders/mod.rs
@@ -3,6 +3,7 @@ use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;
 use crate::lib::error::{BuildError, DfxError, DfxResult};
 use crate::lib::models::canister::CanisterPool;
+use crate::util::command::direct_or_shell_command;
 use anyhow::{bail, Context};
 use candid::Principal as CanisterId;
 use candid_parser::utils::CandidSource;
@@ -27,7 +28,6 @@ mod motoko;
 mod pull;
 mod rust;
 
-use crate::util::command::direct_or_shell_command;
 pub use custom::custom_download;
 
 #[derive(Debug)]

--- a/src/dfx/src/lib/project/templates.rs
+++ b/src/dfx/src/lib/project/templates.rs
@@ -3,6 +3,12 @@ use dfx_core::config::project_templates::{
     Category, ProjectTemplate, ProjectTemplateName, ResourceLocation,
 };
 
+const NPM_INSTALL: &str = "npm install --quiet --no-progress --workspaces --if-present";
+const NPM_INSTALL_SPINNER_MESSAGE: &str = "Installing node dependencies...";
+const NPM_INSTALL_FAILURE_WARNING: &str =
+    "An error occurred. See the messages above for more details.";
+const CARGO_UPDATE_FAILURE_MESSAGE: &str = "You will need to run it yourself (or a similar command like `cargo vendor`), because `dfx build` will use the --locked flag with Cargo.";
+
 pub fn builtin_templates() -> Vec<ProjectTemplate> {
     let motoko = ProjectTemplate {
         name: ProjectTemplateName("motoko".to_string()),
@@ -11,10 +17,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_motoko_files,
         },
         category: Category::Backend,
+        post_create: vec![],
+        post_create_failure_warning: None,
+        post_create_spinner_message: None,
+        requirements: vec![],
         sort_order: 0,
-        update_cargo_lockfile: false,
-        has_js: false,
-        install_node_dependencies: false,
     };
 
     let rust = ProjectTemplate {
@@ -24,10 +31,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_rust_files,
         },
         category: Category::Backend,
+        post_create: vec!["cargo update".to_string()],
+        post_create_failure_warning: Some(CARGO_UPDATE_FAILURE_MESSAGE.to_string()),
+        post_create_spinner_message: None,
+        requirements: vec![],
         sort_order: 1,
-        update_cargo_lockfile: true,
-        has_js: false,
-        install_node_dependencies: false,
     };
 
     let azle = ProjectTemplate {
@@ -37,10 +45,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_azle_files,
         },
         category: Category::Backend,
+        post_create: vec![],
+        post_create_failure_warning: None,
+        post_create_spinner_message: None,
+        requirements: vec![ProjectTemplateName("dfx_js_base".to_string())],
         sort_order: 2,
-        update_cargo_lockfile: false,
-        has_js: true,
-        install_node_dependencies: false,
     };
 
     let kybra = ProjectTemplate {
@@ -50,10 +59,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_kybra_files,
         },
         category: Category::Backend,
+        post_create: vec![],
+        post_create_failure_warning: None,
+        post_create_spinner_message: None,
+        requirements: vec![],
         sort_order: 2,
-        update_cargo_lockfile: false,
-        has_js: false,
-        install_node_dependencies: false,
     };
 
     let sveltekit = ProjectTemplate {
@@ -63,10 +73,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_svelte_files,
         },
         category: Category::Frontend,
+        post_create: vec![NPM_INSTALL.to_string()],
+        post_create_failure_warning: Some(NPM_INSTALL_FAILURE_WARNING.to_string()),
+        post_create_spinner_message: Some(NPM_INSTALL_SPINNER_MESSAGE.to_string()),
+        requirements: vec![ProjectTemplateName("dfx_js_base".to_string())],
         sort_order: 0,
-        update_cargo_lockfile: false,
-        has_js: true,
-        install_node_dependencies: true,
     };
 
     let react = ProjectTemplate {
@@ -76,10 +87,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_react_files,
         },
         category: Category::Frontend,
+        post_create: vec![NPM_INSTALL.to_string()],
+        post_create_failure_warning: Some(NPM_INSTALL_FAILURE_WARNING.to_string()),
+        post_create_spinner_message: Some(NPM_INSTALL_SPINNER_MESSAGE.to_string()),
+        requirements: vec![ProjectTemplateName("dfx_js_base".to_string())],
         sort_order: 1,
-        update_cargo_lockfile: false,
-        has_js: true,
-        install_node_dependencies: true,
     };
 
     let vue = ProjectTemplate {
@@ -89,10 +101,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_vue_files,
         },
         category: Category::Frontend,
+        post_create: vec![NPM_INSTALL.to_string()],
+        post_create_failure_warning: Some(NPM_INSTALL_FAILURE_WARNING.to_string()),
+        post_create_spinner_message: Some(NPM_INSTALL_SPINNER_MESSAGE.to_string()),
+        requirements: vec![ProjectTemplateName("dfx_js_base".to_string())],
         sort_order: 2,
-        update_cargo_lockfile: false,
-        has_js: true,
-        install_node_dependencies: true,
     };
 
     let vanilla = ProjectTemplate {
@@ -102,10 +115,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_vanillajs_files,
         },
         category: Category::Frontend,
+        post_create: vec![NPM_INSTALL.to_string()],
+        post_create_failure_warning: Some(NPM_INSTALL_FAILURE_WARNING.to_string()),
+        post_create_spinner_message: Some(NPM_INSTALL_SPINNER_MESSAGE.to_string()),
+        requirements: vec![ProjectTemplateName("dfx_js_base".to_string())],
         sort_order: 3,
-        update_cargo_lockfile: false,
-        has_js: true,
-        install_node_dependencies: true,
     };
 
     let simple_assets = ProjectTemplate {
@@ -115,10 +129,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_assets_files,
         },
         category: Category::Frontend,
+        post_create: vec![],
+        post_create_failure_warning: None,
+        post_create_spinner_message: None,
+        requirements: vec![],
         sort_order: 4,
-        update_cargo_lockfile: false,
-        has_js: false,
-        install_node_dependencies: false,
     };
 
     let sveltekit_tests = ProjectTemplate {
@@ -128,10 +143,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_svelte_test_files,
         },
         category: Category::FrontendTest,
+        post_create: vec![],
+        post_create_failure_warning: None,
+        post_create_spinner_message: None,
+        requirements: vec![],
         sort_order: 0,
-        update_cargo_lockfile: false,
-        has_js: false,
-        install_node_dependencies: false,
     };
 
     let react_tests = ProjectTemplate {
@@ -141,10 +157,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_react_test_files,
         },
         category: Category::FrontendTest,
+        post_create: vec![],
+        post_create_failure_warning: None,
+        post_create_spinner_message: None,
+        requirements: vec![],
         sort_order: 0,
-        update_cargo_lockfile: false,
-        has_js: false,
-        install_node_dependencies: false,
     };
 
     let vue_tests = ProjectTemplate {
@@ -154,10 +171,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_vue_test_files,
         },
         category: Category::FrontendTest,
+        post_create: vec![],
+        post_create_failure_warning: None,
+        post_create_spinner_message: None,
+        requirements: vec![],
         sort_order: 0,
-        update_cargo_lockfile: false,
-        has_js: false,
-        install_node_dependencies: false,
     };
 
     let vanillajs_tests = ProjectTemplate {
@@ -167,10 +185,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_vanillajs_test_files,
         },
         category: Category::FrontendTest,
+        post_create: vec![],
+        post_create_failure_warning: None,
+        post_create_spinner_message: None,
+        requirements: vec![],
         sort_order: 0,
-        update_cargo_lockfile: false,
-        has_js: false,
-        install_node_dependencies: false,
     };
 
     let internet_identity = ProjectTemplate {
@@ -180,10 +199,11 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_internet_identity_files,
         },
         category: Category::Extra,
+        post_create: vec![],
+        post_create_failure_warning: None,
+        post_create_spinner_message: None,
+        requirements: vec![],
         sort_order: 0,
-        update_cargo_lockfile: false,
-        has_js: false,
-        install_node_dependencies: false,
     };
 
     let bitcoin = ProjectTemplate {
@@ -193,10 +213,25 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
             get_archive_fn: assets::new_project_bitcoin_files,
         },
         category: Category::Extra,
+        post_create: vec![],
+        post_create_failure_warning: None,
+        post_create_spinner_message: None,
+        requirements: vec![],
         sort_order: 1,
-        update_cargo_lockfile: false,
-        has_js: false,
-        install_node_dependencies: false,
+    };
+
+    let js_base = ProjectTemplate {
+        name: ProjectTemplateName("dfx_js_base".to_string()),
+        display: "<never shown>>".to_string(),
+        resource_location: ResourceLocation::Bundled {
+            get_archive_fn: assets::new_project_js_files,
+        },
+        category: Category::Support,
+        post_create: vec![],
+        post_create_failure_warning: None,
+        post_create_spinner_message: None,
+        requirements: vec![],
+        sort_order: 2,
     };
 
     vec![
@@ -215,5 +250,6 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         vanillajs_tests,
         internet_identity,
         bitcoin,
+        js_base,
     ]
 }


### PR DESCRIPTION
# Description

Reworks the project template properties in preparation for extensions to be able to define them.
New properties:
- `requirements`: Other project templates that this project requires to be patched in also.   Used to patch in the base JS files.
- `post_create`: commands to execute after adding a new canister to the project, like `npm install` or `cargo update`
- `post_create_spinner_message`: some post-create commands hide their output
- `post_create_failurea_warning`: log a warning instead of aborting on error

These replace `has_js`, `update_cargo_lockfile`, and `install_node_dependencies`, which reflected the previous hard-coded behavior.

Fixes https://dfinity.atlassian.net/browse/SDK-1833

# How Has This Been Tested?

Covered by existing CI, and run manually to witness the spinners.'

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
