### PR TITLE
fix: removes unnecessary tsc step in sveltekit build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+### fix: removes unnecessary tsc step in sveltekit build script
+
 ### feat!: `dfx info pocketic-config-port`
 
 Due to the incompatibility between the APIs on the replica port and the PocketIC port, `dfx info replica-port`

--- a/src/dfx/assets/project_templates/svelte/src/__frontend_name__/package.json
+++ b/src/dfx/assets/project_templates/svelte/src/__frontend_name__/package.json
@@ -7,7 +7,7 @@
     "setup": "npm i && dfx canister create __backend_name__ && dfx generate __backend_name__ && dfx deploy",
     "start": "vite --port 3000",
     "prebuild": "dfx generate",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "format": "prettier --write \"src/**/*.{json,js,jsx,ts,tsx,css,scss}\""
   },
   "dependencies": {


### PR DESCRIPTION
# Description

We were encountering build failures on the sveltekit starter, and this will both improve the build process and and unblock CI

# Checklist:

- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
