### PR TITLE
feat: add spinner for Candid UI canister creation

### DIFF
--- a/src/dfx/src/lib/named_canister.rs
+++ b/src/dfx/src/lib/named_canister.rs
@@ -11,7 +11,7 @@ use dfx_core::config::model::canister_id_store::CanisterIdStore;
 use fn_error_context::context;
 use ic_utils::interfaces::management_canister::builders::InstallMode;
 use ic_utils::interfaces::ManagementCanister;
-use slog::{debug, info};
+use slog::debug;
 use std::io::Read;
 use url::{Host::Domain, Url};
 
@@ -33,7 +33,7 @@ pub async fn install_ui_canister(
     }
     fetch_root_key_if_needed(env).await?;
     let mgr = ManagementCanister::create(env.get_agent());
-    let spinner = env.new_spinner(format!("Creating UI canister on the {} network", network.name).into());
+    let spinner = env.new_spinner("Creating UI canister".into());
     debug!(
         env.get_logger(),
         "Creating UI canister on the {} network.", network.name
@@ -59,7 +59,6 @@ pub async fn install_ui_canister(
     let canister_id = match some_canister_id {
         Some(id) => id,
         None => {
-            spinner.set_message("creating UI canister".into());
             mgr.create_canister()
                 .as_provisional_create_with_amount(None)
                 .with_effective_canister_id(env.get_effective_canister_id())
@@ -68,14 +67,14 @@ pub async fn install_ui_canister(
                 .0
         }
     };
-    spinner.set_message("installing code into UI canister".into());
+    spinner.set_message("Installing code into UI canister".into());
     mgr.install_code(&canister_id, wasm.as_slice())
         .with_mode(InstallMode::Install)
         .await
         .context("Install wasm call failed.")?;
     id_store.add(env.get_logger(), UI_CANISTER, &canister_id.to_text(), None)?;
     spinner.finish_and_clear();
-    info!(
+    debug!(
         env.get_logger(),
         "The UI canister on the \"{}\" network is \"{}\"",
         network.name,

--- a/src/dfx/src/lib/named_canister.rs
+++ b/src/dfx/src/lib/named_canister.rs
@@ -11,7 +11,7 @@ use dfx_core::config::model::canister_id_store::CanisterIdStore;
 use fn_error_context::context;
 use ic_utils::interfaces::management_canister::builders::InstallMode;
 use ic_utils::interfaces::ManagementCanister;
-use slog::info;
+use slog::{debug, info};
 use std::io::Read;
 use url::{Host::Domain, Url};
 
@@ -33,7 +33,8 @@ pub async fn install_ui_canister(
     }
     fetch_root_key_if_needed(env).await?;
     let mgr = ManagementCanister::create(env.get_agent());
-    info!(
+    let spinner = env.new_spinner(format!("Creating UI canister on the {} network", network.name).into());
+    debug!(
         env.get_logger(),
         "Creating UI canister on the {} network.", network.name
     );
@@ -58,6 +59,7 @@ pub async fn install_ui_canister(
     let canister_id = match some_canister_id {
         Some(id) => id,
         None => {
+            spinner.set_message("creating UI canister".into());
             mgr.create_canister()
                 .as_provisional_create_with_amount(None)
                 .with_effective_canister_id(env.get_effective_canister_id())
@@ -66,11 +68,13 @@ pub async fn install_ui_canister(
                 .0
         }
     };
+    spinner.set_message("installing code into UI canister".into());
     mgr.install_code(&canister_id, wasm.as_slice())
         .with_mode(InstallMode::Install)
         .await
         .context("Install wasm call failed.")?;
     id_store.add(env.get_logger(), UI_CANISTER, &canister_id.to_text(), None)?;
+    spinner.finish_and_clear();
     info!(
         env.get_logger(),
         "The UI canister on the \"{}\" network is \"{}\"",


### PR DESCRIPTION
# Description

Display a spinner when creating/installing the Candid UI canister, and log about it to debug, not info.

Part of https://dfinity.atlassian.net/browse/SDK-1944

# How Has This Been Tested?

Tested locally

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
