### PR TITLE
feat: Support `follow` mode for 'dfx canister logs'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # UNRELEASED
 
+### feat: Support 'follow' mode for 'dfx canister logs'
+Support `follow` mode for `dfx canister logs`
+- `--follow` to fetch logs continuously until interrupted with `Ctrl+C`
+- `--interval` to specify the interval in seconds between log fetches
+
 ### feat: Improve 'dfx canister logs' with several options
 
 Improve `dfx canister logs` with several options

--- a/docs/cli-reference/dfx-canister.mdx
+++ b/docs/cli-reference/dfx-canister.mdx
@@ -639,9 +639,11 @@ You can specify the following options for the `dfx canister logs` command.
 
 | Option                      | Description                                                                                         |
 |-----------------------------|-----------------------------------------------------------------------------------------------------|
-| `--tail <tail>`             | Specifies to show the last number of the logs.                                                      |
+| `--follow`                  | Specifies to fetch logs continuously until interrupted with `Ctrl+C`.                               |
+| `--interval <interval>`     | Specifies the interval in seconds between log fetches when following logs. Defaults to 2 seconds.   |
 | `--since <since>`           | Specifies to show the logs newer than a relative duration, with the valid units `s`, `m`, `h`, `d`. |
 | `--since-time <since-time>` | Specifies to show the logs newer than a specific timestamp. Required either `nanoseconds` since Unix epoch or `RFC3339` format (e.g. `2021-05-06T19:17:10.000000002Z`). |
+| `--tail <tail>`             | Specifies to show the last number of the logs.                                                      |
 
 ### Examples
 
@@ -696,6 +698,12 @@ The command displays output similar to the following:
 ``` log
 [44. 2021-05-06T19:17:15.000000001Z]: Five seconds later
 [45. 2021-05-06T19:17:15.000000002Z]: (bytes) 0xc0ffee
+```
+
+To fetch logs continuously, you can run the following command:
+
+``` bash
+dfx canister logs hello_world --follow
 ```
 
 ## dfx canister metadata

--- a/src/dfx/src/commands/canister/logs.rs
+++ b/src/dfx/src/commands/canister/logs.rs
@@ -160,11 +160,7 @@ pub async fn exec(env: &dyn Environment, opts: LogsOpts, call_sender: &CallSende
         };
         let filtered_logs = filter_canister_logs(&logs, filter_opts);
 
-        if filtered_logs.is_empty() {
-            println!("No logs");
-        } else {
-            println!("{}", format_canister_logs(filtered_logs).join("\n"));
-        }
+        println!("{}", format_canister_logs(filtered_logs).join("\n"));
     }
 
     Ok(())


### PR DESCRIPTION
# Description

Support `follow` mode for 'dfx canister logs':
- `--follow` to enable the follow mode, which keeps fetching the logs continuously.
- `--interval` to set the interval.

Fixes # (issue)

[SDK-2069](https://dfinity.atlassian.net/browse/SDK-2069)

# How Has This Been Tested?

- Unit test added.
- Manually tested locally.
- Cannot find an elegant way to test in the e2e test framework.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.


[SDK-2069]: https://dfinity.atlassian.net/browse/SDK-2069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ