### PR TITLE
fix: Add known extensions to telemetry

### DIFF
--- a/e2e/tests-dfx/telemetry.bash
+++ b/e2e/tests-dfx/telemetry.bash
@@ -68,11 +68,13 @@ teardown() {
 }
 
 @test "telemetry reprocesses extension commands" {
-    local log
+    local log n
     log=$(dfx info telemetry-log-path)
     assert_command dfx extension install nns --version 0.3.1
-    assert_command dfx nns import
-    assert_command jq -se 'last | .command == "extension run" and (.parameters | any(.name == "name"))' "$log"
+    assert_command jq -se 'last | .command == "extension run" and (.parameters | any(.name == "@extension_name" and .value == "nns"))' "$log"
+    n=$(jq -sr 'map(select(has("command"))) | length' "$log")
+    assert_command dfx nns help
+    assert_command jq -se '(map(select(has("command"))) | length) == $n' --argjson n "$n" "$log"
 }
 
 @test "concurrent commands do not corrupt the log file" {

--- a/src/dfx/src/commands/extension/run.rs
+++ b/src/dfx/src/commands/extension/run.rs
@@ -1,11 +1,13 @@
 use crate::lib::environment::Environment;
 use crate::lib::error::DfxResult;
+use crate::lib::telemetry::Telemetry;
 use clap::Parser;
 use std::ffi::OsString;
 
 #[derive(Parser, Debug)]
 pub struct RunOpts {
     /// Specifies the name of the extension to run.
+    #[arg(id = "@extension_name", value_name = "NAME")]
     name: OsString,
     /// Specifies the parameters to pass to the extension.
     #[arg(allow_hyphen_values = true)]
@@ -23,6 +25,9 @@ impl From<Vec<OsString>> for RunOpts {
 }
 
 pub fn exec(env: &dyn Environment, opts: RunOpts) -> DfxResult<()> {
+    if opts.params.iter().any(|p| p == "--help" || p == "help") {
+        Telemetry::mark_current_command_likely_noise();
+    }
     let mgr = env.get_extension_manager();
     let project_root = env
         .get_config()?


### PR DESCRIPTION
Records when `dfx extension run` is used with `nns` or `sns`, unless it is a help command.