### PR TITLE
fix: download remote did files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### fix: `dfx canister install` and `dfx deploy` with `--no-asset-upgrade` no longer hang indefinitely when wasm is not up to date
 
+### fix: `dfx` downloads `.did` files for remote canisters
+
 ### feat: streamlined output during asset synchronization
 
 # 0.25.0

--- a/e2e/assets/remote/download_did/canister_ids.json
+++ b/e2e/assets/remote/download_did/canister_ids.json
@@ -1,0 +1,5 @@
+{
+    "hello_backend": {
+        "ic": "aaaaa-aa"
+    }
+}

--- a/e2e/assets/remote/download_did/dfx.json
+++ b/e2e/assets/remote/download_did/dfx.json
@@ -1,0 +1,25 @@
+{
+  "canisters": {
+    "hello_backend": {
+      "main": "main.mo",
+      "type": "motoko",
+      "dependencies": [
+        "internet_identity"
+      ]
+    },
+    "internet_identity": {
+      "type": "custom",
+      "candid": "https://github.com/dfinity/internet-identity/releases/download/release-2024-12-13/internet_identity.did",
+      "wasm": "https://github.com/dfinity/internet-identity/releases/download/release-2024-12-13/internet_identity_dev.wasm.gz",
+      "init_arg": "(opt record { captcha_config = opt record { max_unsolved_captchas= 50:nat64; captcha_trigger = variant {Static = variant {CaptchaDisabled}}}})",
+      "remote": {
+        "id": {
+          "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
+        }
+      },
+      "frontend": {}
+    }
+  },
+  "output_env_file": ".env",
+  "version": 1
+}

--- a/e2e/assets/remote/download_did/main.mo
+++ b/e2e/assets/remote/download_did/main.mo
@@ -1,0 +1,3 @@
+import II "canister:internet_identity";
+
+actor {};

--- a/e2e/tests-dfx/remote.bash
+++ b/e2e/tests-dfx/remote.bash
@@ -345,3 +345,9 @@ teardown() {
   assert_match "CANISTER_ID_REMOTE: qoctq-giaaa-aaaaa-aaaea-cai"
   assert_contains "CANISTER_CANDID_PATH_REMOTE: $(pwd -P)/remotecandid.did"
 }
+
+@test "build step downloads dependency .did files" {
+  install_asset remote/download_did
+  assert_command dfx build --ic -v
+  assert_not_contains ".did file for canister 'internet_identity' does not exist"
+}

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -839,7 +839,7 @@ impl CanisterPool {
         log: &Logger,
         build_config: &BuildConfig,
     ) -> DfxResult<()> {
-        self.download(build_config).await?;
+        self.download().await?;
         let outputs = self.build(env, log, build_config)?;
 
         for output in outputs {
@@ -849,8 +849,9 @@ impl CanisterPool {
         Ok(())
     }
 
-    async fn download(&self, build_config: &BuildConfig) -> DfxResult {
-        for canister in self.canisters_to_build(build_config) {
+    async fn download(&self) -> DfxResult {
+        // Download canister wasms and .did files
+        for canister in self.canisters.iter() {
             let info = canister.get_info();
 
             if info.is_custom() {

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -850,7 +850,6 @@ impl CanisterPool {
     }
 
     async fn download(&self) -> DfxResult {
-        // Download canister wasms and .did files
         for canister in self.canisters.iter() {
             let info = canister.get_info();
 


### PR DESCRIPTION
# Description

If `canisters.<dependency canister>.candid` is a URL and `canisters.<dependency canister>.remote.candid` is `null`, then `dfx build` failed when the project was not first built for a non-remote network because the candid file was not properly downloaded.

Fixes [SDK-1793](https://dfinity.atlassian.net/browse/SDK-1793)

# How Has This Been Tested?

added e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-1793]: https://dfinity.atlassian.net/browse/SDK-1793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ