### PR TITLE
fix: restrict additional properties for canisters in `dfx.json` schema

### DIFF
--- a/docs/dfx-json-schema.json
+++ b/docs/dfx-json-schema.json
@@ -546,7 +546,8 @@
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "ConfigCanistersCanisterRemote": {
       "title": "Remote Canister Configuration",


### PR DESCRIPTION
This PR improves `dfx.json` schema validation by restricting unknown properties on canister objects. The motivation is to provide a warning/error when, for instance, specifying a `build` property for a non-custom canister.
