### PR TITLE
fix: create II subnet when using PocketIC

### DIFF
--- a/src/dfx/src/actors/pocketic.rs
+++ b/src/dfx/src/actors/pocketic.rs
@@ -326,7 +326,7 @@ async fn initialize_pocketic(
     let mut subnet_config_set = ExtendedSubnetConfigSet {
         nns: Some(SubnetSpec::default()),
         sns: Some(SubnetSpec::default()),
-        ii: None,
+        ii: Some(SubnetSpec::default()),
         fiduciary: None,
         bitcoin: None,
         system: vec![],


### PR DESCRIPTION
Unlike fiduciary and bitcoin subnet (or a regular application subnet), PocketIC cannot create the II subnet dynamically (when needed) because the II subnet has been split out of the NNS subnet and PocketIC does not support dynamic subnet creation of subnets that have been split.