### PR TITLE
chore: update agent deps in frontend projects

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -126,6 +126,7 @@ jobs:
           time dfx new smoke
           cd smoke
           time dfx start --background
+          time npm install
           time dfx deploy
           time dfx canister call smoke_backend greet '("fire")'
           time curl --fail http://localhost:"$(dfx info webserver-port)"/sample-asset.txt?canisterId=$(dfx canister id smoke_frontend)
@@ -207,6 +208,7 @@ jobs:
           dfx new e2e_project
           cd e2e_project
           dfx start --background --clean
+          npm install
           dfx deploy 2>&1 | tee deploy.log
           echo FRONTEND_URL=$(grep "_frontend:" deploy.log | grep -Eo "(http|https)://[a-zA-Z0-9./?=_&%:-]*") >> $GITHUB_ENV
           echo CANDID_URL=$(grep "_backend:" deploy.log | grep -Eo "(http|https)://[a-zA-Z0-9./?=_&%:-]*") >> $GITHUB_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+### chore: update agent version in frontend templates. move the dependencies to top-level package.json 
+
 ### chore: improve error message when trying to use the local replica when it is not running
 
 ### Frontend canister

--- a/src/dfx/assets/project_templates/any_js/package.json
+++ b/src/dfx/assets/project_templates/any_js/package.json
@@ -1,16 +1,21 @@
 {
-    "name": "__project_name__",
-    "type": "module",
-    "scripts": {
-        "start": "npm start --workspaces --if-present",
-        "prebuild": "npm run prebuild --workspaces --if-present",
-        "build": "npm run build --workspaces --if-present",
-        "pretest": "npm run prebuild --workspaces --if-present",
-        "test": "npm test --workspaces --if-present"
-    },
-    "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-    },
-    "workspaces": [ ]
+  "name": "__project_name__",
+  "type": "module",
+  "scripts": {
+    "start": "npm start --workspaces --if-present",
+    "prebuild": "npm run prebuild --workspaces --if-present",
+    "build": "npm run build --workspaces --if-present",
+    "pretest": "npm run prebuild --workspaces --if-present",
+    "test": "npm test --workspaces --if-present"
+  },
+  "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=7.0.0"
+  },
+  "dependencies": {
+    "@dfinity/agent": "^2.1.3",
+    "@dfinity/candid": "^2.1.3",
+    "@dfinity/principal": "^2.1.3"
+  },
+  "workspaces": []
 }

--- a/src/dfx/assets/project_templates/react/src/__frontend_name__/package.json
+++ b/src/dfx/assets/project_templates/react/src/__frontend_name__/package.json
@@ -12,10 +12,7 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "@dfinity/agent": "^1.4.0",
-    "@dfinity/candid": "^1.4.0",
-    "@dfinity/principal": "^1.4.0"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.14",

--- a/src/dfx/assets/project_templates/svelte/src/__frontend_name__/package.json
+++ b/src/dfx/assets/project_templates/svelte/src/__frontend_name__/package.json
@@ -11,9 +11,6 @@
     "format": "prettier --write \"src/**/*.{json,js,jsx,ts,tsx,css,scss}\""
   },
   "dependencies": {
-    "@dfinity/agent": "^1.4.0",
-    "@dfinity/candid": "^1.4.0",
-    "@dfinity/principal": "^1.4.0"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.4",

--- a/src/dfx/assets/project_templates/vanilla_js/src/__frontend_name__/package.json
+++ b/src/dfx/assets/project_templates/vanilla_js/src/__frontend_name__/package.json
@@ -21,9 +21,6 @@
     "vitest": "^2.0.5"
   },
   "dependencies": {
-    "@dfinity/agent": "^1.4.0",
-    "@dfinity/candid": "^1.4.0",
-    "@dfinity/principal": "^1.4.0",
     "lit-html": "^2.8.0"
   }
 }

--- a/src/dfx/assets/project_templates/vue/src/__frontend_name__/package.json
+++ b/src/dfx/assets/project_templates/vue/src/__frontend_name__/package.json
@@ -22,9 +22,6 @@
   },
   "dependencies": {
     "pinia": "^2.1.6",
-    "vue": "^3.3.4",
-    "@dfinity/agent": "^1.4.0",
-    "@dfinity/candid": "^1.4.0",
-    "@dfinity/principal": "^1.4.0"
+    "vue": "^3.3.4"
   }
 }


### PR DESCRIPTION
# Description

This PR updates the agent version used in frontend templates generated by `dfx new` and moves the `@dfinity/<package>` dependencies out into the top-level package.json. 

Fixes # (issue)
Some users have reported issues running builds successfully with 2.x versions of the agent, so this resolves those issues.

# How Has This Been Tested?

Manual tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
