### PR TITLE
fix: default effective canister id for PocketIC

### DIFF
--- a/e2e/tests-dfx/start.bash
+++ b/e2e/tests-dfx/start.bash
@@ -29,6 +29,18 @@ teardown() {
   dfx_stop
 }
 
+@test "start and stop with specified canister id" {
+  dfx_start
+
+  dfx_new hello
+  dfx deploy hello_backend --specified-id gt2iw-kiaaa-aaad7-qaaaa-cai
+
+  dfx_stop
+
+  dfx_start
+  dfx_stop
+}
+
 @test "start and stop with different options" {
   [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: clean required"
   dfx_start --artificial-delay 101

--- a/src/dfx/src/actors/pocketic.rs
+++ b/src/dfx/src/actors/pocketic.rs
@@ -385,25 +385,12 @@ async fn initialize_pocketic(
             instance_id,
             topology,
         } => {
-            let subnets = match replica_config.subnet_type {
-                ReplicaSubnetType::Application => topology.get_app_subnets(),
-                ReplicaSubnetType::System => topology.get_system_subnets(),
-                ReplicaSubnetType::VerifiedApplication => topology.get_verified_app_subnets(),
-            };
-            if subnets.len() != 1 {
-                return Err(anyhow!("Internal error: PocketIC topology contains multiple subnets of the same subnet kind."));
-            }
-            let subnet_id = subnets[0];
-            let subnet_config = topology.subnet_configs.get(&subnet_id).ok_or(anyhow!(
-                "Internal error: subnet id {} not found in PocketIC topology",
-                subnet_id
-            ))?;
-            let effective_canister_id =
-                Principal::from_slice(&subnet_config.canister_ranges[0].start.canister_id);
+            let default_effective_canister_id: Principal =
+                topology.default_effective_canister_id.into();
             let effective_config = CachedConfig::pocketic(
                 replica_config,
                 replica_rev().into(),
-                Some(effective_canister_id),
+                Some(default_effective_canister_id),
             );
             save_json_file(effective_config_path, &effective_config)?;
             instance_id


### PR DESCRIPTION
This PR retrieves the default effective canister ID for PocketIC from the corresponding field in the topology instead of deriving it from the topology manually. This simplifies dfx and also fixes an issue: the manual derivation of the default effective canister id failed after creating a canister with a specified canister id and restarting dfx without --clean.