### PR TITLE
test: run fewer tests on macos

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,9 +55,9 @@ jobs:
       matrix:
         # We build a dynamic-linked linux binary because otherwise HSM support fails with:
         #   Error: IO: Dynamic loading not supported
-        os: [macos-13-large, ubuntu-22.04, ubuntu-24.04, windows-2022]
+        os: [macos-13, ubuntu-22.04, ubuntu-24.04, windows-2022]
         include:
-          - os: macos-13-large
+          - os: macos-13
             target: x86_64-apple-darwin
             binary_path: target/x86_64-apple-darwin/release/dfx
           - os: ubuntu-22.04
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13-large, ubuntu-22.04, ubuntu-24.04]
+        os: [macos-13, ubuntu-22.04, ubuntu-24.04]
     steps:
       - uses: actions/checkout@v4
       - name: Download dfx binary
@@ -184,7 +184,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13-large, ubuntu-22.04, ubuntu-24.04]
+        os: [macos-13, ubuntu-22.04, ubuntu-24.04]
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4

--- a/scripts/workflows/e2e-matrix.py
+++ b/scripts/workflows/e2e-matrix.py
@@ -3,26 +3,55 @@
 import json
 import os
 
+# Only run these tests on macOS
+MACOS_TESTS = ["dfx/bitcoin", "dfx/canister_http_adapter", "dfx/start"]
+
+# All supported backends
+ALL_BACKENDS = ["pocketic", "replica"]
+
+# Skip specific test-backend combinations
+EXCLUDE = [
+    {
+        "backend": "pocketic",
+        "test": "dfx/canister_http_adapter"
+    }
+]
 
 def test_scripts(prefix):
-    all = os.listdir("e2e/tests-{}".format(prefix))
-    bash = filter(lambda filename: filename.endswith(".bash"), all)
-    tests = list(map(lambda filename: "{}/{}".format(prefix, filename[:-5]), bash))
-    return tests
+    all_files = os.listdir(f"e2e/tests-{prefix}")
+    bash_files = filter(lambda f: f.endswith(".bash"), all_files)
+    return [f"{prefix}/{filename[:-5]}" for filename in bash_files]
 
+all_tests = sorted(
+    test_scripts("dfx") +
+    test_scripts("replica") +
+    test_scripts("icx-asset")
+)
 
-test = sorted(test_scripts("dfx") + test_scripts("replica") + test_scripts("icx-asset"))
+include = []
+
+for test in all_tests:
+    for backend in ALL_BACKENDS:
+        if {"backend": backend, "test": test} in EXCLUDE:
+            continue
+
+        # Ubuntu: run everything
+        include.append({
+            "test": test,
+            "backend": backend,
+            "os": "ubuntu-22.04"
+        })
+
+        # macOS: only run selected tests
+        if test in MACOS_TESTS:
+            include.append({
+                "test": test,
+                "backend": backend,
+                "os": "macos-13"
+            })
 
 matrix = {
-    "test": test,
-    "backend": ["pocketic", "replica"],
-    "os": ["macos-13-large", "ubuntu-22.04"],
-    "exclude": [
-        {
-            "backend": "pocketic",
-            "test": "dfx/canister_http_adapter"
-        }
-    ]
+    "include": include,
 }
 
 print(json.dumps(matrix))


### PR DESCRIPTION
Only run selected tests on macos, and also use the `macos-13` runners.

Fixes https://dfinity.atlassian.net/browse/SDK-2067
