### PR TITLE
chore: improve dfx deploy message.

### DIFF
--- a/e2e/tests-dfx/deploy.bash
+++ b/e2e/tests-dfx/deploy.bash
@@ -187,6 +187,11 @@ teardown() {
   assert_contains "Creating a wallet canister"
 }
 
+@test "deploy without starting returns the correct error message" {
+  assert_command_fail dfx deploy
+  assert_contains "Failed to fetch the root key, did you run 'dfx start' to start the local replica?"
+}
+
 @test "can deploy gzip wasm" {
   jq '.canisters.hello_backend.gzip=true' dfx.json | sponge dfx.json
   dfx_start

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -162,7 +162,9 @@ pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
     let call_sender = CallSender::from(&opts.wallet, env.get_network_descriptor())
         .map_err(|e| anyhow!("Failed to determine call sender: {}", e))?;
 
-    runtime.block_on(fetch_root_key_if_needed(&env))?;
+    // This is where we try to talk to replica first.
+    runtime.block_on(fetch_root_key_if_needed(&env))
+        .map_err(|e| anyhow!("Failed to fetch the root key, did you run 'dfx start' to start the local replica?\n{}", e))?;
 
     runtime.block_on(deploy_canisters(
         &env,

--- a/src/dfx/src/commands/deploy.rs
+++ b/src/dfx/src/commands/deploy.rs
@@ -162,9 +162,7 @@ pub fn exec(env: &dyn Environment, opts: DeployOpts) -> DfxResult {
     let call_sender = CallSender::from(&opts.wallet, env.get_network_descriptor())
         .map_err(|e| anyhow!("Failed to determine call sender: {}", e))?;
 
-    // This is where we try to talk to replica first.
-    runtime.block_on(fetch_root_key_if_needed(&env))
-        .map_err(|e| anyhow!("Failed to fetch the root key, did you run 'dfx start' to start the local replica?\n{}", e))?;
+    runtime.block_on(fetch_root_key_if_needed(&env))?;
 
     runtime.block_on(deploy_canisters(
         &env,

--- a/src/dfx/src/lib/root_key.rs
+++ b/src/dfx/src/lib/root_key.rs
@@ -1,11 +1,12 @@
 use crate::{lib::error::DfxResult, Environment};
-
+use anyhow::anyhow;
 use dfx_core::network::root_key;
 
 pub async fn fetch_root_key_if_needed(env: &dyn Environment) -> DfxResult {
     let agent = env.get_agent();
     let network = env.get_network_descriptor();
-    root_key::fetch_root_key_when_non_mainnet(agent, network).await?;
+    root_key::fetch_root_key_when_non_mainnet(agent, network).await
+        .map_err(|e| anyhow!("Failed to fetch the root key, did you run 'dfx start' to start the local replica?\n{}", e))?;
     Ok(())
 }
 


### PR DESCRIPTION
# Description

Improve `dfx deploy` error message to let users know what to do next.

```
$ dfx deploy
Error: Failed to fetch the root key, did you run 'dfx start' to start the local replica?
An error happened during communication with the replica: error sending request for url (http://127.0.0.1:4943/api/v2/status)
```

Fixes # (issue)

# How Has This Been Tested?

Added an e2e test.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
