### PR TITLE
chore!: reduce error output verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,8 @@ Total query response payload size: 0 Bytes
 Log visibility: controllers
 ```
 
+### chore!: Print error traces only in verbose (`-v`) mode or if no proper error message is available
+
 ## Dependencies
 
 ### Frontend canister

--- a/src/dfx/src/commands/canister/call.rs
+++ b/src/dfx/src/commands/canister/call.rs
@@ -336,8 +336,11 @@ To figure out the id of your wallet, run 'dfx identity get-wallet (--network ic)
     let cycles = opts.with_cycles.unwrap_or(0);
 
     if call_sender == &CallSender::SelectedId && cycles != 0 {
-        return Err(DiagnosedError::new("It is only possible to send cycles from a canister.".to_string(), "To send the same function call from your wallet (a canister), run the command using 'dfx canister call <other arguments> (--network ic) --wallet <wallet id>'.\n\
-        To figure out the id of your wallet, run 'dfx identity get-wallet (--network ic)'.".to_string())).context("Function caller is not a canister.");
+        let explanation = "It is only possible to send cycles from a canister.";
+        let action_suggestion = "To send the same function call from your wallet (a canister), run the command using 'dfx canister call <other arguments> (--network ic) --wallet <wallet id>'.\n\
+        To figure out the id of your wallet, run 'dfx identity get-wallet (--network ic)'.";
+        return Err(DiagnosedError::new(explanation, action_suggestion))
+            .context("Function caller is not a canister.");
     }
 
     if is_query {

--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -137,8 +137,8 @@ pub async fn exec(
         if threshold_in_seconds > 50_000_000 /* ~1.5 years */ && !opts.confirm_very_long_freezing_threshold
         {
             return Err(DiagnosedError::new(
-                "The freezing threshold is defined in SECONDS before the canister would run out of cycles, not in cycles.".to_string(),
-                "If you truly want to set a freezing threshold that is longer than a year, please run the same command, but with the flag --confirm-very-long-freezing-threshold to confirm you want to do this.".to_string(),
+                "The freezing threshold is defined in SECONDS before the canister would run out of cycles, not in cycles.",
+                "If you truly want to set a freezing threshold that is longer than a year, please run the same command, but with the flag --confirm-very-long-freezing-threshold to confirm you want to do this.",
             )).context("Misunderstanding is very likely.");
         }
     }

--- a/src/dfx/src/lib/operations/canister/motoko_playground.rs
+++ b/src/dfx/src/lib/operations/canister/motoko_playground.rs
@@ -228,10 +228,10 @@ pub async fn playground_install_code(
         .await
         .map_err(|err| {
             if is_asset_canister && err.to_string().contains("Wasm is not whitelisted") {
-                anyhow!(DiagnosedError {
-                    error_explanation: Some("The frontend canister wasm needs to be allowlisted in the playground but it isn't. This is a mistake in the release process.".to_string()),
-                    action_suggestion: Some("Please report this on forum.dfinity.org and mention your dfx version. You can get the version with 'dfx --version'.".to_string()),
-                })
+                anyhow!(DiagnosedError::new(
+                    "The frontend canister wasm needs to be allowlisted in the playground but it isn't. This is a mistake in the release process.",
+                    "Please report this on forum.dfinity.org and mention your dfx version. You can get the version with 'dfx --version'."
+                ))
             } else {
                 anyhow!(err)
             }

--- a/src/dfx/src/lib/operations/ledger.rs
+++ b/src/dfx/src/lib/operations/ledger.rs
@@ -191,7 +191,7 @@ Your principal for ICP wallets and decentralized exchanges: {}
         principal.to_text()
     );
 
-    DiagnosedError::new(explanation.to_string(), suggestion)
+    DiagnosedError::new(explanation, suggestion)
 }
 
 fn retryable(agent_error: &AgentError) -> bool {

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -1,6 +1,6 @@
 #![allow(special_module_name)]
 use crate::config::{dfx_version, dfx_version_str};
-use crate::lib::diagnosis::{diagnose, Diagnosis};
+use crate::lib::diagnosis::{diagnose, DiagnosedError};
 use crate::lib::environment::{Environment, EnvironmentImpl};
 use crate::lib::error::DfxResult;
 use crate::lib::logger::{create_root_logger, LoggingMode};
@@ -67,44 +67,48 @@ fn setup_logging(opts: &CliOpts) -> (i64, slog::Logger) {
     (verbose_level, create_root_logger(verbose_level, mode))
 }
 
-fn print_error_and_diagnosis(err: Error, error_diagnosis: Diagnosis) {
+fn print_error_and_diagnosis(log_level: Option<i64>, err: Error, error_diagnosis: DiagnosedError) {
     let mut stderr = util::stderr_wrapper::stderr_wrapper();
 
     // print error chain stack
-    for (level, cause) in err.chain().enumerate() {
-        if cause.to_string().is_empty() {
-            continue;
+    if log_level.unwrap_or_default() > 0 // DEBUG or more verbose
+        || !error_diagnosis.contains_diagnosis()
+    {
+        for (level, cause) in err.chain().enumerate() {
+            if cause.to_string().is_empty() {
+                continue;
+            }
+
+            let (color, prefix) = if level == 0 {
+                (term::color::RED, "Error")
+            } else {
+                (term::color::YELLOW, "Caused by")
+            };
+            stderr
+                .fg(color)
+                .expect("Failed to set stderr output color.");
+            write!(stderr, "{prefix}: ").expect("Failed to write to stderr.");
+            stderr
+                .reset()
+                .expect("Failed to reset stderr output color.");
+
+            writeln!(stderr, "{cause}").expect("Failed to write to stderr.");
         }
-
-        let (color, prefix) = if level == 0 {
-            (term::color::RED, "Error")
-        } else {
-            (term::color::YELLOW, "Caused by")
-        };
-        stderr
-            .fg(color)
-            .expect("Failed to set stderr output color.");
-        write!(stderr, "{prefix}: ").expect("Failed to write to stderr.");
-        stderr
-            .reset()
-            .expect("Failed to reset stderr output color.");
-
-        writeln!(stderr, "{cause}").expect("Failed to write to stderr.");
     }
 
     // print diagnosis
-    if let Some(error_explanation) = error_diagnosis.0 {
+    if let Some(explanation) = error_diagnosis.explanation {
         stderr
-            .fg(term::color::YELLOW)
+            .fg(term::color::RED)
             .expect("Failed to set stderr output color.");
-        writeln!(stderr, "Error explanation:").expect("Failed to write to stderr.");
+        writeln!(stderr, "Error:").expect("Failed to write to stderr.");
         stderr
             .reset()
             .expect("Failed to reset stderr output color.");
 
-        writeln!(stderr, "{}", error_explanation).expect("Failed to write to stderr.");
+        writeln!(stderr, "{}", explanation).expect("Failed to write to stderr.");
     }
-    if let Some(action_suggestion) = error_diagnosis.1 {
+    if let Some(action_suggestion) = error_diagnosis.action_suggestion {
         stderr
             .fg(term::color::YELLOW)
             .expect("Failed to set stderr output color.");
@@ -138,7 +142,7 @@ fn get_args_altered_for_extension_run(
     Ok(args)
 }
 
-fn inner_main() -> DfxResult {
+fn inner_main(log_level: &mut Option<i64>) -> DfxResult {
     let em = ExtensionManager::new(dfx_version())?;
     let installed_extension_manifests = em.load_installed_extension_manifests()?;
     let builtin_templates = builtin_templates();
@@ -154,6 +158,7 @@ fn inner_main() -> DfxResult {
     }
 
     let (verbose_level, log) = setup_logging(&cli_opts);
+    *log_level = Some(verbose_level);
     let identity = cli_opts.identity;
     let effective_canister_id = cli_opts.provisional_create_canister_effective_canister_id;
 
@@ -171,10 +176,11 @@ fn inner_main() -> DfxResult {
 }
 
 fn main() {
-    let result = inner_main();
+    let mut log_level: Option<i64> = None;
+    let result = inner_main(&mut log_level);
     if let Err(err) = result {
         let error_diagnosis = diagnose(&err);
-        print_error_and_diagnosis(err, error_diagnosis);
+        print_error_and_diagnosis(log_level, err, error_diagnosis);
         std::process::exit(255);
     }
 }


### PR DESCRIPTION
# Description

Error messages are very verbose. Current example:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ca02ba34-97f5-4568-9050-ead6de5759c5" />

With this PR the 'stack trace' is only displayed if either no nice error message is available or if verbose mode is explicitly requested. No trace:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4771e2fc-823f-479e-8161-51b41deb91a8" />

No nice error message available:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9fd904ae-059d-429d-adbd-98ebbeea9d36" />

Verbose mode:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d89c6c8a-1727-4050-899a-300ec6184f08" />


# How Has This Been Tested?

Manually.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
