### PR TITLE
fix: update-replica.sh for commit starting with digit

### DIFF
--- a/scripts/update-replica.sh
+++ b/scripts/update-replica.sh
@@ -35,7 +35,7 @@ niv update sns-x86_64-darwin -a rev="$SHA"
 niv update sns-x86_64-linux -a rev="$SHA"
 
 # pocket-ic client needs to be upgraded to the same SHA as the pocket-ic server
-perl -i.bak -pe "s/(pocket-ic = {[^}]*rev = \")[a-f0-9]+(\")/\1$SHA\2/" src/dfx/Cargo.toml
+perl -i.bak -pe "s/(pocket-ic = {[^}]*rev = \")[a-f0-9]+(\")/\${1}$SHA\${2}/" src/dfx/Cargo.toml
 cargo update -p pocket-ic # refresh the lock file
 
 echo "Writing asset sources"


### PR DESCRIPTION
This PR fixes the update-replica.sh script to also support commits starting with a digit. Previously, the expression `\1$SHA\2` where `$SHA` gets substituted for `3e24396441e4c7380928d4e8b4ccff7de77d0e7e` (for instance) would be [interpreted](https://github.com/dfinity/sdk/actions/runs/12389699213/job/34583240855) as `\13` followed by `e24396441e4c7380928d4e8b4ccff7de77d0e7e` and `\2` instead of `\1` followed by `e24396441e4c7380928d4e8b4ccff7de77d0e7e` and `\2`.

The new perl command has been tested manually on Ubuntu 24.04.1 LTS and perl5 (revision 5 version 38 subversion 2).