### PR TITLE
chore: convert CanisterIdStore to a global

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,7 @@ dependencies = [
  "mime_guess",
  "mockito",
  "num-traits",
+ "once_cell",
  "os_str_bytes",
  "patch",
  "pem 1.1.1",
@@ -4436,9 +4437,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "opaque-debug"

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -44,6 +44,7 @@ bytes.workspace = true
 candid = { workspace = true }
 candid_parser = { workspace = true, features = ["random", "assist"] }
 cargo_metadata = "0.18.1"
+ci_info = "0.14"
 clap = { workspace = true, features = [
     "derive",
     "env",
@@ -86,6 +87,7 @@ lazy_static.workspace = true
 mime.workspace = true
 mime_guess.workspace = true
 num-traits.workspace = true
+once_cell = "1.21.1"
 os_str_bytes = { version = "6.3.0", features = ["conversions"] }
 patch = "0.7.0"
 pem.workspace = true
@@ -116,8 +118,8 @@ tempfile.workspace = true
 term = "0.7.0"
 thiserror.workspace = true
 time = { workspace = true, features = [
-    "serde",
     "macros",
+    "serde",
     "serde-human-readable",
 ] }
 tokio = { workspace = true, features = ["full"] }
@@ -125,7 +127,6 @@ url.workspace = true
 walkdir.workspace = true
 walrus = "0.21.1"
 which = "4.2.5"
-ci_info = "0.14"
 
 [target.'cfg(windows)'.dependencies]
 junction = "1.0.0"

--- a/src/dfx/src/commands/canister/delete.rs
+++ b/src/dfx/src/commands/canister/delete.rs
@@ -95,12 +95,9 @@ async fn delete_canister(
     initial_margin: Option<u128>,
 ) -> DfxResult {
     let log = env.get_logger();
-    let mut canister_id_store = env.get_canister_id_store()?;
+    let canister_id_store = env.get_canister_id_store()?;
     let (canister_id, canister_name_to_delete) = match Principal::from_text(canister) {
-        Ok(canister_id) => (
-            canister_id,
-            canister_id_store.get_name_in_project(canister).cloned(),
-        ),
+        Ok(canister_id) => (canister_id, canister_id_store.get_name_in_project(canister)),
         Err(_) => (canister_id_store.get(canister)?, Some(canister.to_string())),
     };
 

--- a/src/dfx/src/commands/canister/install.rs
+++ b/src/dfx/src/commands/canister/install.rs
@@ -82,7 +82,7 @@ pub async fn exec(
     fetch_root_key_if_needed(env).await?;
 
     let mode_hint = opts.install_mode.mode_for_canister_install()?;
-    let mut canister_id_store = env.get_canister_id_store()?;
+    let canister_id_store = env.get_canister_id_store()?;
     let network = env.get_network_descriptor();
 
     if mode_hint == InstallModeHint::Reinstall && (opts.canister.is_none() || opts.all) {
@@ -164,7 +164,7 @@ pub async fn exec(
                 // streamlined version, we can ignore most of the environment
                 install_canister(
                     env,
-                    &mut canister_id_store,
+                    canister_id_store,
                     canister_id,
                     &canister_info,
                     Some(&wasm_path),
@@ -184,7 +184,7 @@ pub async fn exec(
             } else {
                 install_canister(
                     env,
-                    &mut canister_id_store,
+                    canister_id_store,
                     canister_id,
                     &canister_info,
                     None,
@@ -221,7 +221,7 @@ pub async fn exec(
                 let canister_info = CanisterInfo::load(&config, canister, Some(canister_id))?;
                 install_canister(
                     env,
-                    &mut canister_id_store,
+                    canister_id_store,
                     canister_id,
                     &canister_info,
                     None,

--- a/src/dfx/src/commands/canister/update_settings.rs
+++ b/src/dfx/src/commands/canister/update_settings.rs
@@ -169,7 +169,8 @@ pub async fn exec(
         let canister_id = CanisterId::from_text(canister_name_or_id)
             .or_else(|_| canister_id_store.get(canister_name_or_id))?;
         let textual_cid = canister_id.to_text();
-        let canister_name = canister_id_store.get_name(&textual_cid).map(|x| &**x);
+        let canister_name = canister_id_store.get_name(&textual_cid);
+        let canister_name = canister_name.as_deref();
 
         let compute_allocation =
             get_compute_allocation(opts.compute_allocation, config_interface, canister_name)?;

--- a/src/dfx/src/commands/canister/url.rs
+++ b/src/dfx/src/commands/canister/url.rs
@@ -41,8 +41,8 @@ pub async fn exec(env: &dyn Environment, opts: CanisterUrlOpts) -> DfxResult {
     let canister_id_text = Principal::to_text(&canister_id);
     if let Some(canister_name) = canister_id_store.get_name(&canister_id_text) {
         if let Some(canisters) = &config.get_config().canisters {
-            if let Some(canister_config) = canisters.get(canister_name) {
-                let canister_info = CanisterInfo::load(&config, canister_name, Some(canister_id))?;
+            if let Some(canister_config) = canisters.get(&canister_name) {
+                let canister_info = CanisterInfo::load(&config, &canister_name, Some(canister_id))?;
                 let green = Style::new().green();
 
                 // Display as frontend if it's an asset canister, or custome type with a frontend.

--- a/src/dfx/src/lib/environment.rs
+++ b/src/dfx/src/lib/environment.rs
@@ -17,6 +17,7 @@ use dfx_core::identity::identity_manager::{IdentityManager, InitializeIdentity};
 use fn_error_context::context;
 use ic_agent::{Agent, Identity};
 use indicatif::MultiProgress;
+use once_cell::sync::OnceCell;
 use pocket_ic::nonblocking::PocketIc;
 use semver::Version;
 use slog::{Logger, Record};
@@ -84,13 +85,7 @@ pub trait Environment {
 
     fn get_extension_manager(&self) -> &ExtensionManager;
 
-    fn get_canister_id_store(&self) -> Result<CanisterIdStore, CanisterIdStoreError> {
-        CanisterIdStore::new(
-            self.get_logger(),
-            self.get_network_descriptor(),
-            self.get_config()?,
-        )
-    }
+    fn get_canister_id_store(&self) -> Result<&CanisterIdStore, CanisterIdStoreError>;
 }
 
 pub enum ProjectConfig {
@@ -103,6 +98,7 @@ pub struct EnvironmentImpl {
     project_config: RefCell<ProjectConfig>,
     shared_networks_config: Arc<NetworksConfig>,
     tool_config: Arc<Mutex<ToolConfig>>,
+    canister_id_store: OnceCell<CanisterIdStore>,
 
     cache: VersionCache,
 
@@ -129,6 +125,7 @@ impl EnvironmentImpl {
             cache: VersionCache::with_version(&version),
             project_config: RefCell::new(ProjectConfig::NotLoaded),
             shared_networks_config: Arc::new(shared_networks_config),
+            canister_id_store: OnceCell::new(),
             tool_config: Arc::new(Mutex::new(tool_config)),
             version: version.clone(),
             logger: None,
@@ -231,6 +228,16 @@ impl Environment for EnvironmentImpl {
         self.get_config()?.ok_or_else(|| anyhow!(
             "Cannot find dfx configuration file in the current working directory. Did you forget to create one?"
         ))
+    }
+
+    fn get_canister_id_store(&self) -> Result<&CanisterIdStore, CanisterIdStoreError> {
+        self.canister_id_store.get_or_try_init(|| {
+            CanisterIdStore::new(
+                self.get_logger(),
+                self.get_network_descriptor(),
+                self.get_config()?,
+            )
+        })
     }
 
     fn get_project_temp_dir(&self) -> DfxResult<Option<PathBuf>> {
@@ -414,6 +421,10 @@ impl<'a> Environment for AgentEnvironment<'a> {
         ))
     }
 
+    fn get_canister_id_store(&self) -> Result<&CanisterIdStore, CanisterIdStoreError> {
+        self.backend.get_canister_id_store()
+    }
+
     fn get_project_temp_dir(&self) -> DfxResult<Option<PathBuf>> {
         self.backend.get_project_temp_dir()
     }
@@ -519,7 +530,7 @@ pub mod test_env {
         fn get_cache(&self) -> VersionCache {
             unimplemented!()
         }
-        fn get_canister_id_store(&self) -> Result<CanisterIdStore, CanisterIdStoreError> {
+        fn get_canister_id_store(&self) -> Result<&CanisterIdStore, CanisterIdStoreError> {
             unimplemented!()
         }
         fn get_config(&self) -> Result<Option<Arc<Config>>, LoadDfxConfigError> {

--- a/src/dfx/src/lib/models/canister.rs
+++ b/src/dfx/src/lib/models/canister.rs
@@ -458,7 +458,7 @@ pub struct CanisterPool {
 struct PoolConstructHelper<'a> {
     config: &'a Config,
     builder_pool: BuilderPool,
-    canister_id_store: CanisterIdStore,
+    canister_id_store: &'a CanisterIdStore,
     generate_cid: bool,
     canisters_map: &'a mut Vec<Arc<Canister>>,
 }

--- a/src/dfx/src/lib/named_canister.rs
+++ b/src/dfx/src/lib/named_canister.rs
@@ -21,7 +21,7 @@ pub const MAINNET_UI_CANISTER_INTERFACE_PRINCIPAL: &str = "a4gq6-oaaaa-aaaab-qaa
 #[context("Failed to install candid UI canister.")]
 pub async fn install_ui_canister(
     env: &dyn Environment,
-    id_store: &mut CanisterIdStore,
+    id_store: &CanisterIdStore,
     some_canister_id: Option<Principal>,
 ) -> DfxResult<Principal> {
     let network = env.get_network_descriptor();
@@ -97,7 +97,7 @@ pub fn get_ui_canister_url(env: &dyn Environment) -> DfxResult<Option<Url>> {
         let url =
             Url::parse(&url).with_context(|| format!("Failed to parse Candid UI url {}.", &url))?;
         Ok(Some(url))
-    } else if let Some(candid_ui_id) = get_ui_canister_id(&env.get_canister_id_store()?) {
+    } else if let Some(candid_ui_id) = get_ui_canister_id(env.get_canister_id_store()?) {
         let mut url = Url::parse(&network_descriptor.providers[0]).with_context(|| {
             format!(
                 "Failed to parse network provider {}.",

--- a/src/dfx/src/lib/operations/canister/create_canister.rs
+++ b/src/dfx/src/lib/operations/canister/create_canister.rs
@@ -50,7 +50,7 @@ pub async fn create_canister(
     let config = env.get_config_or_anyhow()?;
     let config_interface = config.get_config();
 
-    let mut canister_id_store = env.get_canister_id_store()?;
+    let canister_id_store = env.get_canister_id_store()?;
 
     let network_name = get_network_context()?;
 

--- a/src/dfx/src/lib/operations/canister/deploy_canisters.rs
+++ b/src/dfx/src/lib/operations/canister/deploy_canisters.rs
@@ -117,7 +117,7 @@ pub async fn deploy_canisters(
         register_canisters(
             env,
             &canisters_to_deploy,
-            &initial_canister_id_store,
+            initial_canister_id_store,
             with_cycles,
             specified_id_from_cli,
             call_sender,
@@ -164,11 +164,11 @@ pub async fn deploy_canisters(
             info!(log, "Deployed canisters.");
         }
         PrepareForProposal(canister_name) => {
-            prepare_assets_for_commit(env, &initial_canister_id_store, &config, canister_name)
+            prepare_assets_for_commit(env, initial_canister_id_store, &config, canister_name)
                 .await?
         }
         ComputeEvidence(canister_name) => {
-            compute_evidence(env, &initial_canister_id_store, &config, canister_name).await?
+            compute_evidence(env, initial_canister_id_store, &config, canister_name).await?
         }
     }
 
@@ -331,7 +331,7 @@ async fn install_canisters(
 ) -> DfxResult {
     let spinner = env.new_spinner("Installing canisters...".into());
 
-    let mut canister_id_store = env.get_canister_id_store()?;
+    let canister_id_store = env.get_canister_id_store()?;
 
     for canister_name in canister_names {
         let canister_id = canister_id_store.get(canister_name)?;
@@ -339,7 +339,7 @@ async fn install_canisters(
 
         install_canister(
             env,
-            &mut canister_id_store,
+            canister_id_store,
             canister_id,
             &canister_info,
             None,

--- a/src/dfx/src/lib/operations/canister/install_canister.rs
+++ b/src/dfx/src/lib/operations/canister/install_canister.rs
@@ -42,7 +42,7 @@ use super::motoko_playground::playground_install_code;
 #[context("Failed to install wasm module to canister '{}'.", canister_info.get_name())]
 pub async fn install_canister(
     env: &dyn Environment,
-    canister_id_store: &mut CanisterIdStore,
+    canister_id_store: &CanisterIdStore,
     canister_id: Principal,
     canister_info: &CanisterInfo,
     wasm_path_override: Option<&Path>,

--- a/src/dfx/src/lib/operations/canister/motoko_playground.rs
+++ b/src/dfx/src/lib/operations/canister/motoko_playground.rs
@@ -30,7 +30,7 @@ pub struct CanisterInfo {
 }
 
 impl CanisterInfo {
-    pub fn from(id: Principal, timestamp: &AcquisitionDateTime) -> Self {
+    pub fn from(id: Principal, timestamp: AcquisitionDateTime) -> Self {
         let timestamp = candid::Int::from(timestamp.unix_timestamp_nanos());
         Self { id, timestamp }
     }
@@ -135,7 +135,7 @@ pub async fn reserve_canister_with_playground(
         bail!("Cannot reserve playground canister in CI, please run `dfx start` to use the local replica.")
     }
 
-    let mut canister_id_store = env.get_canister_id_store()?;
+    let canister_id_store = env.get_canister_id_store()?;
     let (timestamp, nonce) = create_nonce();
     let get_can_arg = Encode!(&GetCanisterIdArgs { timestamp, nonce }, &Origin::new())?;
     let result = agent
@@ -165,7 +165,7 @@ pub async fn reserve_canister_with_playground(
 pub async fn authorize_asset_uploader(
     env: &dyn Environment,
     canister_id: Principal,
-    canister_timestamp: &AcquisitionDateTime,
+    canister_timestamp: AcquisitionDateTime,
     principal_to_authorize: &Principal,
 ) -> DfxResult {
     let agent = env.get_agent();
@@ -194,7 +194,7 @@ pub async fn authorize_asset_uploader(
 pub async fn playground_install_code(
     env: &dyn Environment,
     canister_id: Principal,
-    canister_timestamp: &AcquisitionDateTime,
+    canister_timestamp: AcquisitionDateTime,
     arg: &[u8],
     wasm_module: &[u8],
     mode: InstallMode,


### PR DESCRIPTION
CanisterIdStore is a handle to global state via every mutating method saving to the file system, but still presents as a data structure it's meaningful to create a new instance of. This PR changes it to a property of Environment instead of something you create. 