### PR TITLE
chore: improve error message when asset wasm is not allowlisted in playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 This used to be a warning. A hard error can abort the command so that no insecure state will be on the mainnet.
 
-Users can surpress this error by setting `export DFX_WARNING=-mainnet_plaintext_identity`.
+Users can suppress this error by setting `export DFX_WARNING=-mainnet_plaintext_identity`.
 
 The warning won't display when executing commands like `dfx deploy --playground`.
 
@@ -47,6 +47,9 @@ How to resolve the error:
 Please top up your cycles balance by converting ICP to cycles like below:
 'dfx cycles convert --amount=0.123'.
 ```
+
+If users run `dfx deploy --playground` but the backend is not updated with the latest frontend canister wasm
+the error message will explain this properly and recommends asking for help on the forum since this can't be resolved by users.
 
 ### chore: improve `dfx cycles convert` messages.
 


### PR DESCRIPTION
# Description

When we forget to allowlist the latest frontend canister wasm to the playground backend the error message is incomprehensible to users:
```
Error: Failed while trying to deploy canisters.
Caused by: Failed while trying to install all canisters.
Caused by: Failed to install wasm module to canister 'ii_integration_frontend'.
Caused by: install failed
Caused by: The replica returned a rejection error: reject code CanisterReject, reject message IC0503: Error from Canister ozk6r-tyaaa-aaaab-qab4a-cai: Canister called `ic0.trap` with message: Wasm is not whitelisted.
Consider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: http://internetcomputer.org/docs/current/references/execution-errors#trapped-explicitly, error code None
```

New error message:
```
Error: Failed while trying to deploy canisters.
Caused by: Failed while trying to install all canisters.
Caused by: Failed to install wasm module to canister 'hello_frontend'.
Error explanation:
The frontend canister wasm needs to be allowlisted in the playground but it isn't. This is a mistake in the release process.
How to resolve the error:
Please report this on forum.dfinity.org and mention your dfx version. You can get the version with 'dfx --version'.
```

The removed `.context("install failed")` did not add any useful info.

Fixes [SDKTG-418](https://dfinity.atlassian.net/browse/SDKTG-418)

# How Has This Been Tested?

Tested manually.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDKTG-418]: https://dfinity.atlassian.net/browse/SDKTG-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ