### PR TITLE
chore: enable canister logs tests for PocketIC

### DIFF
--- a/scripts/workflows/e2e-matrix.py
+++ b/scripts/workflows/e2e-matrix.py
@@ -25,10 +25,6 @@ matrix = {
         {
             "backend": "pocketic",
             "test": "dfx/canister_http_adapter"
-        },
-        {
-            "backend": "pocketic",
-            "test": "dfx/canister_logs"
         }
     ]
 }


### PR DESCRIPTION
This PR enables canister logs tests for PocketIC since PocketIC does support canister logs.