### PR TITLE
feat: progress bars for asset upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### fix: `dfx canister install` and `dfx deploy` with `--no-asset-upgrade` no longer hang indefinitely when wasm is not up to date
 
+### feat: streamlined output during asset synchronization
+
 # 0.25.0
 
 ### fix: correctly detects hyphenated Rust bin crates

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -905,7 +905,7 @@ check_permission_failure() {
   dd if=/dev/urandom of=src/e2e_project_frontend/assets/asset2.bin bs=400000 count=1
 
   dfx_start
-  assert_command dfx deploy
+  assert_command dfx deploy -v
 
   assert_match '/asset1.bin 1/1'
   assert_match '/asset2.bin 1/1'
@@ -1649,7 +1649,7 @@ EOF
   assert_match "200 OK" "$stderr"
 
   # redirect survives upgrade
-  assert_command dfx deploy --upgrade-unchanged
+  assert_command dfx deploy --upgrade-unchanged -v
   assert_match "is already installed"
 
   assert_command curl --fail -vv http://localhost:"$PORT"/test_alias_file.html?canisterId="$ID"
@@ -1922,7 +1922,7 @@ WARN: {
     },
   ]' > src/e2e_project_frontend/assets/somedir/.ic-assets.json5
 
-  assert_command dfx deploy
+  assert_command dfx deploy -v
   assert_match '/somedir/upload-me.txt 1/1 \(8 bytes\) sha [0-9a-z]* \(with cache and 1 header\)'
 }
 

--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -912,7 +912,7 @@ check_permission_failure() {
 
   dd if=/dev/urandom of=src/e2e_project_frontend/assets/asset2.bin bs=400000 count=1
 
-  assert_command dfx deploy
+  assert_command dfx deploy -v
   assert_match '/asset1.bin.*is already installed'
   assert_match '/asset2.bin 1/1'
 }

--- a/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
+++ b/src/canisters/frontend/ic-asset/src/batch_upload/plumbing.rs
@@ -10,12 +10,13 @@ use crate::error::CreateEncodingError;
 use crate::error::CreateEncodingError::EncodeContentFailed;
 use crate::error::CreateProjectAssetError;
 use crate::error::SetEncodingError;
+use crate::AssetSyncProgressRenderer;
 use candid::Nat;
 use futures::future::try_join_all;
 use futures::TryFutureExt;
 use ic_utils::Canister;
 use mime::Mime;
-use slog::{debug, info, Logger};
+use slog::{debug, Logger};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -89,14 +90,22 @@ impl<'agent> ChunkUploader<'agent> {
         &self,
         contents: &[u8],
         semaphores: &Semaphores,
+        progress: Option<&dyn AssetSyncProgressRenderer>,
     ) -> Result<usize, CreateChunkError> {
         let uploader_chunk_id = self.chunks.fetch_add(1, Ordering::SeqCst);
         self.bytes.fetch_add(contents.len(), Ordering::SeqCst);
         if contents.len() == MAX_CHUNK_SIZE || self.api_version < 2 {
-            let canister_chunk_id =
-                create_chunk(&self.canister, &self.batch_id, contents, semaphores).await?;
+            let canister_chunk_id = create_chunk(
+                &self.canister,
+                &self.batch_id,
+                contents,
+                semaphores,
+                progress,
+            )
+            .await?;
             let mut map = self.id_mapping.lock().await;
             map.insert(uploader_chunk_id, canister_chunk_id);
+
             Ok(uploader_chunk_id)
         } else {
             self.add_to_upload_queue(uploader_chunk_id, contents).await;
@@ -106,7 +115,8 @@ impl<'agent> ChunkUploader<'agent> {
             //  - Tested with: `for i in $(seq 1 50); do dd if=/dev/urandom of="src/hello_frontend/assets/file_$i.bin" bs=$(shuf -i 1-2000000 -n 1) count=1; done && dfx deploy hello_frontend`
             //  - Result: Roughly 15% of batches under 90% full.
             // With other byte ranges (e.g. `shuf -i 1-3000000 -n 1`) stats improve significantly
-            self.upload_chunks(4 * MAX_CHUNK_SIZE, semaphores).await?;
+            self.upload_chunks(4 * MAX_CHUNK_SIZE, semaphores, progress)
+                .await?;
             Ok(uploader_chunk_id)
         }
     }
@@ -115,6 +125,7 @@ impl<'agent> ChunkUploader<'agent> {
         &self,
         semaphores: &Semaphores,
         mode: Mode,
+        progress: Option<&dyn AssetSyncProgressRenderer>,
     ) -> Result<(), CreateChunkError> {
         let max_retained_bytes = if mode == Mode::ByProposal {
             // Never add data to the commit_batch args, because they have to fit in a single call.
@@ -124,7 +135,8 @@ impl<'agent> ChunkUploader<'agent> {
             MAX_CHUNK_SIZE / 2
         };
 
-        self.upload_chunks(max_retained_bytes, semaphores).await
+        self.upload_chunks(max_retained_bytes, semaphores, progress)
+            .await
     }
 
     pub(crate) fn bytes(&self) -> usize {
@@ -174,6 +186,7 @@ impl<'agent> ChunkUploader<'agent> {
         &self,
         max_retained_bytes: usize,
         semaphores: &Semaphores,
+        progress: Option<&dyn AssetSyncProgressRenderer>,
     ) -> Result<(), CreateChunkError> {
         let mut queue = self.upload_queue.lock().await;
 
@@ -202,7 +215,7 @@ impl<'agent> ChunkUploader<'agent> {
         try_join_all(batches.into_iter().map(|chunks| async move {
             let (uploader_chunk_ids, chunks): (Vec<_>, Vec<_>) = chunks.into_iter().unzip();
             let canister_chunk_ids =
-                create_chunks(&self.canister, &self.batch_id, chunks, semaphores).await?;
+                create_chunks(&self.canister, &self.batch_id, chunks, semaphores, progress).await?;
             let mut map = self.id_mapping.lock().await;
             for (uploader_id, canister_id) in uploader_chunk_ids
                 .into_iter()
@@ -227,6 +240,7 @@ async fn make_project_asset_encoding(
     content_encoding: &str,
     semaphores: &Semaphores,
     logger: &Logger,
+    progress: Option<&dyn AssetSyncProgressRenderer>,
 ) -> Result<ProjectAssetEncoding, CreateChunkError> {
     let sha256 = content.sha256();
 
@@ -249,7 +263,7 @@ async fn make_project_asset_encoding(
     };
 
     let uploader_chunk_ids = if already_in_place {
-        info!(
+        debug!(
             logger,
             "  {}{} ({} bytes) sha {} is already installed",
             &asset_descriptor.key,
@@ -267,10 +281,11 @@ async fn make_project_asset_encoding(
             content_encoding,
             semaphores,
             logger,
+            progress,
         )
         .await?
     } else {
-        info!(
+        debug!(
             logger,
             "  {}{} ({} bytes) sha {} will be uploaded",
             &asset_descriptor.key,
@@ -298,6 +313,7 @@ async fn make_encoding(
     force_encoding: bool,
     semaphores: &Semaphores,
     logger: &Logger,
+    progress: Option<&dyn AssetSyncProgressRenderer>,
 ) -> Result<Option<(String, ProjectAssetEncoding)>, CreateEncodingError> {
     match encoder {
         ContentEncoder::Identity => {
@@ -309,6 +325,7 @@ async fn make_encoding(
                 CONTENT_ENCODING_IDENTITY,
                 semaphores,
                 logger,
+                progress,
             )
             .await
             .map_err(CreateEncodingError::CreateChunkFailed)?;
@@ -331,6 +348,7 @@ async fn make_encoding(
                     &content_encoding,
                     semaphores,
                     logger,
+                    progress,
                 )
                 .await
                 .map_err(CreateEncodingError::CreateChunkFailed)?;
@@ -349,12 +367,14 @@ async fn make_encodings(
     content: &Content,
     semaphores: &Semaphores,
     logger: &Logger,
+    progress: Option<&dyn AssetSyncProgressRenderer>,
 ) -> Result<HashMap<String, ProjectAssetEncoding>, CreateEncodingError> {
     let encoders = asset_descriptor
         .config
         .encodings
         .clone()
         .unwrap_or_else(|| default_encoders(&content.media_type));
+
     // The identity encoding is always uploaded if it's in the list of chosen encodings.
     // Other encoding are only uploaded if they save bytes compared to identity.
     // The encoding is forced through the filter if there is no identity encoding to compare against.
@@ -372,6 +392,7 @@ async fn make_encodings(
                 force_encoding,
                 semaphores,
                 logger,
+                progress,
             )
         })
         .collect();
@@ -392,6 +413,7 @@ async fn make_project_asset(
     canister_assets: &HashMap<String, AssetDetails>,
     semaphores: &Semaphores,
     logger: &Logger,
+    progress: Option<&dyn AssetSyncProgressRenderer>,
 ) -> Result<ProjectAsset, CreateProjectAssetError> {
     let file_size = dfx_core::fs::metadata(&asset_descriptor.source)?.len();
     let permits = std::cmp::max(
@@ -412,9 +434,13 @@ async fn make_project_asset(
         &content,
         semaphores,
         logger,
+        progress,
     )
     .await?;
 
+    if let Some(progress) = progress {
+        progress.increment_complete_assets();
+    }
     Ok(ProjectAsset {
         asset_descriptor,
         media_type: content.media_type,
@@ -428,9 +454,13 @@ pub(crate) async fn make_project_assets(
     canister_assets: &HashMap<String, AssetDetails>,
     mode: Mode,
     logger: &Logger,
+    progress: Option<&dyn AssetSyncProgressRenderer>,
 ) -> Result<HashMap<String, ProjectAsset>, CreateProjectAssetError> {
     let semaphores = Semaphores::new();
 
+    if let Some(progress) = progress {
+        progress.set_total_assets(asset_descriptors.len());
+    }
     let project_asset_futures: Vec<_> = asset_descriptors
         .iter()
         .map(|loc| {
@@ -440,13 +470,14 @@ pub(crate) async fn make_project_assets(
                 canister_assets,
                 &semaphores,
                 logger,
+                progress,
             )
         })
         .collect();
     let project_assets = try_join_all(project_asset_futures).await?;
     if let Some(uploader) = chunk_upload_target {
         uploader
-            .finalize_upload(&semaphores, mode)
+            .finalize_upload(&semaphores, mode, progress)
             .await
             .map_err(|err| {
                 CreateProjectAssetError::CreateEncodingError(
@@ -470,11 +501,14 @@ async fn upload_content_chunks(
     content_encoding: &str,
     semaphores: &Semaphores,
     logger: &Logger,
+    progress: Option<&dyn AssetSyncProgressRenderer>,
 ) -> Result<Vec<usize>, CreateChunkError> {
     if content.data.is_empty() {
         let empty = vec![];
-        let chunk_id = chunk_uploader.create_chunk(&empty, semaphores).await?;
-        info!(
+        let chunk_id = chunk_uploader
+            .create_chunk(&empty, semaphores, progress)
+            .await?;
+        debug!(
             logger,
             "  {}{} 1/1 (0 bytes) sha {}",
             &asset_descriptor.key,
@@ -484,6 +518,9 @@ async fn upload_content_chunks(
         return Ok(vec![chunk_id]);
     }
 
+    if let Some(progress) = progress {
+        progress.add_total_bytes(content.data.len());
+    }
     let count = (content.data.len() + MAX_CHUNK_SIZE - 1) / MAX_CHUNK_SIZE;
     let chunks_futures: Vec<_> = content
         .data
@@ -491,9 +528,9 @@ async fn upload_content_chunks(
         .enumerate()
         .map(|(i, data_chunk)| {
             chunk_uploader
-                .create_chunk(data_chunk, semaphores)
+                .create_chunk(data_chunk, semaphores, progress)
                 .map_ok(move |chunk_id| {
-                    info!(
+                    debug!(
                         logger,
                         "  {}{} {}/{} ({} bytes) sha {} {}",
                         &asset_descriptor.key,

--- a/src/canisters/frontend/ic-asset/src/lib.rs
+++ b/src/canisters/frontend/ic-asset/src/lib.rs
@@ -20,7 +20,7 @@
 //!     .with_agent(&agent)
 //!     .build()?;
 //! let logger = slog::Logger::root(slog::Discard, slog::o!());
-//! ic_asset::sync(&canister, &[concat!(env!("CARGO_MANIFEST_DIR"), "assets/").as_ref()], false, &logger).await?;
+//! ic_asset::sync(&canister, &[concat!(env!("CARGO_MANIFEST_DIR"), "assets/").as_ref()], false, &logger, None).await?;
 //! # Ok(())
 //! # }
 

--- a/src/canisters/frontend/ic-asset/src/lib.rs
+++ b/src/canisters/frontend/ic-asset/src/lib.rs
@@ -36,11 +36,13 @@ mod batch_upload;
 mod canister_api;
 pub mod error;
 mod evidence;
+mod progress;
 pub mod security_policy;
 mod sync;
 mod upload;
 
 pub use evidence::compute_evidence;
+pub use progress::{AssetSyncProgressRenderer, AssetSyncState};
 pub use sync::prepare_sync_for_proposal;
 pub use sync::sync;
 pub use upload::upload;

--- a/src/canisters/frontend/ic-asset/src/progress.rs
+++ b/src/canisters/frontend/ic-asset/src/progress.rs
@@ -1,0 +1,57 @@
+/// .
+#[derive(Debug)]
+pub enum AssetSyncState {
+    /// Walk the source directories and build a list of assets to sync
+    GatherAssetDescriptors,
+
+    /// List all assets already in the canister
+    ListAssets,
+
+    /// Get properties of all assets already in the canister
+    GetAssetProperties,
+
+    /// Create the batch
+    CreateBatch,
+
+    /// Upload content encodings (chunks)
+    StageContents,
+
+    /// Build the list of operations to apply all changes
+    AssembleBatch,
+
+    /// Commit (execute) batch operations
+    CommitBatch,
+
+    /// All done
+    Done,
+}
+
+/// Display progress of the synchronization process
+pub trait AssetSyncProgressRenderer {
+    /// Set the current state of the synchronization process
+    fn set_state(&self, state: AssetSyncState);
+
+    /// Set the total number of assets to get properties for
+    fn set_asset_properties_to_retrieve(&self, total: usize);
+
+    /// Increment the number of assets for which properties have been retrieved
+    fn inc_asset_properties_retrieved(&self);
+
+    /// Set the total number of assets to sync
+    fn set_total_assets(&self, total: usize);
+
+    /// Increment the number of assets that have been synced
+    fn increment_complete_assets(&self);
+
+    /// Set the total number of bytes to upload
+    fn add_total_bytes(&self, add: usize);
+
+    /// Increment the number of bytes that have been uploaded
+    fn add_uploaded_bytes(&self, add: usize);
+
+    /// Set the total number of batch operations
+    fn set_total_batch_operations(&self, total: usize);
+
+    /// Increase the number of batch operations that have been committed
+    fn add_committed_batch_operations(&self, add: usize);
+}

--- a/src/canisters/frontend/ic-asset/src/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/upload.rs
@@ -14,6 +14,7 @@ use crate::canister_api::methods::{
 use crate::canister_api::types::batch_upload::v0;
 use crate::error::CompatibilityError::DowngradeV1TOV0Failed;
 use crate::error::UploadError::{self, CommitBatchFailed, CreateBatchFailed, ListAssetsFailed};
+use crate::AssetSyncProgressRenderer;
 use ic_utils::Canister;
 use slog::{info, Logger};
 use std::collections::HashMap;
@@ -24,6 +25,7 @@ pub async fn upload(
     canister: &Canister<'_>,
     files: HashMap<String, PathBuf>,
     logger: &Logger,
+    progress: Option<&dyn AssetSyncProgressRenderer>,
 ) -> Result<(), UploadError> {
     let asset_descriptors: Vec<AssetDescriptor> = files
         .iter()
@@ -52,6 +54,7 @@ pub async fn upload(
         &canister_assets,
         NormalDeploy,
         logger,
+        progress,
     )
     .await?;
 

--- a/src/canisters/frontend/icx-asset/src/commands/sync.rs
+++ b/src/canisters/frontend/icx-asset/src/commands/sync.rs
@@ -9,6 +9,6 @@ pub(crate) async fn sync(
     logger: &Logger,
 ) -> anyhow::Result<()> {
     let dirs: Vec<&Path> = o.directory.iter().map(|d| d.as_path()).collect();
-    ic_asset::sync(canister, &dirs, o.no_delete, logger).await?;
+    ic_asset::sync(canister, &dirs, o.no_delete, logger, None).await?;
     Ok(())
 }

--- a/src/canisters/frontend/icx-asset/src/commands/upload.rs
+++ b/src/canisters/frontend/icx-asset/src/commands/upload.rs
@@ -12,7 +12,7 @@ pub(crate) async fn upload(
     logger: &Logger,
 ) -> anyhow::Result<()> {
     let key_map = get_key_map(&opts.files)?;
-    ic_asset::upload(canister, key_map, logger).await?;
+    ic_asset::upload(canister, key_map, logger, None).await?;
     Ok(())
 }
 

--- a/src/dfx-core/src/progress/mod.rs
+++ b/src/dfx-core/src/progress/mod.rs
@@ -1,0 +1,3 @@
+mod progress_bar;
+
+pub use progress_bar::ProgressBar;

--- a/src/dfx/src/actors/mod.rs
+++ b/src/dfx/src/actors/mod.rs
@@ -1,3 +1,4 @@
+use self::pocketic::PocketIc;
 use crate::actors::btc_adapter::signals::BtcAdapterReadySubscribe;
 use crate::actors::btc_adapter::BtcAdapter;
 use crate::actors::canister_http_adapter::signals::CanisterHttpAdapterReadySubscribe;
@@ -17,8 +18,6 @@ use pocketic_proxy::{PocketIcProxy, PocketIcProxyConfig};
 use post_start::PostStart;
 use std::fs;
 use std::path::PathBuf;
-
-use self::pocketic::PocketIc;
 
 pub mod btc_adapter;
 pub mod canister_http_adapter;

--- a/src/dfx/src/lib/mod.rs
+++ b/src/dfx/src/lib/mod.rs
@@ -26,6 +26,7 @@ pub mod nns_types;
 pub mod operations;
 pub mod package_arguments;
 pub mod program;
+pub mod progress;
 pub mod progress_bar;
 pub mod project;
 pub mod replica;

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -376,7 +376,7 @@ async fn prepare_assets_for_commit(
 
     let agent = env.get_agent();
 
-    prepare_assets_for_proposal(&canister_info, agent, env.get_logger()).await?;
+    prepare_assets_for_proposal(&canister_info, agent, env).await?;
 
     Ok(())
 }
@@ -414,7 +414,8 @@ async fn compute_evidence(
         .build()
         .context("Failed to build asset canister caller.")?;
 
-    let evidence = ic_asset::compute_evidence(&canister, &source_paths, env.get_logger()).await?;
+    let evidence =
+        ic_asset::compute_evidence(&canister, &source_paths, env.get_logger(), None).await?;
     println!("{}", evidence);
 
     Ok(())

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -265,8 +265,8 @@ The command line value will be used.",
                 .context("Failed to authorize your principal with the canister. You can still control the canister by using your wallet with the --wallet flag.")?;
         };
 
-        info!(log, "Uploading assets to asset canister...");
-        post_install_store_assets(canister_info, agent, log).await?;
+        debug!(log, "Uploading assets to asset canister...");
+        post_install_store_assets(env, canister_info, agent).await?;
     }
     if !canister_info.get_post_install().is_empty() {
         let config = env.get_config()?;

--- a/src/dfx/src/lib/progress/asset_sync_progress_renderer.rs
+++ b/src/dfx/src/lib/progress/asset_sync_progress_renderer.rs
@@ -1,0 +1,161 @@
+use crate::lib::environment::Environment;
+use crate::lib::progress_bar::ProgressBar;
+use ic_asset::{AssetSyncProgressRenderer, AssetSyncState};
+use std::cell::OnceCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub struct EnvAssetSyncProgressRenderer<'a> {
+    pub env: &'a dyn Environment,
+
+    topline: ProgressBar,
+    bytes: OnceCell<ProgressBar>,
+
+    // getting properties of assets already in canister
+    total_assets_to_retrieve_properties: AtomicUsize,
+    assets_retrieved_properties: AtomicUsize,
+
+    // staging assets
+    total_assets: AtomicUsize,
+    complete_assets: AtomicUsize,
+
+    // uploading content
+    total_bytes: AtomicUsize,
+    uploaded_bytes: AtomicUsize,
+
+    // committing batch
+    total_batch_operations: AtomicUsize,
+    committed_batch_operations: AtomicUsize,
+}
+
+impl<'a> EnvAssetSyncProgressRenderer<'a> {
+    pub fn new(env: &'a dyn Environment) -> Self {
+        let topline = env.new_spinner("Synchronizing assets".into());
+
+        let total_assets_to_retrieve_properties = AtomicUsize::new(0);
+        let assets_retrieved_properties = AtomicUsize::new(0);
+
+        let total_assets = AtomicUsize::new(0);
+        let complete_assets = AtomicUsize::new(0);
+
+        let bytes = OnceCell::new(); // env.new_spinner("Uploading content...".into());
+        let total_bytes = AtomicUsize::new(0);
+        let uploaded_bytes = AtomicUsize::new(0);
+
+        let total_batch_operations = AtomicUsize::new(0);
+        let committed_batch_operations = AtomicUsize::new(0);
+
+        Self {
+            env,
+            topline,
+            total_assets_to_retrieve_properties,
+            assets_retrieved_properties,
+            total_assets,
+            complete_assets,
+            bytes,
+            total_bytes,
+            uploaded_bytes,
+            total_batch_operations,
+            committed_batch_operations,
+        }
+    }
+
+    fn get_bytes_progress_bar(&self) -> &ProgressBar {
+        self.bytes
+            .get_or_init(|| self.env.new_spinner("Uploading content...".into()))
+    }
+
+    fn update_get_asset_properties(&self) {
+        let total = self
+            .total_assets_to_retrieve_properties
+            .load(Ordering::SeqCst);
+        let got = self.assets_retrieved_properties.load(Ordering::SeqCst);
+        self.topline
+            .set_message(format!("Read asset properties: {}/{}", got, total).into());
+    }
+
+    fn update_assets(&self) {
+        let total = self.total_assets.load(Ordering::SeqCst);
+        let complete = self.complete_assets.load(Ordering::SeqCst);
+        self.topline
+            .set_message(format!("Staged: {}/{} assets", complete, total).into());
+    }
+
+    fn update_bytes(&self) {
+        let uploaded = self.uploaded_bytes.load(Ordering::SeqCst);
+        self.get_bytes_progress_bar()
+            .set_message(format!("Uploaded content: {} bytes", uploaded).into());
+    }
+
+    fn update_commit_batch(&self) {
+        let total = self.total_batch_operations.load(Ordering::SeqCst);
+        let committed = self.committed_batch_operations.load(Ordering::SeqCst);
+        self.topline
+            .set_message(format!("Committed batch: {}/{} operations", committed, total).into());
+    }
+}
+
+impl<'a> AssetSyncProgressRenderer for EnvAssetSyncProgressRenderer<'a> {
+    fn set_state(&self, state: AssetSyncState) {
+        if matches!(state, AssetSyncState::CommitBatch) {
+            if let Some(bar) = self.bytes.get() {
+                bar.finish_and_clear();
+            }
+        }
+        if matches!(state, AssetSyncState::Done) {
+            self.topline.finish_and_clear();
+            return;
+        }
+
+        let msg = match state {
+            AssetSyncState::GatherAssetDescriptors => "Gathering asset descriptors",
+            AssetSyncState::ListAssets => "Listing assets",
+            AssetSyncState::GetAssetProperties => "Getting asset properties",
+            AssetSyncState::CreateBatch => "Creating batch",
+            AssetSyncState::StageContents => "Staging contents",
+            AssetSyncState::AssembleBatch => "Assembling batch",
+            AssetSyncState::CommitBatch => "Committing batch",
+            AssetSyncState::Done => unreachable!(),
+        };
+        self.topline.set_message(msg.into());
+    }
+
+    fn set_asset_properties_to_retrieve(&self, total: usize) {
+        self.total_assets_to_retrieve_properties
+            .store(total, Ordering::SeqCst);
+    }
+    fn inc_asset_properties_retrieved(&self) {
+        self.assets_retrieved_properties
+            .fetch_add(1, Ordering::SeqCst);
+        self.update_get_asset_properties();
+    }
+
+    fn set_total_assets(&self, total: usize) {
+        self.total_assets.store(total, Ordering::SeqCst);
+        self.update_assets();
+    }
+
+    fn increment_complete_assets(&self) {
+        self.complete_assets.fetch_add(1, Ordering::SeqCst);
+        self.update_assets();
+    }
+
+    fn add_total_bytes(&self, add: usize) {
+        self.total_bytes.fetch_add(add, Ordering::SeqCst);
+        self.update_bytes();
+    }
+    fn add_uploaded_bytes(&self, add: usize) {
+        self.uploaded_bytes.fetch_add(add, Ordering::SeqCst);
+        self.update_bytes();
+    }
+
+    fn set_total_batch_operations(&self, total: usize) {
+        self.total_batch_operations
+            .fetch_add(total, Ordering::SeqCst);
+    }
+
+    fn add_committed_batch_operations(&self, add: usize) {
+        self.committed_batch_operations
+            .fetch_add(add, Ordering::SeqCst);
+        self.update_commit_batch();
+    }
+}

--- a/src/dfx/src/lib/progress/mod.rs
+++ b/src/dfx/src/lib/progress/mod.rs
@@ -1,0 +1,3 @@
+mod asset_sync_progress_renderer;
+
+pub use asset_sync_progress_renderer::EnvAssetSyncProgressRenderer;


### PR DESCRIPTION
# Description

Added spinners to reflect asset synchronization progress. Changed logging from info to debug.

Fixes: https://dfinity.atlassian.net/browse/SDK-1944

Now the output looks like this (while assets are being uploaded)
```
dfx deploy
Deploying all canisters.
Creating canisters...
Created a wallet canister on the "local" network for user "default" with ID "bnz7o-iuaaa-aaaaa-qaaaa-cai"
scraped-portal-backend canister created with canister id: bkyz2-fmaaa-aaaaa-qaaaq-cai
scraped-portal-frontend canister created with canister id: bd3sg-teaaa-aaaaa-qaaba-cai
Building canisters...
Installing canisters...
Creating UI canister on the local network.
The UI canister on the "local" network is "be2us-64aaa-aaaaa-qaabq-cai"
Installing code for canister scraped-portal-backend, with canister ID bkyz2-fmaaa-aaaaa-qaaaq-cai
Installing code for canister scraped-portal-frontend, with canister ID bd3sg-teaaa-aaaaa-qaaba-cai
WARN: This project does not define a security policy for some assets.
WARN: You should define a security policy in .ic-assets.json5. For example:
WARN: [
WARN:   {
WARN:     "match": "**/*",
WARN:     "security_policy": "standard"
WARN:   }
WARN: ]
WARN: Assets without any security policy: all
WARN: To disable the policy warning, define "disable_security_policy_warning": true in .ic-assets.json5.
⠤ Staged: 164/7828 assets
⠐ Uploaded content: 9499792 bytes                
```

# How Has This Been Tested?

Tested locally

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
