### PR TITLE
fix: update svelte.config.js to properly handle TypeScript

### DIFF
--- a/src/dfx/assets/project_templates/svelte/src/__frontend_name__/svelte.config.js
+++ b/src/dfx/assets/project_templates/svelte/src/__frontend_name__/svelte.config.js
@@ -1,7 +1,9 @@
 import adapter from '@sveltejs/adapter-static';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
+  preprocess: vitePreprocess(),
   kit: {
     // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
     // If your environment is not supported or you settled on a specific environment, switch out the adapter.


### PR DESCRIPTION
# Description

TypeScript syntax inside the script tags of SvelteKit routes and components isn't properly handled without adding vitePreprocess, crashing the application.

With vitePreprocess, it works.

Fixes # (issue)

# How Has This Been Tested?

I tried building an application from scratch with dfx new -> rust -> sveltekit, and it crashed when using syntax like ```type MyType = { propertyA: string; propertyB: ArrayBuffer };``` inside a ```<script lang="ts"></script>``` tag in a svelte component or sveltekit page. Adding vitePreprocess solved it.

# Checklist:

- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation. => Not necessary
