### PR TITLE
fix: clear state when switching from shared to project network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # UNRELEASED
 
+### fix: clear state when switching from shared to project network
+
+dfx would try to reuse canister ids when switching from a shared network to a project network,
+which would cause errors since those canister ids wouldn't exist. dfx now deletes the .dfx
+directory if it was previously used with the shared local network.
+
 ### feat: Set canister ids using `dfx canister set-id <canister name> <principal>`
 
 Added the counterpart to `dfx canister id <canister name>`. Networks can be targeted as usual using `--network <network name>` or the `--ic` shorthand for mainnet.

--- a/e2e/tests-dfx/project_local_network.bash
+++ b/e2e/tests-dfx/project_local_network.bash
@@ -12,6 +12,20 @@ teardown() {
   standard_teardown
 }
 
+@test "switch from shared to project network" {
+  dfx_new hello
+  dfx_start
+  dfx deploy
+  dfx stop
+
+  # the above will have created .dfx/local/canister_ids.json,
+  # which won't be valid for the new network.
+
+  define_project_network
+  dfx_start
+  dfx deploy
+}
+
 @test "dfx start starts a local network if dfx.json defines one" {
   dfx_new hello
   cat dfx.json

--- a/src/dfx-core/src/network/directory.rs
+++ b/src/dfx-core/src/network/directory.rs
@@ -33,6 +33,14 @@ pub fn ensure_cohesive_network_directory(
                 crate::fs::write(&project_network_id_path, &network_id)?;
             }
         }
+    } else if let Some(LocalNetworkScopeDescriptor::Project { .. }) = &scope {
+        // see if there is a network-id file in the directory
+        // this indicates the previous configuration was for the shared local network
+        // so we need to reset the .dfx directory
+        let project_network_id_path = directory.join("network-id");
+        if project_network_id_path.exists() {
+            crate::fs::remove_dir_all(directory)?;
+        }
     }
 
     Ok(())

--- a/src/dfx-core/src/network/directory.rs
+++ b/src/dfx-core/src/network/directory.rs
@@ -34,11 +34,10 @@ pub fn ensure_cohesive_network_directory(
             }
         }
     } else if let Some(LocalNetworkScopeDescriptor::Project { .. }) = &scope {
-        // see if there is a network-id file in the directory
-        // this indicates the previous configuration was for the shared local network
-        // so we need to reset the .dfx directory
-        let project_network_id_path = directory.join("network-id");
-        if project_network_id_path.exists() {
+        // a network-id file indicates the previous configuration was for the shared local network.
+        // canister ids, at minimum, will no longer be valid
+        let network_id_path = directory.join("network-id");
+        if network_id_path.exists() {
             crate::fs::remove_dir_all(directory)?;
         }
     }


### PR DESCRIPTION
# Description

After editing dfx.json to define a local network, dfx would try to continue to reuse canister ids defined for the shared network. This would cause errors since those canisters most likely did not exist.

This PR deletes the .dfx directory if the configuration changes from using the shared local network to the project network.

Fixes https://dfinity.atlassian.net/browse/SDK-2062

# How Has This Been Tested?

Added an e2e test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
