### PR TITLE
chore: update Azle templates to 0.24.1

### DIFF
--- a/src/dfx/assets/project_templates/any_js/tsconfig.json
+++ b/src/dfx/assets/project_templates/any_js/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "target": "ES2020",
-        "experimentalDecorators": true,
-        "strictPropertyInitialization": false,
+        "module": "ES2020",
         "moduleResolution": "node",
         "allowJs": true,
         "outDir": "HACK_BECAUSE_OF_ALLOW_JS"

--- a/src/dfx/assets/project_templates/azle/dfx.json-patch
+++ b/src/dfx/assets/project_templates/azle/dfx.json-patch
@@ -3,21 +3,8 @@
         "path": "/canisters/__backend_name__",
         "op": "add",
         "value": {
-            "type": "custom",
-            "main": "src/__backend_name__/src/index.ts",
-            "candid": "src/__backend_name__/__backend_name__.did",
-            "build": "npx azle __backend_name__",
-            "wasm": ".azle/__backend_name__/__backend_name__.wasm",
-            "gzip": true,
-            "tech_stack": {
-                "language": {
-                    "javascript": {},
-                    "typescript": {}
-                },
-                "cdk": {
-                    "azle": {}
-                }
-            }
+            "type": "azle",
+            "main": "src/__backend_name__/src/index.ts"
         }
     }
 ]

--- a/src/dfx/assets/project_templates/azle/src/__backend_name__/__backend_name__.did
+++ b/src/dfx/assets/project_templates/azle/src/__backend_name__/__backend_name__.did
@@ -1,3 +1,0 @@
-service : {
-    "greet" : (text) -> (text) query;
-}

--- a/src/dfx/assets/project_templates/azle/src/__backend_name__/package.json
+++ b/src/dfx/assets/project_templates/azle/src/__backend_name__/package.json
@@ -4,6 +4,6 @@
     "private": true,
     "type": "module",
     "dependencies": {
-        "azle": "^0.19.0"
+        "azle": "^0.24.1"
     }
 }

--- a/src/dfx/assets/project_templates/azle/src/__backend_name__/src/index.ts
+++ b/src/dfx/assets/project_templates/azle/src/__backend_name__/src/index.ts
@@ -1,7 +1,15 @@
-import { Canister, query, text } from 'azle';
+import { IDL, query, update } from 'azle';
 
-export default Canister({
-    greet: query([text], text, (name) => {
-        return `Hello, ${name}!`;
-    })
-})
+export default class {
+    message: string = 'Hello world!';
+
+    @query([], IDL.Text)
+    getMessage(): string {
+        return this.message;
+    }
+
+    @update([IDL.Text])
+    setMessage(message: string): void {
+        this.message = message;
+    }
+}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

The `dfx new` command for `Azle` has been out-of-date for a while now. This PR updates `Azle`'s templates to the latest version and simplifies the templates with new changes possible because of the latest version.

# How Has This Been Tested?

I built the sdk locally and manually used the `dfx new` command to create a new example project. I then deployed the project and checked that it worked in the Candid UI.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). (From @lastmjs Is this considered a breaking change?)
- [ ] I have edited the CHANGELOG accordingly. (From @lastmjs do I need to edit the CHANGELOG?)
- [ ] I have made corresponding changes to the documentation. (From @lastmjs Azle's documentation in DFINITY's web properties is generally out-of-date...I hear that soon DFINITY will simply point to Demergent Labs' documentation) 
