### PR TITLE
refactor: error return for get_shared_network_data_directory

### DIFF
--- a/src/dfx-core/src/config/directories.rs
+++ b/src/dfx-core/src/config/directories.rs
@@ -1,7 +1,6 @@
 use crate::error::config::ConfigError;
 use crate::error::config::ConfigError::{
-    DetermineConfigDirectoryFailed, DetermineSharedNetworkDirectoryFailed,
-    EnsureConfigDirectoryExistsFailed,
+    DetermineConfigDirectoryFailed, EnsureConfigDirectoryExistsFailed,
 };
 use crate::error::get_user_home::GetUserHomeError;
 use crate::error::get_user_home::GetUserHomeError::NoHomeInEnvironment;
@@ -18,9 +17,11 @@ pub fn project_dirs() -> Result<&'static ProjectDirs, GetUserHomeError> {
     DIRS.as_ref().ok_or(NoHomeInEnvironment())
 }
 
-pub fn get_shared_network_data_directory(network: &str) -> Result<PathBuf, ConfigError> {
-    let project_dirs = project_dirs().map_err(DetermineSharedNetworkDirectoryFailed)?;
-    Ok(project_dirs.data_local_dir().join("network").join(network))
+pub fn get_shared_network_data_directory(network: &str) -> Result<PathBuf, GetUserHomeError> {
+    Ok(project_dirs()?
+        .data_local_dir()
+        .join("network")
+        .join(network))
 }
 
 pub fn get_user_dfx_config_dir() -> Result<PathBuf, ConfigError> {

--- a/src/dfx-core/src/error/config.rs
+++ b/src/dfx-core/src/error/config.rs
@@ -14,9 +14,6 @@ pub enum ConfigError {
 
     #[error("Failed to determine config directory path")]
     DetermineConfigDirectoryFailed(#[source] GetUserHomeError),
-
-    #[error("Failed to determine shared network data directory")]
-    DetermineSharedNetworkDirectoryFailed(#[source] GetUserHomeError),
 }
 
 #[derive(Error, Debug)]

--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -208,8 +208,8 @@ pub enum MapWalletsToRenamedIdentityError {
     #[error("Failed to get config directory for identity manager")]
     GetConfigDirectoryFailed(#[source] ConfigError),
 
-    #[error("Failed to get shared network data directory")]
-    GetSharedNetworkDataDirectoryFailed(#[source] ConfigError),
+    #[error(transparent)]
+    GetSharedNetworkDataDirectoryFailed(#[from] GetUserHomeError),
 
     #[error("Failed to rename wallet global config key")]
     RenameWalletGlobalConfigKeyFailed(#[source] RenameWalletGlobalConfigKeyError),

--- a/src/dfx-core/src/error/network_config.rs
+++ b/src/dfx-core/src/error/network_config.rs
@@ -1,8 +1,8 @@
 use crate::error::config::{ConfigError, GetTempPathError};
 use crate::error::fs::ReadToStringError;
+use crate::error::get_user_home::GetUserHomeError;
 use crate::error::socket_addr_conversion::SocketAddrConversionError;
 use crate::error::uri::UriError;
-
 use candid::types::principal::PrincipalError;
 use std::num::ParseIntError;
 use std::path::PathBuf;
@@ -15,6 +15,9 @@ pub enum NetworkConfigError {
 
     #[error(transparent)]
     Config(#[from] ConfigError),
+
+    #[error(transparent)]
+    DetermineSharedNetworkDirectoryFailed(#[from] GetUserHomeError),
 
     #[error(transparent)]
     UriError(#[from] UriError),

--- a/src/dfx-core/src/network/provider.rs
+++ b/src/dfx-core/src/network/provider.rs
@@ -10,8 +10,8 @@ use crate::config::model::network_descriptor::{
     NetworkDescriptor, NetworkTypeDescriptor, PLAYGROUND_NETWORK_NAME,
 };
 use crate::error::network_config::NetworkConfigError::{
-    self, NetworkNotFound, NoNetworkContext, NoProvidersForNetwork, ParsePortValueFailed,
-    ParseProviderUrlFailed, ReadWebserverPortFailed,
+    self, DetermineSharedNetworkDirectoryFailed, NetworkNotFound, NoNetworkContext,
+    NoProvidersForNetwork, ParsePortValueFailed, ParseProviderUrlFailed, ReadWebserverPortFailed,
 };
 use crate::identity::WALLET_CONFIG_FILENAME;
 use crate::util;
@@ -203,7 +203,8 @@ fn create_url_based_network_descriptor(
         // OS-friendly directory name for it.
         let name = util::network_to_pathcompat(network_name);
         let is_ic = NetworkDescriptor::is_ic(&name, &vec![url.to_string()]);
-        let data_directory = get_shared_network_data_directory(network_name)?;
+        let data_directory = get_shared_network_data_directory(network_name)
+            .map_err(DetermineSharedNetworkDirectoryFailed)?;
         let network_type = NetworkTypeDescriptor::new(
             NetworkType::Ephemeral,
             &data_directory.join(WALLET_CONFIG_FILENAME),
@@ -285,7 +286,8 @@ fn create_shared_network_descriptor(
             logger,
         );
 
-        let data_directory = get_shared_network_data_directory(network_name)?;
+        let data_directory = get_shared_network_data_directory(network_name)
+            .map_err(DetermineSharedNetworkDirectoryFailed)?;
 
         let ephemeral_wallet_config_path = data_directory.join(WALLET_CONFIG_FILENAME);
 


### PR DESCRIPTION
# Description

This PR refactors one method to return a method-specific error type, for the only error that can occur, rather than `ConfigError`, which could indicate many things.

Made here in order to make an upcoming PR slightly smaller.

# How Has This Been Tested?

refactor covered by CI

