### PR TITLE
chore: improve error message when local replica not running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+### chore: improve error message when trying to use the local replica when it is not running
+
 ### Frontend canister
 
 Allow setting permissions lists in init arguments just like in upgrade arguments.

--- a/e2e/tests-dfx/error_context.bash
+++ b/e2e/tests-dfx/error_context.bash
@@ -211,3 +211,13 @@ teardown() {
   assert_contains "it did not contain a function that dfx was looking for"
   assert_contains "dfx identity set-wallet <PRINCIPAL> --identity <IDENTITY>"
 }
+
+@test "Local replica not running has nice error messages" {
+  dfx_new
+  assert_command_fail dfx ping local
+  assert_contains "You are trying to connect to the local replica but dfx cannot connect to it."
+  assert_command_fail dfx deploy
+  assert_contains "You are trying to connect to the local replica but dfx cannot connect to it."
+  assert_command_fail dfx canister call um5iw-rqaaa-aaaaq-qaaba-cai some_method
+  assert_contains "You are trying to connect to the local replica but dfx cannot connect to it."
+}


### PR DESCRIPTION
# Description

The current error message for a non-running local replica is not great:

```
Error: Failed while waiting for agent status.
Caused by: An error happened during communication with the replica: error sending request for url (http://127.0.0.1:4943/api/v2/status)
Caused by: error sending request for url (http://127.0.0.1:4943/api/v2/status)
Caused by: client error (Connect)
Caused by: tcp connect error: Connection refused (os error 61)
Caused by: Connection refused (os error 61)
```

This PR adds a nice message explaining in understandable words what the problem is and what to do.

# How Has This Been Tested?

added e2e, some manual testing

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
