### PR TITLE
feat: Extend `dfx ledger transfer` and `dfx ledger balance` to support ICRC1 standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+### feat: Extend `dfx ledger transfer` and `dfx ledger balance` to support ICRC-1 standard
+
+Extend `dfx ledger transfer` and `dfx ledger balance` to support [ICRC-1 standard](https://github.com/dfinity/ICRC-1/tree/main/standards/ICRC-1).
+
 # 0.26.0
 
 ### feat!: `dfx start` uses `--pocketic` by default

--- a/docs/cli-reference/dfx-ledger.mdx
+++ b/docs/cli-reference/dfx-ledger.mdx
@@ -26,7 +26,7 @@ Depending on the `dfx ledger` subcommand you specify, additional arguments, opti
 | `help`                                | Displays usage information message for a specified subcommand.                       |
 | [`notify`](#dfx-ledger-notify)                   | Notifies the ledger when there is a send transaction to the cycles minting canister. |
 | [`top-up`](#dfx-ledger-top-up)                   | Tops up a canister with cycles minted from ICP.                                      |
-| [`transfer`](#dfx-ledger-transfer)               | Transfers ICP from the user to the destination Account Identifier.                   |
+| [`transfer`](#dfx-ledger-transfer)               | Transfers ICP from the user to the destination Account Identifier or principal.      |
 | [`transfer-from`](#dfx-ledger-transfer-from)     | Transfer ICP from the approver princiapl to another principal.                       |
 
 To view usage information for a specific subcommand, specify the subcommand and the `--help` flag. For example, to see usage information for `dfx ledger transfer`, you can run the following command:
@@ -165,9 +165,18 @@ dfx ledger balance [of] [flag] --network ic
 
 You can specify the following argument for the `dfx ledger balance` command.
 
-| Argument | Description                                                                                                                                                                 |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `<of>`   | Specify an Account Identifier to get the balance. If this command is not specified, the command returns the balance of ICP tokens for the currently-selected user identity. |
+| Argument | Description                                                                                    |
+|----------|------------------------------------------------------------------------------------------------|
+| `<of>`   | Specify an Account Identifier to get the balance of. If both this argument and `--of-principal` option are not specified, the currently-selected user identity will be used. |
+
+### Options
+
+You can specify the following argument for the `dfx ledger balance` command.
+
+| Option                          | Description                                                             |
+|---------------------------------|-------------------------------------------------------------------------|
+| `--of-principal <of_principal>` | Specifies the principal to get the balance of.                          |
+| `--subaccount <subaccount>`     | Specifies the subaccount to get the balance of.                         |
 
 ### Examples
 
@@ -179,7 +188,17 @@ dfx ledger balance 03e3d86f29a069c6f2c5c48e01bc084e4ea18ad02b0eec8fccadf4487183c
 
 This command displays an ICP amount similar to the following:
 
-    2.49798000 ICP
+```bash
+2.49798000 ICP
+```
+
+You can also use the `dfx ledger balance` command to get the balance of a principal, please check the [ICRC-1 standard](https://github.com/dfinity/ICRC-1/tree/main/standards/ICRC-1) for more information.
+
+For example, you can run the following command to get the balance of a principal:
+
+```bash
+dfx ledger balance --of-principal tdrdy-ztedg-ftfrj-mwmqh-wjl3j-pty4c-j63lp-xfvtt-7jxvp-4ialz-3ae --network ic
+```
 
 ## dfx ledger create-canister
 
@@ -421,13 +440,16 @@ You can specify the following argument for the `dfx ledger transfer` command.
 
 You can specify the following argument for the `dfx ledger transfer` command.
 
-| Option              | Description                                                                                                                                                                                                     |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--amount <amount>` | Specifies the number of ICP tokens to transfer. Can be specified as a number with up to eight (8) decimal places.                                                                                               |
+| Option              | Description                                                                         |
+|---------------------|-------------------------------------------------------------------------------------|
+| `--amount <amount>` | Specifies the number of ICP tokens to transfer. Can be specified as a number with up to eight (8) decimal places. |
+| `--created-at-time <timestamp>`| Specify the timestamp-nanoseconds for the `created_at_time` field on the ledger transfer request. Useful for controlling transaction-de-duplication. https://internetcomputer.org/docs/current/developer-docs/integrations/icrc-1/#transaction-deduplication- |
 | `--e8s <e8s>`       | Specifies e8s as a whole number, where one e8 is smallest partition of an ICP token. For example, 1.05000000 is 1 ICP and 5000000 e8s. You can use this option alone or in conjunction with the `--icp` option. |
-| `--fee <fee>`       | Specifies a transaction fee. The default is 10000 e8s.                                                                                                                                                          |
-| `--icp <icp>`       | Specifies ICP as a whole number. You can use this option alone or in conjunction with `--e8s`.                                                                                                                  |
-| `--created-at-time <timestamp>`| Specify the timestamp-nanoseconds for the `created_at_time` field on the ledger transfer request. Useful for controlling transaction-de-duplication. https://internetcomputer.org/docs/current/developer-docs/integrations/icrc-1/#transaction-deduplication-  |
+| `--fee <fee>`       | Specifies a transaction fee. The default is 0.00010000 ICP (10000 e8s).             |
+| `--from-subaccount <from_subaccount>` | Specifies the subaccount from which you want to transfer ICP tokens. |
+| `--icp <icp>`       | Specifies ICP as a whole number. You can use this option alone or in conjunction with `--e8s`. |
+| `--to-principal <to_principal>` | Specifies the principal to which you want to transfer ICP tokens.       |
+| `--to-subaccount <to_subaccount>` | Specifies the subaccount to which you want to transfer ICP tokens.    |
 
 ### Examples
 
@@ -461,9 +483,19 @@ dfx ledger transfer dd81336dbfef5c5870e84b48405c7b229c07ad999fdcacb85b9b9850bd60
 
 This command displays output similar to the following:
 
-    Transfer sent at BlockHeight: 59513
+```bash
+Transfer sent at BlockHeight: 59513
+```
 
 You can then use the `dfx ledger balance --network ic` command to check that your account balance reflects the transaction you just made.
+
+You can also use the `dfx ledger transfer` command to send ICP to the principal of the destination, please check the [ICRC-1 standard](https://github.com/dfinity/ICRC-1/tree/main/standards/ICRC-1) for more information.
+
+For example, you can run the following command to send some of your ICP tokens to a principal of the destination:
+
+```bash
+dfx ledger transfer --to-principal tdrdy-ztedg-ftfrj-mwmqh-wjl3j-pty4c-j63lp-xfvtt-7jxvp-4ialz-3ae --amount 1 --memo 1 --network ic
+```
 
 ## dfx ledger transfer-from
 

--- a/e2e/tests-dfx/ledger.bash
+++ b/e2e/tests-dfx/ledger.bash
@@ -127,11 +127,11 @@ current_time_nanoseconds() {
   assert_contains "Transfer sent at block index"
 
   # The owner(alice) transferred 50 ICP to david and paid transaction fee which is 0.0001 ICP.
-  assert_command dfx ledger balance --identity alice
+  assert_command dfx ledger balance
   assert_eq "999999949.99990000 ICP"
 
   # The receiver(david) received 50 ICP.
-  assert_command dfx ledger balance --identity david
+  assert_command dfx ledger balance --of-principal "$DAVID"
   assert_match "50.00000000 ICP"
 
   # Test approve, transfer-from and allowance.
@@ -148,6 +148,7 @@ current_time_nanoseconds() {
   assert_match "Allowance 100.00000000 ICP"
 
   dfx identity use bob
+
   assert_command dfx ledger balance
   assert_match "1000000000.00000000 ICP"
 
@@ -156,7 +157,7 @@ current_time_nanoseconds() {
 
   # The spender(bob) transferred 50 ICP to david from the approver(alice).
   # And the approver(alice) paid transaction fee which is 0.0001 ICP
-  assert_command dfx ledger balance --identity alice
+  assert_command dfx ledger balance --of-principal "$ALICE"
   assert_eq "999999899.99970000 ICP"
 
   # The spender(bob) remains 49.99990000 ICP allowance from the approver(alice).
@@ -164,11 +165,11 @@ current_time_nanoseconds() {
   assert_match "Allowance 49.99990000 ICP"
 
   # The spender(bob) balance is unchanged.
-  assert_command dfx ledger balance --identity bob
+  assert_command dfx ledger balance --of-principal "$BOB"
   assert_match "1000000000.00000000 ICP"
 
   # The receiver(david) received 50 ICP.
-  assert_command dfx ledger balance --identity david
+  assert_command dfx ledger balance --of-principal "$DAVID"
   assert_match "100.00000000 ICP"
 }
 
@@ -202,6 +203,7 @@ current_time_nanoseconds() {
   assert_command dfx ledger balance --identity alice
   assert_match "999999999.99990000 ICP"
 }
+
 tc_to_num() {
   if [[ $1 =~ T ]]; then
     echo "${1%%[^0-9]*}000000000000"

--- a/src/dfx/src/commands/ledger/allowance.rs
+++ b/src/dfx/src/commands/ledger/allowance.rs
@@ -57,7 +57,7 @@ pub async fn exec(env: &dyn Environment, opts: AllowanceOpts) -> DfxResult {
         subaccount: opts.spender_subaccount,
     };
 
-    let allowance = ledger::allowance(agent, &canister_id, owner, spender).await?;
+    let allowance = ledger::icrc2_allowance(agent, &canister_id, owner, spender).await?;
 
     let icp = ICPTs::from_e8s(allowance.allowance.0.try_into()?);
 

--- a/src/dfx/src/commands/ledger/approve.rs
+++ b/src/dfx/src/commands/ledger/approve.rs
@@ -74,7 +74,7 @@ pub async fn exec(env: &dyn Environment, opts: ApproveOpts) -> DfxResult {
             .as_nanos() as u64,
     );
 
-    let result = ledger::approve(
+    let result = ledger::icrc2_approve(
         agent,
         env.get_logger(),
         &canister_id,

--- a/src/dfx/src/commands/ledger/approve.rs
+++ b/src/dfx/src/commands/ledger/approve.rs
@@ -53,8 +53,8 @@ pub struct ApproveOpts {
     #[arg(long)]
     memo: Option<u64>,
 
-    #[arg(long)]
     /// Canister ID of the ledger canister.
+    #[arg(long)]
     ledger_canister_id: Option<Principal>,
 }
 

--- a/src/dfx/src/commands/ledger/balance.rs
+++ b/src/dfx/src/commands/ledger/balance.rs
@@ -1,11 +1,14 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
+use crate::lib::ledger_types::MAINNET_LEDGER_CANISTER_ID;
 use crate::lib::nns_types::account_identifier::{AccountIdentifier, Subaccount};
+use crate::lib::nns_types::icpts::ICPTs;
 use crate::lib::operations::ledger;
 use crate::lib::root_key::fetch_root_key_if_needed;
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use candid::Principal;
 use clap::Parser;
+use icrc_ledger_types::icrc1;
 use std::str::FromStr;
 
 /// Prints the account balance of the user
@@ -13,6 +16,10 @@ use std::str::FromStr;
 pub struct BalanceOpts {
     /// Specifies an AccountIdentifier to get the balance of
     of: Option<String>,
+
+    /// Specifies a principal to get the balance of
+    #[arg(long, conflicts_with("of"))]
+    of_principal: Option<Principal>,
 
     /// Subaccount of the selected identity to get the balance of
     #[arg(long, conflicts_with("of"))]
@@ -24,21 +31,38 @@ pub struct BalanceOpts {
 }
 
 pub async fn exec(env: &dyn Environment, opts: BalanceOpts) -> DfxResult {
-    fetch_root_key_if_needed(env).await?;
-    let sender = env
-        .get_selected_identity_principal()
-        .expect("Selected identity not instantiated.");
-    let subacct = opts.subaccount;
-    let acc_id = opts
-        .of
-        .map_or_else(
-            || Ok(AccountIdentifier::new(sender, subacct)),
-            |v| AccountIdentifier::from_str(&v),
-        )
-        .map_err(|err| anyhow!(err))?;
     let agent = env.get_agent();
 
-    let balance = ledger::balance(agent, &acc_id, opts.ledger_canister_id).await?;
+    fetch_root_key_if_needed(env).await?;
+
+    let balance = if let Some(of) = opts.of {
+        let account_id = AccountIdentifier::from_str(&of)
+            .map_err(|e| anyhow!(e))
+            .with_context(|| {
+                format!(
+                    "Failed to parse transfer destination from string '{}'.",
+                    &of
+                )
+            })?;
+
+        ledger::balance(agent, &account_id, opts.ledger_canister_id).await?
+    } else {
+        let canister_id = opts
+            .ledger_canister_id
+            .unwrap_or(MAINNET_LEDGER_CANISTER_ID);
+
+        let owner = opts.of_principal.unwrap_or_else(|| {
+            env.get_selected_identity_principal()
+                .expect("Selected identity not instantiated.")
+        });
+        let of = icrc1::account::Account {
+            owner,
+            subaccount: opts.subaccount.map(|s| s.0),
+        };
+
+        let balance = ledger::icrc1_balance(agent, &canister_id, of).await?;
+        ICPTs::from_e8s(balance.try_into()?)
+    };
 
     println!("{balance}");
 

--- a/src/dfx/src/commands/ledger/show_subnet_types.rs
+++ b/src/dfx/src/commands/ledger/show_subnet_types.rs
@@ -11,8 +11,8 @@ const GET_SUBNET_TYPES_TO_SUBNETS_METHOD: &str = "get_subnet_types_to_subnets";
 /// Show available subnet types in the cycles minting canister.
 #[derive(Parser)]
 pub struct ShowSubnetTypesOpts {
-    #[arg(long)]
     /// Canister ID of the cycles minting canister.
+    #[arg(long)]
     cycles_minting_canister_id: Option<Principal>,
 }
 

--- a/src/dfx/src/commands/ledger/transfer.rs
+++ b/src/dfx/src/commands/ledger/transfer.rs
@@ -24,7 +24,7 @@ pub struct TransferOpts {
     #[arg(long, conflicts_with("to"))]
     to_principal: Option<Principal>,
 
-    /// Transfer cycles to this subaccount.
+    /// Transfer ICP to this subaccount.
     #[arg(long, value_parser = icrc_subaccount_parser, requires("to_principal"))]
     to_subaccount: Option<icrc1::account::Subaccount>,
 

--- a/src/dfx/src/commands/ledger/transfer.rs
+++ b/src/dfx/src/commands/ledger/transfer.rs
@@ -4,19 +4,29 @@ use crate::lib::error::DfxResult;
 use crate::lib::ledger_types::{Memo, MAINNET_LEDGER_CANISTER_ID};
 use crate::lib::nns_types::account_identifier::{AccountIdentifier, Subaccount};
 use crate::lib::nns_types::icpts::{ICPTs, TRANSACTION_FEE};
-use crate::lib::operations::ledger::transfer;
+use crate::lib::operations::ledger::{icrc1_transfer, transfer};
 use crate::lib::root_key::fetch_root_key_if_needed;
-use crate::util::clap::parsers::{e8s_parser, memo_parser};
+use crate::util::clap::parsers::{e8s_parser, icrc_subaccount_parser, memo_parser};
 use anyhow::{anyhow, Context};
 use candid::Principal;
 use clap::Parser;
+use icrc_ledger_types::icrc1;
 use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Transfer ICP from the user to the destination account identifier.
+/// Transfer ICP from the user to the destination account identifier or principal.
 #[derive(Parser)]
 pub struct TransferOpts {
     /// AccountIdentifier of transfer destination.
-    to: String,
+    to: Option<String>,
+
+    /// Principal of transfer destination.
+    #[arg(long, conflicts_with("to"))]
+    to_principal: Option<Principal>,
+
+    /// Transfer cycles to this subaccount.
+    #[arg(long, value_parser = icrc_subaccount_parser, requires("to_principal"))]
+    to_subaccount: Option<icrc1::account::Subaccount>,
 
     /// Subaccount to transfer from.
     #[arg(long)]
@@ -44,8 +54,8 @@ pub struct TransferOpts {
     #[arg(long)]
     fee: Option<ICPTs>,
 
-    #[arg(long)]
     /// Canister ID of the ledger canister.
+    #[arg(long)]
     ledger_canister_id: Option<Principal>,
 
     /// Transaction timestamp, in nanoseconds, for use in controlling transaction-deduplication, default is system-time. // https://internetcomputer.org/docs/current/developer-docs/integrations/icrc-1/#transaction-deduplication-
@@ -56,20 +66,6 @@ pub struct TransferOpts {
 pub async fn exec(env: &dyn Environment, opts: TransferOpts) -> DfxResult {
     let amount = get_icpts_from_args(opts.amount, opts.icp, opts.e8s)?;
 
-    let fee = opts.fee.unwrap_or(TRANSACTION_FEE);
-
-    let memo = Memo(opts.memo);
-
-    let to = AccountIdentifier::from_str(&opts.to)
-        .map_err(|e| anyhow!(e))
-        .with_context(|| {
-            format!(
-                "Failed to parse transfer destination from string '{}'.",
-                &opts.to
-            )
-        })?
-        .to_address();
-
     let agent = env.get_agent();
 
     fetch_root_key_if_needed(env).await?;
@@ -78,18 +74,75 @@ pub async fn exec(env: &dyn Environment, opts: TransferOpts) -> DfxResult {
         .ledger_canister_id
         .unwrap_or(MAINNET_LEDGER_CANISTER_ID);
 
-    let _block_height = transfer(
-        agent,
-        env.get_logger(),
-        &canister_id,
-        memo,
-        amount,
-        fee,
-        opts.from_subaccount,
-        to,
-        opts.created_at_time,
-    )
-    .await?;
+    if let Some(to) = opts.to {
+        let fee = opts.fee.unwrap_or(TRANSACTION_FEE);
+        let memo = Memo(opts.memo);
+
+        let to = AccountIdentifier::from_str(&to)
+            .map_err(|e| anyhow!(e))
+            .with_context(|| {
+                format!(
+                    "Failed to parse transfer destination from string '{}'.",
+                    &to
+                )
+            })?
+            .to_address();
+
+        let _block_height = transfer(
+            agent,
+            env.get_logger(),
+            &canister_id,
+            memo,
+            amount,
+            fee,
+            opts.from_subaccount,
+            to,
+            opts.created_at_time,
+        )
+        .await?;
+    } else if let Some(to) = opts.to_principal {
+        let to = icrc1::account::Account {
+            owner: to,
+            subaccount: opts.to_subaccount,
+        };
+
+        let created_at_time = opts.created_at_time.unwrap_or(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as u64,
+        );
+
+        let result = icrc1_transfer(
+            agent,
+            env.get_logger(),
+            &canister_id,
+            opts.from_subaccount.map(|s| s.0),
+            to,
+            amount,
+            opts.fee,
+            Some(opts.memo),
+            created_at_time,
+        )
+        .await;
+
+        if result.is_err() && opts.created_at_time.is_none() {
+            slog::warn!(
+                env.get_logger(),
+                "If you retry this operation, use --created-at-time {}",
+                created_at_time
+            );
+        }
+        let block_index = result?;
+
+        slog::info!(
+            env.get_logger(),
+            "Transfer sent at block index {}",
+            block_index
+        );
+    } else {
+        return Err(anyhow!("Please provide the transfer destination."));
+    }
 
     Ok(())
 }

--- a/src/dfx/src/commands/ledger/transfer_from.rs
+++ b/src/dfx/src/commands/ledger/transfer_from.rs
@@ -50,8 +50,8 @@ pub struct TransferFromOpts {
     #[arg(long)]
     memo: Option<u64>,
 
-    #[arg(long)]
     /// Canister ID of the ledger canister.
+    #[arg(long)]
     ledger_canister_id: Option<Principal>,
 }
 

--- a/src/dfx/src/commands/ledger/transfer_from.rs
+++ b/src/dfx/src/commands/ledger/transfer_from.rs
@@ -80,7 +80,7 @@ pub async fn exec(env: &dyn Environment, opts: TransferFromOpts) -> DfxResult {
         subaccount: opts.to_subaccount,
     };
 
-    let result = ledger::transfer_from(
+    let result = ledger::icrc2_transfer_from(
         agent,
         env.get_logger(),
         &canister_id,

--- a/src/dfx/src/lib/operations/cycles_ledger.rs
+++ b/src/dfx/src/lib/operations/cycles_ledger.rs
@@ -12,6 +12,10 @@ use crate::lib::ic_attributes::CanisterSettings as DfxCanisterSettings;
 use crate::lib::operations::canister::create_canister::{
     CANISTER_CREATE_FEE, CANISTER_INITIAL_CYCLE_BALANCE,
 };
+use crate::lib::operations::{
+    ICRC1_BALANCE_OF_METHOD, ICRC1_TRANSFER_METHOD, ICRC2_APPROVE_METHOD,
+    ICRC2_TRANSFER_FROM_METHOD,
+};
 use crate::lib::retryable::retryable;
 use crate::lib::telemetry::{CyclesHost, Telemetry};
 use crate::util::clap::subnet_selection_opt::SubnetSelectionType;
@@ -32,10 +36,6 @@ use icrc_ledger_types::icrc2::approve::ApproveError;
 use icrc_ledger_types::icrc2::transfer_from::TransferFromError;
 use slog::{info, Logger};
 
-const ICRC1_BALANCE_OF_METHOD: &str = "icrc1_balance_of";
-const ICRC1_TRANSFER_METHOD: &str = "icrc1_transfer";
-const ICRC2_APPROVE_METHOD: &str = "icrc2_approve";
-const ICRC2_TRANSFER_FROM_METHOD: &str = "icrc2_transfer_from";
 const WITHDRAW_METHOD: &str = "withdraw";
 const CREATE_CANISTER_METHOD: &str = "create_canister";
 const CYCLES_LEDGER_DEPOSIT_METHOD: &str = "deposit";

--- a/src/dfx/src/lib/operations/ledger.rs
+++ b/src/dfx/src/lib/operations/ledger.rs
@@ -1,6 +1,9 @@
 use crate::lib::diagnosis::DiagnosedError;
 use crate::lib::ledger_types::{AccountIdBlob, BlockHeight, Memo, TransferError};
 use crate::lib::nns_types::account_identifier::Subaccount;
+use crate::lib::operations::{
+    ICRC1_TRANSFER_METHOD, ICRC2_ALLOWANCE_METHOD, ICRC2_APPROVE_METHOD, ICRC2_TRANSFER_FROM_METHOD,
+};
 use crate::lib::{
     error::DfxResult,
     ledger_types::{
@@ -34,10 +37,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const ACCOUNT_BALANCE_METHOD: &str = "account_balance_dfx";
 const TRANSFER_METHOD: &str = "transfer";
-const ICRC1_TRANSFER_METHOD: &str = "icrc1_transfer";
-const ICRC2_APPROVE_METHOD: &str = "icrc2_approve";
-const ICRC2_TRANSFER_FROM_METHOD: &str = "icrc2_transfer_from";
-const ICRC2_ALLOWANCE_METHOD: &str = "icrc2_allowance";
 
 pub async fn balance(
     agent: &Agent,

--- a/src/dfx/src/lib/operations/ledger.rs
+++ b/src/dfx/src/lib/operations/ledger.rs
@@ -2,7 +2,8 @@ use crate::lib::diagnosis::DiagnosedError;
 use crate::lib::ledger_types::{AccountIdBlob, BlockHeight, Memo, TransferError};
 use crate::lib::nns_types::account_identifier::Subaccount;
 use crate::lib::operations::{
-    ICRC1_TRANSFER_METHOD, ICRC2_ALLOWANCE_METHOD, ICRC2_APPROVE_METHOD, ICRC2_TRANSFER_FROM_METHOD,
+    ICRC1_BALANCE_OF_METHOD, ICRC1_TRANSFER_METHOD, ICRC2_ALLOWANCE_METHOD, ICRC2_APPROVE_METHOD,
+    ICRC2_TRANSFER_FROM_METHOD,
 };
 use crate::lib::{
     error::DfxResult,
@@ -56,6 +57,26 @@ pub async fn balance(
         .build()
         .call()
         .await?;
+    Ok(result)
+}
+
+pub async fn icrc1_balance(
+    agent: &Agent,
+    canister_id: &Principal,
+    owner: icrc1::account::Account,
+) -> DfxResult<u128> {
+    let canister = Canister::builder()
+        .with_agent(agent)
+        .with_canister_id(*canister_id)
+        .build()?;
+
+    let (result,) = canister
+        .query(ICRC1_BALANCE_OF_METHOD)
+        .with_arg(owner)
+        .build()
+        .call()
+        .await?;
+
     Ok(result)
 }
 

--- a/src/dfx/src/lib/operations/ledger.rs
+++ b/src/dfx/src/lib/operations/ledger.rs
@@ -261,7 +261,7 @@ pub async fn icrc1_transfer(
     Ok(block_index)
 }
 
-pub async fn transfer_from(
+pub async fn icrc2_transfer_from(
     agent: &Agent,
     logger: &Logger,
     canister_id: &Principal,
@@ -320,7 +320,7 @@ pub async fn transfer_from(
     Ok(block_index)
 }
 
-pub async fn approve(
+pub async fn icrc2_approve(
     agent: &Agent,
     logger: &Logger,
     canister_id: &Principal,
@@ -380,7 +380,7 @@ pub async fn approve(
     Ok(block_index)
 }
 
-pub async fn allowance(
+pub async fn icrc2_allowance(
     agent: &Agent,
     canister_id: &Principal,
     owner: icrc1::account::Account,

--- a/src/dfx/src/lib/operations/mod.rs
+++ b/src/dfx/src/lib/operations/mod.rs
@@ -2,3 +2,9 @@ pub mod canister;
 pub mod cmc;
 pub mod cycles_ledger;
 pub mod ledger;
+
+const ICRC1_BALANCE_OF_METHOD: &str = "icrc1_balance_of";
+const ICRC1_TRANSFER_METHOD: &str = "icrc1_transfer";
+const ICRC2_ALLOWANCE_METHOD: &str = "icrc2_allowance";
+const ICRC2_APPROVE_METHOD: &str = "icrc2_approve";
+const ICRC2_TRANSFER_FROM_METHOD: &str = "icrc2_transfer_from";


### PR DESCRIPTION
# Description

Extend `dfx ledger transfer` and `dfx ledger balance` to support [ICRC1 standard](https://github.com/dfinity/ICRC-1/tree/main/standards/ICRC-1).

Fixes # (issue)

[SDK-2014](https://dfinity.atlassian.net/browse/SDK-2014)
[SDK-2016](https://dfinity.atlassian.net/browse/SDK-2016)

# How Has This Been Tested?

Covered by e2e tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.


[SDK-2014]: https://dfinity.atlassian.net/browse/SDK-2014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SDK-2016]: https://dfinity.atlassian.net/browse/SDK-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ