### PR TITLE
chore: update description of the output folder of 'dfx generate'.

### DIFF
--- a/docs/cli-reference/dfx-generate.mdx
+++ b/docs/cli-reference/dfx-generate.mdx
@@ -32,7 +32,7 @@ The behavior of `dfx generate` is controlled by the `dfx.json` configuration fil
 
 | Field          | Description                                                                                                                                  |
 |----------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| `output`       | Directory to place declarations for the canister. Default is `src/declarations/<canister_name>`.                                             |
+| `output`       | Directory to place declarations for the canister. Default is `src/declarations/<canister_name>`. This directory is only used by `dfx`, please do not put your own files under it. |
 | `bindings`     | List of languages to generate type declarations. Options are `"js", "ts", "did", "mo"`. Default is `["js", "ts", "did"]`.                    |
 | `env_override` | String that will replace `process.env.CANISTER_ID_{canister_name_uppercase}` in the `src/dfx/assets/language_bindings/canister.js` template. |
 


### PR DESCRIPTION
# Description

Update the description of the output folder of `dfx generate` to notify users not to put their own files under the output folder. We [delete the output folder](https://github.com/dfinity/sdk/blob/master/src/dfx/src/lib/builders/mod.rs#L128) before generating the binding files.

Fixes # (issue)

[SDK-1435](https://dfinity.atlassian.net/browse/SDK-1435)

# How Has This Been Tested?

Only document change.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-1435]: https://dfinity.atlassian.net/browse/SDK-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ