### PR TITLE
chore: fix the wrong place for the changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # UNRELEASED
 
+### feat: Improve 'dfx canister logs' with several options
+
+Improve `dfx canister logs` with several options
+- `--tail <n>` to show the last `n` log entries
+- `--since` to show the logs newer than a relative duration
+- `--since-time` to show the logs newer than a specific timestamp
+
 # 0.26.1
 
 ### fix: clear state when switching from shared to project network
@@ -21,13 +28,6 @@ Use the `account_balance` rather than the legacy `account_balance_dfx` on the IC
 ### feat: Extend `dfx ledger transfer` and `dfx ledger balance` to support ICRC-1 standard
 
 Extend `dfx ledger transfer` and `dfx ledger balance` to support [ICRC-1 standard](https://github.com/dfinity/ICRC-1/tree/main/standards/ICRC-1).
-
-### feat: Improve 'dfx canister logs' with several options
-
-Improve `dfx canister logs` with several options
-- `--tail <n>` to show the last `n` log entries
-- `--since` to show the logs newer than a relative duration
-- `--since-time` to show the logs newer than a specific timestamp
 
 ## Dependencies
 


### PR DESCRIPTION
# Description

Fixed the wrong place for the changelog introduced by merging.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
