### PR TITLE
fix: fix: dfx deploy --by-proposal no longer sends chunk data in ProposeCommitBatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 # UNRELEASED
 
+### fix: `dfx deploy --by-proposal` no longer sends chunk data in ProposeCommitBatch
+
+Recently we made `dfx deploy` include some chunk data in CommitBatch, in order to streamline
+deploys for smaller projects. `dfx deploy` splits up larger change lists and submits them in
+smaller batches, in order to remain within message and compute limits.
+
+This change also applied to `dfx deploy --by-proposal`, which submits all changes in a single
+message. This made it more likely that `dfx deploy --by-proposal` will fail due to exceeding
+message limits.
+
+This fix makes it so `dfx deploy --by-proposal` never includes this chunk data in
+ProposeCommitBatch, which will allow for more changes before hitting message limits.
+
 ### feat: `dfx start --pocketic` supports `--force` and shared networks.
 
 `dfx start --pocketic` is now compatible with `--force` and shared networks.

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -209,7 +209,7 @@ check_permission_failure() {
     # commit batch without content: 1,978,870 bytes
     # commit batch with content: 2,889,392 bytes
     # change finalize_upload to always pass MAX_CHUNK_SIZE/2 to see this fail
-    dd if=/dev/random of=src/e2e_project_frontend/assets/$a bs=650 count=1
+    dd if=/dev/random of=src/e2e_project_frontend/assets/"$a" bs=650 count=1
   done
 
   assert_command dfx deploy e2e_project_frontend --by-proposal --identity prepare

--- a/src/canisters/frontend/ic-asset/src/evidence/mod.rs
+++ b/src/canisters/frontend/ic-asset/src/evidence/mod.rs
@@ -55,8 +55,14 @@ pub async fn compute_evidence(
         logger,
         "Computing evidence for batch operations for assets in the project.",
     );
-    let project_assets =
-        make_project_assets(None, asset_descriptors, &canister_assets, logger).await?;
+    let project_assets = make_project_assets(
+        None,
+        asset_descriptors,
+        &canister_assets,
+        crate::batch_upload::plumbing::Mode::ByProposal,
+        logger,
+    )
+    .await?;
 
     let mut operations = assemble_batch_operations(
         None,

--- a/src/canisters/frontend/ic-asset/src/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/sync.rs
@@ -3,6 +3,7 @@ use crate::asset::config::{
 };
 use crate::batch_upload::operations::BATCH_UPLOAD_API_VERSION;
 use crate::batch_upload::plumbing::ChunkUploader;
+use crate::batch_upload::plumbing::Mode::{ByProposal, NormalDeploy};
 use crate::batch_upload::{
     self,
     operations::AssetDeletionReason,
@@ -48,6 +49,7 @@ pub async fn upload_content_and_assemble_sync_operations(
     canister_api_version: u16,
     dirs: &[&Path],
     no_delete: bool,
+    mode: batch_upload::plumbing::Mode,
     logger: &Logger,
 ) -> Result<CommitBatchArguments, UploadContentError> {
     let asset_descriptors = gather_asset_descriptors(dirs, logger)?;
@@ -82,6 +84,7 @@ pub async fn upload_content_and_assemble_sync_operations(
         Some(&chunk_uploader),
         asset_descriptors,
         &canister_assets,
+        mode,
         logger,
     )
     .await
@@ -133,6 +136,7 @@ pub async fn sync(
         canister_api_version,
         dirs,
         no_delete,
+        NormalDeploy,
         logger,
     )
     .await?;
@@ -214,6 +218,7 @@ pub async fn prepare_sync_for_proposal(
         canister_api_version,
         dirs,
         false,
+        ByProposal,
         logger,
     )
     .await?;

--- a/src/canisters/frontend/ic-asset/src/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/upload.rs
@@ -1,5 +1,6 @@
 use crate::asset::config::AssetConfig;
 use crate::batch_upload::operations::BATCH_UPLOAD_API_VERSION;
+use crate::batch_upload::plumbing::Mode::NormalDeploy;
 use crate::batch_upload::{
     self,
     operations::AssetDeletionReason,
@@ -49,6 +50,7 @@ pub async fn upload(
         Some(&chunk_upload_target),
         asset_descriptors,
         &canister_assets,
+        NormalDeploy,
         logger,
     )
     .await?;


### PR DESCRIPTION
# Description

`dfx deploy` now tries to pack content encoding data into the CommitBatch arguments, in order to streamline deploys for smaller projects.  Larger deploys split up synchronization operations into multiple batches, in order to avoid exceeding message size or computation limits.

However, the above also applied to `dfx deploy --by-proposal`, which has to submit all synchronization operations in the same ProposeCommitBatchArguments.  Including asset contents increases the changes of exceeding message size limits.

This PR makes `dfx deploy --by-proposal` never include asset content in the ProposeCommitBatchArguments, instead uploading all contents with create_chunk or create_chunks.

Fixes https://dfinity.atlassian.net/browse/SDK-1914

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
