### PR TITLE
fix: Do not set NODE_ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+### chore: `dfx deploy --ic` does not set `NODE_ENV` to `production` anymore
+
 # 0.24.3
 
 ### feat: Bitcoin support in PocketIC

--- a/src/dfx/src/lib/builders/assets.rs
+++ b/src/dfx/src/lib/builders/assets.rs
@@ -12,7 +12,6 @@ use anyhow::{anyhow, Context};
 use candid::Principal as CanisterId;
 use console::style;
 use dfx_core::config::cache::Cache;
-use dfx_core::config::model::network_descriptor::NetworkDescriptor;
 use fn_error_context::context;
 use slog::{o, Logger};
 use std::fs;
@@ -212,10 +211,6 @@ fn build_frontend(
 
         if let Some(workspace) = workspace {
             cmd.arg("--workspace").arg(workspace);
-        }
-
-        if NetworkDescriptor::is_ic(network_name, &vec![]) {
-            cmd.env("NODE_ENV", "production");
         }
 
         for (var, value) in vars {


### PR DESCRIPTION
# Description

When deploying to the mainnet, dfx sets the `NODE_ENV` env variable which causes a different behavior with `devDependencies` than when deploying locally. 
To remove this inconsistency between local/remote deployment, we should abstain from setting this variable when deploying to mainnet.