### PR TITLE
feat: DfxInterfaceBuilder can provide extension manager

### DIFF
--- a/src/dfx-core/src/error/cache.rs
+++ b/src/dfx-core/src/error/cache.rs
@@ -5,6 +5,7 @@ use crate::error::fs::{
 };
 use crate::error::get_current_exe::GetCurrentExeError;
 use crate::error::get_user_home::GetUserHomeError;
+use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -32,6 +33,18 @@ pub enum EnsureCacheVersionsDirError {
 
     #[error(transparent)]
     GetCacheRoot(#[from] GetCacheRootError),
+}
+
+#[derive(Error, Debug)]
+pub enum GetVersionFromCachePathError {
+    #[error("no filename in cache path '{0}'")]
+    NoCachePathFilename(PathBuf),
+
+    #[error("filename in cache path '{0}' is not valid UTF-8")]
+    CachePathFilenameNotUtf8(PathBuf),
+
+    #[error("cannot parse version from cache path filename")]
+    ParseVersion(#[from] semver::Error),
 }
 
 #[derive(Error, Debug)]

--- a/src/dfx-core/src/error/interface.rs
+++ b/src/dfx-core/src/error/interface.rs
@@ -1,0 +1,18 @@
+use crate::error::extension::NewExtensionManagerError;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum NewExtensionManagerFromCachePathError {
+    #[error("no filename in cache path '{0}'")]
+    NoCachePathFilename(PathBuf),
+
+    #[error("filename in cache path '{0}' is not valid UTF-8")]
+    CachePathFilenameNotUtf8(PathBuf),
+
+    #[error("cannot parse version from cache path filename")]
+    ParseVersion(#[from] semver::Error),
+
+    #[error(transparent)]
+    NewExtensionManager(#[from] NewExtensionManagerError),
+}

--- a/src/dfx-core/src/error/interface.rs
+++ b/src/dfx-core/src/error/interface.rs
@@ -1,17 +1,11 @@
+use crate::error::cache::GetVersionFromCachePathError;
 use crate::error::extension::NewExtensionManagerError;
-use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum NewExtensionManagerFromCachePathError {
-    #[error("no filename in cache path '{0}'")]
-    NoCachePathFilename(PathBuf),
-
-    #[error("filename in cache path '{0}' is not valid UTF-8")]
-    CachePathFilenameNotUtf8(PathBuf),
-
-    #[error("cannot parse version from cache path filename")]
-    ParseVersion(#[from] semver::Error),
+    #[error(transparent)]
+    GetVersionFromCachePath(#[from] GetVersionFromCachePathError),
 
     #[error(transparent)]
     NewExtensionManager(#[from] NewExtensionManagerError),

--- a/src/dfx-core/src/error/mod.rs
+++ b/src/dfx-core/src/error/mod.rs
@@ -12,6 +12,7 @@ pub mod fs;
 pub mod get_current_exe;
 pub mod get_user_home;
 pub mod identity;
+pub mod interface;
 pub mod keyring;
 pub mod load_dfx_config;
 pub mod load_networks_config;

--- a/src/dfx-core/src/interface/builder.rs
+++ b/src/dfx-core/src/interface/builder.rs
@@ -1,3 +1,4 @@
+use crate::config::cache::get_version_from_cache_path;
 use crate::error::extension::NewExtensionManagerError;
 use crate::error::interface::NewExtensionManagerFromCachePathError;
 use crate::extension::manager::ExtensionManager;
@@ -100,20 +101,7 @@ impl DfxInterfaceBuilder {
         self,
         cache_path: &Path,
     ) -> Result<Self, NewExtensionManagerFromCachePathError> {
-        let version = {
-            let version = cache_path
-                .file_name()
-                .ok_or(NewExtensionManagerFromCachePathError::NoCachePathFilename(
-                    cache_path.to_path_buf(),
-                ))?
-                .to_str()
-                .ok_or(
-                    NewExtensionManagerFromCachePathError::CachePathFilenameNotUtf8(
-                        cache_path.to_path_buf(),
-                    ),
-                )?;
-            Version::parse(version)?
-        };
+        let version = get_version_from_cache_path(cache_path)?;
 
         Ok(self.with_extension_manager(version)?)
     }

--- a/src/dfx-core/src/interface/builder.rs
+++ b/src/dfx-core/src/interface/builder.rs
@@ -1,16 +1,16 @@
-use crate::config::cache::get_version_from_cache_path;
-use crate::error::extension::NewExtensionManagerError;
-use crate::error::interface::NewExtensionManagerFromCachePathError;
-use crate::extension::manager::ExtensionManager;
 use crate::{
+    config::cache::get_version_from_cache_path,
     config::model::{
         dfinity::{Config, NetworksConfig},
         network_descriptor::NetworkDescriptor,
     },
     error::{
         builder::{BuildAgentError, BuildDfxInterfaceError, BuildIdentityError},
+        extension::NewExtensionManagerError,
+        interface::NewExtensionManagerFromCachePathError,
         network_config::NetworkConfigError,
     },
+    extension::manager::ExtensionManager,
     identity::{identity_manager::InitializeIdentity, IdentityManager},
     network::{
         provider::{create_network_descriptor, LocalBindDetermination},

--- a/src/dfx-core/src/interface/builder.rs
+++ b/src/dfx-core/src/interface/builder.rs
@@ -1,3 +1,6 @@
+use crate::error::extension::NewExtensionManagerError;
+use crate::error::interface::NewExtensionManagerFromCachePathError;
+use crate::extension::manager::ExtensionManager;
 use crate::{
     config::model::{
         dfinity::{Config, NetworksConfig},
@@ -16,6 +19,8 @@ use crate::{
 };
 use ic_agent::{agent::route_provider::RoundRobinRouteProvider, Agent, Identity};
 use reqwest::Client;
+use semver::Version;
+use std::path::Path;
 use std::sync::Arc;
 
 #[derive(PartialEq)]
@@ -42,14 +47,17 @@ pub struct DfxInterfaceBuilder {
     /// There is no need to set this for the local network, where the root key is fetched by default.
     /// This would typically be set for a testnet, or an alias for the local network.
     force_fetch_root_key_insecure_non_mainnet_only: bool,
+
+    extension_manager: Option<ExtensionManager>,
 }
 
 impl DfxInterfaceBuilder {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             identity: IdentityPicker::Selected,
             network: NetworkPicker::Local,
             force_fetch_root_key_insecure_non_mainnet_only: false,
+            extension_manager: None,
         }
     }
 
@@ -77,6 +85,39 @@ impl DfxInterfaceBuilder {
         self.with_network(NetworkPicker::Named(name.to_string()))
     }
 
+    pub fn with_extension_manager(
+        self,
+        version: Version,
+    ) -> Result<Self, NewExtensionManagerError> {
+        let extension_manager = Some(ExtensionManager::new(&version)?);
+        Ok(Self {
+            extension_manager,
+            ..self
+        })
+    }
+
+    pub fn with_extension_manager_from_cache_path(
+        self,
+        cache_path: &Path,
+    ) -> Result<Self, NewExtensionManagerFromCachePathError> {
+        let version = {
+            let version = cache_path
+                .file_name()
+                .ok_or(NewExtensionManagerFromCachePathError::NoCachePathFilename(
+                    cache_path.to_path_buf(),
+                ))?
+                .to_str()
+                .ok_or(
+                    NewExtensionManagerFromCachePathError::CachePathFilenameNotUtf8(
+                        cache_path.to_path_buf(),
+                    ),
+                )?;
+            Version::parse(version)?
+        };
+
+        Ok(self.with_extension_manager(version)?)
+    }
+
     pub fn with_force_fetch_root_key_insecure_non_mainnet_only(self) -> Self {
         Self {
             force_fetch_root_key_insecure_non_mainnet_only: true,
@@ -88,7 +129,7 @@ impl DfxInterfaceBuilder {
         let fetch_root_key = self.network == NetworkPicker::Local
             || self.force_fetch_root_key_insecure_non_mainnet_only;
         let networks_config = NetworksConfig::new()?;
-        let config = Config::from_current_dir(None)?.map(Arc::new);
+        let config = Config::from_current_dir(self.extension_manager.as_ref())?.map(Arc::new);
         let network_descriptor = self.build_network_descriptor(config.clone(), &networks_config)?;
         let identity = self.build_identity()?;
         let agent = self.build_agent(identity.clone(), &network_descriptor)?;


### PR DESCRIPTION
# Description

`DfxInterfaceBuilder::build` loads dfx.json. If dfx.json has a canister with a type defined by an extension, then it's necessary to provide an ExtensionManager, otherwise the loader won't recognize the canister's `type`.

This adds methods to DfxInterfaceBuilder, as well as a standalone method for extracting the dfx version from the dfx cache path.

Required for https://dfinity.atlassian.net/browse/SDK-1832

# How Has This Been Tested?

Tested in https://github.com/dfinity/dfx-extensions/pull/153

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
