### PR TITLE
fix: commands with --all parameter skip remote canisters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ Added a flag `--replica` to `dfx start`. This flag currently has no effect.
 Once PocketIC becomes the default for `dfx start` this flag will start the replica instead.
 You can use the `--replica` flag already to write scripts that anticipate that change.
 
+### fix: all commands with --all parameter skip remote canisters
+
+This affects the following commands:
+- `dfx canister delete`
+- `dfx canister deposit-cycles`
+- `dfx canister start`
+- `dfx canister status`
+- `dfx canister stop`
+- `dfx canister uninstall-code`
+- `dfx canister update-settings`
+- `dfx ledger fabricate-cycles`
+
 # 0.24.3
 
 ### feat: Bitcoin support in PocketIC

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -458,6 +458,13 @@ current_time_nanoseconds() {
   assert_eq "2399699700000 cycles."
   assert_command dfx canister status e2e_project_backend
   assert_contains "Balance: 3_100_002_100_000 Cycles"
+
+  # deposit-cycles --all skips remote canisters
+  jq '.canisters.remote.remote.id.local="rdmx6-jaaaa-aaaaa-aaadq-cai"' dfx.json | sponge dfx.json
+  assert_command dfx canister deposit-cycles 10000 --all --identity bob
+  assert_contains "Skipping canister 'remote' because it is remote for network 'local'"
+  assert_contains "Depositing 10000 cycles onto e2e_project_backend"
+  assert_not_contains "Depositing 10000 cycles onto remote"
 }
 
 @test "top-up deduplication" {

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -201,6 +201,9 @@ teardown() {
   assert_command jq .remote canister_ids.json
   assert_eq "null"
 
+  assert_command dfx canister update-settings --log-visibility public --all --network actuallylocal
+  assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
+
   assert_command dfx canister stop --all --network actuallylocal
   assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
 

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -201,6 +201,9 @@ teardown() {
   assert_command jq .remote canister_ids.json
   assert_eq "null"
 
+  assert_command dfx canister status --all --network actuallylocal
+  assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
+
   assert_command dfx canister update-settings --log-visibility public --all --network actuallylocal
   assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
 

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -210,6 +210,12 @@ teardown() {
   assert_command dfx canister stop --all --network actuallylocal
   assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
 
+  assert_command dfx canister start --all --network actuallylocal
+  assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
+
+  # have to stop to uninstall
+  assert_command dfx canister stop --all --network actuallylocal
+
   assert_command dfx canister uninstall-code --all --network actuallylocal
   assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
 

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -204,6 +204,9 @@ teardown() {
   assert_command dfx canister stop --all --network actuallylocal
   assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
 
+  assert_command dfx canister uninstall-code --all --network actuallylocal
+  assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
+
   # Assert frontend declarations are actually created
   dfx generate
   assert_file_exists "src/declarations/remote/remote.did"

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -137,7 +137,7 @@ teardown() {
   assert_match "Canister 'remote' is a remote canister on network 'actuallylocal', and cannot be installed from here."
 }
 
-@test "canister create --all, canister install --all skip remote canisters" {
+@test "all commands with --all skip remote canisters" {
   install_asset remote/actual
   dfx_start
   setup_actuallylocal_shared_network
@@ -208,6 +208,11 @@ teardown() {
   assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
 
   assert_command dfx canister uninstall-code --all --network actuallylocal
+  assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
+
+  assert_command dfx build --all --network actuallylocal
+
+  assert_command dfx canister delete --all --network actuallylocal
   assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
 
   # Assert frontend declarations are actually created

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -201,6 +201,9 @@ teardown() {
   assert_command jq .remote canister_ids.json
   assert_eq "null"
 
+  assert_command dfx ledger fabricate-cycles --all --t 100 --network actuallylocal
+  assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
+
   assert_command dfx canister status --all --network actuallylocal
   assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
 

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -201,6 +201,9 @@ teardown() {
   assert_command jq .remote canister_ids.json
   assert_eq "null"
 
+  assert_command dfx canister stop --all --network actuallylocal
+  assert_contains "Skipping canister 'remote' because it is remote for network 'actuallylocal'"
+
   # Assert frontend declarations are actually created
   dfx generate
   assert_file_exists "src/declarations/remote/remote.did"

--- a/e2e/tests-dfx/update_settings.bash
+++ b/e2e/tests-dfx/update_settings.bash
@@ -14,25 +14,6 @@ teardown() {
   standard_teardown
 }
 
-@test "the --all option excludes remote canisters" {
-  dfx_new
-  dfx_start
-  assert_command dfx deploy e2e_project_backend
-  assert_command dfx canister status e2e_project_backend
-
-  jq '.canisters.internet_identity.remote.id.local = "rdmx6-jaaaa-aaaaa-aaadq-cai"' dfx.json | sponge dfx.json
-
-  # Test --all code path.
-  assert_command dfx canister update-settings --log-visibility public --all
-  assert_contains "Skipping canister 'internet_identity' because it is remote for network 'local'"
-  assert_command dfx canister status e2e_project_backend
-  assert_contains "Log visibility: public"
-  assert_command dfx canister update-settings --log-visibility controllers --all
-  assert_command dfx canister status e2e_project_backend
-  assert_contains "Log visibility: controllers"
-
-}
-
 @test "set reserved cycles limit" {
     dfx_start
     assert_command dfx deploy hello_backend

--- a/e2e/tests-dfx/update_settings.bash
+++ b/e2e/tests-dfx/update_settings.bash
@@ -14,6 +14,25 @@ teardown() {
   standard_teardown
 }
 
+@test "the --all option excludes remote canisters" {
+  dfx_new
+  dfx_start
+  assert_command dfx deploy e2e_project_backend
+  assert_command dfx canister status e2e_project_backend
+
+  jq '.canisters.internet_identity.remote.id.local = "rdmx6-jaaaa-aaaaa-aaadq-cai"' dfx.json | sponge dfx.json
+
+  # Test --all code path.
+  assert_command dfx canister update-settings --log-visibility public --all
+  assert_contains "Skipping canister 'internet_identity' because it is remote for network 'local'"
+  assert_command dfx canister status e2e_project_backend
+  assert_contains "Log visibility: public"
+  assert_command dfx canister update-settings --log-visibility controllers --all
+  assert_command dfx canister status e2e_project_backend
+  assert_contains "Log visibility: controllers"
+
+}
+
 @test "set reserved cycles limit" {
     dfx_start
     assert_command dfx deploy hello_backend

--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -6,7 +6,7 @@ use crate::lib::ic_attributes::{
     get_compute_allocation, get_freezing_threshold, get_log_visibility, get_memory_allocation,
     get_reserved_cycles_limit, get_wasm_memory_limit, CanisterSettings,
 };
-use crate::lib::operations::canister::create_canister;
+use crate::lib::operations::canister::{create_canister, skip_remote_canister};
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::util::clap::parsers::{
     compute_allocation_parser, freezing_threshold_parser, log_visibility_parser,
@@ -245,15 +245,7 @@ pub async fn exec(
                 if pull_canisters_in_config.contains_key(canister_name) {
                     continue;
                 }
-                let canister_is_remote =
-                    config_interface.is_remote_canister(canister_name, &network.name)?;
-                if canister_is_remote {
-                    info!(
-                        env.get_logger(),
-                        "Skipping canister '{canister_name}' because it is remote for network '{}'",
-                        &network.name,
-                    );
-
+                if skip_remote_canister(env, canister_name)? {
                     continue;
                 }
                 let specified_id = config_interface.get_specified_id(canister_name)?;

--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -350,8 +350,21 @@ pub async fn exec(
         )
         .await
     } else if opts.all {
-        if let Some(canisters) = &config.get_config().canisters {
+        let config_interface = config.get_config();
+        let network = env.get_network_descriptor();
+        if let Some(canisters) = &config_interface.canisters {
             for canister in canisters.keys() {
+                let canister_is_remote =
+                    config_interface.is_remote_canister(canister, &network.name)?;
+                if canister_is_remote {
+                    info!(
+                        env.get_logger(),
+                        "Skipping canister '{canister}' because it is remote for network '{}'",
+                        &network.name,
+                    );
+
+                    continue;
+                }
                 delete_canister(
                     env,
                     canister,

--- a/src/dfx/src/commands/canister/deposit_cycles.rs
+++ b/src/dfx/src/commands/canister/deposit_cycles.rs
@@ -144,9 +144,23 @@ pub async fn exec(
         .await
     } else if opts.all {
         let config = env.get_config_or_anyhow()?;
+        let config_interface = config.get_config();
+        let network = env.get_network_descriptor();
 
-        if let Some(canisters) = &config.get_config().canisters {
+        if let Some(canisters) = &config_interface.canisters {
             for canister in canisters.keys() {
+                let canister_is_remote =
+                    config_interface.is_remote_canister(canister, &network.name)?;
+                if canister_is_remote {
+                    info!(
+                        env.get_logger(),
+                        "Skipping canister '{canister}' because it is remote for network '{}'",
+                        &network.name,
+                    );
+
+                    continue;
+                }
+
                 deposit_cycles(
                     env,
                     canister,

--- a/src/dfx/src/commands/canister/deposit_cycles.rs
+++ b/src/dfx/src/commands/canister/deposit_cycles.rs
@@ -3,6 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::lib::error::DfxResult;
 use crate::lib::identity::wallet::get_or_create_wallet_canister;
 use crate::lib::operations::canister;
+use crate::lib::operations::canister::skip_remote_canister;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use crate::lib::{environment::Environment, operations::cycles_ledger};
 use crate::util::clap::parsers::{cycle_amount_parser, icrc_subaccount_parser};
@@ -144,20 +145,10 @@ pub async fn exec(
         .await
     } else if opts.all {
         let config = env.get_config_or_anyhow()?;
-        let config_interface = config.get_config();
-        let network = env.get_network_descriptor();
 
-        if let Some(canisters) = &config_interface.canisters {
+        if let Some(canisters) = &config.get_config().canisters {
             for canister in canisters.keys() {
-                let canister_is_remote =
-                    config_interface.is_remote_canister(canister, &network.name)?;
-                if canister_is_remote {
-                    info!(
-                        env.get_logger(),
-                        "Skipping canister '{canister}' because it is remote for network '{}'",
-                        &network.name,
-                    );
-
+                if skip_remote_canister(env, canister)? {
                     continue;
                 }
 

--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -10,6 +10,7 @@ use crate::util::clap::install_mode::{InstallModeHint, InstallModeOpt};
 use dfx_core::canister::{install_canister_wasm, install_mode_to_prompt};
 use dfx_core::identity::CallSender;
 
+use crate::lib::operations::canister::skip_remote_canister;
 use anyhow::bail;
 use candid::Principal;
 use clap::Parser;
@@ -187,7 +188,6 @@ pub async fn exec(
     } else if opts.all {
         // Install all canisters.
         let config = env.get_config_or_anyhow()?;
-        let config_interface = config.get_config();
         let env_file = config.get_output_env_file(opts.output_env_file)?;
         let pull_canisters_in_config = get_pull_canisters_in_config(env)?;
         if let Some(canisters) = &config.get_config().canisters {
@@ -195,13 +195,7 @@ pub async fn exec(
                 if pull_canisters_in_config.contains_key(canister) {
                     continue;
                 }
-                if config_interface.is_remote_canister(canister, &network.name)? {
-                    info!(
-                        env.get_logger(),
-                        "Skipping canister '{}' because it is remote for network '{}'",
-                        canister,
-                        &network.name,
-                    );
+                if skip_remote_canister(env, canister)? {
                     continue;
                 }
 

--- a/src/dfx/src/commands/canister/start.rs
+++ b/src/dfx/src/commands/canister/start.rs
@@ -1,6 +1,7 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::operations::canister;
+use crate::lib::operations::canister::skip_remote_canister;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use candid::Principal;
 use clap::Parser;
@@ -51,19 +52,10 @@ pub async fn exec(
         start_canister(env, canister, call_sender).await
     } else if opts.all {
         let config = env.get_config_or_anyhow()?;
-        let config_interface = config.get_config();
-        let network = env.get_network_descriptor();
-        if let Some(canisters) = &config_interface.canisters {
-            for canister in canisters.keys() {
-                let canister_is_remote =
-                    config_interface.is_remote_canister(canister, &network.name)?;
-                if canister_is_remote {
-                    info!(
-                        env.get_logger(),
-                        "Skipping canister '{canister}' because it is remote for network '{}'",
-                        &network.name,
-                    );
 
+        if let Some(canisters) = &config.get_config().canisters {
+            for canister in canisters.keys() {
+                if skip_remote_canister(env, canister)? {
                     continue;
                 }
 

--- a/src/dfx/src/commands/canister/start.rs
+++ b/src/dfx/src/commands/canister/start.rs
@@ -51,8 +51,22 @@ pub async fn exec(
         start_canister(env, canister, call_sender).await
     } else if opts.all {
         let config = env.get_config_or_anyhow()?;
-        if let Some(canisters) = &config.get_config().canisters {
+        let config_interface = config.get_config();
+        let network = env.get_network_descriptor();
+        if let Some(canisters) = &config_interface.canisters {
             for canister in canisters.keys() {
+                let canister_is_remote =
+                    config_interface.is_remote_canister(canister, &network.name)?;
+                if canister_is_remote {
+                    info!(
+                        env.get_logger(),
+                        "Skipping canister '{canister}' because it is remote for network '{}'",
+                        &network.name,
+                    );
+
+                    continue;
+                }
+
                 start_canister(env, canister, call_sender).await?;
             }
         }

--- a/src/dfx/src/commands/canister/status.rs
+++ b/src/dfx/src/commands/canister/status.rs
@@ -1,13 +1,13 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::operations::canister;
+use crate::lib::operations::canister::skip_remote_canister;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use candid::Principal;
 use clap::Parser;
 use dfx_core::identity::CallSender;
 use fn_error_context::context;
 use ic_utils::interfaces::management_canister::LogVisibility;
-use slog::info;
 
 /// Returns the current status of a canister: Running, Stopping, or Stopped. Also carries information like balance, current settings, memory used and everything returned by 'info'.
 #[derive(Parser)]
@@ -96,19 +96,10 @@ pub async fn exec(
         canister_status(env, canister, call_sender).await
     } else if opts.all {
         let config = env.get_config_or_anyhow()?;
-        let config_interface = config.get_config();
-        let network = env.get_network_descriptor();
-        if let Some(canisters) = &config_interface.canisters {
-            for canister in canisters.keys() {
-                let canister_is_remote =
-                    config_interface.is_remote_canister(canister, &network.name)?;
-                if canister_is_remote {
-                    info!(
-                        env.get_logger(),
-                        "Skipping canister '{canister}' because it is remote for network '{}'",
-                        &network.name,
-                    );
 
+        if let Some(canisters) = &config.get_config().canisters {
+            for canister in canisters.keys() {
+                if skip_remote_canister(env, canister)? {
                     continue;
                 }
 

--- a/src/dfx/src/commands/canister/stop.rs
+++ b/src/dfx/src/commands/canister/stop.rs
@@ -52,8 +52,22 @@ pub async fn exec(
         stop_canister(env, canister, call_sender).await
     } else if opts.all {
         let config = env.get_config_or_anyhow()?;
-        if let Some(canisters) = &config.get_config().canisters {
+        let config_interface = config.get_config();
+        let network = env.get_network_descriptor();
+        if let Some(canisters) = &config_interface.canisters {
             for canister in canisters.keys() {
+                let canister_is_remote =
+                    config_interface.is_remote_canister(canister, &network.name)?;
+                if canister_is_remote {
+                    info!(
+                        env.get_logger(),
+                        "Skipping canister '{canister}' because it is remote for network '{}'",
+                        &network.name,
+                    );
+
+                    continue;
+                }
+
                 stop_canister(env, canister, call_sender).await?;
             }
         }

--- a/src/dfx/src/commands/canister/stop.rs
+++ b/src/dfx/src/commands/canister/stop.rs
@@ -1,6 +1,7 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::operations::canister;
+use crate::lib::operations::canister::skip_remote_canister;
 use crate::lib::root_key::fetch_root_key_if_needed;
 use candid::Principal;
 use clap::Parser;
@@ -52,19 +53,10 @@ pub async fn exec(
         stop_canister(env, canister, call_sender).await
     } else if opts.all {
         let config = env.get_config_or_anyhow()?;
-        let config_interface = config.get_config();
-        let network = env.get_network_descriptor();
-        if let Some(canisters) = &config_interface.canisters {
-            for canister in canisters.keys() {
-                let canister_is_remote =
-                    config_interface.is_remote_canister(canister, &network.name)?;
-                if canister_is_remote {
-                    info!(
-                        env.get_logger(),
-                        "Skipping canister '{canister}' because it is remote for network '{}'",
-                        &network.name,
-                    );
 
+        if let Some(canisters) = &config.get_config().canisters {
+            for canister in canisters.keys() {
+                if skip_remote_canister(env, canister)? {
                     continue;
                 }
 

--- a/src/dfx/src/commands/canister/uninstall_code.rs
+++ b/src/dfx/src/commands/canister/uninstall_code.rs
@@ -53,9 +53,22 @@ pub async fn exec(
         uninstall_code(env, canister, call_sender).await
     } else if opts.all {
         let config = env.get_config_or_anyhow()?;
+        let config_interface = config.get_config();
+        let network = env.get_network_descriptor();
 
-        if let Some(canisters) = &config.get_config().canisters {
+        if let Some(canisters) = &config_interface.canisters {
             for canister in canisters.keys() {
+                let canister_is_remote =
+                    config_interface.is_remote_canister(canister, &network.name)?;
+                if canister_is_remote {
+                    info!(
+                        env.get_logger(),
+                        "Skipping canister '{canister}' because it is remote for network '{}'",
+                        &network.name,
+                    );
+
+                    continue;
+                }
                 uninstall_code(env, canister, call_sender).await?;
             }
         }

--- a/src/dfx/src/commands/ledger/fabricate_cycles.rs
+++ b/src/dfx/src/commands/ledger/fabricate_cycles.rs
@@ -120,8 +120,22 @@ pub async fn exec(env: &dyn Environment, opts: FabricateCyclesOpts) -> DfxResult
         deposit_minted_cycles(env, canister, &CallSender::SelectedId, cycles).await
     } else if opts.all {
         let config = env.get_config_or_anyhow()?;
-        if let Some(canisters) = &config.get_config().canisters {
+        let config_interface = config.get_config();
+        let network = env.get_network_descriptor();
+        if let Some(canisters) = &config_interface.canisters {
             for canister in canisters.keys() {
+                let canister_is_remote =
+                    config_interface.is_remote_canister(canister, &network.name)?;
+                if canister_is_remote {
+                    info!(
+                        env.get_logger(),
+                        "Skipping canister '{canister}' because it is remote for network '{}'",
+                        &network.name,
+                    );
+
+                    continue;
+                }
+
                 deposit_minted_cycles(env, canister, &CallSender::SelectedId, cycles).await?;
             }
         }

--- a/src/dfx/src/lib/operations/canister/mod.rs
+++ b/src/dfx/src/lib/operations/canister/mod.rs
@@ -2,10 +2,12 @@ pub(crate) mod create_canister;
 pub(crate) mod deploy_canisters;
 pub(crate) mod install_canister;
 pub mod motoko_playground;
+mod skip_remote_canister;
 
 pub use create_canister::create_canister;
 use ic_utils::interfaces::management_canister::Snapshot;
 pub use install_canister::install_wallet;
+pub use skip_remote_canister::skip_remote_canister;
 
 use crate::lib::canister_info::CanisterInfo;
 use crate::lib::environment::Environment;

--- a/src/dfx/src/lib/operations/canister/skip_remote_canister.rs
+++ b/src/dfx/src/lib/operations/canister/skip_remote_canister.rs
@@ -1,0 +1,17 @@
+use crate::lib::environment::Environment;
+use crate::lib::error::DfxResult;
+use slog::info;
+
+pub fn skip_remote_canister(env: &dyn Environment, canister: &str) -> DfxResult<bool> {
+    let config = env.get_config_or_anyhow()?;
+    let config_interface = config.get_config();
+    let network = env.get_network_descriptor();
+    let canister_is_remote = config_interface.is_remote_canister(canister, &network.name)?;
+    if canister_is_remote {
+        info!(
+            env.get_logger(),
+            "Skipping canister '{canister}' because it is remote for network '{}'", &network.name,
+        );
+    }
+    Ok(canister_is_remote)
+}


### PR DESCRIPTION
# Description

Fixed the following commands such that they skip remote canisters when the `--all` parameter is passed:
- `dfx canister delete`
- `dfx canister deposit-cycles`
- `dfx canister start`
- `dfx canister status`
- `dfx canister stop`
- `dfx canister uninstall-code`
- `dfx canister update-settings`
- `dfx ledger fabricate-cycles`

Fixes https://dfinity.atlassian.net/browse/SDK-1784

# How Has This Been Tested?

Updated e2e tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
