### PR TITLE
feat: add dfx info telemetry-log-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 As [announced](https://forum.dfinity.org/t/dfx-replacing-the-local-replica-with-pocketic/40167) `dfx start` now runs PocketIC by default.
 Running a local replica is still possible with `--replica`, but this option will be removed in the near future.
 
+### feat: `dfx info telemetry-log-path`
+
+Displays the path of the telemetry log file.
+
 # 0.25.1
 
 ### feat: `skip_cargo_audit` flag in dfx.json to skip `cargo audit` build step

--- a/docs/cli-reference/dfx-info.mdx
+++ b/docs/cli-reference/dfx-info.mdx
@@ -22,6 +22,7 @@ These are the types of information that the `dfx info` command can display.
 | pocketic-config-port | The listening port of PocketIC.                                                                                    |
 | replica-rev          | The revision of the bundled replica.                                                                               |
 | security-policy      | Show the headers that gets applied to assets in .ic-assets.json5 if "security_policy" is "standard" or "hardened". |
+| telemetry-log-path   | Show the path to the telemetry log.                                                                                |
 | webserver-port       | The local webserver port.                                                                                          |
 
 ## Options

--- a/e2e/tests-dfx/info.bash
+++ b/e2e/tests-dfx/info.bash
@@ -14,6 +14,18 @@ teardown() {
   standard_teardown
 }
 
+@test "displays the telemetry log path" {
+  assert_command dfx info telemetry-log-path
+
+  if [ "$(uname)" == "Darwin" ]; then
+    assert_eq "$HOME/Library/Caches/org.dfinity.dfx/telemetry/telemetry.log"
+  elif [ "$(uname)" == "Linux" ]; then
+    assert_eq "$HOME/.cache/dfx/telemetry/telemetry.log"
+  else
+     echo "Unsupported OS" | fail
+  fi
+}
+
 @test "displays the replica port" {
   if [[ ! "$USE_REPLICA" ]]
   then

--- a/src/dfx/src/commands/info/mod.rs
+++ b/src/dfx/src/commands/info/mod.rs
@@ -1,12 +1,14 @@
 mod pocketic_config_port;
 mod replica_port;
 mod webserver_port;
+
 use crate::commands::info::{replica_port::get_replica_port, webserver_port::get_webserver_port};
 use crate::lib::agent::create_anonymous_agent_environment;
 use crate::lib::error::DfxResult;
 use crate::lib::info;
 use crate::lib::named_canister::get_ui_canister_url;
 use crate::lib::network::network_opt::NetworkOpt;
+use crate::lib::telemetry::Telemetry;
 use crate::Environment;
 use anyhow::{bail, Context};
 use clap::{Parser, Subcommand};
@@ -29,6 +31,8 @@ enum InfoType {
     ReplicaPort,
     /// Show the port that PocketIC is using, if it is running
     PocketicConfigPort,
+    /// Show the path to the telemetry log file
+    TelemetryLogPath,
 }
 
 #[derive(Parser)]
@@ -65,6 +69,10 @@ pub fn exec(env: &dyn Environment, opts: InfoOpts) -> DfxResult {
             .get_path()
             .to_str()
             .context("Failed to convert networks.json path to a string.")?
+            .to_string(),
+        InfoType::TelemetryLogPath => Telemetry::get_log_path()?
+            .to_str()
+            .context("Failed to convert telemetry path to a string.")?
             .to_string(),
     };
     println!("{}", value);

--- a/src/dfx/src/lib/telemetry.rs
+++ b/src/dfx/src/lib/telemetry.rs
@@ -3,7 +3,9 @@ use crate::CliOpts;
 use anyhow::Context;
 use clap::parser::ValueSource;
 use clap::{ArgMatches, Command, CommandFactory};
+use dfx_core::config::directories::project_dirs;
 use std::ffi::OsString;
+use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 static TELEMETRY: OnceLock<Mutex<Telemetry>> = OnceLock::new();
@@ -54,6 +56,14 @@ impl Telemetry {
         telemetry.arguments = arguments;
 
         Ok(())
+    }
+
+    pub fn get_log_path() -> DfxResult<PathBuf> {
+        let path = project_dirs()?
+            .cache_dir()
+            .join("telemetry")
+            .join("telemetry.log");
+        Ok(path)
     }
 }
 


### PR DESCRIPTION
# Description

`dfx info telemetry-log-path` reports the path to the telemetry log file.

Fixes https://dfinity.atlassian.net/browse/SDK-1979

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
