### PR TITLE
feat!: default to PocketIC

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -160,8 +160,8 @@ jobs:
           echo "archive=$(pwd)/e2e/archive" >> "$GITHUB_ENV"
           echo "assets=$(pwd)/e2e/assets" >> "$GITHUB_ENV"
           echo "utils=$(pwd)/e2e/utils" >> "$GITHUB_ENV"
-          if [ "${{ matrix.backend == 'pocketic' || '' }}" ]; then
-            echo "USE_POCKETIC=1" >> "$GITHUB_ENV"
+          if [ "${{ matrix.backend == 'replica' || '' }}" ]; then
+            echo "USE_REPLICA=1" >> "$GITHUB_ENV"
           fi
           export
       - name: Download bats-support as a git submodule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # UNRELEASED
 
+### feat!: `dfx start` uses `--pocketic` by default
+
+As [announced](https://forum.dfinity.org/t/dfx-replacing-the-local-replica-with-pocketic/40167) `dfx start` now runs PocketIC by default.
+Running a local replica is still possible with `--replica`, but this option will be removed in the near future.
+
 # 0.25.1
 
 ### feat: `skip_cargo_audit` flag in dfx.json to skip `cargo audit` build step

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,19 +59,19 @@ If there is already an entry in the 'Unreleased' section, change it; if not, add
 
 #### Running End-to-End Tests
 
+This runs the end-to-end tests against the
+[PocketIC emulator](https://github.com/dfinity/pocketic).
+
 ``` bash
 sdk $ bats e2e/tests-dfx/*.bash
 sdk $ bats e2e/tests-replica/*.bash
 ```
 
-#### Running End-to-End Tests Against Reference IC
-
-This runs the end-to-end tests against the
-[PocketIC emulator](https://github.com/dfinity/pocketic).
+#### Running End-to-End Tests Against Local Replica
 
 ``` bash
-sdk $ USE_POCKETIC=1 bats e2e/tests-dfx/*.bash
-sdk $ USE_POCKETIC=1 bats e2e/tests-replica/*.bash
+sdk $ USE_REPLICA=1 bats e2e/tests-dfx/*.bash
+sdk $ USE_REPLICA=1 bats e2e/tests-replica/*.bash
 ```
 
 ## Conventional Commits

--- a/e2e/assets/expect_scripts/ctrl_c_right_after_dfx_start.exp
+++ b/e2e/assets/expect_scripts/ctrl_c_right_after_dfx_start.exp
@@ -5,8 +5,8 @@ set timeout 330
 
 spawn dfx cache install
 expect "Installed dfx"
-if [info exists env(USE_POCKETIC)] {
-    spawn dfx start --pocketic --clean
+if [info exists env(USE_REPLICA)] {
+    spawn dfx start --replica --clean
 } else {
     spawn dfx start --clean
 }

--- a/e2e/tests-dfx/bitcoin.bash
+++ b/e2e/tests-dfx/bitcoin.bash
@@ -37,7 +37,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "dfx restarts replica when ic-btc-adapter restarts" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
+  [[ ! "$USE_REPLICA" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new_assets hello
   dfx_start --enable-bitcoin
 
@@ -87,7 +87,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "dfx start --bitcoin-node <node> implies --enable-bitcoin" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
+  [[ ! "$USE_REPLICA" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new hello
   dfx_start "--bitcoin-node" "127.0.0.1:18444"
 
@@ -95,7 +95,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "dfx start --enable-bitcoin with no other configuration succeeds" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
+  [[ ! "$USE_REPLICA" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new hello
 
   dfx_start --enable-bitcoin
@@ -114,7 +114,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "can enable bitcoin through default configuration - dfx start" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
+  [[ ! "$USE_REPLICA" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new hello
   define_project_network
   set_project_default_bitcoin_enabled
@@ -125,7 +125,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "can enable bitcoin through shared local network - dfx start" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
+  [[ ! "$USE_REPLICA" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new hello
   set_shared_local_network_bitcoin_enabled
 
@@ -135,7 +135,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "can enable bitcoin through local network configuration - dfx start" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
+  [[ ! "$USE_REPLICA" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new hello
   set_local_network_bitcoin_enabled
 
@@ -145,7 +145,7 @@ set_local_network_bitcoin_enabled() {
 }
 
 @test "dfx start with both bitcoin and canister http enabled" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
+  [[ ! "$USE_REPLICA" ]] && skip "skipped for pocketic: bitcoin adapter is a replica implementation detail"
   dfx_new hello
 
   dfx_start --enable-bitcoin --enable-canister-http

--- a/e2e/tests-dfx/call.bash
+++ b/e2e/tests-dfx/call.bash
@@ -199,7 +199,7 @@ teardown() {
   dfx canister create --all
   dfx build
   dfx canister install hello_backend
-  [[ "$USE_POCKETIC" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_backend
+  [[ ! "$USE_REPLICA" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_backend
   assert_command dfx canister call hello_backend recurse 100
 }
 
@@ -369,13 +369,13 @@ function impersonate_sender() {
 }
 
 @test "impersonate management canister as sender" {
-    [[ ! "$USE_POCKETIC" ]] && skip "skipped for replica: impersonating sender is only supported for PocketIC"
+    [[ "$USE_REPLICA" ]] && skip "skipped for replica: impersonating sender is only supported for PocketIC"
 
     impersonate_sender "aaaaa-aa"
 }
 
 @test "impersonate new random identity as sender" {
-    [[ ! "$USE_POCKETIC" ]] && skip "skipped for replica: impersonating sender is only supported for PocketIC"
+    [[ "$USE_REPLICA" ]] && skip "skipped for replica: impersonating sender is only supported for PocketIC"
 
     dfx identity new impersonated_identity --storage-mode plaintext
     IDENTITY_PRINCIPAL="$(dfx --identity impersonated_identity identity get-principal)"

--- a/e2e/tests-dfx/create.bash
+++ b/e2e/tests-dfx/create.bash
@@ -43,7 +43,7 @@ teardown() {
 }
 
 @test "create succeeds when specify large canister ID" {
-  [[ "$USE_POCKETIC" ]] && skip "skipped for pocketic: nonexistent subnet ranges are unsupported"
+  [[ ! "$USE_REPLICA" ]] && skip "skipped for pocketic: nonexistent subnet ranges are unsupported"
   dfx_start
   # hhn2s-5l777-77777-7777q-cai is the canister ID of (u64::MAX / 2)
   assert_command dfx canister create e2e_project_backend --specified-id hhn2s-5l777-77777-7777q-cai
@@ -56,7 +56,7 @@ teardown() {
   # nojwb-ieaaa-aaaaa-aaaaa-cai is the canister ID of (u64::MAX / 2 + 1)
   assert_command_fail dfx canister create e2e_project_backend --specified-id nojwb-ieaaa-aaaaa-aaaaa-cai
 
-  if [[ "$USE_POCKETIC" ]]; then
+  if [[ ! "$USE_REPLICA" ]]; then
     assert_match "The effective canister ID nojwb-ieaaa-aaaaa-aaaaa-cai does not belong to an existing subnet and it is not a mainnet canister ID."
   else
     assert_match "Specified CanisterId nojwb-ieaaa-aaaaa-aaaaa-cai is not hosted by subnet"
@@ -407,7 +407,7 @@ function textual_decode() {
 }
 
 @test "create targets application subnet in PocketIC" {
-  [[ ! "$USE_POCKETIC" ]] && skip "skipped for replica: no support for multiple subnets"
+  [[ "$USE_REPLICA" ]] && skip "skipped for replica: no support for multiple subnets"
   dfx_start
   # create the backend canister without a wallet canister so that the backend canister is the only canister ever created
   assert_command dfx canister create e2e_project_backend --no-wallet

--- a/e2e/tests-dfx/info.bash
+++ b/e2e/tests-dfx/info.bash
@@ -15,7 +15,7 @@ teardown() {
 }
 
 @test "displays the replica port" {
-  if [[ "$USE_POCKETIC" ]]
+  if [[ ! "$USE_REPLICA" ]]
   then
     assert_command_fail dfx info pocketic-config-port
     assert_contains "No PocketIC port found"

--- a/e2e/tests-dfx/ledger.bash
+++ b/e2e/tests-dfx/ledger.bash
@@ -5,7 +5,7 @@ load ../utils/_
 install_nns() {
   dfx_start_for_nns_install
 
-  dfx extension install nns --version 0.4.3
+  dfx extension install nns --version 0.5.0
   dfx nns install --ledger-accounts 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 22ca7edac648b814e81d7946e8bacea99280e07c5f51a04ba7a38009d8ad8e89 5a94fe181e9d411c58726cb87cbf2d016241b6c350bc3330e4869ca76e54ecbc
 }
 

--- a/e2e/tests-dfx/ledger.bash
+++ b/e2e/tests-dfx/ledger.bash
@@ -161,7 +161,7 @@ tc_to_num() {
   assert_match "Canister was topped up with 500000000000000 cycles"
   balance_now=$(tc_to_num "$(dfx wallet balance)")
 
-  (( balance_now - balance > 600000000000000 ))
+  (( balance_now - balance > 400000000000000 ))
 
   # Transaction Deduplication
   t=$(current_time_nanoseconds)
@@ -204,7 +204,7 @@ tc_to_num() {
   dfx_new
   assert_command dfx canister create e2e_project_backend
   assert_command dfx ledger top-up e2e_project_backend --amount 5
-  assert_contains "Canister was topped up with 617283500000000 cycles"
+  assert_contains "Canister was topped up with 500000000000000 cycles"
 }
 
 @test "ledger create-canister" {

--- a/e2e/tests-dfx/ledger.bash
+++ b/e2e/tests-dfx/ledger.bash
@@ -158,7 +158,7 @@ tc_to_num() {
   balance=$(tc_to_num "$(dfx wallet balance)")
 
   assert_command dfx ledger top-up "$wallet" --icp 5
-  assert_match "Canister was topped up with 617283500000000 cycles"
+  assert_match "Canister was topped up with 500000000000000 cycles"
   balance_now=$(tc_to_num "$(dfx wallet balance)")
 
   (( balance_now - balance > 600000000000000 ))

--- a/e2e/tests-dfx/playground.bash
+++ b/e2e/tests-dfx/playground.bash
@@ -47,8 +47,8 @@ setup_playground() {
 
 @test "canister lifecycle" {
   assert_command dfx canister create --all --playground
-  [[ "$USE_POCKETIC" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_backend --playground
-  [[ "$USE_POCKETIC" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_frontend --playground
+  [[ ! "$USE_REPLICA" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_backend --playground
+  [[ ! "$USE_REPLICA" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_frontend --playground
 
   assert_command dfx deploy --playground
   assert_command dfx canister --playground call hello_backend greet '("player")'
@@ -81,9 +81,9 @@ setup_playground() {
   rm -rf hello
   dfx_new_frontend hello
 
-  [[ "$USE_POCKETIC" ]] && assert_command dfx canister create --all --playground
-  [[ "$USE_POCKETIC" ]] && assert_command dfx ledger fabricate-cycles --t 9999999 --canister hello_backend --playground
-  [[ "$USE_POCKETIC" ]] && assert_command dfx ledger fabricate-cycles --t 9999999 --canister hello_frontend --playground
+  [[ ! "$USE_REPLICA" ]] && assert_command dfx canister create --all --playground
+  [[ ! "$USE_REPLICA" ]] && assert_command dfx ledger fabricate-cycles --t 9999999 --canister hello_backend --playground
+  [[ ! "$USE_REPLICA" ]] && assert_command dfx ledger fabricate-cycles --t 9999999 --canister hello_frontend --playground
 
   assert_command dfx deploy --playground
   assert_command dfx canister --playground call hello_backend greet '("player")'
@@ -107,8 +107,8 @@ setup_playground() {
 # instrument the asset canister during upload which would run into execution limits.
 @test "playground-installed asset canister is same wasm as normal asset canister" {
   assert_command dfx canister create --all --playground
-  [[ "$USE_POCKETIC" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_backend --playground
-  [[ "$USE_POCKETIC" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_frontend --playground
+  [[ ! "$USE_REPLICA" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_backend --playground
+  [[ ! "$USE_REPLICA" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_frontend --playground
 
   assert_command dfx deploy --playground
   PLAYGROUND_HASH=$(dfx canister --playground info hello_frontend | grep hash)
@@ -120,8 +120,8 @@ setup_playground() {
 
 @test "playground canister upgrades work with Motoko Enhanced Orthogonal Persistence" {
   assert_command dfx canister create --all --playground
-  [[ "$USE_POCKETIC" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_backend --playground
-  [[ "$USE_POCKETIC" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_frontend --playground
+  [[ ! "$USE_REPLICA" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_backend --playground
+  [[ ! "$USE_REPLICA" ]] && dfx ledger fabricate-cycles --t 9999999 --canister hello_frontend --playground
   
   # enable EOP
   jq '.canisters.hello_backend.args="--enhanced-orthogonal-persistence"' dfx.json | sponge dfx.json

--- a/e2e/tests-dfx/start.bash
+++ b/e2e/tests-dfx/start.bash
@@ -170,11 +170,11 @@ teardown() {
   assert_command dfx canister call hello_backend greet '("Alpha")'
   assert_eq '("Hello, Alpha!")'
 
-  REPLICA_PID=$([[ "$USE_POCKETIC" ]] && get_pocketic_pid || get_replica_pid)
+  REPLICA_PID=$([[ ! "$USE_REPLICA" ]] && get_pocketic_pid || get_replica_pid)
 
   echo "replica pid is $REPLICA_PID"
 
-  [[ "$USE_POCKETIC" ]] && curl -X DELETE "http://localhost:$(get_pocketic_port)/instances/0"
+  [[ ! "$USE_REPLICA" ]] && curl -X DELETE "http://localhost:$(get_pocketic_port)/instances/0"
   kill -KILL "$REPLICA_PID"
   assert_process_exits "$REPLICA_PID" 15s
 
@@ -234,13 +234,13 @@ teardown() {
   assert_command dfx canister call hello_backend greet '("Alpha")'
   assert_eq '("Hello, Alpha!")'
 
-  REPLICA_PID=$([[ "$USE_POCKETIC" ]] && get_pocketic_pid || get_replica_pid)
+  REPLICA_PID=$([[ ! "$USE_REPLICA" ]] && get_pocketic_pid || get_replica_pid)
   POCKETIC_PROXY_PID=$(get_pocketic_proxy_pid)
 
   echo "replica pid is $REPLICA_PID"
   echo "pocket-ic proxy pid is $POCKETIC_PROXY_PID"
 
-  [[ "$USE_POCKETIC" ]] && curl -X DELETE "http://localhost:$(get_pocketic_port)/instances/0"
+  [[ ! "$USE_REPLICA" ]] && curl -X DELETE "http://localhost:$(get_pocketic_port)/instances/0"
   kill -KILL "$REPLICA_PID"
   assert_process_exits "$REPLICA_PID" 15s
   assert_process_exits "$POCKETIC_PROXY_PID" 15s
@@ -281,7 +281,7 @@ teardown() {
   jq ".local.replica.port=$replica_port" "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
 
   dfx_start
-  if [[ "$USE_POCKETIC" ]]; then
+  if [[ ! "$USE_REPLICA" ]]; then
     assert_command dfx info pocketic-config-port
   else
     assert_command dfx info replica-port

--- a/e2e/tests-dfx/start.bash
+++ b/e2e/tests-dfx/start.bash
@@ -289,83 +289,83 @@ teardown() {
   assert_eq "$replica_port"
 }
 
-@test "dfx starts replica with subnet_type application - project defaults" {
+@test "dfx starts replica with subnet type application - project defaults" {
   install_asset subnet_type/project_defaults/application
   define_project_network
   jq '.defaults.replica.log_level="info"' dfx.json | sponge dfx.json
 
-  assert_command dfx start --background
-  assert_match "subnet_type: Application"
+  assert_command dfx start --background -v
+  assert_match "subnet type: Application"
 }
 
-@test "dfx starts replica with subnet_type verifiedapplication - project defaults" {
+@test "dfx starts replica with subnet type verifiedapplication - project defaults" {
   install_asset subnet_type/project_defaults/verified_application
   define_project_network
   jq '.defaults.replica.log_level="info"' dfx.json | sponge dfx.json
 
-  assert_command dfx start --background
-  assert_match "subnet_type: VerifiedApplication"
+  assert_command dfx start --background -v
+  assert_match "subnet type: VerifiedApplication"
 }
 
-@test "dfx starts replica with subnet_type system - project defaults" {
+@test "dfx starts replica with subnet type system - project defaults" {
   install_asset subnet_type/project_defaults/system
   define_project_network
   jq '.defaults.replica.log_level="info"' dfx.json | sponge dfx.json
 
-  assert_command dfx start --background
-  assert_match "subnet_type: System"
+  assert_command dfx start --background -v
+  assert_match "subnet type: System"
 }
 
-@test "dfx starts replica with subnet_type application - local network" {
+@test "dfx starts replica with subnet type application - local network" {
   install_asset subnet_type/project_network_settings/application
   define_project_network
   jq '.networks.local.replica.log_level="info"' dfx.json | sponge dfx.json
 
-  assert_command dfx start --background
-  assert_match "subnet_type: Application"
+  assert_command dfx start --background -v
+  assert_match "subnet type: Application"
 }
 
-@test "dfx starts replica with subnet_type verifiedapplication - local network" {
+@test "dfx starts replica with subnet type verifiedapplication - local network" {
   install_asset subnet_type/project_network_settings/verified_application
   define_project_network
   jq '.networks.local.replica.log_level="info"' dfx.json | sponge dfx.json
 
-  assert_command dfx start --background
-  assert_match "subnet_type: VerifiedApplication"
+  assert_command dfx start --background -v
+  assert_match "subnet type: VerifiedApplication"
 }
 
-@test "dfx starts replica with subnet_type system - local network" {
+@test "dfx starts replica with subnet type system - local network" {
   install_asset subnet_type/project_network_settings/system
   define_project_network
   jq '.networks.local.replica.log_level="info"' dfx.json | sponge dfx.json
 
-  assert_command dfx start --background
-  assert_match "subnet_type: System"
+  assert_command dfx start --background -v
+  assert_match "subnet type: System"
 }
 
 
-@test "dfx starts replica with subnet_type application - shared network" {
+@test "dfx starts replica with subnet type application - shared network" {
   install_shared_asset subnet_type/shared_network_settings/application
   jq '.local.replica.log_level="info"' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
 
-  assert_command dfx start --background
-  assert_match "subnet_type: Application"
+  assert_command dfx start --background -v
+  assert_match "subnet type: Application"
 }
 
-@test "dfx starts replica with subnet_type verifiedapplication - shared network" {
+@test "dfx starts replica with subnet type verifiedapplication - shared network" {
   install_shared_asset subnet_type/shared_network_settings/verified_application
   jq '.local.replica.log_level="info"' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
 
-  assert_command dfx start --background
-  assert_match "subnet_type: VerifiedApplication"
+  assert_command dfx start --background -v
+  assert_match "subnet type: VerifiedApplication"
 }
 
-@test "dfx starts replica with subnet_type system - shared network" {
+@test "dfx starts replica with subnet type system - shared network" {
   install_shared_asset subnet_type/shared_network_settings/system
   jq '.local.replica.log_level="info"' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
 
-  assert_command dfx start --background
-  assert_match "subnet_type: System"
+  assert_command dfx start --background -v
+  assert_match "subnet type: System"
 }
 
 @test "dfx start detects if dfx is already running - shared network" {

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -145,8 +145,8 @@ dfx_start() {
 
     # By default, start on random port for parallel test execution
     add_default_parameter "--host" "127.0.0.1:0"
-    if [[ "$USE_POCKETIC" ]]; then
-        add_default_parameter "--pocketic"
+    if [[ "$USE_REPLICA" ]]; then
+        add_default_parameter "--replica"
     fi
     add_default_parameter "--artificial-delay" "100"
 
@@ -158,10 +158,7 @@ dfx_start() {
 
     dfx start --background "${args[@]}" 3>&-
 
-    if [[ "$USE_POCKETIC" ]]; then
-        test -f "$E2E_NETWORK_DATA_DIRECTORY/pocket-ic-port"
-        port=$(< "$E2E_NETWORK_DATA_DIRECTORY/pocket-ic-port")
-    else
+    if [[ "$USE_REPLICA" ]]; then
         dfx_config_root="$E2E_NETWORK_DATA_DIRECTORY/replica-configuration"
         printf "Configuration Root for DFX: %s\n" "${dfx_config_root}"
         test -f "${dfx_config_root}/replica-1.port"
@@ -169,6 +166,9 @@ dfx_start() {
         if [ "$port" == "" ]; then
           port=$(jq -r .local.replica.port "$E2E_NETWORKS_JSON")
         fi
+    else
+        test -f "$E2E_NETWORK_DATA_DIRECTORY/pocket-ic-port"
+        port=$(< "$E2E_NETWORK_DATA_DIRECTORY/pocket-ic-port")
     fi
     webserver_port=$(cat "$E2E_NETWORK_DATA_DIRECTORY/webserver-port")
 
@@ -240,10 +240,10 @@ setup_actuallylocal_shared_network() {
 
 setup_local_shared_network() {
     local replica_port
-    if [[ "$USE_POCKETIC" ]]; then
-        replica_port=$(get_pocketic_port)
-    else
+    if [[ "$USE_REPLICA" ]]; then
         replica_port=$(get_replica_port)
+    else
+        replica_port=$(get_pocketic_port)
     fi
 
     [ ! -f "$E2E_NETWORKS_JSON" ] && echo "{}" >"$E2E_NETWORKS_JSON"

--- a/src/dfx-core/src/config/model/settings_digest.rs
+++ b/src/dfx-core/src/config/model/settings_digest.rs
@@ -43,7 +43,7 @@ struct ReplicaSettings {
 #[derive(Serialize, Deserialize, PartialEq, Eq)]
 struct BackendSettings<'a> {
     settings: Cow<'a, ReplicaSettings>,
-    pocketic: bool,
+    replica: bool,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq)]
@@ -57,9 +57,9 @@ pub fn get_settings_digest(
     ic_repo_commit: &str,
     local_server_descriptor: &LocalServerDescriptor,
     artificial_delay: u32,
-    pocketic: bool,
+    replica: bool,
 ) -> String {
-    let backend = get_replica_backend_settings(local_server_descriptor, artificial_delay, pocketic);
+    let backend = get_replica_backend_settings(local_server_descriptor, artificial_delay, replica);
     let settings = Settings {
         ic_repo_commit: ic_repo_commit.into(),
         backend,
@@ -72,7 +72,7 @@ pub fn get_settings_digest(
 fn get_replica_backend_settings(
     local_server_descriptor: &LocalServerDescriptor,
     artificial_delay: u32,
-    pocketic: bool,
+    replica: bool,
 ) -> BackendSettings {
     let http_handler = HttpHandlerSettings {
         port: if let Some(port) = local_server_descriptor.replica.port {
@@ -103,6 +103,6 @@ fn get_replica_backend_settings(
     };
     BackendSettings {
         settings: Cow::Owned(replica_settings),
-        pocketic,
+        replica,
     }
 }

--- a/src/dfx/src/commands/start.rs
+++ b/src/dfx/src/commands/start.rs
@@ -82,13 +82,13 @@ pub struct StartOpts {
     domain: Vec<String>,
 
     /// Runs PocketIC instead of the replica
+    /// Currently this has no effect.
     #[clap(long, alias = "emulator")]
+    #[allow(unused)]
     pocketic: bool,
 
     /// Runs the replica instead of pocketic.
-    /// Currently this has no effect.
     #[clap(long, conflicts_with = "pocketic")]
-    #[allow(unused)]
     replica: bool,
 }
 
@@ -156,8 +156,8 @@ pub fn exec(
         enable_canister_http,
         artificial_delay,
         domain,
-        pocketic,
-        replica: _,
+        pocketic: _,
+        replica,
     }: StartOpts,
 ) -> DfxResult {
     if !background {
@@ -192,7 +192,7 @@ pub fn exec(
         enable_canister_http,
         domain,
         artificial_delay,
-        pocketic,
+        replica,
     )?;
 
     let local_server_descriptor = network_descriptor.local_server_descriptor()?;
@@ -333,10 +333,10 @@ pub fn exec(
         replica_config
     };
 
-    let effective_config = if pocketic {
-        CachedConfig::pocketic(&replica_config, replica_rev().into(), None)
-    } else {
+    let effective_config = if replica {
         CachedConfig::replica(&replica_config, replica_rev().into())
+    } else {
+        CachedConfig::pocketic(&replica_config, replica_rev().into(), None)
     };
 
     let is_shared_network = matches!(
@@ -364,16 +364,7 @@ pub fn exec(
     let _proxy = system.block_on(async move {
         let shutdown_controller = start_shutdown_controller(env)?;
 
-        let port_ready_subscribe: Recipient<PortReadySubscribe> = if pocketic {
-            let server = start_pocketic_actor(
-                env,
-                replica_config,
-                local_server_descriptor,
-                shutdown_controller.clone(),
-                pocketic_port_path,
-            )?;
-            server.recipient()
-        } else {
+        let port_ready_subscribe: Recipient<PortReadySubscribe> = if replica {
             let btc_adapter_ready_subscribe = btc_adapter_config
                 .map(|btc_adapter_config| {
                     start_btc_adapter_actor(
@@ -406,6 +397,15 @@ pub fn exec(
                 canister_http_adapter_ready_subscribe,
             )?;
             replica.recipient()
+        } else {
+            let server = start_pocketic_actor(
+                env,
+                replica_config,
+                local_server_descriptor,
+                shutdown_controller.clone(),
+                pocketic_port_path,
+            )?;
+            server.recipient()
         };
 
         let pocketic_proxy_config = PocketIcProxyConfig {
@@ -496,7 +496,7 @@ pub fn apply_command_line_parameters(
     enable_canister_http: bool,
     domain: Vec<String>,
     artificial_delay: u32,
-    pocketic: bool,
+    replica: bool,
 ) -> DfxResult<NetworkDescriptor> {
     if enable_canister_http {
         warn!(
@@ -531,7 +531,7 @@ pub fn apply_command_line_parameters(
         replica_rev(),
         &local_server_descriptor,
         artificial_delay,
-        pocketic,
+        replica,
     );
 
     local_server_descriptor = local_server_descriptor.with_settings_digest(settings_digest);


### PR DESCRIPTION
# Description

As [announced](https://forum.dfinity.org/t/dfx-replacing-the-local-replica-with-pocketic/40167) `dfx start` now runs PocketIC by default.
Running a local replica is still possible with `--replica`, but this option will be removed in the near future.

Fixes [SDK-1989](https://dfinity.atlassian.net/browse/SDK-1989)

# How Has This Been Tested?

Covered by e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-1989]: https://dfinity.atlassian.net/browse/SDK-1989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ