### PR TITLE
chore: update command comment

### DIFF
--- a/docs/cli-reference/dfx-identity.mdx
+++ b/docs/cli-reference/dfx-identity.mdx
@@ -136,7 +136,7 @@ dfx identity export alice >generated-id.pem
 
 ## dfx identity import
 
-Use the `dfx identity import` command to create a user identity by importing the user’s key information or security certificate from a PEM file.
+Use the `dfx identity import` command to create a user identity by importing the user’s key information or security certificate from a PEM file or seed phrase file.
 
 *Password policy*: If an identity is imported using `--storage-mode password-protected`, the following requirements apply to the password:
 - The password needs to be longer than 8 characters.

--- a/src/dfx/src/commands/identity/import.rs
+++ b/src/dfx/src/commands/identity/import.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-/// Creates a new identity from a PEM file.
+/// Creates a new identity from a PEM file or seed phrase file.
 #[derive(Parser)]
 pub struct ImportOpts {
     /// The identity to create.


### PR DESCRIPTION
`dfx identity --help` only shows PEM file imports for `dfx identity import` but is actually also capable of handling seed phrase files as well