### PR TITLE
chore: updated the canister creation fee to 500B cycles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Running a local replica is still possible with `--replica`, but this option will
 
 ### fix: Warning and error messages now correctly suggest `dfx info security-policy` when suboptimal security policies get used
 
+### chore: updated the canister creation fee to 500B cycles.
+
+Updated the canister creation fee to `500B` cycles as [documented](https://internetcomputer.org/docs/building-apps/essentials/gas-cost#cycles-price-breakdown).
+
 # 0.25.1
 
 ### feat: `skip_cargo_audit` flag in dfx.json to skip `cargo audit` build step

--- a/e2e/tests-dfx/cycles-ledger.bash
+++ b/e2e/tests-dfx/cycles-ledger.bash
@@ -390,74 +390,74 @@ current_time_nanoseconds() {
   assert_command dfx cycles balance --precise --identity bob
   assert_eq "2400000000000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_000_000_000 Cycles"
+  assert_contains "Balance: 3_500_000_000_000 Cycles"
 
   assert_command dfx cycles top-up e2e_project_backend 100000 --identity bob
   assert_command dfx cycles balance --precise --identity bob
   assert_eq "2399899900000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_000_100_000 Cycles"
+  assert_contains "Balance: 3_500_000_100_000 Cycles"
 
   assert_command dfx canister deposit-cycles 100000 e2e_project_backend --identity bob
   assert_command dfx cycles balance --precise --identity bob
   assert_eq "2399799800000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_000_200_000 Cycles"
+  assert_contains "Balance: 3_500_000_200_000 Cycles"
 
   # subaccount to canister
   assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT1"
   assert_eq "2600000000000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_000_200_000 Cycles"
+  assert_contains "Balance: 3_500_000_200_000 Cycles"
 
   assert_command dfx cycles top-up e2e_project_backend 300000 --identity bob --from-subaccount "$BOB_SUBACCT1"
   assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT1"
   assert_eq "2599899700000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_000_500_000 Cycles"
+  assert_contains "Balance: 3_500_000_500_000 Cycles"
 
   assert_command dfx canister deposit-cycles 300000 e2e_project_backend --identity bob --from-subaccount "$BOB_SUBACCT1"
   assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT1"
   assert_eq "2599799400000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_000_800_000 Cycles"
+  assert_contains "Balance: 3_500_000_800_000 Cycles"
 
   # subaccount to canister - by canister id
   assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT2"
   assert_eq "2700000000000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_000_800_000 Cycles"
+  assert_contains "Balance: 3_500_000_800_000 Cycles"
 
   assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" 600000 --identity bob --from-subaccount "$BOB_SUBACCT2"
   assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT2"
   assert_eq "2699899400000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_001_400_000 Cycles"
+  assert_contains "Balance: 3_500_001_400_000 Cycles"
 
   assert_command dfx canister deposit-cycles 600000 "$(dfx canister id e2e_project_backend)" --identity bob --from-subaccount "$BOB_SUBACCT2"
   assert_command dfx cycles balance --precise --identity bob --subaccount "$BOB_SUBACCT2"
   assert_eq "2699798800000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_002_000_000 Cycles"
+  assert_contains "Balance: 3_500_002_000_000 Cycles"
 
   # deduplication
   t=$(current_time_nanoseconds)
   assert_command dfx cycles balance --precise --identity bob
   assert_eq "2399799800000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_002_000_000 Cycles"
+  assert_contains "Balance: 3_500_002_000_000 Cycles"
 
   assert_command dfx canister deposit-cycles 100000 e2e_project_backend --identity bob --created-at-time "$t"
   assert_command dfx cycles balance --precise --identity bob
   assert_eq "2399699700000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_002_100_000 Cycles"
+  assert_contains "Balance: 3_500_002_100_000 Cycles"
 
   assert_command dfx canister deposit-cycles 100000 e2e_project_backend --identity bob --created-at-time "$t"
   assert_command dfx cycles balance --precise --identity bob
   assert_eq "2399699700000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_002_100_000 Cycles"
+  assert_contains "Balance: 3_500_002_100_000 Cycles"
 
   # deposit-cycles --all skips remote canisters
   jq '.canisters.remote.remote.id.local="rdmx6-jaaaa-aaaaa-aaadq-cai"' dfx.json | sponge dfx.json
@@ -492,7 +492,7 @@ current_time_nanoseconds() {
   assert_command dfx cycles balance --precise --identity bob
   assert_eq "2400000000000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_000_000_000 Cycles"
+  assert_contains "Balance: 3_500_000_000_000 Cycles"
 
   t=$(current_time_nanoseconds)
   assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" --created-at-time "$t" 100000 --identity bob
@@ -501,7 +501,7 @@ current_time_nanoseconds() {
   assert_command dfx cycles balance --precise --identity bob
   assert_eq "2399899900000 cycles."
   assert_command dfx canister status e2e_project_backend
-  assert_contains "Balance: 3_100_000_100_000 Cycles"
+  assert_contains "Balance: 3_500_000_100_000 Cycles"
 
   # same created-at-time: dupe
   assert_command dfx cycles top-up "$(dfx canister id e2e_project_backend)" --created-at-time "$t" 100000 --identity bob

--- a/src/dfx/src/lib/operations/canister/create_canister.rs
+++ b/src/dfx/src/lib/operations/canister/create_canister.rs
@@ -25,8 +25,8 @@ use icrc_ledger_types::icrc1::account::Subaccount;
 use slog::{debug, info, warn};
 use std::format;
 
-// The cycle fee for create request is 0.1T cycles.
-pub const CANISTER_CREATE_FEE: u128 = 100_000_000_000_u128;
+// The cycle fee for create request is 0.5T cycles.
+pub const CANISTER_CREATE_FEE: u128 = 500_000_000_000_u128;
 // We do not know the minimum cycle balance a canister should have.
 // For now create the canister with 3T cycle balance.
 pub const CANISTER_INITIAL_CYCLE_BALANCE: u128 = 3_000_000_000_000_u128;


### PR DESCRIPTION
# Description

Updated the canister creation fee to `500B` cycles as [documented](https://internetcomputer.org/docs/building-apps/essentials/gas-cost#cycles-price-breakdown).

Please check the [forum post](https://forum.dfinity.org/t/evaluating-compute-pricing-in-response-to-increased-demand-on-the-internet-computer-protocol/36565) for more info.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
