### PR TITLE
fix: fetch effective canister id from PocketIC topology

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Check dynamically-linked libraries (macos)
         run: |
           ACTUAL="$(otool -L ${{ matrix.binary_path }}/dfx | awk 'NR > 1{ print $1 }' | grep -v /System/Library/Frameworks | sort | awk -v d=" " '{s=(NR==1?s:s d)$0}END{printf "%s",s}')"
-          EXPECTED="/usr/lib/libSystem.B.dylib /usr/lib/libc++.1.dylib /usr/lib/libiconv.2.dylib /usr/lib/libobjc.A.dylib"
+          EXPECTED="/usr/lib/libSystem.B.dylib /usr/lib/libc++.1.dylib /usr/lib/libiconv.2.dylib"
           echo "Dynamically-linked libraries:"
           echo "  Actual:   $ACTUAL"
           echo "  Expected: $EXPECTED"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Check dynamically-linked libraries (macos)
         run: |
           ACTUAL="$(otool -L ${{ matrix.binary_path }}/dfx | awk 'NR > 1{ print $1 }' | grep -v /System/Library/Frameworks | sort | awk -v d=" " '{s=(NR==1?s:s d)$0}END{printf "%s",s}')"
-          EXPECTED="/usr/lib/libSystem.B.dylib /usr/lib/libc++.1.dylib /usr/lib/libiconv.2.dylib"
+          EXPECTED="/usr/lib/libSystem.B.dylib /usr/lib/libc++.1.dylib /usr/lib/libiconv.2.dylib /usr/lib/libobjc.A.dylib"
           echo "Dynamically-linked libraries:"
           echo "  Actual:   $ACTUAL"
           echo "  Expected: $EXPECTED"

--- a/e2e/tests-dfx/create.bash
+++ b/e2e/tests-dfx/create.bash
@@ -401,9 +401,9 @@ teardown() {
 # The following function decodes a canister id in the textual form into its binary form
 # and is taken from the [IC Interface Specification](https://internetcomputer.org/docs/current/references/ic-interface-spec#principal).
 function textual_decode() {
-  echo -n "$1" | tr -d - | tr a-z A-Z |
+  echo -n "$1" | tr -d - | tr "[:lower:]" "[:upper:]" |
   fold -w 8 | xargs -n1 printf '%-8s' | tr ' ' = |
-  base32 -d | xxd -p | tr -d '\n' | cut -b9- | tr a-z A-Z
+  base32 -d | xxd -p | tr -d '\n' | cut -b9- | tr "[:lower:]" "[:upper:]"
 }
 
 @test "create targets application subnet in PocketIC" {
@@ -420,11 +420,11 @@ function textual_decode() {
   # find application subnet id in the topology
   for subnet_id in $(echo "${TOPOLOGY}" | jq keys[])
   do
-    SUBNET_KIND="$(echo $TOPOLOGY | jq -r ".${subnet_id}.\"subnet_kind\"")"
+    SUBNET_KIND="$(echo "$TOPOLOGY" | jq -r ".${subnet_id}.\"subnet_kind\"")"
     if [ "${SUBNET_KIND}" == "Application" ]
     then
       # find the expected canister id as the beginning of the first canister range of the app subnet
-      EXPECTED_CANISTER_ID_BASE64="$(echo $TOPOLOGY | jq -r ".${subnet_id}.\"canister_ranges\"[0].\"start\".\"canister_id\"")"
+      EXPECTED_CANISTER_ID_BASE64="$(echo "$TOPOLOGY" | jq -r ".${subnet_id}.\"canister_ranges\"[0].\"start\".\"canister_id\"")"
     fi
   done
   # check if the actual canister id matches the expected canister id

--- a/e2e/tests-dfx/create.bash
+++ b/e2e/tests-dfx/create.bash
@@ -397,3 +397,40 @@ teardown() {
   assert_contains "${ALICE_PRINCIPAL}"
   assert_contains "${BOB_PRINCIPAL}"
 }
+
+# The following function decodes a canister id in the textual form into its binary form
+# and is taken from the [IC Interface Specification](https://internetcomputer.org/docs/current/references/ic-interface-spec#principal).
+function textual_decode() {
+  echo -n "$1" | tr -d - | tr a-z A-Z |
+  fold -w 8 | xargs -n1 printf '%-8s' | tr ' ' = |
+  base32 -d | xxd -p | tr -d '\n' | cut -b9- | tr a-z A-Z
+}
+
+@test "create targets application subnet in PocketIC" {
+  [[ ! "$USE_POCKETIC" ]] && skip "skipped for replica: no support for multiple subnets"
+  dfx_start
+  # create the backend canister without a wallet canister so that the backend canister is the only canister ever created
+  assert_command dfx canister create e2e_project_backend --no-wallet
+  # actual canister id
+  CANISTER_ID="$(dfx canister id e2e_project_backend)"
+  # base64 encode the actual canister id
+  CANISTER_ID_BASE64="$(textual_decode "${CANISTER_ID}" | xxd -r -p | base64)"
+  # fetch topology from PocketIC server
+  TOPOLOGY="$(curl "http://127.0.0.1:$(dfx info replica-port)/instances/0/read/topology")"
+  # find application subnet id in the topology
+  for subnet_id in $(echo "${TOPOLOGY}" | jq keys[])
+  do
+    SUBNET_KIND="$(echo $TOPOLOGY | jq -r ".${subnet_id}.\"subnet_kind\"")"
+    if [ "${SUBNET_KIND}" == "Application" ]
+    then
+      # find the expected canister id as the beginning of the first canister range of the app subnet
+      EXPECTED_CANISTER_ID_BASE64="$(echo $TOPOLOGY | jq -r ".${subnet_id}.\"canister_ranges\"[0].\"start\".\"canister_id\"")"
+    fi
+  done
+  # check if the actual canister id matches the expected canister id
+  if [ "${CANISTER_ID_BASE64}" != "${EXPECTED_CANISTER_ID_BASE64}" ]
+  then
+    echo "Canister id ${CANISTER_ID_BASE64} does not match expected canister id ${EXPECTED_CANISTER_ID_BASE64}"
+    exit 1
+  fi
+}

--- a/src/dfx-core/src/config/model/replica_config.rs
+++ b/src/dfx-core/src/config/model/replica_config.rs
@@ -1,4 +1,5 @@
 use crate::config::model::dfinity::{ReplicaLogLevel, ReplicaSubnetType};
+use candid::Principal;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::default::Default;
@@ -192,6 +193,7 @@ pub enum CachedReplicaConfig<'a> {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct CachedConfig<'a> {
     pub replica_rev: String,
+    pub effective_canister_id: Option<Principal>,
     #[serde(flatten)]
     pub config: CachedReplicaConfig<'a>,
 }
@@ -200,23 +202,29 @@ impl<'a> CachedConfig<'a> {
     pub fn replica(config: &'a ReplicaConfig, replica_rev: String) -> Self {
         Self {
             replica_rev,
+            effective_canister_id: None,
             config: CachedReplicaConfig::Replica {
                 config: Cow::Borrowed(config),
             },
         }
     }
-    pub fn pocketic(config: &'a ReplicaConfig, replica_rev: String) -> Self {
+    pub fn pocketic(
+        config: &'a ReplicaConfig,
+        replica_rev: String,
+        effective_canister_id: Option<Principal>,
+    ) -> Self {
         Self {
             replica_rev,
+            effective_canister_id,
             config: CachedReplicaConfig::PocketIc {
                 config: Cow::Borrowed(config),
             },
         }
     }
-    pub fn is_pocketic(&self) -> bool {
-        matches!(self.config, CachedReplicaConfig::PocketIc { .. })
-    }
     pub fn can_share_state(&self, other: &Self) -> bool {
         self == other
+    }
+    pub fn get_effective_canister_id(&self) -> Option<Principal> {
+        self.effective_canister_id
     }
 }

--- a/src/dfx/src/actors/mod.rs
+++ b/src/dfx/src/actors/mod.rs
@@ -203,6 +203,7 @@ pub fn start_pocketic_actor(
 
     let actor_config = pocketic::Config {
         pocketic_path,
+        effective_config_path: local_server_descriptor.effective_config_path(),
         replica_config,
         port: local_server_descriptor.replica.port,
         port_file: pocketic_port_path,

--- a/src/dfx/src/actors/pocketic.rs
+++ b/src/dfx/src/actors/pocketic.rs
@@ -419,7 +419,7 @@ async fn initialize_pocketic(
 }
 
 #[cfg(not(unix))]
-fn initialize_pocketic(_: u16, _: &ReplicaConfig, _: Logger) -> DfxResult<usize> {
+fn initialize_pocketic(_: u16, _: &Path, _: &ReplicaConfig, _: Logger) -> DfxResult<usize> {
     bail!("PocketIC not supported on this platform")
 }
 

--- a/src/dfx/src/actors/pocketic.rs
+++ b/src/dfx/src/actors/pocketic.rs
@@ -4,15 +4,20 @@ use crate::actors::shutdown_controller::signals::outbound::Shutdown;
 use crate::actors::shutdown_controller::signals::ShutdownSubscribe;
 use crate::actors::shutdown_controller::ShutdownController;
 use crate::lib::error::{DfxError, DfxResult};
+#[cfg(unix)]
 use crate::lib::info::replica_rev;
 use actix::{
     Actor, ActorContext, ActorFutureExt, Addr, AsyncContext, Context, Handler, Recipient,
     ResponseActFuture, Running, WrapFuture,
 };
 use anyhow::{anyhow, bail};
+#[cfg(unix)]
 use candid::Principal;
 use crossbeam::channel::{unbounded, Receiver, Sender};
-use dfx_core::config::model::replica_config::{CachedConfig, ReplicaConfig};
+#[cfg(unix)]
+use dfx_core::config::model::replica_config::CachedConfig;
+use dfx_core::config::model::replica_config::ReplicaConfig;
+#[cfg(unix)]
 use dfx_core::json::save_json_file;
 use slog::{debug, error, info, warn, Logger};
 use std::ops::ControlFlow::{self, *};

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -323,7 +323,7 @@ pub fn exec(
     };
 
     let effective_config = if pocketic {
-        CachedConfig::pocketic(&replica_config, replica_rev().into())
+        CachedConfig::pocketic(&replica_config, replica_rev().into(), None)
     } else {
         CachedConfig::replica(&replica_config, replica_rev().into())
     };

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -1,4 +1,3 @@
-use crate::actors::pocketic::POCKETIC_EFFECTIVE_CANISTER_ID;
 use crate::config::cache::DiskBasedCache;
 use crate::config::dfx_version;
 use crate::lib::error::DfxResult;
@@ -298,8 +297,7 @@ impl<'a> AgentEnvironment<'a> {
         let url = network_descriptor.first_provider()?;
         let effective_canister_id = if let Some(d) = &network_descriptor.local_server_descriptor {
             d.effective_config()?
-                .is_some_and(|c| c.is_pocketic())
-                .then_some(POCKETIC_EFFECTIVE_CANISTER_ID)
+                .and_then(|c| c.get_effective_canister_id())
         } else {
             None
         };


### PR DESCRIPTION
# Description

This PR fetches the effective canister id from the PocketIC topology instead of using a hard-coded canister id. The motivation for this fix is that changes to the PocketIC topology (e.g., adding a new subnet) might render the hard-coded canister id not belong to the expected subnet.

# How Has This Been Tested?

A new bash test has been added.