### PR TITLE
fix: dfx deploy to the playground fails for a fresh project; CLI reads DFX_NETWORK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 # UNRELEASED
 
+### feat: all commands will use the DFX_NETWORK from the environment
+
+If `DFX_NETWORK` is set in the environment, all commands will use that network by default.
+The `--network` parameter will take precedence if provided.
+
+### fix: dfx generate now honors the --network parameter
+This fixes an issue where `dfx deploy --playground` would fail if the project
+had not been previously built for the local network.
+
 ### feat: facade pull ICP, ckBTC, ckETH ledger canisters
 
 The ledger canisters can be pulled even though they are not really "pullable".

--- a/docs/cli-reference/dfx-envars.mdx
+++ b/docs/cli-reference/dfx-envars.mdx
@@ -40,6 +40,11 @@ Use the `DFX_INSTALLATION_ROOT` environment variable to specify a different loca
 
 The `.cache/dfinity/uninstall.sh` script uses this environment variable to identify the root directory for your SDK installation.
 
+## DFX_NETWORK
+
+Use the `DFX_NETWORK` environment variable to specify the network that you want to use when you run `dfx` commands.
+If you pass the `--network` option to a `dfx` command, the value of the `DFX_NETWORK` environment variable is ignored.
+
 ## DFX_VERSION
 
 Use the `DFX_VERSION` environment variable to identify a specific version of the SDK that you want to install.

--- a/e2e/tests-dfx/generate.bash
+++ b/e2e/tests-dfx/generate.bash
@@ -139,14 +139,13 @@ teardown() {
   assert_command dfx generate
 }
 
-@test "dfx generate --network is still valid" {
-  # The option has no effect, but is still accepted to not break existing scripts
+@test "dfx generate --network is accepted" {
   dfx_new hello
   assert_command dfx generate --network local
+  assert_file_exists ".dfx/local/canisters/hello_backend/service.did"
 
-  # Option is not advertised anymore
-  assert_command dfx generate --help
-  assert_not_contains "--network"
+  assert_command dfx generate --playground
+  assert_file_exists ".dfx/playground/canisters/hello_backend/service.did"
 }
 
 @test "dfx generate does not delete source candid file of Rust canister when bindings contains no did" {

--- a/e2e/tests-dfx/playground.bash
+++ b/e2e/tests-dfx/playground.bash
@@ -76,6 +76,20 @@ setup_playground() {
   assert_command dfx canister --playground info "$CANISTER"
 }
 
+@test "deploy fresh project to playground" {
+  cd ..
+  rm -rf hello
+  dfx_new_frontend hello
+
+  [[ "$USE_POCKETIC" ]] && assert_command dfx canister create --all --playground
+  [[ "$USE_POCKETIC" ]] && assert_command dfx ledger fabricate-cycles --t 9999999 --canister hello_backend --playground
+  [[ "$USE_POCKETIC" ]] && assert_command dfx ledger fabricate-cycles --t 9999999 --canister hello_frontend --playground
+
+  assert_command dfx deploy --playground
+  assert_command dfx canister --playground call hello_backend greet '("player")'
+  assert_match "Hello, player!"
+}
+
 @test "Handle timeout correctly" {
   assert_command dfx canister create hello_backend --playground -vv
   assert_match "Reserved canister 'hello_backend'"

--- a/src/dfx/src/commands/generate.rs
+++ b/src/dfx/src/commands/generate.rs
@@ -4,6 +4,7 @@ use crate::lib::builders::BuildConfig;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::models::canister::CanisterPool;
+use crate::lib::network::network_opt::NetworkOpt;
 use clap::Parser;
 use tokio::runtime::Runtime;
 
@@ -14,14 +15,12 @@ pub struct GenerateOpts {
     /// If you do not specify a canister name, generates types for all canisters.
     canister_name: Option<String>,
 
-    // Deprecated/hidden because it had/has no effect.
-    // Cannot use 'hide' on a flattened  object - inlined the flattened network specifier
-    #[arg(long, global = true, hide = true)]
-    network: Option<String>,
+    #[command(flatten)]
+    network: NetworkOpt,
 }
 
 pub fn exec(env: &dyn Environment, opts: GenerateOpts) -> DfxResult {
-    let env = create_anonymous_agent_environment(env, None)?;
+    let env = create_anonymous_agent_environment(env, opts.network.to_network_name())?;
     let log = env.get_logger();
 
     // Read the config.

--- a/src/dfx/src/lib/network/network_opt.rs
+++ b/src/dfx/src/lib/network/network_opt.rs
@@ -9,7 +9,7 @@ pub struct NetworkOpt {
     /// A valid URL (starting with `http:` or `https:`) can be used here, and a special
     /// ephemeral network will be created specifically for this request. E.g.
     /// "http://localhost:12345/" is a valid network name.
-    #[arg(long, global(true), group = "network-select")]
+    #[arg(long, env = "DFX_NETWORK", global(true), group = "network-select")]
     network: Option<String>,
 
     /// Shorthand for --network=playground.


### PR DESCRIPTION
# Description

The `prebuild` step in all of the default projects is `dfx generate`. Since no `--network` parameter was provided, the generate step happens for the `local` network. When deploying with `dfx deploy --playground`, this would only work if at least `dfx build` (to the local network) had been run previously.

This PR makes all commands look for the `DFX_NETWORK` parameter if no `--network` parameter was passed.

Fixes:
 - https://dfinity.atlassian.net/browse/SDK-1882
 - https://dfinity.atlassian.net/browse/SDK-1860
 - https://dfinity.atlassian.net/browse/SDK-1605

# How Has This Been Tested?

Added an e2e test and tested manually.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
