### PR TITLE
feat: dfx canister set-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+### feat: Set canister ids using `dfx canister set-id <canister name> <principal>`
+
+Added the counterpart to `dfx canister id <canister name>`. Networks can be targeted as usual using `--network <network name>` or the `--ic` shorthand for mainnet.
+
 ### chore: use `account_balance` instead of the legacy `account_balance_dfx`
 
 Use the `account_balance` rather than the legacy `account_balance_dfx` on the ICP ledger.

--- a/docs/cli-reference/dfx-canister.mdx
+++ b/docs/cli-reference/dfx-canister.mdx
@@ -770,7 +770,7 @@ dfx canister set-id <canister_name> <principal>
 
 ### Arguments
 
-You can use the following argument with the `dfx canister id` command.
+You can use the following argument with the `dfx canister set-id` command.
 
 | Argument        | Description                                                                      |
 |-----------------|----------------------------------------------------------------------------------|

--- a/docs/cli-reference/dfx-canister.mdx
+++ b/docs/cli-reference/dfx-canister.mdx
@@ -38,6 +38,7 @@ For reference information and examples that illustrate using `dfx canister` comm
 | [`metadata`](#dfx-canister-metadata)               | Displays metadata in a canister.                                                                                                                       |
 | [`request-status`](#dfx-canister-request-status)   | Requests the status of a call to a canister.                                                                                                           |
 | [`send`](#dfx-canister-send)                       | Send a previously-signed message.                                                                                                                      |
+| [`set-id`](#dfx-canister-id)                       | Sets the identifier of a canister.                                                                                                                     |
 | [`sign`](#dfx-canister-send)                       | Sign a canister call and generate message file.                                                                                                        |
 | [`start`](#dfx-canister-start)                     | Starts a stopped canister.                                                                                                                             |
 | [`status`](#dfx-canister-status)                   | Returns the current status of a canister as defined [here](https://internetcomputer.org/docs/current/references/ic-interface-spec#ic-canister_status). |
@@ -752,6 +753,50 @@ Use the `dfx canister send` command to send a signed message created using the `
 genesis token canister (GTC) to create a neuron on your behalf by running the following command:
 
 `dfx canister send message.json`
+
+## dfx canister set-id
+
+Use the `dfx canister set-id` command to set the canister identifier/principal for a specific canister name.
+
+Note that you can only run this command from within the project directory structure. For example, if your project name
+is `hello_world`, your current working directory must be the `hello_world` top-level project directory or one of its
+subdirectories.
+
+### Basic usage
+
+``` bash
+dfx canister set-id <canister_name> <principal>
+```
+
+### Arguments
+
+You can use the following argument with the `dfx canister id` command.
+
+| Argument        | Description                                                                      |
+|-----------------|----------------------------------------------------------------------------------|
+| `canister_name` | Specifies the name of the canister for which you want to set an identifier.      |
+| `principal`     | Specifies the principal of the canister for which you want to set an identifier. |
+
+### Options
+
+You can use the following options with the `dfx canister set-id` command.
+
+| Option      | Description                                   |
+|-------------|-----------------------------------------------|
+| `--network` | The network for which you want to set the id. |
+
+### Examples
+
+You can use the `dfx canister set-id` command to set the canister identifier for a specific canister name.
+
+``` bash
+dfx canister set-id hello_backend qhbym-qaaaa-aaaaa-aaafq-cai
+```
+
+The command displays output similar to the following:
+
+``` bash
+Set canister id for hello_backend to qhbym-qaaaa-aaaaa-aaafq-cai
 
 ## dfx canister sign
 

--- a/e2e/tests-dfx/id.bash
+++ b/e2e/tests-dfx/id.bash
@@ -96,3 +96,14 @@ teardown() {
   assert_command dfx canister --network somethingelse id external_canister
   assert_match "rkp4c-7iaaa-aaaaa-aaaca-cai"
 }
+
+@test "set-id writes canister id for specified network" {
+  CANISTER_ID="qhbym-qaaaa-aaaaa-aaafq-cai"
+  assert_command dfx canister --network ic set-id hello_backend $CANISTER_ID
+
+  assert_command dfx canister id hello_backend --network ic
+  assert_contains $CANISTER_ID
+
+  assert_command_fail dfx canister id hello_backend --network local
+  assert_contains "Cannot find canister id"
+}

--- a/src/dfx/src/commands/canister/mod.rs
+++ b/src/dfx/src/commands/canister/mod.rs
@@ -17,6 +17,7 @@ mod logs;
 mod metadata;
 mod request_status;
 mod send;
+mod set_id;
 mod sign;
 mod snapshot;
 mod start;
@@ -54,6 +55,7 @@ pub enum SubCommand {
     Metadata(metadata::CanisterMetadataOpts),
     RequestStatus(request_status::RequestStatusOpts),
     Send(send::CanisterSendOpts),
+    SetId(set_id::CanisterSetIdOpts),
     Sign(sign::CanisterSignOpts),
     Snapshot(snapshot::SnapshotOpts),
     Start(start::CanisterStartOpts),
@@ -67,7 +69,7 @@ pub enum SubCommand {
 
 pub fn exec(env: &dyn Environment, opts: CanisterOpts) -> DfxResult {
     let agent_env;
-    let env = if matches!(&opts.subcmd, SubCommand::Id(_)) {
+    let env = if matches!(&opts.subcmd, SubCommand::Id(_) | SubCommand::SetId(_)) {
         env
     } else {
         agent_env = create_agent_environment(env, opts.network.to_network_name())?;
@@ -88,6 +90,7 @@ pub fn exec(env: &dyn Environment, opts: CanisterOpts) -> DfxResult {
             SubCommand::Metadata(v) => metadata::exec(env, v).await,
             SubCommand::RequestStatus(v) => request_status::exec(env, v).await,
             SubCommand::Send(v) => send::exec(env, v, &call_sender()?).await,
+            SubCommand::SetId(v) => set_id::exec(env, v).await,
             SubCommand::Sign(v) => sign::exec(env, v, &call_sender()?).await,
             SubCommand::Snapshot(v) => snapshot::exec(env, v, &call_sender()?).await,
             SubCommand::Start(v) => start::exec(env, v, &call_sender()?).await,

--- a/src/dfx/src/commands/canister/set_id.rs
+++ b/src/dfx/src/commands/canister/set_id.rs
@@ -1,0 +1,44 @@
+use crate::lib::environment::Environment;
+use crate::lib::error::DfxResult;
+use crate::lib::network::network_opt::NetworkOpt;
+use candid::Principal;
+use clap::Parser;
+use dfx_core::config::model::canister_id_store::CanisterIdStore;
+use dfx_core::network::provider::{create_network_descriptor, LocalBindDetermination};
+use slog::info;
+
+/// Sets the identifier of a canister.
+#[derive(Parser)]
+pub struct CanisterSetIdOpts {
+    /// Specifies the name of the canister.
+    canister: String,
+
+    /// Specifies the id of the canister.
+    id: Principal,
+
+    #[command(flatten)]
+    network: NetworkOpt,
+}
+
+pub async fn exec(env: &dyn Environment, opts: CanisterSetIdOpts) -> DfxResult {
+    env.get_config_or_anyhow()?;
+    let log = env.get_logger();
+    let network_descriptor = create_network_descriptor(
+        env.get_config()?,
+        env.get_networks_config(),
+        opts.network.to_network_name(),
+        None,
+        LocalBindDetermination::AsConfigured,
+    )?;
+    let canister_id_store =
+        CanisterIdStore::new(env.get_logger(), &network_descriptor, env.get_config()?)?;
+
+    canister_id_store.add(log, &opts.canister, &opts.id.to_string(), None)?;
+    info!(
+        log,
+        "Set canister id for {} to {}",
+        opts.canister,
+        opts.id.to_string()
+    );
+    Ok(())
+}


### PR DESCRIPTION
# Description

Added the counterpart to `dfx canister id <canister name>`. Networks can be targeted as usual using `--network <network name>` or the `--ic` shorthand for mainnet.

Requested through DMs, and answers the occasional forum question where people ask how to set a specific canister id after creating a canister through NNS dapp.

# How Has This Been Tested?

Added e2e

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
