### PR TITLE
chore: Add source information to all errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ ic-cdk = "0.13.1"
 ic-identity-hsm = { version = "0.39", git = "https://github.com/dfinity/agent-rs", rev = "9ebf6314ce2fcb36772c7d81d6d414b4628d6101" }
 ic-utils = { version = "0.39", git = "https://github.com/dfinity/agent-rs", rev = "9ebf6314ce2fcb36772c7d81d6d414b4628d6101" }
 
-aes-gcm = "0.10.3"
+aes-gcm = { version = "0.10.3", features = ["std"] }
 anyhow = "1.0.56"
 anstyle = "1.0.0"
-argon2 = "0.4.0"
+argon2 = { version = "0.4.0", features = ["std"] }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 base64 = "0.13.0"
 byte-unit = "4.0.14"
@@ -65,7 +65,7 @@ proptest = "1.0.0"
 reqwest = { version = "0.12.4", default-features = false, features = [
     "rustls-tls",
 ] }
-ring = "0.17.12"
+ring = { version = "0.17.12", features = ["std"] }
 schemars = "0.8"
 sec1 = "0.3.0"
 serde = "1.0"

--- a/src/canisters/frontend/ic-asset/src/asset/config.rs
+++ b/src/canisters/frontend/ic-asset/src/asset/config.rs
@@ -951,12 +951,11 @@ mod with_tempdir {
         assert_eq!(
             assets_config.err().unwrap().to_string(),
             format!(
-                "Malformed JSON asset config file '{}':  {}",
+                "Malformed JSON asset config file '{}'",
                 assets_dir
                     .join(ASSETS_CONFIG_FILENAME_JSON)
                     .to_str()
                     .unwrap(),
-                "--> 1:1\n  |\n1 | \n  | ^---\n  |\n  = expected array, boolean, null, number, object, or string"
             )
         );
     }
@@ -970,12 +969,11 @@ mod with_tempdir {
         assert_eq!(
             assets_config.err().unwrap().to_string(),
             format!(
-                "Malformed JSON asset config file '{}':  {}",
+                "Malformed JSON asset config file '{}'",
                 assets_dir
                     .join(ASSETS_CONFIG_FILENAME_JSON)
                     .to_str()
                     .unwrap(),
-                "--> 1:5\n  |\n1 | [[[{{{\n  |     ^---\n  |\n  = expected identifier or string"
             )
         );
     }
@@ -995,12 +993,11 @@ mod with_tempdir {
         assert_eq!(
             assets_config.err().unwrap().to_string(),
             format!(
-                "Malformed JSON asset config file '{}':  {}",
+                "Malformed JSON asset config file '{}'",
                 assets_dir
                     .join(ASSETS_CONFIG_FILENAME_JSON)
                     .to_str()
                     .unwrap(),
-                "--> 2:19\n  |\n2 |         {\"match\": \"{{{\\\\\\\", \"cache\": {\"max_age\": 900}},\n  |                   ^---\n  |\n  = expected boolean or null"
             )
         );
     }

--- a/src/canisters/frontend/ic-asset/src/error/assemble_commit_batch_argument.rs
+++ b/src/canisters/frontend/ic-asset/src/error/assemble_commit_batch_argument.rs
@@ -6,6 +6,6 @@ use super::SetEncodingError;
 #[derive(Error, Debug)]
 pub enum AssembleCommitBatchArgumentError {
     /// Failed to set encoding.
-    #[error("Failed to set encoding: {0}")]
+    #[error("Failed to set encoding")]
     SetEncodingFailed(#[from] SetEncodingError),
 }

--- a/src/canisters/frontend/ic-asset/src/error/compute_evidence.rs
+++ b/src/canisters/frontend/ic-asset/src/error/compute_evidence.rs
@@ -32,5 +32,5 @@ pub enum ComputeEvidenceError {
 
     /// Failed to list assets in the asset canister.
     #[error("Failed to list assets: {0}")]
-    ListAssets(AgentError),
+    ListAssets(#[source] AgentError),
 }

--- a/src/canisters/frontend/ic-asset/src/error/compute_evidence.rs
+++ b/src/canisters/frontend/ic-asset/src/error/compute_evidence.rs
@@ -31,6 +31,6 @@ pub enum ComputeEvidenceError {
     HashContent(#[from] HashContentError),
 
     /// Failed to list assets in the asset canister.
-    #[error("Failed to list assets: {0}")]
+    #[error("Failed to list assets")]
     ListAssets(#[source] AgentError),
 }

--- a/src/canisters/frontend/ic-asset/src/error/create_chunk.rs
+++ b/src/canisters/frontend/ic-asset/src/error/create_chunk.rs
@@ -5,14 +5,14 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum CreateChunkError {
     /// Failed in call to create_chunk, or in waiting for response.
-    #[error("Failed to create chunk: {0}")]
+    #[error("Failed to create chunk")]
     CreateChunk(#[source] AgentError),
 
     /// Failed in call to create_chunks, or in waiting for response.
-    #[error("Failed to create chunks: {0}")]
+    #[error("Failed to create chunks")]
     CreateChunks(#[source] AgentError),
 
     /// Failed to decode the create chunk response.
-    #[error("Failed to decode create chunk response: {0}")]
+    #[error("Failed to decode create chunk response")]
     DecodeCreateChunkResponse(#[source] candid::Error),
 }

--- a/src/canisters/frontend/ic-asset/src/error/create_chunk.rs
+++ b/src/canisters/frontend/ic-asset/src/error/create_chunk.rs
@@ -6,13 +6,13 @@ use thiserror::Error;
 pub enum CreateChunkError {
     /// Failed in call to create_chunk, or in waiting for response.
     #[error("Failed to create chunk: {0}")]
-    CreateChunk(AgentError),
+    CreateChunk(#[source] AgentError),
 
     /// Failed in call to create_chunks, or in waiting for response.
     #[error("Failed to create chunks: {0}")]
-    CreateChunks(AgentError),
+    CreateChunks(#[source] AgentError),
 
     /// Failed to decode the create chunk response.
     #[error("Failed to decode create chunk response: {0}")]
-    DecodeCreateChunkResponse(candid::Error),
+    DecodeCreateChunkResponse(#[source] candid::Error),
 }

--- a/src/canisters/frontend/ic-asset/src/error/create_encoding.rs
+++ b/src/canisters/frontend/ic-asset/src/error/create_encoding.rs
@@ -7,9 +7,9 @@ use thiserror::Error;
 pub enum CreateEncodingError {
     /// Failed when creating a chunk.
     #[error("Failed to create chunk: {0}")]
-    CreateChunkFailed(CreateChunkError),
+    CreateChunkFailed(#[source] CreateChunkError),
 
     /// Failed when encoding asset content.
     #[error("Failed to encode content of '{0}' with {1} encoding: {2}")]
-    EncodeContentFailed(String, ContentEncoder, std::io::Error),
+    EncodeContentFailed(String, ContentEncoder, #[source] std::io::Error),
 }

--- a/src/canisters/frontend/ic-asset/src/error/create_encoding.rs
+++ b/src/canisters/frontend/ic-asset/src/error/create_encoding.rs
@@ -6,10 +6,10 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum CreateEncodingError {
     /// Failed when creating a chunk.
-    #[error("Failed to create chunk: {0}")]
+    #[error("Failed to create chunk")]
     CreateChunkFailed(#[source] CreateChunkError),
 
     /// Failed when encoding asset content.
-    #[error("Failed to encode content of '{0}' with {1} encoding: {2}")]
+    #[error("Failed to encode content of '{0}' with {1} encoding")]
     EncodeContentFailed(String, ContentEncoder, #[source] std::io::Error),
 }

--- a/src/canisters/frontend/ic-asset/src/error/create_project_asset.rs
+++ b/src/canisters/frontend/ic-asset/src/error/create_project_asset.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum CreateProjectAssetError {
     /// Failed to create an asset encoding in the asset canister.
-    #[error("Failed to create encoding: {0}")]
+    #[error("Failed to create encoding")]
     CreateEncodingError(#[from] CreateEncodingError),
 
     /// Failed to find out the file size of an asset.

--- a/src/canisters/frontend/ic-asset/src/error/gather_asset_descriptors.rs
+++ b/src/canisters/frontend/ic-asset/src/error/gather_asset_descriptors.rs
@@ -12,7 +12,7 @@ pub enum GatherAssetDescriptorsError {
     DuplicateAssetKey(String, Box<PathBuf>, Box<PathBuf>),
 
     /// Failed to get asset configuration.
-    #[error("Failed to get asset configuration: {0}")]
+    #[error("Failed to get asset configuration")]
     GetAssetConfigFailed(#[from] GetAssetConfigError),
 
     /// Failed to canonicalize a directory entry.
@@ -24,7 +24,7 @@ pub enum GatherAssetDescriptorsError {
     InvalidSourceDirectory(#[source] CanonicalizePathError),
 
     /// Failed to load the asset configuration for a directory.
-    #[error("Failed to load asset configuration: {0}")]
+    #[error("Failed to load asset configuration")]
     LoadConfigFailed(#[source] AssetLoadConfigError),
 
     /// One or more assets use the hardened security policy but don't actually specify any hardenings compared to the standard security policy.

--- a/src/canisters/frontend/ic-asset/src/error/gather_asset_descriptors.rs
+++ b/src/canisters/frontend/ic-asset/src/error/gather_asset_descriptors.rs
@@ -25,7 +25,7 @@ pub enum GatherAssetDescriptorsError {
 
     /// Failed to load the asset configuration for a directory.
     #[error("Failed to load asset configuration: {0}")]
-    LoadConfigFailed(AssetLoadConfigError),
+    LoadConfigFailed(#[source] AssetLoadConfigError),
 
     /// One or more assets use the hardened security policy but don't actually specify any hardenings compared to the standard security policy.
     #[error("This project uses the hardened security policy for some assets, but does not actually configure any custom improvements over the standard policy. To get started, look at 'dfx info security-policy'. It shows the default security policy along with suggestions on how to improve it.\n{0}")]

--- a/src/canisters/frontend/ic-asset/src/error/get_asset_properties.rs
+++ b/src/canisters/frontend/ic-asset/src/error/get_asset_properties.rs
@@ -5,6 +5,6 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum GetAssetPropertiesError {
     /// The call to get_asset_properties failed.
-    #[error("Failed to get asset properties for {0}: {1}")]
+    #[error("Failed to get asset properties for {0}")]
     GetAssetPropertiesFailed(String, #[source] AgentError),
 }

--- a/src/canisters/frontend/ic-asset/src/error/get_asset_properties.rs
+++ b/src/canisters/frontend/ic-asset/src/error/get_asset_properties.rs
@@ -6,5 +6,5 @@ use thiserror::Error;
 pub enum GetAssetPropertiesError {
     /// The call to get_asset_properties failed.
     #[error("Failed to get asset properties for {0}: {1}")]
-    GetAssetPropertiesFailed(String, AgentError),
+    GetAssetPropertiesFailed(String, #[source] AgentError),
 }

--- a/src/canisters/frontend/ic-asset/src/error/hash_content.rs
+++ b/src/canisters/frontend/ic-asset/src/error/hash_content.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 pub enum HashContentError {
     /// Failed to encode the content in order to compute the hash.
     #[error("Failed to encode content of '{0}' with {1} encoding: {2}")]
-    EncodeContentFailed(String, ContentEncoder, std::io::Error),
+    EncodeContentFailed(String, ContentEncoder, #[source] std::io::Error),
 
     /// Failed to load asset content from the filesystem.
     #[error("failed to load content")]

--- a/src/canisters/frontend/ic-asset/src/error/hash_content.rs
+++ b/src/canisters/frontend/ic-asset/src/error/hash_content.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum HashContentError {
     /// Failed to encode the content in order to compute the hash.
-    #[error("Failed to encode content of '{0}' with {1} encoding: {2}")]
+    #[error("Failed to encode content of '{0}' with {1} encoding")]
     EncodeContentFailed(String, ContentEncoder, #[source] std::io::Error),
 
     /// Failed to load asset content from the filesystem.

--- a/src/canisters/frontend/ic-asset/src/error/load_config.rs
+++ b/src/canisters/frontend/ic-asset/src/error/load_config.rs
@@ -12,11 +12,11 @@ pub enum AssetLoadConfigError {
 
     /// Failed to load a rule from the asset configuration file.
     #[error("Failed to load rule in {0}: {1}")]
-    LoadRuleFailed(PathBuf, LoadRuleError),
+    LoadRuleFailed(PathBuf, #[source] LoadRuleError),
 
     /// An asset configuration file was not valid JSON5.
     #[error("Malformed JSON asset config file '{0}': {1}")]
-    MalformedAssetConfigFile(PathBuf, json5::Error),
+    MalformedAssetConfigFile(PathBuf, #[source] json5::Error),
 
     /// both `assets.json` and `assets.json5` files exist in the same directory.
     #[error("both {} and {} files exist in the same directory (dir = {:?})",

--- a/src/canisters/frontend/ic-asset/src/error/load_config.rs
+++ b/src/canisters/frontend/ic-asset/src/error/load_config.rs
@@ -11,11 +11,11 @@ pub enum AssetLoadConfigError {
     InvalidRootDir(PathBuf),
 
     /// Failed to load a rule from the asset configuration file.
-    #[error("Failed to load rule in {0}: {1}")]
+    #[error("Failed to load rule in {0}")]
     LoadRuleFailed(PathBuf, #[source] LoadRuleError),
 
     /// An asset configuration file was not valid JSON5.
-    #[error("Malformed JSON asset config file '{0}': {1}")]
+    #[error("Malformed JSON asset config file '{0}'")]
     MalformedAssetConfigFile(PathBuf, #[source] json5::Error),
 
     /// both `assets.json` and `assets.json5` files exist in the same directory.

--- a/src/canisters/frontend/ic-asset/src/error/load_rule.rs
+++ b/src/canisters/frontend/ic-asset/src/error/load_rule.rs
@@ -9,6 +9,6 @@ pub enum LoadRuleError {
     FormGlobPatternFailed(PathBuf, String),
 
     /// The glob pattern was not valid.
-    #[error("{0} is not a valid glob pattern: {1}")]
+    #[error("{0} is not a valid glob pattern")]
     InvalidGlobPattern(String, #[source] globset::Error),
 }

--- a/src/canisters/frontend/ic-asset/src/error/load_rule.rs
+++ b/src/canisters/frontend/ic-asset/src/error/load_rule.rs
@@ -10,5 +10,5 @@ pub enum LoadRuleError {
 
     /// The glob pattern was not valid.
     #[error("{0} is not a valid glob pattern: {1}")]
-    InvalidGlobPattern(String, globset::Error),
+    InvalidGlobPattern(String, #[source] globset::Error),
 }

--- a/src/canisters/frontend/ic-asset/src/error/prepare_sync_for_proposal.rs
+++ b/src/canisters/frontend/ic-asset/src/error/prepare_sync_for_proposal.rs
@@ -6,11 +6,11 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum PrepareSyncForProposalError {
     /// Failed while requesting that the asset canister compute evidence.
-    #[error("Failed to compute evidence: {0}")]
+    #[error("Failed to compute evidence")]
     ComputeEvidence(#[source] AgentError),
 
     /// Failed while calling propose_commit_batch.
-    #[error("Failed to propose batch to commit: {0}")]
+    #[error("Failed to propose batch to commit")]
     ProposeCommitBatch(#[source] AgentError),
 
     /// Failed while uploading content for synchronization.

--- a/src/canisters/frontend/ic-asset/src/error/prepare_sync_for_proposal.rs
+++ b/src/canisters/frontend/ic-asset/src/error/prepare_sync_for_proposal.rs
@@ -7,11 +7,11 @@ use thiserror::Error;
 pub enum PrepareSyncForProposalError {
     /// Failed while requesting that the asset canister compute evidence.
     #[error("Failed to compute evidence: {0}")]
-    ComputeEvidence(AgentError),
+    ComputeEvidence(#[source] AgentError),
 
     /// Failed while calling propose_commit_batch.
     #[error("Failed to propose batch to commit: {0}")]
-    ProposeCommitBatch(AgentError),
+    ProposeCommitBatch(#[source] AgentError),
 
     /// Failed while uploading content for synchronization.
     #[error(transparent)]

--- a/src/canisters/frontend/ic-asset/src/error/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/error/sync.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 pub enum SyncError {
     /// Failed when calling commit_batch
     #[error("Failed to commit batch: {0}")]
-    CommitBatchFailed(AgentError),
+    CommitBatchFailed(#[source] AgentError),
 
     /// Failed when trying to work with an older asset canister.
     #[error(transparent)]

--- a/src/canisters/frontend/ic-asset/src/error/sync.rs
+++ b/src/canisters/frontend/ic-asset/src/error/sync.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum SyncError {
     /// Failed when calling commit_batch
-    #[error("Failed to commit batch: {0}")]
+    #[error("Failed to commit batch")]
     CommitBatchFailed(#[source] AgentError),
 
     /// Failed when trying to work with an older asset canister.

--- a/src/canisters/frontend/ic-asset/src/error/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/error/upload.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum UploadError {
     /// Failed when calling commit_batch.
-    #[error("Commit batch failed: {0}")]
+    #[error("Commit batch failed")]
     CommitBatchFailed(#[source] AgentError),
 
     /// Failure when trying to work with an older asset canister.
@@ -16,18 +16,18 @@ pub enum UploadError {
     Compatibility(#[from] CompatibilityError),
 
     /// Failed when calling create_batch.
-    #[error("Create batch failed: {0}")]
+    #[error("Create batch failed")]
     CreateBatchFailed(#[source] AgentError),
 
     /// Failed when assembling commit_batch argument.
-    #[error("Failed to assemble commit_batch argument: {0}")]
+    #[error("Failed to assemble commit_batch argument")]
     AssembleCommitBatchArgumentFailed(#[from] AssembleCommitBatchArgumentError),
 
     /// Failed when creating project assets.
-    #[error("Failed to create project asset: {0}")]
+    #[error("Failed to create project asset")]
     CreateProjectAssetFailed(#[from] CreateProjectAssetError),
 
     /// Failed when calling the list method.
-    #[error("List assets failed: {0}")]
+    #[error("List assets failed")]
     ListAssetsFailed(#[source] AgentError),
 }

--- a/src/canisters/frontend/ic-asset/src/error/upload.rs
+++ b/src/canisters/frontend/ic-asset/src/error/upload.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 pub enum UploadError {
     /// Failed when calling commit_batch.
     #[error("Commit batch failed: {0}")]
-    CommitBatchFailed(AgentError),
+    CommitBatchFailed(#[source] AgentError),
 
     /// Failure when trying to work with an older asset canister.
     #[error(transparent)]
@@ -17,7 +17,7 @@ pub enum UploadError {
 
     /// Failed when calling create_batch.
     #[error("Create batch failed: {0}")]
-    CreateBatchFailed(AgentError),
+    CreateBatchFailed(#[source] AgentError),
 
     /// Failed when assembling commit_batch argument.
     #[error("Failed to assemble commit_batch argument: {0}")]
@@ -29,5 +29,5 @@ pub enum UploadError {
 
     /// Failed when calling the list method.
     #[error("List assets failed: {0}")]
-    ListAssetsFailed(AgentError),
+    ListAssetsFailed(#[source] AgentError),
 }

--- a/src/canisters/frontend/ic-asset/src/error/upload_content.rs
+++ b/src/canisters/frontend/ic-asset/src/error/upload_content.rs
@@ -10,19 +10,19 @@ use super::AssembleCommitBatchArgumentError;
 #[derive(Error, Debug)]
 pub enum UploadContentError {
     /// Failed when assembling commit_batch argument.
-    #[error("Failed to assemble commit_batch argument: {0}")]
+    #[error("Failed to assemble commit_batch argument")]
     AssembleCommitBatchArgumentFailed(#[source] AssembleCommitBatchArgumentError),
 
     /// Failed when calling create_batch.
-    #[error("Failed to create batch: {0}")]
+    #[error("Failed to create batch")]
     CreateBatchFailed(#[source] AgentError),
 
     /// Failed when creating project assets.
-    #[error("Failed to create project asset: {0}")]
+    #[error("Failed to create project asset")]
     CreateProjectAssetError(#[from] CreateProjectAssetError),
 
     /// Failed when building list of assets to synchronize.
-    #[error("Failed to gather asset descriptors: {0}")]
+    #[error("Failed to gather asset descriptors")]
     GatherAssetDescriptorsFailed(#[from] GatherAssetDescriptorsError),
 
     /// Failed when getting asset properties.
@@ -30,6 +30,6 @@ pub enum UploadContentError {
     GetAssetPropertiesFailed(#[from] GetAssetPropertiesError),
 
     /// Failed when calling the list method.
-    #[error("Failed to list assets: {0}")]
+    #[error("Failed to list assets")]
     ListAssetsFailed(#[source] AgentError),
 }

--- a/src/canisters/frontend/ic-asset/src/error/upload_content.rs
+++ b/src/canisters/frontend/ic-asset/src/error/upload_content.rs
@@ -11,11 +11,11 @@ use super::AssembleCommitBatchArgumentError;
 pub enum UploadContentError {
     /// Failed when assembling commit_batch argument.
     #[error("Failed to assemble commit_batch argument: {0}")]
-    AssembleCommitBatchArgumentFailed(AssembleCommitBatchArgumentError),
+    AssembleCommitBatchArgumentFailed(#[source] AssembleCommitBatchArgumentError),
 
     /// Failed when calling create_batch.
     #[error("Failed to create batch: {0}")]
-    CreateBatchFailed(AgentError),
+    CreateBatchFailed(#[source] AgentError),
 
     /// Failed when creating project assets.
     #[error("Failed to create project asset: {0}")]
@@ -31,5 +31,5 @@ pub enum UploadContentError {
 
     /// Failed when calling the list method.
     #[error("Failed to list assets: {0}")]
-    ListAssetsFailed(AgentError),
+    ListAssetsFailed(#[source] AgentError),
 }

--- a/src/dfx-core/Cargo.toml
+++ b/src/dfx-core/Cargo.toml
@@ -21,7 +21,7 @@ bip32 = "0.4.0"
 byte-unit = { workspace = true, features = ["serde"] }
 bytes.workspace = true
 candid = { workspace = true }
-clap = { workspace = true, features = ["string"] }
+clap = { workspace = true, features = ["string", "derive"] }
 dialoguer = { workspace = true }
 directories-next.workspace = true
 dunce = "1.0"

--- a/src/dfx-core/src/error/encryption.rs
+++ b/src/dfx-core/src/error/encryption.rs
@@ -3,13 +3,13 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum EncryptionError {
     #[error("Failed to decrypt content: {0}")]
-    DecryptContentFailed(aes_gcm::Error),
+    DecryptContentFailed(#[source] aes_gcm::Error),
 
     #[error("Failed to encrypt content: {0}")]
-    EncryptContentFailed(aes_gcm::Error),
+    EncryptContentFailed(#[source] aes_gcm::Error),
 
     #[error("Failed to hash password: {0}")]
-    HashPasswordFailed(argon2::password_hash::Error),
+    HashPasswordFailed(#[source] argon2::password_hash::Error),
 
     #[error("Failed to generate nonce: {0}")]
     NonceGenerationFailed(ring::error::Unspecified),
@@ -18,5 +18,5 @@ pub enum EncryptionError {
     ReadUserPasswordFailed(#[source] dialoguer::Error),
 
     #[error("Failed to generate salt: {0}")]
-    SaltGenerationFailed(ring::error::Unspecified),
+    SaltGenerationFailed(#[source] ring::error::Unspecified),
 }

--- a/src/dfx-core/src/error/encryption.rs
+++ b/src/dfx-core/src/error/encryption.rs
@@ -2,21 +2,21 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum EncryptionError {
-    #[error("Failed to decrypt content: {0}")]
+    #[error("Failed to decrypt content")]
     DecryptContentFailed(#[source] aes_gcm::Error),
 
-    #[error("Failed to encrypt content: {0}")]
+    #[error("Failed to encrypt content")]
     EncryptContentFailed(#[source] aes_gcm::Error),
 
-    #[error("Failed to hash password: {0}")]
+    #[error("Failed to hash password")]
     HashPasswordFailed(#[source] argon2::password_hash::Error),
 
-    #[error("Failed to generate nonce: {0}")]
+    #[error("Failed to generate nonce")]
     NonceGenerationFailed(ring::error::Unspecified),
 
     #[error("Failed to read user input")]
     ReadUserPasswordFailed(#[source] dialoguer::Error),
 
-    #[error("Failed to generate salt: {0}")]
+    #[error("Failed to generate salt")]
     SaltGenerationFailed(#[source] ring::error::Unspecified),
 }

--- a/src/dfx-core/src/error/encryption.rs
+++ b/src/dfx-core/src/error/encryption.rs
@@ -12,7 +12,7 @@ pub enum EncryptionError {
     HashPasswordFailed(#[source] argon2::password_hash::Error),
 
     #[error("Failed to generate nonce")]
-    NonceGenerationFailed(ring::error::Unspecified),
+    NonceGenerationFailed(#[source] ring::error::Unspecified),
 
     #[error("Failed to read user input")]
     ReadUserPasswordFailed(#[source] dialoguer::Error),


### PR DESCRIPTION
ic-asset was missing agent errors, and dfx-core was missing crypto errors. Also removed `{}` formatting of source errors per [this comment](<https://github.com/dfinity/sdk/pull/4149#discussion_r2004352895>).