### PR TITLE
fix: --no-asset-upgrade hangs forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+### fix: `dfx canister install` and `dfx deploy` with `--no-asset-upgrade` no longer hang indefinitely when wasm is not up to date
+
 # 0.25.0
 
 ### fix: correctly detects hyphenated Rust bin crates

--- a/e2e/tests-dfx/install.bash
+++ b/e2e/tests-dfx/install.bash
@@ -241,10 +241,11 @@ teardown() {
 @test "--no-asset-upgrade skips asset upgrade" {
   dfx_start
   use_asset_wasm 0.12.1
-  dfx deploy
+  assert_command dfx deploy
   assert_command dfx canister info e2e_project_frontend
   assert_contains db07e7e24f6f8ddf53c33a610713259a7c1eb71c270b819ebd311e2d223267f0
   use_default_asset_wasm
+  assert_command dfx build e2e_project_frontend # otherwise the new wasm is not picked up
   assert_command dfx canister install e2e_project_frontend --mode upgrade --no-asset-upgrade
   assert_command dfx canister info e2e_project_frontend
   assert_contains db07e7e24f6f8ddf53c33a610713259a7c1eb71c270b819ebd311e2d223267f0

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -79,33 +79,10 @@ pub async fn install_canister(
         read_module_metadata(agent, canister_id, "enhanced-orthogonal-persistence")
             .await
             .map(|_| WasmMemoryPersistence::Keep);
-    // let mode = if let InstallModeHint::Auto(options) = mode_hint {
-    //     if installed_module_hash.is_some() {
-    //         InstallMode::Upgrade(Some(CanisterUpgradeOptions {
-    //             wasm_memory_persistence,
-    //             skip_pre_upgrade: None,
-    //         }))
-    //     } else {
-    //         InstallMode::Install
-    //     }
-    // } else {
-    //     InstallMode::Install
-    // };
     let mode = mode_hint.to_install_mode(
         installed_module_hash.is_some(),
         wasm_memory_persistence_embedded,
     );
-
-    // let mode = mode.unwrap_or_else(|| {
-    //     if installed_module_hash.is_some() {
-    //         InstallMode::Upgrade(Some(CanisterUpgradeOptions {
-    //             wasm_memory_persistence,
-    //             skip_pre_upgrade: None,
-    //         }))
-    //     } else {
-    //         InstallMode::Install
-    //     }
-    // });
     let mode_str = install_mode_to_prompt(&mode);
     let canister_name = canister_info.get_name();
     info!(
@@ -242,16 +219,15 @@ The command line value will be used.",
             )
             .await?;
         }
+        wait_for_module_hash(
+            env,
+            agent,
+            canister_id,
+            installed_module_hash.as_deref(),
+            &new_hash,
+        )
+        .await?;
     }
-
-    wait_for_module_hash(
-        env,
-        agent,
-        canister_id,
-        installed_module_hash.as_deref(),
-        &new_hash,
-    )
-    .await?;
 
     if canister_info.is_assets() {
         if let Some(canister_timeout) = canister_id_store.get_timestamp(canister_info.get_name()) {


### PR DESCRIPTION
# Description

When running `dfx deploy --no-asset-upgrade` or `dfx canister install --no-asset-upgrade` on an asset canister that is not up to date then dfx hangs forever with `Waiting for module change to be reflected in system state tree...`

Example:
```
% dfx deploy --ic --no-asset-upgrade
Deploying all canisters.
All canisters have already been created.
Building canisters...
[...]
Installing canisters...
Upgrading code for canister fe-app, with canister ID <id>
Waiting for module change to be reflected in system state tree...
Waiting for module change to be reflected in system state tree...
Waiting for module change to be reflected in system state tree...
[keeps waiting forever]
```

The problem was that dfx waited for the new wasm hash to show up in the state tree even if the new wasm was not actually installed.

# How Has This Been Tested?

Covered by e2e. If the fixed test is run on `master` then it never completes.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
