### PR TITLE
chore: improve error message for 'dfx deploy'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ Added a flag `--replica` to `dfx start`. This flag currently has no effect.
 Once PocketIC becomes the default for `dfx start` this flag will start the replica instead.
 You can use the `--replica` flag already to write scripts that anticipate that change.
 
+### chore: improve `dfx deploy` messages.
+
+If users run `dfx deploy` without enough cycles, show additional messages to indicate what to do next.
+```
+Error explanation:
+Insufficient cycles balance to create the canister.
+How to resolve the error:
+Please top up your cycles balance by converting ICP to cycles like below:
+'dfx cycles convert --amount=0.123 --ic'.
+```
+
 # 0.24.3
 
 ### feat: Bitcoin support in PocketIC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Error explanation:
 Insufficient cycles balance to create the canister.
 How to resolve the error:
 Please top up your cycles balance by converting ICP to cycles like below:
-'dfx cycles convert --amount=0.123 --ic'.
+'dfx cycles convert --amount=0.123'.
 ```
 
 # 0.24.3

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -591,6 +591,17 @@ current_time_nanoseconds() {
 
   assert_command dfx deploy
 
+  # Test canister creation failure before topping up cycles.
+  cd ..
+  dfx_new canister_creation_failed
+
+  export DFX_DISABLE_AUTO_WALLET=1
+  assert_command_fail dfx canister create canister_creation_failed_backend --with-cycles 1T --identity alice
+  assert_contains "Insufficient cycles balance to create the canister."
+
+  ## Back to top up cycles.
+  cd ../temporary
+
   assert_command dfx canister call depositor deposit "(record {to = record{owner = principal \"$ALICE\";};cycles = 13_400_000_000_000;})" --identity cycle-giver
   assert_command dfx canister call depositor deposit "(record {to = record{owner = principal \"$ALICE\"; subaccount = opt blob \"$ALICE_SUBACCT1_CANDID\"};cycles = 2_600_000_000_000;})" --identity cycle-giver
 

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -595,6 +595,7 @@ current_time_nanoseconds() {
   cd ..
   dfx_new canister_creation_failed
 
+  # shellcheck disable=SC2030,SC2031
   export DFX_DISABLE_AUTO_WALLET=1
   assert_command_fail dfx canister create canister_creation_failed_backend --with-cycles 1T --identity alice
   assert_contains "Insufficient cycles balance to create the canister."
@@ -605,6 +606,7 @@ current_time_nanoseconds() {
   assert_command dfx canister call depositor deposit "(record {to = record{owner = principal \"$ALICE\";};cycles = 13_400_000_000_000;})" --identity cycle-giver
   assert_command dfx canister call depositor deposit "(record {to = record{owner = principal \"$ALICE\"; subaccount = opt blob \"$ALICE_SUBACCT1_CANDID\"};cycles = 2_600_000_000_000;})" --identity cycle-giver
 
+  # shellcheck disable=SC2103
   cd ..
   dfx_new
   # setup done

--- a/src/dfx/src/lib/diagnosis.rs
+++ b/src/dfx/src/lib/diagnosis.rs
@@ -2,6 +2,7 @@ use crate::lib::cycles_ledger_types::create_canister::CreateCanisterError;
 use crate::lib::error_code;
 use anyhow::Error as AnyhowError;
 use dfx_core::error::root_key::FetchRootKeyError;
+use dfx_core::network::provider::get_network_context;
 use ic_agent::agent::{RejectCode, RejectResponse};
 use ic_agent::AgentError;
 use ic_asset::error::{GatherAssetDescriptorsError, SyncError, UploadContentError};
@@ -275,8 +276,22 @@ fn insufficient_cycles(err: &CreateCanisterError) -> bool {
 }
 
 fn diagnose_insufficient_cycles() -> Diagnosis {
+    let network = match get_network_context() {
+        Ok(value) => {
+            if value == "local" {
+                "".to_string()
+            } else {
+                format!(" --network {}", value)
+            }
+        }
+        Err(_) => "".to_string(),
+    };
+
     let explanation = "Insufficient cycles balance to create the canister.";
-    let suggestion = "Please top up your cycles balance by converting ICP to cycles like below:
-'dfx cycles convert --amount=0.123 --ic'.";
-    (Some(explanation.to_string()), Some(suggestion.to_string()))
+    let suggestion = format!(
+        "Please top up your cycles balance by converting ICP to cycles like below:
+'dfx cycles convert --amount=0.123{}'",
+        network
+    );
+    (Some(explanation.to_string()), Some(suggestion))
 }

--- a/src/dfx/src/lib/diagnosis.rs
+++ b/src/dfx/src/lib/diagnosis.rs
@@ -1,3 +1,4 @@
+use crate::lib::cycles_ledger_types::create_canister::CreateCanisterError;
 use crate::lib::error_code;
 use anyhow::Error as AnyhowError;
 use dfx_core::error::root_key::FetchRootKeyError;
@@ -69,6 +70,12 @@ pub fn diagnose(err: &AnyhowError) -> Diagnosis {
     if let Some(sync_error) = err.downcast_ref::<SyncError>() {
         if duplicate_asset_key_dist_and_src(sync_error) {
             return diagnose_duplicate_asset_key_dist_and_src();
+        }
+    }
+
+    if let Some(_create_canister_err) = err.downcast_ref::<CreateCanisterError>() {
+        if insufficient_cycles(_create_canister_err) {
+            return diagnose_insufficient_cycles();
         }
     }
 
@@ -260,5 +267,19 @@ fn diagnose_ledger_not_found() -> Diagnosis {
     let suggestion =
         "Run the command with '--ic' flag if you want to manage the ICP on the mainnet.";
 
+    (Some(explanation.to_string()), Some(suggestion.to_string()))
+}
+
+fn insufficient_cycles(err: &CreateCanisterError) -> bool {
+    match err {
+        CreateCanisterError::InsufficientFunds { balance: _ } => true,
+        _ => false,
+    }
+}
+
+fn diagnose_insufficient_cycles() -> Diagnosis {
+    let explanation = "Insufficient cycles balance to create the canister.";
+    let suggestion = "Please top up your cycles balance by converting ICP to cycles like below:
+'dfx cycles convert --amount=0.123 --ic'.";
     (Some(explanation.to_string()), Some(suggestion.to_string()))
 }

--- a/src/dfx/src/lib/diagnosis.rs
+++ b/src/dfx/src/lib/diagnosis.rs
@@ -271,10 +271,7 @@ fn diagnose_ledger_not_found() -> Diagnosis {
 }
 
 fn insufficient_cycles(err: &CreateCanisterError) -> bool {
-    match err {
-        CreateCanisterError::InsufficientFunds { balance: _ } => true,
-        _ => false,
-    }
+    matches!(err, CreateCanisterError::InsufficientFunds { balance: _ })
 }
 
 fn diagnose_insufficient_cycles() -> Diagnosis {

--- a/src/dfx/src/lib/diagnosis.rs
+++ b/src/dfx/src/lib/diagnosis.rs
@@ -73,8 +73,8 @@ pub fn diagnose(err: &AnyhowError) -> Diagnosis {
         }
     }
 
-    if let Some(_create_canister_err) = err.downcast_ref::<CreateCanisterError>() {
-        if insufficient_cycles(_create_canister_err) {
+    if let Some(create_canister_err) = err.downcast_ref::<CreateCanisterError>() {
+        if insufficient_cycles(create_canister_err) {
             return diagnose_insufficient_cycles();
         }
     }


### PR DESCRIPTION
# Description

If users run `dfx deploy` without enough cycles, show additional messages to indicate what to do next.
```
Error explanation:
Insufficient cycles balance to create the canister.
How to resolve the error:
Please top up your cycles balance by converting ICP to cycles like below:
'dfx cycles convert --amount=0.123 --ic'.
```

Fixes # (issue)

[SDK-1867](https://dfinity.atlassian.net/browse/SDK-1867)

# How Has This Been Tested?

Tested manually.


# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-1867]: https://dfinity.atlassian.net/browse/SDK-1867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ