### PR TITLE
fix: address already in use error in dfx start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,6 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-term",
- "socket2 0.5.7",
  "supports-color",
  "sysinfo",
  "tar",

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -104,7 +104,6 @@ shell-words = "1.1.0"
 slog = { workspace = true, features = ["max_level_trace"] }
 slog-async.workspace = true
 slog-term.workspace = true
-socket2 = "0.5.5"
 supports-color = "2.1.0"
 sysinfo = "0.28.4"
 tar.workspace = true

--- a/src/dfx/src/util/mod.rs
+++ b/src/dfx/src/util/mod.rs
@@ -34,7 +34,7 @@ const DECIMAL_POINT: char = '.';
 // thus, we need to recreate SocketAddr with the kernel-provided dynamically allocated port here.
 #[context("Failed to find available socket address")]
 pub fn get_reusable_socket_addr(ip: IpAddr, port: u16) -> DfxResult<SocketAddr> {
-    let listener = TcpListener::bind(&SocketAddr::new(ip, port))
+    let listener = TcpListener::bind(SocketAddr::new(ip, port))
         .with_context(|| format!("Failed to bind socket to {}:{}.", ip, port))?;
     listener
         .local_addr()


### PR DESCRIPTION
This PR fixes errors of the form

```
$ dfx start --clean
Running dfx start for version 0.24.2+rev23.dirty-3b68fe37
Using project-specific network 'local' defined in /home/martin/orbit/dfx.json
Error: Failed to get frontend address.
Caused by: Failed to find available socket address
Caused by: Failed to bind socket to 127.0.0.1:4943.
Caused by: Address already in use (os error 98)
```

observed when restarting dfx shortly after browsing a frontend canister making periodic background requests and stopping dfx.

It has been manually confirmed to fix the issue on Ubuntu 24.04.1 LTS.