### PR TITLE
feat: support --replica for dfx start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Users can surpress this error by setting `export DFX_WARNING=-mainnet_plaintext_
 
 The warning won't display when executing commands like `dfx deploy --playground`.
 
+### feat: support `--replica` in `dfx start`
+
+Added a flag `--replica` to `dfx start`. This flag currently has no effect.
+Once PocketIC becomes the default for `dfx start` this flag will start the replica instead.
+You can use the `--replica` flag already to write scripts that anticipate that change.
+
 # 0.24.3
 
 ### feat: Bitcoin support in PocketIC

--- a/docs/cli-reference/dfx-start.mdx
+++ b/docs/cli-reference/dfx-start.mdx
@@ -25,6 +25,7 @@ You can use the following optional flags with the `dfx start` command.
 | `--enable-bitcoin`       | Enables bitcoin integration.                                                                                                                                                                                                                            |
 | `--enable-canister-http` | Enables canister HTTP requests. (deprecated: now enabled by default)                                                                                                                                                                                    |
 | `--pocketic`             | Runs [PocketIC](https://github.com/dfinity/pocketic) instead of the replica.                                                                                                                                                                            |
+| `--replica`              | Runs the replica instead of [PocketIC](https://github.com/dfinity/pocketic).                                                                                                                                                                            |
 
 ## Options
 

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -85,6 +85,12 @@ pub struct StartOpts {
     /// Runs PocketIC instead of the replica
     #[clap(long, alias = "emulator")]
     pocketic: bool,
+
+    /// Runs the replica instead of pocketic.
+    /// Currently this has no effect.
+    #[clap(long, conflicts_with = "pocketic")]
+    #[allow(unused)]
+    replica: bool,
 }
 
 // The frontend webserver is brought up by the bg process; thus, the fg process
@@ -152,6 +158,7 @@ pub fn exec(
         artificial_delay,
         domain,
         pocketic,
+        replica: _,
     }: StartOpts,
 ) -> DfxResult {
     if !background {


### PR DESCRIPTION
# Description

At some point `dfx start --pocketic` will become the default. This raised the following request:

> Can we please have a flag to say "I don't want pocket IC" available before pocket IC becomes the default? It would allow for a smoother transition.

Introducing `dfx start --replica` in this PR in order to make transitions smoother.

# How Has This Been Tested?

No effects - if it compiles it work

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
