### PR TITLE
chore: improve error message for 'dfx cycles convert'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ Added a flag `--replica` to `dfx start`. This flag currently has no effect.
 Once PocketIC becomes the default for `dfx start` this flag will start the replica instead.
 You can use the `--replica` flag already to write scripts that anticipate that change.
 
+### chore: improve `dfx cycles convert` messages.
+
+If users run `dfx cycles convert` without enough ICP tokens, show additional messages to indicate what to do next.
+```
+Error explanation:
+Insufficient ICP balance to finish the transfer transaction.
+How to resolve the error:
+Please top up your ICP balance.
+Please run 'dfx ledger account-id' to get the address for receiving ICP tokens.
+```
+
 # 0.24.3
 
 ### feat: Bitcoin support in PocketIC

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -878,6 +878,10 @@ current_time_nanoseconds() {
 
   deploy_cycles_ledger
 
+  # Test failed to convert ICP to cycles without enough ICP.
+  assert_command_fail dfx cycles convert --amount 12.5 --identity alice
+  assert_contains "Insufficient ICP balance to finish the transfer transaction."
+
   assert_command dfx --identity cycle-giver ledger transfer --memo 1234 --amount 100 "$(dfx ledger account-id --of-principal "$ALICE")"
   assert_command dfx --identity cycle-giver ledger transfer --memo 1234 --amount 100 "$(dfx ledger account-id --of-principal "$ALICE" --subaccount "$ALICE_SUBACCT1")"
 


### PR DESCRIPTION
# Description

If users run `dfx cycles convert` without enough ICP tokens, show additional messages to indicate what to do next.
```
Error explanation:
Insufficient ICP balance to finish the transfer transaction.
How to resolve the error:
Please top up your ICP balance.
Please run 'dfx ledger account-id' to get the address for receiving ICP tokens.
```

Fixes # (issue)
[SDK-1868](https://dfinity.atlassian.net/browse/SDK-1868)

# How Has This Been Tested?

A new e2e test added.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
