### PR TITLE
refactor: Category to ProjectTemplateCategory

### DIFF
--- a/src/dfx-core/src/config/model/mod.rs
+++ b/src/dfx-core/src/config/model/mod.rs
@@ -5,5 +5,6 @@ pub mod dfinity;
 pub mod extension_canister_type;
 pub mod local_server_descriptor;
 pub mod network_descriptor;
+pub mod project_template;
 pub mod replica_config;
 pub mod settings_digest;

--- a/src/dfx-core/src/config/model/project_template.rs
+++ b/src/dfx-core/src/config/model/project_template.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ProjectTemplateCategory {
+    Backend,
+    Frontend,
+    FrontendTest,
+    Extra,
+    Support,
+}

--- a/src/dfx-core/src/config/project_templates.rs
+++ b/src/dfx-core/src/config/project_templates.rs
@@ -1,3 +1,4 @@
+use crate::config::model::project_template::ProjectTemplateCategory;
 use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::fmt::Display;
@@ -10,15 +11,6 @@ type GetArchiveFn = fn() -> Result<tar::Archive<flate2::read::GzDecoder<&'static
 pub enum ResourceLocation {
     /// The template's assets are compiled into the dfx binary
     Bundled { get_archive_fn: GetArchiveFn },
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Category {
-    Backend,
-    Frontend,
-    FrontendTest,
-    Extra,
-    Support,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -44,7 +36,7 @@ pub struct ProjectTemplate {
 
     /// Used to determine which CLI group (`--type`, `--backend`, `--frontend`)
     /// as well as for interactive selection
-    pub category: Category,
+    pub category: ProjectTemplateCategory,
 
     /// Other project templates to patch in alongside this one
     pub requirements: Vec<ProjectTemplateName>,
@@ -99,7 +91,7 @@ pub fn find_project_template(name: &ProjectTemplateName) -> Option<ProjectTempla
     PROJECT_TEMPLATES.get().unwrap().get(name).cloned()
 }
 
-pub fn get_sorted_templates(category: Category) -> Vec<ProjectTemplate> {
+pub fn get_sorted_templates(category: ProjectTemplateCategory) -> Vec<ProjectTemplate> {
     PROJECT_TEMPLATES
         .get()
         .unwrap()
@@ -114,7 +106,7 @@ pub fn get_sorted_templates(category: Category) -> Vec<ProjectTemplate> {
         .collect()
 }
 
-pub fn project_template_cli_names(category: Category) -> Vec<String> {
+pub fn project_template_cli_names(category: ProjectTemplateCategory) -> Vec<String> {
     PROJECT_TEMPLATES
         .get()
         .unwrap()

--- a/src/dfx/src/commands/new.rs
+++ b/src/dfx/src/commands/new.rs
@@ -11,9 +11,10 @@ use anyhow::{anyhow, bail, ensure, Context, Error};
 use clap::builder::PossibleValuesParser;
 use clap::Parser;
 use console::{style, Style};
+use dfx_core::config::model::project_template::ProjectTemplateCategory as Category;
 use dfx_core::config::project_templates::{
     find_project_template, get_project_template, get_sorted_templates, project_template_cli_names,
-    Category, ProjectTemplate, ProjectTemplateName, ResourceLocation,
+    ProjectTemplate, ProjectTemplateName, ResourceLocation,
 };
 use dfx_core::json::{load_json_file, save_json_file};
 use dialoguer::theme::ColorfulTheme;

--- a/src/dfx/src/lib/project/templates.rs
+++ b/src/dfx/src/lib/project/templates.rs
@@ -1,7 +1,6 @@
 use crate::util::assets;
-use dfx_core::config::project_templates::{
-    Category, ProjectTemplate, ProjectTemplateName, ResourceLocation,
-};
+use dfx_core::config::model::project_template::ProjectTemplateCategory;
+use dfx_core::config::project_templates::{ProjectTemplate, ProjectTemplateName, ResourceLocation};
 
 const NPM_INSTALL: &str = "npm install --quiet --no-progress --workspaces --if-present";
 const NPM_INSTALL_SPINNER_MESSAGE: &str = "Installing node dependencies...";
@@ -16,7 +15,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_motoko_files,
         },
-        category: Category::Backend,
+        category: ProjectTemplateCategory::Backend,
         post_create: vec![],
         post_create_failure_warning: None,
         post_create_spinner_message: None,
@@ -30,7 +29,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_rust_files,
         },
-        category: Category::Backend,
+        category: ProjectTemplateCategory::Backend,
         post_create: vec!["cargo update".to_string()],
         post_create_failure_warning: Some(CARGO_UPDATE_FAILURE_MESSAGE.to_string()),
         post_create_spinner_message: None,
@@ -44,7 +43,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_azle_files,
         },
-        category: Category::Backend,
+        category: ProjectTemplateCategory::Backend,
         post_create: vec![],
         post_create_failure_warning: None,
         post_create_spinner_message: None,
@@ -58,7 +57,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_kybra_files,
         },
-        category: Category::Backend,
+        category: ProjectTemplateCategory::Backend,
         post_create: vec![],
         post_create_failure_warning: None,
         post_create_spinner_message: None,
@@ -72,7 +71,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_svelte_files,
         },
-        category: Category::Frontend,
+        category: ProjectTemplateCategory::Frontend,
         post_create: vec![NPM_INSTALL.to_string()],
         post_create_failure_warning: Some(NPM_INSTALL_FAILURE_WARNING.to_string()),
         post_create_spinner_message: Some(NPM_INSTALL_SPINNER_MESSAGE.to_string()),
@@ -86,7 +85,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_react_files,
         },
-        category: Category::Frontend,
+        category: ProjectTemplateCategory::Frontend,
         post_create: vec![NPM_INSTALL.to_string()],
         post_create_failure_warning: Some(NPM_INSTALL_FAILURE_WARNING.to_string()),
         post_create_spinner_message: Some(NPM_INSTALL_SPINNER_MESSAGE.to_string()),
@@ -100,7 +99,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_vue_files,
         },
-        category: Category::Frontend,
+        category: ProjectTemplateCategory::Frontend,
         post_create: vec![NPM_INSTALL.to_string()],
         post_create_failure_warning: Some(NPM_INSTALL_FAILURE_WARNING.to_string()),
         post_create_spinner_message: Some(NPM_INSTALL_SPINNER_MESSAGE.to_string()),
@@ -114,7 +113,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_vanillajs_files,
         },
-        category: Category::Frontend,
+        category: ProjectTemplateCategory::Frontend,
         post_create: vec![NPM_INSTALL.to_string()],
         post_create_failure_warning: Some(NPM_INSTALL_FAILURE_WARNING.to_string()),
         post_create_spinner_message: Some(NPM_INSTALL_SPINNER_MESSAGE.to_string()),
@@ -128,7 +127,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_assets_files,
         },
-        category: Category::Frontend,
+        category: ProjectTemplateCategory::Frontend,
         post_create: vec![],
         post_create_failure_warning: None,
         post_create_spinner_message: None,
@@ -142,7 +141,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_svelte_test_files,
         },
-        category: Category::FrontendTest,
+        category: ProjectTemplateCategory::FrontendTest,
         post_create: vec![],
         post_create_failure_warning: None,
         post_create_spinner_message: None,
@@ -156,7 +155,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_react_test_files,
         },
-        category: Category::FrontendTest,
+        category: ProjectTemplateCategory::FrontendTest,
         post_create: vec![],
         post_create_failure_warning: None,
         post_create_spinner_message: None,
@@ -170,7 +169,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_vue_test_files,
         },
-        category: Category::FrontendTest,
+        category: ProjectTemplateCategory::FrontendTest,
         post_create: vec![],
         post_create_failure_warning: None,
         post_create_spinner_message: None,
@@ -184,7 +183,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_vanillajs_test_files,
         },
-        category: Category::FrontendTest,
+        category: ProjectTemplateCategory::FrontendTest,
         post_create: vec![],
         post_create_failure_warning: None,
         post_create_spinner_message: None,
@@ -198,7 +197,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_internet_identity_files,
         },
-        category: Category::Extra,
+        category: ProjectTemplateCategory::Extra,
         post_create: vec![],
         post_create_failure_warning: None,
         post_create_spinner_message: None,
@@ -212,7 +211,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_bitcoin_files,
         },
-        category: Category::Extra,
+        category: ProjectTemplateCategory::Extra,
         post_create: vec![],
         post_create_failure_warning: None,
         post_create_spinner_message: None,
@@ -226,7 +225,7 @@ pub fn builtin_templates() -> Vec<ProjectTemplate> {
         resource_location: ResourceLocation::Bundled {
             get_archive_fn: assets::new_project_js_files,
         },
-        category: Category::Support,
+        category: ProjectTemplateCategory::Support,
         post_create: vec![],
         post_create_failure_warning: None,
         post_create_spinner_message: None,


### PR DESCRIPTION
Moves the `Category` type into the config/model package, next to other types serialized from JSON. This will reduce the changes in https://github.com/dfinity/sdk/pull/4012.
