### PR TITLE
fix: properly suggest `dfx info security-policy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 As [announced](https://forum.dfinity.org/t/dfx-replacing-the-local-replica-with-pocketic/40167) `dfx start` now runs PocketIC by default.
 Running a local replica is still possible with `--replica`, but this option will be removed in the near future.
 
+### fix: Warning and error messages now correctly suggest `dfx info security-policy` when suboptimal security policies get used
+
 # 0.25.1
 
 ### feat: `skip_cargo_audit` flag in dfx.json to skip `cargo audit` build step

--- a/src/canisters/frontend/ic-asset/src/error/gather_asset_descriptors.rs
+++ b/src/canisters/frontend/ic-asset/src/error/gather_asset_descriptors.rs
@@ -28,6 +28,6 @@ pub enum GatherAssetDescriptorsError {
     LoadConfigFailed(AssetLoadConfigError),
 
     /// One or more assets use the hardened security policy but don't actually specify any hardenings compared to the standard security policy.
-    #[error("This project uses the hardened security policy for some assets, but does not actually configure any custom improvements over the standard policy. To get started, look at 'dfx info canister-security-policy'. It shows the default security policy along with suggestions on how to improve it.\n{0}")]
+    #[error("This project uses the hardened security policy for some assets, but does not actually configure any custom improvements over the standard policy. To get started, look at 'dfx info security-policy'. It shows the default security policy along with suggestions on how to improve it.\n{0}")]
     HardenedSecurityPolicyIsNotHardened(String),
 }

--- a/src/canisters/frontend/ic-asset/src/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/sync.rs
@@ -422,7 +422,7 @@ pub(crate) fn gather_asset_descriptors(
                 "some"
             };
             warn!(logger, "This project uses the default security policy for {qnt} assets. While it is set up to work with many applications, it is recommended to further harden the policy to increase security against attacks like XSS.");
-            warn!(logger, "To get started, have a look at 'dfx info canister-security-policy'. It shows the default security policy along with suggestions on how to improve it.");
+            warn!(logger, "To get started, have a look at 'dfx info security-policy'. It shows the default security policy along with suggestions on how to improve it.");
             if standard_policy_assets.len() != asset_descriptors.len() {
                 warn!(logger, "Unhardened assets:");
                 for asset in &standard_policy_assets {


### PR DESCRIPTION
# Description

When using unhardened security policies dfx incorrectly prints
```
WARN: This project uses the default security policy for all assets. While it is set up to work with many applications, it is recommended to further harden the policy to increase security against attacks like XSS.
WARN: To get started, have a look at 'dfx info canister-security-policy'. It shows the default security policy along with suggestions on how to improve it.
```

It should recommend `dfx info security-policy` instead.

# How Has This Been Tested?

tested manually

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
