### PR TITLE
fix: store wallets.json with backend data files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ Implement `dfx ledger allowance` subcommand that complies with the [ICRC-2](http
 - Add VetKD types and methods to management canister IDL
 - The VetKD test key id `Bls12_381_G2:dfx_test_key` is now enabled when starting `dfx` with `--replica`.
 
+### fix: dfx will no longer try to use a nonexistent wallet after changing backend settings without --clean
+
+After running `dfx start` with different options, dfx would try to use a wallet that was created
+on a previous run, which would fail. Now, dfx will create a new wallet if the settings have changed.
+
 ## Dependencies
 
 ### Motoko

--- a/e2e/tests-dfx/error_context.bash
+++ b/e2e/tests-dfx/error_context.bash
@@ -20,33 +20,35 @@ teardown() {
 
   assert_command dfx identity get-wallet
 
-  echo "invalid json" >"$E2E_SHARED_LOCAL_NETWORK_DATA_DIRECTORY/wallets.json"
+  WALLETS_JSON="$(shared_wallets_json)"
+
+  echo "invalid json" >"$WALLETS_JSON"
 
   assert_command_fail dfx identity get-wallet
-  assert_match "failed to parse contents of .*/network/local/wallets.json as json"
+  assert_match "failed to parse contents of .*/network/local/[0-9a-f]+/wallets.json as json"
   assert_match "expected value at line 1 column 1"
 
   assert_command_fail dfx wallet upgrade
-  assert_match "failed to parse contents of .*/network/local/wallets.json as json"
+  assert_match "failed to parse contents of .*/network/local/[0-9a-f]+/wallets.json as json"
   assert_match "expected value at line 1 column 1"
 
-  echo '{ "identities": {} }' >"$E2E_SHARED_LOCAL_NETWORK_DATA_DIRECTORY/wallets.json"
+  echo '{ "identities": {} }' >"$WALLETS_JSON"
 
   # maybe you were sudo when you made it
-  chmod u=w,go= "$E2E_SHARED_LOCAL_NETWORK_DATA_DIRECTORY/wallets.json"
+  chmod u=w,go= "$WALLETS_JSON"
   assert_command_fail dfx identity get-wallet
-  assert_match "failed to read .*/network/local/wallets.json"
+  assert_match "failed to read .*/network/local/[0-9a-f]+/wallets.json"
   assert_match "Permission denied"
 
   assert_command_fail dfx wallet upgrade
-  assert_match "failed to read .*/network/local/wallets.json"
+  assert_match "failed to read .*/network/local/[0-9a-f]+/wallets.json"
   assert_match "Permission denied"
 
   # can't write it?
-  chmod u=r,go= "$E2E_SHARED_LOCAL_NETWORK_DATA_DIRECTORY/wallets.json"
+  chmod u=r,go= "$WALLETS_JSON"
   assert_command dfx identity new --storage-mode plaintext alice
   assert_command_fail dfx identity get-wallet --identity alice
-  assert_match "failed to write to .*/local/wallets.json"
+  assert_match "failed to write to .*/local/[0-9a-f]+/wallets.json"
   assert_match "Permission denied"
 }
 

--- a/e2e/tests-dfx/network.bash
+++ b/e2e/tests-dfx/network.bash
@@ -30,17 +30,17 @@ teardown() {
 }
 
 @test "create with wallet stores canister ids for configured-ephemeral networks in canister_ids.json" {
+  echo "{}" | jq '.local.type="ephemeral"' >"$E2E_NETWORKS_JSON"
+
   dfx_start
 
-  setup_actuallylocal_shared_network
-  jq '.actuallylocal.type="ephemeral"' "$E2E_NETWORKS_JSON" | sponge "$E2E_NETWORKS_JSON"
-  dfx_set_wallet
+  dfx_set_wallet local
 
-  dfx canister create --all --network actuallylocal
+  dfx canister create --all
 
   # canister creates writes to a spinner (stderr), not stdout
-  assert_command dfx canister id e2e_project_backend --network actuallylocal
-  assert_match "$(jq -r .e2e_project_backend.actuallylocal .dfx/actuallylocal/canister_ids.json)"
+  assert_command dfx canister id e2e_project_backend
+  assert_match "$(jq -r .e2e_project_backend.local .dfx/local/canister_ids.json)"
 }
 
 @test "create stores canister ids for default-ephemeral local networks in .dfx/{network}canister_ids.json" {

--- a/e2e/tests-dfx/project_local_network.bash
+++ b/e2e/tests-dfx/project_local_network.bash
@@ -108,11 +108,13 @@ teardown() {
 @test "with a shared network, wallet id is stored in the shared location" {
   dfx_start
 
-  assert_file_not_exists "$E2E_SHARED_LOCAL_NETWORK_DATA_DIRECTORY/wallets.json"
+  WALLETS_JSON="$(shared_wallets_json)"
+
+  assert_file_not_exists "$WALLETS_JSON"
 
   WALLET_ID="$(dfx identity get-wallet)"
 
-  assert_command jq -r .identities.default.local "$E2E_SHARED_LOCAL_NETWORK_DATA_DIRECTORY/wallets.json"
+  assert_command jq -r .identities.default.local "$WALLETS_JSON"
   assert_eq "$WALLET_ID"
   assert_file_not_exists .dfx/local/wallets.json
 }

--- a/e2e/tests-dfx/wallet.bash
+++ b/e2e/tests-dfx/wallet.bash
@@ -242,6 +242,18 @@ teardown() {
   assert_match "There is no wallet defined for identity 'default' on network 'local'.  Nothing to do."
 }
 
+@test "creates a new wallet when switching between pocketic and replica" {
+  dfx_new hello
+
+  USE_REPLICA=1 dfx_start --artificial-delay 101
+  dfx deploy
+
+  dfx_stop
+
+  USE_REPLICA="" dfx_start --artificial-delay 99
+  dfx deploy
+}
+
 @test "creates new wallet if backend changes" {
   dfx_new hello
 

--- a/e2e/utils/_.bash
+++ b/e2e/utils/_.bash
@@ -220,10 +220,18 @@ dfx_stop() {
 }
 
 dfx_set_wallet() {
+  local network="${1:-actuallylocal}"
+
   export WALLET_CANISTER_ID
   WALLET_CANISTER_ID=$(dfx identity get-wallet)
-  assert_command dfx identity set-wallet "${WALLET_CANISTER_ID}" --force --network actuallylocal
+  assert_command dfx identity set-wallet "${WALLET_CANISTER_ID}" --force --network "${network}"
   assert_match 'Wallet set successfully.'
+}
+
+shared_wallets_json() {
+  SETTINGS_DIGEST="$(jq -r .settings_digest "$E2E_SHARED_LOCAL_NETWORK_DATA_DIRECTORY/network-id")"
+  WALLETS_JSON="$E2E_SHARED_LOCAL_NETWORK_DATA_DIRECTORY/$SETTINGS_DIGEST/wallets.json"
+  echo "$WALLETS_JSON"
 }
 
 setup_actuallylocal_project_network() {

--- a/src/dfx-core/src/config/directories.rs
+++ b/src/dfx-core/src/config/directories.rs
@@ -1,12 +1,15 @@
-use crate::error::config::ConfigError;
+use crate::config::model::local_server_descriptor::NetworkMetadata;
 use crate::error::config::ConfigError::{
     DetermineConfigDirectoryFailed, EnsureConfigDirectoryExistsFailed,
 };
+use crate::error::config::{ConfigError, GetSharedWalletConfigPathError};
 use crate::error::get_user_home::GetUserHomeError;
 use crate::error::get_user_home::GetUserHomeError::NoHomeInEnvironment;
 #[cfg(not(windows))]
 use crate::foundation::get_user_home;
 use crate::fs::composite::ensure_dir_exists;
+use crate::identity::WALLET_CONFIG_FILENAME;
+use crate::json::load_json_file;
 use directories_next::ProjectDirs;
 use std::path::PathBuf;
 
@@ -22,6 +25,23 @@ pub fn get_shared_network_data_directory(network: &str) -> Result<PathBuf, GetUs
         .data_local_dir()
         .join("network")
         .join(network))
+}
+
+pub fn get_shared_wallet_config_path(
+    network: &str,
+) -> Result<Option<PathBuf>, GetSharedWalletConfigPathError> {
+    let data_dir = get_shared_network_data_directory(network)?;
+
+    let network_id_path = data_dir.join("network-id");
+    if network_id_path.exists() {
+        let network_metadata: NetworkMetadata = load_json_file(&network_id_path)?;
+        let path = data_dir
+            .join(network_metadata.settings_digest)
+            .join(WALLET_CONFIG_FILENAME);
+        Ok(Some(path))
+    } else {
+        Ok(None)
+    }
 }
 
 pub fn get_user_dfx_config_dir() -> Result<PathBuf, ConfigError> {

--- a/src/dfx-core/src/config/model/network_descriptor.rs
+++ b/src/dfx-core/src/config/model/network_descriptor.rs
@@ -7,7 +7,7 @@ use crate::error::network_config::NetworkConfigError::{NetworkHasNoProviders, Ne
 use crate::error::uri::UriError;
 use candid::Principal;
 use slog::Logger;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use url::Url;
 
 pub const MAINNET_MOTOKO_PLAYGROUND_CANISTER_ID: Principal =
@@ -18,7 +18,7 @@ pub const MOTOKO_PLAYGROUND_CANISTER_TIMEOUT_SECONDS: u64 = 1200;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NetworkTypeDescriptor {
     Ephemeral {
-        wallet_config_path: PathBuf,
+        wallet_config_path: Option<PathBuf>,
     },
     Playground {
         playground_canister: Principal,
@@ -40,7 +40,7 @@ pub struct NetworkDescriptor {
 impl NetworkTypeDescriptor {
     pub fn new(
         r#type: NetworkType,
-        ephemeral_wallet_config_path: &Path,
+        ephemeral_wallet_config_path: Option<PathBuf>,
         playground: Option<PlaygroundConfig>,
     ) -> Result<Self, NetworkConfigError> {
         if let Some(playground_config) = playground {
@@ -57,7 +57,7 @@ impl NetworkTypeDescriptor {
         } else {
             match r#type {
                 NetworkType::Ephemeral => Ok(NetworkTypeDescriptor::Ephemeral {
-                    wallet_config_path: ephemeral_wallet_config_path.to_path_buf(),
+                    wallet_config_path: ephemeral_wallet_config_path,
                 }),
                 NetworkType::Persistent => Ok(NetworkTypeDescriptor::Persistent),
             }

--- a/src/dfx-core/src/error/config.rs
+++ b/src/dfx-core/src/error/config.rs
@@ -3,6 +3,7 @@ use crate::error::fs::{
     CanonicalizePathError, CreateDirAllError, EnsureDirExistsError, NoParentPathError,
 };
 use crate::error::get_user_home::GetUserHomeError;
+use crate::error::structured_file::StructuredFileError;
 use handlebars::RenderError;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -112,4 +113,13 @@ pub enum MergeTechStackError {
 
     #[error("expected extension canister type tech_stack to be an object")]
     ExpectedExtensionCanisterTypeTechStackObject,
+}
+
+#[derive(Error, Debug)]
+pub enum GetSharedWalletConfigPathError {
+    #[error(transparent)]
+    GetUserHome(#[from] GetUserHomeError),
+
+    #[error(transparent)]
+    StructuredFileError(#[from] StructuredFileError),
 }

--- a/src/dfx-core/src/error/identity.rs
+++ b/src/dfx-core/src/error/identity.rs
@@ -1,3 +1,4 @@
+use crate::error::config::GetSharedWalletConfigPathError;
 use crate::error::fs::{
     ReadFileError, ReadPermissionsError, RemoveDirectoryAndContentsError, RemoveDirectoryError,
     RemoveFileError, RenameError, SetPermissionsError, WriteFileError,
@@ -209,7 +210,10 @@ pub enum MapWalletsToRenamedIdentityError {
     GetConfigDirectoryFailed(#[source] ConfigError),
 
     #[error(transparent)]
-    GetSharedNetworkDataDirectoryFailed(#[from] GetUserHomeError),
+    GetSharedNetworkDataDirectoryFailed(#[from] GetSharedWalletConfigPathError),
+
+    #[error(transparent)]
+    LoadNetworkMetadata(#[from] StructuredFileError),
 
     #[error("Failed to rename wallet global config key")]
     RenameWalletGlobalConfigKeyFailed(#[source] RenameWalletGlobalConfigKeyError),

--- a/src/dfx-core/src/error/network_config.rs
+++ b/src/dfx-core/src/error/network_config.rs
@@ -1,7 +1,8 @@
-use crate::error::config::{ConfigError, GetTempPathError};
+use crate::error::config::{ConfigError, GetSharedWalletConfigPathError, GetTempPathError};
 use crate::error::fs::ReadToStringError;
 use crate::error::get_user_home::GetUserHomeError;
 use crate::error::socket_addr_conversion::SocketAddrConversionError;
+use crate::error::structured_file::StructuredFileError;
 use crate::error::uri::UriError;
 use candid::types::principal::PrincipalError;
 use std::num::ParseIntError;
@@ -29,7 +30,13 @@ pub enum NetworkConfigError {
     },
 
     #[error(transparent)]
+    GetSharedWalletConfigPathError(#[from] GetSharedWalletConfigPathError),
+
+    #[error(transparent)]
     GetTempPath(#[from] GetTempPathError),
+
+    #[error(transparent)]
+    LoadNetworkId(StructuredFileError),
 
     #[error("Network '{0}' does not specify any network providers.")]
     NetworkHasNoProviders(String),

--- a/src/dfx-core/src/error/wallet_config.rs
+++ b/src/dfx-core/src/error/wallet_config.rs
@@ -16,6 +16,9 @@ pub enum WalletConfigError {
 
     #[error("Failed to save wallet configuration")]
     SaveWalletConfig(#[from] SaveWalletConfigError),
+
+    #[error("cannot use a wallet before dfx start")]
+    NoWalletBeforeDfxStart,
 }
 
 #[derive(Error, Debug)]

--- a/src/dfx-core/src/identity/mod.rs
+++ b/src/dfx-core/src/identity/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Wallets are a map of network-identity, but don't have their own types or manager
 //! type.
-use crate::config::directories::{get_shared_network_data_directory, get_user_dfx_config_dir};
+use crate::config::directories::{get_shared_wallet_config_path, get_user_dfx_config_dir};
 use crate::config::model::network_descriptor::NetworkDescriptor;
 use crate::error::wallet_config::SaveWalletConfigError;
 use crate::error::{
@@ -256,16 +256,15 @@ impl Identity {
             )
             .map_err(RenameWalletGlobalConfigKeyFailed)?;
         }
-        let shared_local_network_wallet_path = get_shared_network_data_directory("local")
-            .map_err(MapWalletsToRenamedIdentityError::GetSharedNetworkDataDirectoryFailed)?
-            .join(WALLET_CONFIG_FILENAME);
-        if shared_local_network_wallet_path.exists() {
-            Identity::rename_wallet_global_config_key(
-                original_identity,
-                renamed_identity,
-                shared_local_network_wallet_path,
-            )
-            .map_err(RenameWalletGlobalConfigKeyFailed)?;
+        if let Some(shared_local_wallet_path) = get_shared_wallet_config_path("local")? {
+            if shared_local_wallet_path.exists() {
+                Identity::rename_wallet_global_config_key(
+                    original_identity,
+                    renamed_identity,
+                    shared_local_wallet_path,
+                )
+                .map_err(RenameWalletGlobalConfigKeyFailed)?;
+            }
         }
         if let Some(temp_dir) = project_temp_dir {
             let local_wallet_path = temp_dir.join("local").join(WALLET_CONFIG_FILENAME);

--- a/src/dfx-core/src/identity/wallet.rs
+++ b/src/dfx-core/src/identity/wallet.rs
@@ -25,7 +25,9 @@ pub fn get_wallet_config_path(
                 .join(name)
                 .join(WALLET_CONFIG_FILENAME)
         }
-        NetworkTypeDescriptor::Ephemeral { wallet_config_path } => wallet_config_path.clone(),
+        NetworkTypeDescriptor::Ephemeral { wallet_config_path } => wallet_config_path
+            .clone()
+            .ok_or(WalletConfigError::NoWalletBeforeDfxStart)?,
     })
 }
 

--- a/src/dfx-core/src/network/provider.rs
+++ b/src/dfx-core/src/network/provider.rs
@@ -1,4 +1,6 @@
-use crate::config::directories::get_shared_network_data_directory;
+use crate::config::directories::{
+    get_shared_network_data_directory, get_shared_wallet_config_path,
+};
 use crate::config::model::dfinity::{
     Config, ConfigDefaults, ConfigLocalProvider, ConfigNetwork, NetworkType, NetworksConfig,
     DEFAULT_PROJECT_LOCAL_BIND, DEFAULT_SHARED_LOCAL_BIND,
@@ -55,7 +57,7 @@ fn config_network_to_network_descriptor(
     project_defaults: Option<&ConfigDefaults>,
     data_directory: PathBuf,
     local_scope: LocalNetworkScopeDescriptor,
-    ephemeral_wallet_config_path: &Path,
+    ephemeral_wallet_config_path: Option<PathBuf>,
     local_bind_determination: &LocalBindDetermination,
     default_local_bind: &str,
     legacy_pid_path: Option<PathBuf>,
@@ -207,7 +209,7 @@ fn create_url_based_network_descriptor(
             .map_err(DetermineSharedNetworkDirectoryFailed)?;
         let network_type = NetworkTypeDescriptor::new(
             NetworkType::Ephemeral,
-            &data_directory.join(WALLET_CONFIG_FILENAME),
+            Some(data_directory.join(WALLET_CONFIG_FILENAME)),
             None,
         )?;
         Ok(NetworkDescriptor {
@@ -286,10 +288,9 @@ fn create_shared_network_descriptor(
             logger,
         );
 
-        let data_directory = get_shared_network_data_directory(network_name)
-            .map_err(DetermineSharedNetworkDirectoryFailed)?;
+        let data_directory = get_shared_network_data_directory(network_name)?;
 
-        let ephemeral_wallet_config_path = data_directory.join(WALLET_CONFIG_FILENAME);
+        let ephemeral_wallet_config_path = get_shared_wallet_config_path(network_name)?;
 
         let local_scope = LocalNetworkScopeDescriptor::shared(&data_directory);
         config_network_to_network_descriptor(
@@ -298,7 +299,7 @@ fn create_shared_network_descriptor(
             None,
             data_directory,
             local_scope,
-            &ephemeral_wallet_config_path,
+            ephemeral_wallet_config_path,
             local_bind_determination,
             DEFAULT_SHARED_LOCAL_BIND,
             None,
@@ -374,7 +375,7 @@ fn create_project_network_descriptor(
                 Some(config.get_config().get_defaults()),
                 data_directory,
                 LocalNetworkScopeDescriptor::Project,
-                &ephemeral_wallet_config_path,
+                Some(ephemeral_wallet_config_path),
                 local_bind_determination,
                 DEFAULT_PROJECT_LOCAL_BIND,
                 legacy_pid_path,


### PR DESCRIPTION
# Description

For the local shared network, `dfx start` stores replica state in a subdirectory based on the configuration of that backend. dfx wasn't storing `wallets.json` in this subdirectory, which meant that when changing settings, dfx would try to use a wallet canister that didn't exist.

This change puts wallets.json in the same subdirectory as the rest of the backend state. 

Fixes https://dfinity.atlassian.net/browse/SDK-1918

I put the changelog entry in the 0.26.0 section because I will port this to the release branch after CR approval here.

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
