### PR TITLE
Bump the NNS Extension used in tests to v0.5.1

### DIFF
--- a/e2e/tests-dfx/ledger.bash
+++ b/e2e/tests-dfx/ledger.bash
@@ -5,7 +5,7 @@ load ../utils/_
 install_nns() {
   dfx_start_for_nns_install
 
-  dfx extension install nns --version 0.5.0
+  dfx extension install nns --version 0.5.1
   dfx nns install --ledger-accounts 345f723e9e619934daac6ae0f4be13a7b0ba57d6a608e511a00fd0ded5866752 22ca7edac648b814e81d7946e8bacea99280e07c5f51a04ba7a38009d8ad8e89 5a94fe181e9d411c58726cb87cbf2d016241b6c350bc3330e4869ca76e54ecbc
 }
 


### PR DESCRIPTION
# Description

The NNS Extension 0.5.0 has a replica rev where ic_nns_init initializes neurons with diminished voting power because of periodic confirmation, while 0.5.1 has the replica rev where ic_nns_init is fixed.

# How Has This Been Tested?

`ledger.bash` should be fixed

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
