### PR TITLE
chore: update tests to show asset canister properly handles special chars

### DIFF
--- a/e2e/tests-dfx/assetscanister.bash
+++ b/e2e/tests-dfx/assetscanister.bash
@@ -738,14 +738,11 @@ check_permission_failure() {
 
   dfx canister  call --query e2e_project_frontend list '(record {})'
 
-  # decode as expected
+  # decode as expected - %c3%a6 is the utf-8 encoding of the ae symbol
   assert_command dfx canister call --query e2e_project_frontend http_request '(record{url="/%c3%a6";headers=vec{};method="GET";body=vec{}})'
   assert_match "filename is an ae symbol" # candid looks like blob "filename is \c3\a6\0a"
 
   assert_command curl --fail -vv http://localhost:"$PORT"/%c3%a6?canisterId="$ID"
-  assert_match "filename is an ae symbol"
-
-  assert_command curl --fail -vv http://localhost:"$PORT"/æ?canisterId="$ID"
   assert_match "filename is an ae symbol"
 
   # fails with because %e6 is not valid utf-8 percent encoding


### PR DESCRIPTION
# Description

A while back the asset canister did not handle special characters in file names correctly. This was recorded in e2e tests and recorder for follow-up in SDK-1247/1420. The behavior was fixed in #3767. This PR now updates the tests to demonstrate more clearly that special characters are handled properly.

Fixes [SDK-1420](https://dfinity.atlassian.net/browse/SDK-1420)

# How Has This Been Tested?

Updated e2e tests to demonstrate correct behavior

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-1420]: https://dfinity.atlassian.net/browse/SDK-1420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ