### PR TITLE
feat: shorten time to report telemetry, esp for betas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@
 As [announced](https://forum.dfinity.org/t/dfx-replacing-the-local-replica-with-pocketic/40167) `dfx start` now runs PocketIC by default.
 Running a local replica is still possible with `--replica`, but this option will be removed in the near future.
 
+### feat: dfx will now report telemetry by default
+
+dfx will now record information about each dfx command executed, and periodically send
+this information to a DFINITY server, by default.
+
+For more information or to comment, please see https://forum.dfinity.org/t/dfx-telemetry-proposal-2025/41569.
+
+You can see what data dfx collects by inspecting the file at `dfx info telemetry-log-path`.
+
+You can disable this entirely with `dfx config telemetry off` or configure it to only collect
+locally with `dfx config telemetry local`.
+
 ### feat: `dfx info telemetry-log-path`
 
 Displays the path of the telemetry log file.

--- a/src/dfx/src/lib/telemetry.rs
+++ b/src/dfx/src/lib/telemetry.rs
@@ -274,8 +274,14 @@ impl Telemetry {
         future_duration: Option<Duration>,
     ) -> DfxResult {
         let future_duration = future_duration.unwrap_or_else(|| {
-            // random 5-7 days in the future
-            let future_seconds = 86400.0 * (5.0 + rand::random::<f64>() * 2.0);
+            let has_prerelease = !dfx_version().pre.is_empty();
+            let future_seconds = if has_prerelease {
+                // random 0.75 - 1.25 days in the future
+                86400.0 * (0.75 + rand::random::<f64>() * 0.5)
+            } else {
+                // random 2-4 days in the future
+                86400.0 * (2.0 + rand::random::<f64>() * 2.0)
+            };
             Duration::from_secs(future_seconds as u64)
         });
         let future_time = Local::now().naive_local() + future_duration;


### PR DESCRIPTION
# Description

Send telemetry every 2-4 days.

For betas, send telemetry every day +/- 6 hours.

Also added a changelog entry for the whole thing.


# How Has This Been Tested?

```
$ rm send-time.txt ; dfx --version ; dfx cache show ; cat send-time.txt
dfx 0.87.1
/Users/ericswanson/.cache/dfinity/versions/0.87.1
2025-03-23 18:23:25
$ rm send-time.txt ; dfx --version ; dfx cache show ; cat send-time.txt
dfx 0.87.1
/Users/ericswanson/.cache/dfinity/versions/0.87.1
2025-03-23 22:35:32
$ rm send-time.txt ; dfx --version ; dfx cache show ; cat send-time.txt
dfx 0.87.1
/Users/ericswanson/.cache/dfinity/versions/0.87.1
2025-03-22 15:28:15

$ rm send-time.txt ; dfx --version ; dfx cache show ; cat send-time.txt
dfx 0.87.1-beta.1
/Users/ericswanson/.cache/dfinity/versions/0.87.1-beta.1
2025-03-21 10:49:11
$ rm send-time.txt ; dfx --version ; dfx cache show ; cat send-time.txt
dfx 0.87.1-beta.1
/Users/ericswanson/.cache/dfinity/versions/0.87.1-beta.1
2025-03-21 15:55:16
$ rm send-time.txt ; dfx --version ; dfx cache show ; cat send-time.txt
dfx 0.87.1-beta.1
/Users/ericswanson/.cache/dfinity/versions/0.87.1-beta.1
2025-03-21 08:56:13
$ rm send-time.txt ; dfx --version ; dfx cache show ; cat send-time.txt
dfx 0.87.1-beta.1
/Users/ericswanson/.cache/dfinity/versions/0.87.1-beta.1
2025-03-21 17:03:56

```


# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
