### PR TITLE
chore: remove remaining pocketic test exclusions

### DIFF
--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -37,7 +37,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "dfx restarts replica when ic-btc-adapter restarts" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: PocketIC does not expose bitcoin adapter"
+  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new_assets hello
   dfx_start --enable-bitcoin
 
@@ -87,7 +87,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "dfx start --bitcoin-node <node> implies --enable-bitcoin" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: PocketIC does not expose bitcoin adapter"
+  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new hello
   dfx_start "--bitcoin-node" "127.0.0.1:18444"
 
@@ -95,7 +95,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "dfx start --enable-bitcoin with no other configuration succeeds" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: PocketIC does not expose bitcoin adapter"
+  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new hello
 
   dfx_start --enable-bitcoin
@@ -114,7 +114,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "can enable bitcoin through default configuration - dfx start" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: PocketIC does not expose bitcoin adapter"
+  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new hello
   define_project_network
   set_project_default_bitcoin_enabled
@@ -125,7 +125,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "can enable bitcoin through shared local network - dfx start" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: PocketIC does not expose bitcoin adapter"
+  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new hello
   set_shared_local_network_bitcoin_enabled
 
@@ -135,7 +135,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "can enable bitcoin through local network configuration - dfx start" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: PocketIC does not expose bitcoin adapter"
+  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new hello
   set_local_network_bitcoin_enabled
 
@@ -145,7 +145,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "dfx start with both bitcoin and canister http enabled" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: PocketIC does not expose bitcoin adapter"
+  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new hello
 
   dfx_start --enable-bitcoin --enable-canister-http

--- a/e2e/tests-dfx/canister_http_adapter.bash
+++ b/e2e/tests-dfx/canister_http_adapter.bash
@@ -2,6 +2,8 @@
 
 load ../utils/_
 
+# all skipped for pocketic: outcall adapter is a replica implementation detail
+
 setup() {
   standard_setup
 }

--- a/e2e/tests-dfx/create.bash
+++ b/e2e/tests-dfx/create.bash
@@ -43,7 +43,7 @@ teardown() {
 }
 
 @test "create succeeds when specify large canister ID" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: subnet range"
+  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: nonexistent subnet ranges are unsupported"
   dfx_start
   # hhn2s-5l777-77777-7777q-cai is the canister ID of (u64::MAX / 2)
   assert_command dfx canister create e2e_project_backend --specified-id hhn2s-5l777-77777-7777q-cai

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -776,7 +776,6 @@ current_time_nanoseconds() {
 }
 
 @test "automatically choose subnet" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: subnet range"
   dfx_start
 
   REGISTRY="rwlgt-iiaaa-aaaaa-aaaaa-cai"

--- a/e2e/tests-dfx/deps.bash
+++ b/e2e/tests-dfx/deps.bash
@@ -723,7 +723,6 @@ Installing canister: $CANISTER_ID_C (dep_c)"
 }
 
 @test "dfx deps can facade pull ckBTC ledger" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic which doesn't have ckBTC subnet"
 
   use_test_specific_cache_root # dfx deps pull will download files to cache
 
@@ -783,7 +782,6 @@ Installing canister: $CANISTER_ID_C (dep_c)"
 
 
 @test "dfx deps can facade pull ckETH ledger" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic which doesn't have ckETH subnet"
 
   use_test_specific_cache_root # dfx deps pull will download files to cache
 

--- a/e2e/tests-dfx/start.bash
+++ b/e2e/tests-dfx/start.bash
@@ -42,7 +42,6 @@ teardown() {
 }
 
 @test "start and stop with different options" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: clean required"
   dfx_start --artificial-delay 101
   dfx_stop
 
@@ -62,7 +61,6 @@ teardown() {
 }
 
 @test "stop and start with other options does not disrupt projects" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: clean required"
   dfx_start --artificial-delay 101
 
   dfx_new p1
@@ -481,17 +479,15 @@ teardown() {
 }
 
 @test "modifying networks.json does not require --clean on restart" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: --force"
   dfx_start
   dfx stop
   assert_command dfx_start
   dfx stop
   jq -n '.local.replica.log_level="warning"' > "$E2E_NETWORKS_JSON"
-  assert_command dfx_start
+  assert_command dfx_start --verbose
 }
 
 @test "project-local networks require --clean if dfx.json was updated" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: --force"
   dfx_new
   define_project_network
   dfx_start

--- a/e2e/tests-dfx/start.bash
+++ b/e2e/tests-dfx/start.bash
@@ -484,7 +484,7 @@ teardown() {
   assert_command dfx_start
   dfx stop
   jq -n '.local.replica.log_level="warning"' > "$E2E_NETWORKS_JSON"
-  assert_command dfx_start --verbose
+  assert_command dfx_start
 }
 
 @test "project-local networks require --clean if dfx.json was updated" {

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -682,6 +682,16 @@ impl ReplicaLogLevel {
             Self::Trace => "trace".to_string(),
         }
     }
+    pub fn to_pocketic_string(&self) -> String {
+        match self {
+            Self::Critical => "CRITICAL".to_string(),
+            Self::Error => "ERROR".to_string(),
+            Self::Warning => "WARN".to_string(),
+            Self::Info => "INFO".to_string(),
+            Self::Debug => "DEBUG".to_string(),
+            Self::Trace => "TRACE".to_string(),
+        }
+    }
 }
 
 /// # Local Replica Configuration

--- a/src/dfx/src/actors/pocketic.rs
+++ b/src/dfx/src/actors/pocketic.rs
@@ -350,7 +350,7 @@ async fn initialize_pocketic(
         nns: Some(SubnetSpec::default()),
         sns: Some(SubnetSpec::default()),
         ii: Some(SubnetSpec::default()),
-        fiduciary: None,
+        fiduciary: Some(SubnetSpec::default()),
         bitcoin: Some(SubnetSpec::default()),
         system: vec![],
         verified_application: vec![],
@@ -369,7 +369,7 @@ async fn initialize_pocketic(
             subnet_config_set,
             state_dir: Some(replica_config.state_manager.state_root.clone()),
             nonmainnet_features: true,
-            log_level: Some(replica_config.log_level.to_ic_starter_string()),
+            log_level: Some(replica_config.log_level.to_pocketic_string()),
             bitcoind_addr: bitcoind_addr.clone(),
         })
         .send()


### PR DESCRIPTION
Tests specifically about the behavior of the bitcoin and outcalls HTTP adapter remain replica-only since those are implementation details. create.bash#4 remains replica-only since it relies on subnets not existing and canister IDs being freeform. Everything else now works with PocketIC after adding a fiduciary subnet.