### PR TITLE
chore: fix dfx cycles convert docs

### DIFF
--- a/docs/cli-reference/dfx-cycles.mdx
+++ b/docs/cli-reference/dfx-cycles.mdx
@@ -135,7 +135,7 @@ You can specify the following arguments for the `dfx cycles convert` command.
 | `--e8s <e8s>`                  | Specify ICP token fractional units—called e8s—as a whole number, where one e8 is the smallest fraction of an ICP token. For example, 1.05000000 is 1 ICP and 5000000 e8s. You can use this option on its own or in conjunction with the `--icp` option. |
 | `--fee <fee>`                  | Specify a transaction fee. The default is 10000 e8s. |
 | `--icp <icp>`                  | Specify ICP tokens as a whole number. You can use this option on its own or in conjunction with `--e8s`. |
-| `--memo <memo>`                | Memo used when depositing the minted cycles. |
+| `--deposit-memo <memo>`        | Memo used when depositing the minted cycles. |
 | `--to-subaccount <subaccount>` | Subaccount where the cycles are deposited. |
 
 ### Examples

--- a/docs/cli-reference/dfx-cycles.mdx
+++ b/docs/cli-reference/dfx-cycles.mdx
@@ -18,8 +18,10 @@ The following subcommands are available:
 
 | Command                               | Description                                                                          |
 |---------------------------------------|--------------------------------------------------------------------------------------|
+| [`approve`](#dfx-cycles-approve)      | Approves a principal to spend cycles on your behalf.                                 |
 | [`balance`](#dfx-cycles-balance)      | Prints the account balance of the user.                                              |
 | [`convert`](#dfx-cycles-convert)      | Convert some of the user's ICP balance into cycles.                                  |
+| [`top-up`](#dfx-cycles-top-up)        | Deposit cycles into a canister.                                                      |
 | [`transfer`](#dfx-cycles-transfer)    | Send cycles to another account.                                                      |
 | `help`                                | Displays usage information message for a specified subcommand.                       |
 


### PR DESCRIPTION
Copy/paste fail when creating docs for `dfx cycles convert --deposit-memo`. Also adding some missing links