### PR TITLE
fix: cargo-deny failure due to toolchain not installed

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - ens/cargo-deny-fix
   pull_request:
 
 concurrency:

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - ens/cargo-deny-fix
   pull_request:
 
 concurrency:
@@ -22,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: rm rust-toolchain.toml
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check bans licenses sources # skip advisories, which are handled by audit.yml


### PR DESCRIPTION

# Description

The license check in CI started failing today. Example: https://github.com/dfinity/sdk/actions/runs/13636726972/job/38121248105?pr=4126

I tried running the command that it asked for, but it didn't help, probably because it's running in a docker container. I tried the v2 action and configuring it to use the rust version that it's used to, but rust-toolchain.toml still overrode it.

This PR removes rust-toolchain.toml when the deny workflow runs so that the workflow can run with what it needs.


