### PR TITLE
fix: only bind to webserver port if the user did not specify one explicitly

### DIFF
--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -597,10 +597,10 @@ fn frontend_address(
 ) -> DfxResult<(String, SocketAddr)> {
     let mut address_and_port = local_server_descriptor.bind_address;
 
-    if !background {
+    if !background && address_and_port.port() == 0 {
         // Since the user may have provided port "0", we need to grab a dynamically
-        // allocated port and construct a resuable SocketAddr which the actix
-        // HttpServer will bind to
+        // allocated port and construct a resuable SocketAddr
+        // to which the PocketIC HTTP gateway later binds.
         address_and_port =
             get_reusable_socket_addr(address_and_port.ip(), address_and_port.port())?;
     }


### PR DESCRIPTION
This PR aims to fix spurious errors of the form
```
Error: Failed to get frontend address.
Caused by: Failed to find available socket address
Caused by: Failed to bind socket to 127.0.0.1:8080.
Caused by: Address already in use (os error 48)
```
by only binding to a webserver port if the user did not specify one explicitly (port is equal to zero) and thus a free port is grabbed by the system.