### PR TITLE
fix: do not use RUST_LOG to configure PocketIC

### DIFF
--- a/src/dfx/src/actors/mod.rs
+++ b/src/dfx/src/actors/mod.rs
@@ -223,7 +223,6 @@ pub fn start_pocketic_actor(
         pid_file: local_server_descriptor.pocketic_pid_path(),
         shutdown_controller,
         logger: Some(env.get_logger().clone()),
-        verbose: env.get_verbose_level() > 0,
     };
     Ok(pocketic::PocketIc::new(actor_config).start())
 }

--- a/src/dfx/src/actors/pocketic.rs
+++ b/src/dfx/src/actors/pocketic.rs
@@ -56,7 +56,6 @@ pub struct Config {
     pub pid_file: PathBuf,
     pub shutdown_controller: Addr<ShutdownController>,
     pub logger: Option<Logger>,
-    pub verbose: bool,
 }
 
 /// A PocketIC actor. Starts the server, can subscribe to a Ready signal and a
@@ -239,9 +238,10 @@ fn pocketic_start_thread(
                 "--ttl",
                 "2592000",
             ]);
-            if !config.verbose {
-                cmd.env("RUST_LOG", "error");
-            }
+            cmd.args([
+                "--log-levels",
+                &config.replica_config.log_level.to_pocketic_string(),
+            ]);
             cmd.stdout(std::process::Stdio::inherit());
             cmd.stderr(std::process::Stdio::inherit());
             #[cfg(unix)]

--- a/src/dfx/src/actors/pocketic_proxy.rs
+++ b/src/dfx/src/actors/pocketic_proxy.rs
@@ -250,7 +250,7 @@ fn pocketic_proxy_start_thread(
             // form the pocket-ic command here similar to replica command
             let mut cmd = std::process::Command::new(&pocketic_proxy_path);
             if !verbose {
-                cmd.env("RUST_LOG", "error");
+                cmd.args(["--log-levels", "error"]);
             }
 
             cmd.args(["--ttl", "2592000"]);


### PR DESCRIPTION
This PR uses the CLI argument `--log-levels` instead of the environment variable `RUST_LOG` when starting the PocketIC server. The motivation for this change is that `RUST_LOG` also affects the log level for the replica (specified [separately](https://github.com/dfinity/sdk/blob/a026b45e227c0622717e0e1060d97a16cf5e3b4c/src/dfx/src/actors/pocketic.rs#L377)) and that `RUST_LOG` might be ignored in a future PocketIC release (see this [PR](https://github.com/dfinity/ic/pull/4897)).