### PR TITLE
chore: bump GH actions to macos-13

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,9 +53,9 @@ jobs:
       matrix:
         # We build a dynamic-linked linux binary because otherwise HSM support fails with:
         #   Error: IO: Dynamic loading not supported
-        os: [macos-12, ubuntu-20.04, ubuntu-22.04, windows-2022]
+        os: [macos-14, ubuntu-20.04, ubuntu-22.04, windows-2022]
         include:
-          - os: macos-12
+          - os: macos-14
             target: x86_64-apple-darwin
             binary_path: target/x86_64-apple-darwin/release/dfx
           - os: ubuntu-20.04
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, ubuntu-20.04, ubuntu-22.04]
+        os: [macos-14, ubuntu-20.04, ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4
       - name: Download dfx binary
@@ -182,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, ubuntu-20.04, ubuntu-22.04]
+        os: [macos-14, ubuntu-20.04, ubuntu-22.04]
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, windows-latest ]
+        os: [ ubuntu-latest, macos-14, windows-latest ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-14, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/prepare-dfx-assets.yml
+++ b/.github/workflows/prepare-dfx-assets.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12 ]
+        os: [ ubuntu-latest, macos-14 ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/prepare-dfx-assets.yml
+++ b/.github/workflows/prepare-dfx-assets.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-14 ]
+        os: [ ubuntu-latest, macos-13 ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
         #   Error: IO: Dynamic loading not supported
         target: [ x86_64-apple-darwin, x86_64-unknown-linux-gnu ]
         include:
-          - os: macos-14
+          - os: macos-13
             target: x86_64-apple-darwin
             binary_path: target/x86_64-apple-darwin/release
             name: x86_64-darwin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
         #   Error: IO: Dynamic loading not supported
         target: [ x86_64-apple-darwin, x86_64-unknown-linux-gnu ]
         include:
-          - os: macos-12
+          - os: macos-14
             target: x86_64-apple-darwin
             binary_path: target/x86_64-apple-darwin/release
             name: x86_64-darwin

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-14 ]
+        os: [ ubuntu-latest, macos-13 ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12 ]
+        os: [ ubuntu-latest, macos-14 ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/scripts/workflows/e2e-matrix.py
+++ b/scripts/workflows/e2e-matrix.py
@@ -16,7 +16,7 @@ test = sorted(test_scripts("dfx") + test_scripts("replica") + test_scripts("icx-
 matrix = {
     "test": test,
     "backend": ["pocketic", "replica"],
-    "os": ["macos-14", "ubuntu-20.04"],
+    "os": ["macos-13", "ubuntu-20.04"],
     "exclude": [
         {
             "backend": "pocketic",

--- a/scripts/workflows/e2e-matrix.py
+++ b/scripts/workflows/e2e-matrix.py
@@ -16,7 +16,7 @@ test = sorted(test_scripts("dfx") + test_scripts("replica") + test_scripts("icx-
 matrix = {
     "test": test,
     "backend": ["pocketic", "replica"],
-    "os": ["macos-12", "ubuntu-20.04"],
+    "os": ["macos-14", "ubuntu-20.04"],
     "exclude": [
         {
             "backend": "pocketic",


### PR DESCRIPTION
`macos-12` support is getting removed - see e.g. [here](https://github.com/actions/runner-images/issues/10721). Bumping all our `macos-12` to `macos-13`