### PR TITLE
chore: update bitcoin regtest configuration to be same as the bitcoin mainnet.

### DIFF
--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -576,7 +576,7 @@ pub fn default_bitcoin_log_level() -> BitcoinAdapterLogLevel {
 }
 
 pub fn default_bitcoin_canister_init_arg() -> String {
-    "(record { stability_threshold = 0 : nat; network = variant { regtest }; blocks_source = principal \"aaaaa-aa\"; fees = record { get_utxos_base = 0 : nat; get_utxos_cycles_per_ten_instructions = 0 : nat; get_utxos_maximum = 0 : nat; get_balance = 0 : nat; get_balance_maximum = 0 : nat; get_current_fee_percentiles = 0 : nat; get_current_fee_percentiles_maximum = 0 : nat;  send_transaction_base = 0 : nat; send_transaction_per_byte = 0 : nat; }; syncing = variant { enabled }; api_access = variant { enabled }; disable_api_if_not_fully_synced = variant { enabled }})".to_string()
+    "(record { stability_threshold = 0 : nat; network = variant { regtest }; blocks_source = principal \"aaaaa-aa\"; fees = record { get_utxos_base = 50000000 : nat; get_utxos_cycles_per_ten_instructions = 10 : nat; get_utxos_maximum = 10000000000 : nat; get_balance = 10000000 : nat; get_balance_maximum = 100000000 : nat; get_block_headers_base = 50000000 : nat; get_block_headers_cycles_per_ten_instructions = 10 : nat; get_block_headers_maximum = 10000000000 : nat; get_current_fee_percentiles = 10000000 : nat; get_current_fee_percentiles_maximum = 100000000 : nat; send_transaction_base = 5000000000 : nat; send_transaction_per_byte = 20000000 : nat; }; syncing = variant { enabled }; api_access = variant { enabled }; disable_api_if_not_fully_synced = variant { enabled }})".to_string()
 }
 
 impl Default for ConfigDefaultsBitcoin {


### PR DESCRIPTION
# Description

Update bitcoin `regtest` configuration to be same as the bitcoin `mainnet`.

```
fees = record {
      get_current_fee_percentiles = 10_000_000 : nat;
      get_utxos_maximum = 10_000_000_000 : nat;
      get_block_headers_cycles_per_ten_instructions = 10 : nat;
      get_current_fee_percentiles_maximum = 100_000_000 : nat;
      send_transaction_per_byte = 20_000_000 : nat;
      get_balance = 10_000_000 : nat;
      get_utxos_cycles_per_ten_instructions = 10 : nat;
      get_block_headers_base = 50_000_000 : nat;
      get_utxos_base = 50_000_000 : nat;
      get_balance_maximum = 100_000_000 : nat;
      send_transaction_base = 5_000_000_000 : nat;
      get_block_headers_maximum = 10_000_000_000 : nat;
    };
```
You can get the fees by `get_config` API on the [BTC Mainnet Canister](https://dashboard.internetcomputer.org/canister/ghsi2-tqaaa-aaaan-aaaca-cai)

Fixes # (issue)
[SDK-2141](https://dfinity.atlassian.net/browse/SDK-2141)

# How Has This Been Tested?

Manually tested locally.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
