### PR TITLE
refactor: remove dead code

### DIFF
--- a/src/dfx-core/src/config/model/local_server_descriptor.rs
+++ b/src/dfx-core/src/config/model/local_server_descriptor.rs
@@ -239,14 +239,6 @@ impl LocalServerDescriptor {
         }
     }
 
-    pub fn with_replica_port(self, port: u16) -> Self {
-        let replica = ConfigDefaultsReplica {
-            port: Some(port),
-            ..self.replica
-        };
-        Self { replica, ..self }
-    }
-
     pub fn with_bitcoin_enabled(self) -> LocalServerDescriptor {
         let bitcoin = ConfigDefaultsBitcoin {
             enabled: true,

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -5,7 +5,6 @@ use crate::actors::{
     start_shutdown_controller,
 };
 use crate::config::dfx_version_str;
-use crate::error_invalid_argument;
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
 use crate::lib::info::replica_rev;
@@ -188,7 +187,6 @@ pub fn exec(
         env.get_logger(),
         network_descriptor,
         host,
-        None,
         enable_bitcoin,
         bitcoin_node,
         enable_canister_http,
@@ -495,7 +493,6 @@ pub fn apply_command_line_parameters(
     logger: &Logger,
     network_descriptor: NetworkDescriptor,
     host: Option<String>,
-    replica_port: Option<String>,
     enable_bitcoin: bool,
     bitcoin_nodes: Vec<SocketAddr>,
     enable_canister_http: bool,
@@ -519,12 +516,6 @@ pub fn apply_command_line_parameters(
             .parse()
             .map_err(|e| anyhow!("Invalid argument: Invalid host: {}", e))?;
         local_server_descriptor = local_server_descriptor.with_bind_address(host);
-    }
-    if let Some(replica_port) = replica_port {
-        let replica_port: u16 = replica_port
-            .parse()
-            .map_err(|err| error_invalid_argument!("Invalid port number: {}", err))?;
-        local_server_descriptor = local_server_descriptor.with_replica_port(replica_port);
     }
     if enable_bitcoin || !bitcoin_nodes.is_empty() {
         local_server_descriptor = local_server_descriptor.with_bitcoin_enabled();


### PR DESCRIPTION
# Description

Removes a parameter that is always passes as `None`. The now-deleted `dfx replica` command used to pass Some(port).
Then removes the resulting dead code.

# How Has This Been Tested?

Refactor covered by CI

