### PR TITLE
test: extension commands with extension defined canister type

### DIFF
--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -25,7 +25,7 @@ teardown() {
 start_and_install_nns() {
   dfx_start_for_nns_install
 
-  dfx extension install nns --version 0.4.3
+  dfx extension install nns --version 0.4.7
   dfx nns install --ledger-accounts "$(dfx ledger account-id --identity cycle-giver)"
 }
 

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -242,7 +242,7 @@ install_extension_from_dfx_extensions_repo() {
   assert_match 'snsx'
 
   assert_command dfx --help
-  assert_match 'snsx.*Toolkit for'
+  assert_match 'snsx.*Initialize, deploy and interact with an SNS'
 
   assert_command dfx snsx --help
 

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -14,8 +14,57 @@ teardown() {
   standard_teardown
 }
 
+@test "run an extension command with a canister type defined by another extension" {
+  install_shared_asset subnet_type/shared_network_settings/system
+  dfx_start_for_nns_install
+
+  install_asset wasm/identity
+  CACHE_DIR=$(dfx cache show)
+  mkdir -p "$CACHE_DIR"/extensions/embera
+  cat > "$CACHE_DIR"/extensions/embera/extension.json <<EOF
+  {
+      "name": "embera",
+      "version": "0.1.0",
+      "homepage": "https://github.com/dfinity/dfx-extensions",
+      "authors": "DFINITY",
+      "summary": "Test extension for e2e purposes.",
+      "categories": [],
+      "keywords": [],
+      "canister_type": {
+       "evaluation_order": [ "wasm" ],
+       "defaults": {
+         "type": "custom",
+         "build": [
+           "echo the embera build step for canister {{canister_name}} with candid {{canister.candid}} and main file {{canister.main}} and gzip is {{canister.gzip}}",
+           "mkdir -p .embera/{{canister_name}}",
+           "cp main.wasm {{canister.wasm}}"
+         ],
+         "gzip": true,
+         "wasm": ".embera/{{canister_name}}/{{canister_name}}.wasm"
+       }
+      }
+  }
+EOF
+  cat > dfx.json <<EOF
+  {
+    "canisters": {
+      "c1": {
+        "type": "embera",
+        "candid": "main.did",
+        "main": "main-file.embera"
+      }
+    }
+  }
+EOF
+
+  dfx extension install nns --version 0.4.7
+  dfx nns install
+}
+
+
 @test "extension canister type" {
-  dfx_start
+  install_shared_asset subnet_type/shared_network_settings/system
+  dfx_start_for_nns_install
 
   install_asset wasm/identity
   CACHE_DIR=$(dfx cache show)
@@ -187,8 +236,8 @@ install_extension_from_dfx_extensions_repo() {
   assert_command dfx extension list
   assert_match 'No extensions installed'
 
-  assert_command dfx extension install "$EXTENSION" --install-as snsx --version 0.2.1
-  assert_contains "Extension 'sns' version 0.2.1 installed successfully, and is available as 'snsx'"
+  assert_command dfx extension install "$EXTENSION" --install-as snsx --version 0.4.7
+  assert_contains "Extension 'sns' version 0.4.7 installed successfully, and is available as 'snsx'"
 
   assert_command dfx extension list
   assert_match 'snsx'

--- a/e2e/tests-dfx/extension.bash
+++ b/e2e/tests-dfx/extension.bash
@@ -63,8 +63,7 @@ EOF
 
 
 @test "extension canister type" {
-  install_shared_asset subnet_type/shared_network_settings/system
-  dfx_start_for_nns_install
+  dfx_start
 
   install_asset wasm/identity
   CACHE_DIR=$(dfx cache show)


### PR DESCRIPTION
# Description

Adds a test that `dfx nns install` works if dfx.json has a canister with a type defined in an extension. Related: https://github.com/dfinity/dfx-extensions/pull/153

Also use a newer nns extension version.

Part of https://dfinity.atlassian.net/browse/SDK-1832

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
