### PR TITLE
chore: do not reuse replica log level for PocketIC server

### DIFF
--- a/src/dfx/src/actors/pocketic.rs
+++ b/src/dfx/src/actors/pocketic.rs
@@ -238,10 +238,7 @@ fn pocketic_start_thread(
                 "--ttl",
                 "2592000",
             ]);
-            cmd.args([
-                "--log-levels",
-                &config.replica_config.log_level.to_pocketic_string(),
-            ]);
+            cmd.args(["--log-levels", "error"]);
             cmd.stdout(std::process::Stdio::inherit());
             cmd.stderr(std::process::Stdio::inherit());
             #[cfg(unix)]


### PR DESCRIPTION
Since RUST_LOG will continue being available in PocketIC (the [PR](https://github.com/dfinity/ic/pull/4897) supposed to change that has been closed), this PR sets the "error" as the default log level for the PocketIC server (to not overload the replica log level for the server). If needed, people can set RUST_LOG, e.g., `RUST_LOG=pocket_ic_server=info,tower_http=info,axum::rejection=trace` to enable logging for individual (server) components.