### PR TITLE
chore: stop HTTP gateway gracefully

### DIFF
--- a/src/dfx/src/actors/pocketic_proxy.rs
+++ b/src/dfx/src/actors/pocketic_proxy.rs
@@ -411,6 +411,6 @@ async fn shutdown_pocketic_proxy(port: u16, instance: usize, logger: Logger) -> 
 }
 
 #[cfg(not(unix))]
-fn shutdown_pocketic(_: u16, _: usize, _: Logger) -> DfxResult {
+fn shutdown_pocketic_proxy(_: u16, _: usize, _: Logger) -> DfxResult {
     bail!("PocketIC not supported on this platform")
 }


### PR DESCRIPTION
This PR stops the HTTP gateway gracefully by sending a shutdown request to the PocketIC server before killing the server process.