### PR TITLE
chore: clarify log message when deploying to playground

### DIFF
--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -332,10 +332,9 @@ async fn wait_for_module_hash(
             Some(reported_hash) => {
                 if env.get_network_descriptor().is_playground() {
                     // Playground may modify wasm before installing, therefore we cannot predict what the hash is supposed to be.
-                    info!(
+                    debug!(
                         env.get_logger(),
-                        "Something is installed in canister {}. Assuming new code is installed.",
-                        canister_id
+                        "Module hash verification is skipped for playground deployments."
                     );
                     break;
                 }


### PR DESCRIPTION
# Description

When deploying to the playground we cannot verify the wasm hash because the playground may change the wasm before deploying. Clarify the message and show it only in verbose mode.

Fixes # SDK-1898

# How Has This Been Tested?

```
❯ ddfx deploy --playground
WARN: Canister 'hello_backend' has timed out.
Deploying all canisters.
Reserving canisters in playground...
Reserved canister 'hello_backend' with id 7gngh-jqaaa-aaaab-qacvq-cai with the playground.
Building canisters...
Installing canisters...
Installing code for canister hello_backend, with canister ID 7gngh-jqaaa-aaaab-qacvq-cai
Deployed canisters.
URLs:
  Backend canister via Candid interface:
    hello_backend: https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=7gngh-jqaaa-aaaab-qacvq-cai
❯ ddfx deploy --playground --verbose
Deploying all canisters.
All canisters have already been created.
Building canisters...
Installing canisters...
Previously installed module hash: Some("725f9a285847835b0789d7f72ce5d606299328644fa97902da54ca492d9978c8")
Upgrading code for canister hello_backend, with canister ID 7gngh-jqaaa-aaaab-qacvq-cai
New wasm module hash: e655e60848af7f9bc8cce486526f75846e8623d09214efbe489ba5f20e067f34
Module hash verification is skipped for playground deployments.
Deployed canisters.
URLs:
  Backend canister via Candid interface:
    hello_backend: https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=7gngh-jqaaa-aaaab-qacvq-cai
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
