### PR TITLE
chore: replace secrets.NIV_UPDATER_TOKEN with actions/create-github-app-token

### DIFF
--- a/.github/workflows/bitcoin-canister-update.yml
+++ b/.github/workflows/bitcoin-canister-update.yml
@@ -26,9 +26,16 @@ jobs:
       - name: Install script dependencies
         run: sudo apt-get install -y moreutils
 
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
       - name: Fetch Bitcoin Canister latest release tag
         env:
-          GH_TOKEN: "${{ secrets.NIV_UPDATER_TOKEN }}"
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           LATEST_TAG=$(gh release view --repo dfinity/bitcoin-canister --json tagName -q .tagName)
           echo "Latest tag is $LATEST_TAG"
@@ -48,9 +55,16 @@ jobs:
       - name: Update sources to use the latest bitcoin canister version
         run: ./scripts/update-btc-canister.sh "$LATEST_TAG"
 
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
       - name: Create PR
         env:
-          GH_TOKEN: "${{ secrets.NIV_UPDATER_TOKEN }}"
+          GH_TOKEN: "${{ steps.app-token.outputs.token }}"
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/broadcast-frontend-hash.yml
+++ b/.github/workflows/broadcast-frontend-hash.yml
@@ -46,10 +46,17 @@ jobs:
           git checkout ${{ inputs.dfx_version }}
           echo "NEW_HASH=$(shasum -a 256 src/distributed/assetstorage.wasm.gz | cut -f1 -d" ")" >> $GITHUB_ENV
 
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
       - name: Checkout dfinity/motoko-playground repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.NIV_UPDATER_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: ${{ env.PLAYGROUND_REPO }}
           path: motoko-playground
 
@@ -63,9 +70,16 @@ jobs:
           echo '    "${{ env.NEW_HASH }}", // dfx ${{ inputs.dfx_version }} frontend canister' >> ${{ env.FILE }}
           echo ']' >> ${{ env.FILE }}
 
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
       - name: Commit files, push changes, and create PR
         env:
-          GH_TOKEN: ${{ secrets.NIV_UPDATER_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         working-directory: ./motoko-playground
         run: |
           git config author.email "${{ github.event.sender.id }}+${{ github.event.sender.login }}@users.noreply.github.com"

--- a/.github/workflows/update-motoko.yml
+++ b/.github/workflows/update-motoko.yml
@@ -1,5 +1,5 @@
 name: "chore: Update Motoko"
-on: 
+on:
   workflow_dispatch:
     inputs:
       motokoVersion:
@@ -37,7 +37,7 @@ jobs:
       run: |
         if [ '${{ github.event.inputs.motokoVersion }}' = 'latest' ]; then
           echo "MOTOKO_VERSION=$(curl -s "${{ env.GH_API_RELEASES_LATEST }}" | jq  -r '.tag_name')" >> $GITHUB_ENV
-        else 
+        else
           echo "MOTOKO_VERSION=${{ github.event.inputs.motokoVersion }}" >> $GITHUB_ENV
         fi
         grep -s "MOTOKO_VERSION" $GITHUB_ENV
@@ -45,7 +45,7 @@ jobs:
     - name: update Motoko
       run: |
         echo "updating Motoko"
-        scripts/update-motoko.sh ${{ env.MOTOKO_VERSION }} 
+        scripts/update-motoko.sh ${{ env.MOTOKO_VERSION }}
 
     - name: setup git config, then create new branch and push new commit to it
       run: |
@@ -55,15 +55,22 @@ jobs:
         git config committer.name "GitHub Actions Bot"
         git config user.email "${{ github.event.sender.id }}+${{ github.event.sender.login }}@users.noreply.github.com"
         git config user.name "${{ github.event.sender.login }}"
-        git checkout -b chore-update-motoko-${{ env.MOTOKO_VERSION }} 
+        git checkout -b chore-update-motoko-${{ env.MOTOKO_VERSION }}
         git add .
         git commit -m "chore: update Motoko version to ${{ env.MOTOKO_VERSION }}"
-        git push origin chore-update-motoko-${{ env.MOTOKO_VERSION }} 
-      
-    - name: create Pull Request, with CHANGELOG.md entry suggestion 
+        git push origin chore-update-motoko-${{ env.MOTOKO_VERSION }}
+
+    - name: Create GitHub App Token
+      uses: actions/create-github-app-token@v2
+      id: app-token
+      with:
+        app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+        private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
+    - name: create Pull Request, with CHANGELOG.md entry suggestion
       uses: actions/github-script@v6
       with:
-        github-token: ${{ secrets.NIV_UPDATER_TOKEN }} # act on behalf of https://github.com/dfinity-bot 
+        github-token: ${{ steps.app-token.outputs.token }}
         script: |
           const { repo, owner } = context.repo;
 

--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -1,5 +1,5 @@
 name: "chore: Update replica"
-on: 
+on:
   workflow_dispatch:
     inputs:
       replicaVersionLatestOrCustom:
@@ -10,7 +10,7 @@ on:
         - latest
         - custom
       customReplicaVersion:
-        description: 'dfinity/ic commit SHA - get the latest Elect Replica Version from https://dashboard.internetcomputer.org/releases'     
+        description: 'dfinity/ic commit SHA - get the latest Elect Replica Version from https://dashboard.internetcomputer.org/releases'
         default: "required if custom"
       sdkBranch:
         description: 'Open PR against this sdk branch'
@@ -44,7 +44,7 @@ jobs:
       run: |
         if [ '${{ github.event.inputs.replicaVersionLatestOrCustom }}' = 'latest' ]; then
           echo "REPLICA_VERSION=$(curl -s "${{ env.IC_RELEASES_API }}" | jq  -r '.data[0].replica_version_id')" >> $GITHUB_ENV
-        else 
+        else
           echo "REPLICA_VERSION=${{ github.event.inputs.customReplicaVersion }}" >> $GITHUB_ENV
         fi
         grep -s "REPLICA_VERSION" $GITHUB_ENV
@@ -52,7 +52,7 @@ jobs:
     - name: update replica
       run: |
         echo "updating the replica"
-        scripts/update-replica.sh ${{ env.REPLICA_VERSION }} 
+        scripts/update-replica.sh ${{ env.REPLICA_VERSION }}
 
     - name: setup git config, then create new branch and push new commit to it
       run: |
@@ -66,11 +66,18 @@ jobs:
         git add .
         git commit -m "chore: update replica version to ${{ env.REPLICA_VERSION }}"
         git push origin chore-update-replica-${{ env.REPLICA_VERSION }}-${{ github.event.inputs.sdkBranch }}
-      
-    - name: create Pull Request, with CHANGELOG.md entry suggestion 
+
+    - name: Create GitHub App Token
+      uses: actions/create-github-app-token@v2
+      id: app-token
+      with:
+        app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+        private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
+    - name: create Pull Request, with CHANGELOG.md entry suggestion
       uses: actions/github-script@v6
       with:
-        github-token: ${{ secrets.NIV_UPDATER_TOKEN }} # act on behalf of https://github.com/dfinity-bot 
+        github-token: ${{ steps.app-token.outputs.token }}
         script: |
           const { repo, owner } = context.repo;
 


### PR DESCRIPTION
# Description

The `dfinity-bot` got removed form GitHub. The GitHub actions in the sdk repo authenticated as this bot using the `NIV_UPDATER_TOKEN` secret which means that these actions will break.

We're switching all repos to use [actions/create-github-app-token](https://github.com/actions/create-github-app-token) because it's more secure.
