### PR TITLE
docs: remove note now that cycles ledger is on mainnet

### DIFF
--- a/docs/cli-reference/dfx-cycles.mdx
+++ b/docs/cli-reference/dfx-cycles.mdx
@@ -4,8 +4,6 @@ import { MarkdownChipRow } from "/src/components/Chip/MarkdownChipRow";
 
 <MarkdownChipRow labels={["Reference"]} />
 
-**NOTE**: The cycles ledger is in development and the dfx cycles command is not expected to work on mainnet at this time.
-
 Use the `dfx cycles` command to manage cycles associated with an identity's principal.
 
 The basic syntax for running `dfx cycles` commands is:


### PR DESCRIPTION
Removes a line from the docs now that the cycles ledger is on mainnet.