### PR TITLE
chore: release dfx-core 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "dfx-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src/dfx-core/CHANGELOG.md
+++ b/src/dfx-core/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1] - 2024-11-08
+
+### Added
+
+ - get_version_from_cache_path function to get the version from the cache path
+ - DfxInterfaceBuilder: with_extension_manager and with_extension_manager_from_cache_path methods
+
+## [0.1.0] - 2024-09-01
+
+Initial Version

--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfx-core"
-version = "0.1.0"
+version = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Adds methods needed to load dfx.json when an extension defines a canister type referenced by the project.