### PR TITLE
feat: store sanitized command-line for telemetry

### DIFF
--- a/src/dfx-core/src/config/project_templates.rs
+++ b/src/dfx-core/src/config/project_templates.rs
@@ -116,9 +116,12 @@ pub fn get_sorted_templates(category: ProjectTemplateCategory) -> Vec<ProjectTem
 pub fn project_template_cli_names(category: ProjectTemplateCategory) -> Vec<String> {
     PROJECT_TEMPLATES
         .get()
-        .unwrap()
-        .values()
-        .filter(|t| t.category == category)
-        .map(|t| t.name.0.clone())
-        .collect()
+        .map(|templates| {
+            templates
+                .values()
+                .filter(|t| t.category == category)
+                .map(|t| t.name.0.clone())
+                .collect()
+        })
+        .unwrap_or_default()
 }

--- a/src/dfx/src/lib/mod.rs
+++ b/src/dfx/src/lib/mod.rs
@@ -35,5 +35,6 @@ pub mod root_key;
 pub mod sign;
 pub mod state_tree;
 pub mod subnet;
+pub mod telemetry;
 pub mod warning;
 pub mod wasm;

--- a/src/dfx/src/lib/telemetry.rs
+++ b/src/dfx/src/lib/telemetry.rs
@@ -42,7 +42,7 @@ impl Telemetry {
             get_deepest_subcommand(&arg_matches, &command);
         let command_name = command_names.join(" ");
 
-        let arguments = get_sanitized_arguments(&deepest_matches, &deepest_command);
+        let arguments = get_sanitized_arguments(deepest_matches, deepest_command);
 
         let mutex = TELEMETRY.get().context("failed to get telemetry mutex")?;
 
@@ -103,7 +103,7 @@ fn get_sanitized_arguments(matches: &ArgMatches, command: &Command) -> Vec<Argum
 
             let sanitized_value = match (possible_values, matches.try_get_one::<String>(id)) {
                 (Some(possible_values), Ok(Some(s)))
-                    if possible_values.iter().any(|pv| pv.matches(&s, true)) =>
+                    if possible_values.iter().any(|pv| pv.matches(s, true)) =>
                 {
                     Some(s.clone())
                 }

--- a/src/dfx/src/lib/telemetry.rs
+++ b/src/dfx/src/lib/telemetry.rs
@@ -1,0 +1,360 @@
+use crate::lib::error::DfxResult;
+use crate::CliOpts;
+use anyhow::Context;
+use clap::parser::ValueSource;
+use clap::{ArgMatches, Command, CommandFactory};
+use std::ffi::OsString;
+use std::sync::{Mutex, OnceLock};
+
+static TELEMETRY: OnceLock<Mutex<Telemetry>> = OnceLock::new();
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ArgumentSource {
+    CommandLine,
+    Environment,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Argument {
+    name: String,
+    value: Option<String>,
+    source: ArgumentSource,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Telemetry {
+    command: String,
+    arguments: Vec<Argument>,
+}
+
+impl Telemetry {
+    pub fn init() {
+        TELEMETRY
+            .set(Mutex::new(Telemetry::default()))
+            .expect("Telemetry already initialized");
+    }
+
+    pub fn set_command_and_arguments(args: &[OsString]) -> DfxResult {
+        let arg_matches = CliOpts::command().try_get_matches_from(args)?;
+
+        let command = CliOpts::command();
+        let (command_names, deepest_matches, deepest_command) =
+            get_deepest_subcommand(&arg_matches, &command);
+        let command_name = command_names.join(" ");
+
+        let arguments = get_sanitized_arguments(&deepest_matches, &deepest_command);
+
+        let mutex = TELEMETRY.get().context("failed to get telemetry mutex")?;
+
+        let mut telemetry = mutex
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to lock telemetry mutex: {:?}", e))?;
+
+        telemetry.command = command_name;
+        telemetry.arguments = arguments;
+
+        Ok(())
+    }
+}
+
+/// Finds the deepest subcommand in both `ArgMatches` and `Command`.
+fn get_deepest_subcommand<'a>(
+    matches: &'a ArgMatches,
+    command: &'a clap::Command,
+) -> (Vec<String>, &'a ArgMatches, &'a clap::Command) {
+    let mut command_names = vec![];
+    let mut deepest_matches = matches;
+    let mut deepest_command = command;
+
+    while let Some((subcommand_name, sub_matches)) = deepest_matches.subcommand() {
+        command_names.push(subcommand_name.to_string());
+        if let Some(sub_command) = deepest_command
+            .get_subcommands()
+            .find(|cmd| cmd.get_name() == subcommand_name)
+        {
+            deepest_matches = sub_matches;
+            deepest_command = sub_command;
+        } else {
+            break;
+        }
+    }
+
+    (command_names, deepest_matches, deepest_command)
+}
+
+fn get_sanitized_arguments(matches: &ArgMatches, command: &Command) -> Vec<Argument> {
+    let mut arguments = vec![];
+
+    let ids = matches.ids().map(|id| id.as_str()).collect::<Vec<_>>();
+
+    for id in &ids {
+        if matches!(matches.try_contains_id(id), Ok(c) if c) {
+            let source = match matches.value_source(id) {
+                Some(ValueSource::CommandLine) => ArgumentSource::CommandLine,
+                Some(ValueSource::EnvVariable) => ArgumentSource::Environment,
+                Some(ValueSource::DefaultValue) => continue,
+                _ => continue, // ValueSource isn't exhaustive
+            };
+
+            let possible_values = command
+                .get_arguments()
+                .find(|arg| arg.get_id() == *id)
+                .map(|arg| arg.get_possible_values());
+
+            let sanitized_value = match (possible_values, matches.try_get_one::<String>(id)) {
+                (Some(possible_values), Ok(Some(s)))
+                    if possible_values.iter().any(|pv| pv.matches(&s, true)) =>
+                {
+                    Some(s.clone())
+                }
+                _ => None,
+            };
+
+            let argument = Argument {
+                name: id.to_string(),
+                value: sanitized_value,
+                source,
+            };
+            arguments.push(argument);
+        }
+    }
+    arguments
+}
+
+#[cfg(test)]
+impl Telemetry {
+    /// Resets telemetry state. This is safe to call multiple times.
+    pub fn init_for_test() {
+        let mutex = TELEMETRY.get_or_init(|| Mutex::new(Telemetry::default()));
+        let mut telemetry = mutex.lock().unwrap();
+        *telemetry = Telemetry::default(); // Reset the contents of the Mutex
+    }
+
+    pub fn get_for_test() -> Telemetry {
+        TELEMETRY.get().unwrap().lock().unwrap().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::MutexGuard;
+
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Sets up the test environment by locking TEST_LOCK and resetting telemetry state.
+    fn setup_test() -> MutexGuard<'static, ()> {
+        let guard = TEST_LOCK.lock().unwrap();
+        Telemetry::init_for_test();
+        guard
+    }
+
+    fn full_command_to_args(full_command: &str) -> Vec<OsString> {
+        full_command
+            .split_whitespace()
+            .map(OsString::from)
+            .collect()
+    }
+
+    fn full_command_to_telemetry(full_command: &str) -> Telemetry {
+        let args = full_command_to_args(full_command);
+        Telemetry::set_command_and_arguments(&args).unwrap();
+        Telemetry::get_for_test()
+    }
+
+    #[test]
+    fn simple() {
+        let _guard = setup_test();
+        let actual = full_command_to_telemetry("dfx deploy");
+        let expected = Telemetry {
+            command: "deploy".to_string(),
+            arguments: vec![],
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn hide_parameter_value() {
+        let _guard = setup_test();
+        let actual = full_command_to_telemetry("dfx canister update-settings --add-log-viewer=evtzg-5hnpy-uoy4t-tn3fa-7c4ca-nweso-exmhj-nt3vs-htbce-pys7c-yqe e2e_project");
+        let expected = Telemetry {
+            command: "canister update-settings".to_string(),
+            arguments: vec![
+                Argument {
+                    name: "add_log_viewer".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "LogVisibilityOpt".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "canister".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+            ],
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn network_param() {
+        let _guard = setup_test();
+        let actual = full_command_to_telemetry("dfx deploy --network local");
+        let expected = Telemetry {
+            command: "deploy".to_string(),
+            arguments: vec![
+                Argument {
+                    name: "network".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "NetworkOpt".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "network-select".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+            ],
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn network_param_in_middle() {
+        let _guard = setup_test();
+        let actual =
+            full_command_to_telemetry("dfx canister --network local --wallet default call a b");
+        let expected = Telemetry {
+            command: "canister call".to_string(),
+            arguments: vec![
+                Argument {
+                    name: "canister_name".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "method_name".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "network".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "wallet".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+            ],
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn ic_param() {
+        let _guard = setup_test();
+        let actual = full_command_to_telemetry("dfx deploy --ic");
+        let expected = Telemetry {
+            command: "deploy".to_string(),
+            arguments: vec![
+                Argument {
+                    name: "ic".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "NetworkOpt".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "network-select".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+            ],
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn canister_call_with_output_type() {
+        let _guard = setup_test();
+        let actual = full_command_to_telemetry("dfx canister call mycan mymeth --output idl");
+        let expected = Telemetry {
+            command: "canister call".to_string(),
+            arguments: vec![
+                Argument {
+                    name: "canister_name".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "method_name".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "output".to_string(),
+                    value: Some("idl".to_string()),
+                    source: ArgumentSource::CommandLine,
+                },
+            ],
+        };
+        assert_eq!(expected, actual)
+    }
+
+    #[test]
+    fn numeric_parameter() {
+        let _guard = setup_test();
+        let actual = full_command_to_telemetry("dfx canister create abc --compute-allocation 60");
+        let expected = Telemetry {
+            command: "canister create".to_string(),
+            arguments: vec![
+                Argument {
+                    name: "canister_name".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "compute_allocation".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+            ],
+        };
+        assert_eq!(expected, actual)
+    }
+
+    #[test]
+    fn bool_param() {
+        let _guard = setup_test();
+        let actual = full_command_to_telemetry("dfx canister create abc --no-wallet");
+        let expected = Telemetry {
+            command: "canister create".to_string(),
+            arguments: vec![
+                Argument {
+                    name: "canister_name".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+                Argument {
+                    name: "no_wallet".to_string(),
+                    value: None,
+                    source: ArgumentSource::CommandLine,
+                },
+            ],
+        };
+        assert_eq!(expected, actual)
+    }
+}

--- a/src/dfx/src/main.rs
+++ b/src/dfx/src/main.rs
@@ -5,6 +5,7 @@ use crate::lib::environment::{Environment, EnvironmentImpl};
 use crate::lib::error::DfxResult;
 use crate::lib::logger::{create_root_logger, LoggingMode};
 use crate::lib::project::templates::builtin_templates;
+use crate::lib::telemetry::Telemetry;
 use anyhow::Error;
 use clap::{ArgAction, CommandFactory, Parser};
 use dfx_core::config::project_templates;
@@ -152,6 +153,7 @@ fn inner_main(log_level: &mut Option<i64>) -> DfxResult {
 
     let args = get_args_altered_for_extension_run(&installed_extension_manifests)?;
 
+    let _ = Telemetry::set_command_and_arguments(&args);
     let cli_opts = CliOpts::parse_from(args);
 
     if matches!(cli_opts.command, commands::DfxCommand::Schema(_)) {
@@ -178,6 +180,8 @@ fn inner_main(log_level: &mut Option<i64>) -> DfxResult {
 }
 
 fn main() {
+    Telemetry::init();
+
     let mut log_level: Option<i64> = None;
     let result = inner_main(&mut log_level);
     if let Err(err) = result {


### PR DESCRIPTION
# Description

Uses the clap CliOpts to get the subcommand and sanitized arguments and save them for later reporting.

While some methods in the Telemetry impl may return a Result, my intent is that the caller will ignore them, as seen in the call from main. The idea is that telemetry shouldn't interfere with what the user is doing.

Fixes https://dfinity.atlassian.net/browse/SDK-1961

# How Has This Been Tested?

Added unit tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
