### PR TITLE
chore: use 'account_balance' instead of the legacy 'account_balance_dfx'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+### chore: use `account_balance` instead of the legacy `account_balance_dfx`
+
+Use the `account_balance` rather than the legacy `account_balance_dfx` on the ICP ledger.
+
 ### feat: Extend `dfx ledger transfer` and `dfx ledger balance` to support ICRC-1 standard
 
 Extend `dfx ledger transfer` and `dfx ledger balance` to support [ICRC-1 standard](https://github.com/dfinity/ICRC-1/tree/main/standards/ICRC-1).

--- a/src/dfx/src/lib/ledger_types/mod.rs
+++ b/src/dfx/src/lib/ledger_types/mod.rs
@@ -121,7 +121,7 @@ pub struct Memo(pub u64);
 
 #[derive(CandidType)]
 pub struct AccountBalanceArgs {
-    pub account: String,
+    pub account: AccountIdBlob,
 }
 
 #[derive(CandidType)]

--- a/src/dfx/src/lib/operations/ledger.rs
+++ b/src/dfx/src/lib/operations/ledger.rs
@@ -36,7 +36,7 @@ use icrc_ledger_types::icrc2::transfer_from::TransferFromError;
 use slog::{info, Logger};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const ACCOUNT_BALANCE_METHOD: &str = "account_balance_dfx";
+const ACCOUNT_BALANCE_METHOD: &str = "account_balance";
 const TRANSFER_METHOD: &str = "transfer";
 
 pub async fn balance(
@@ -52,7 +52,7 @@ pub async fn balance(
     let (result,) = canister
         .query(ACCOUNT_BALANCE_METHOD)
         .with_arg(AccountBalanceArgs {
-            account: acct.to_string(),
+            account: acct.to_address(),
         })
         .build()
         .call()


### PR DESCRIPTION
# Description

Use the [account_balance](https://github.com/dfinity/ic/blob/master/rs/ledger_suite/icp/ledger.did#L489) rather than the legacy [account_balance_dfx](https://github.com/dfinity/ic/blob/master/rs/ledger_suite/icp/ledger.did#L516) on the ICP ledger.

Fixes # (issue)

[SDK-2053](https://dfinity.atlassian.net/browse/SDK-2053)

# How Has This Been Tested?

Covered by the current e2e tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-2053]: https://dfinity.atlassian.net/browse/SDK-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ