### PR TITLE
docs: fixed the document for canister snapshot with '--replace' option.

### DIFF
--- a/docs/cli-reference/dfx-canister.mdx
+++ b/docs/cli-reference/dfx-canister.mdx
@@ -912,7 +912,7 @@ You can use the following arguments with the `dfx canister snapshot create` comm
 | Argument              | Description                                                                    |
 |-----------------------|--------------------------------------------------------------------------------|
 | `<canister>`          | The canister to snapshot.                                                      |
-| `--replace <replace>` | If a snapshot ID is specified, this snapshot will replace it and reuse the ID. |
+| `--replace <replace>` | If a snapshot ID is specified, the snapshot identified by this ID will be deleted and a snapshot with a new ID will be returned. |
 
 ### Examples
 
@@ -1060,7 +1060,7 @@ You can use the following arguments with the `dfx canister snapshot upload` comm
 |-----------------------|--------------------------------------------------------------------------------|
 | `<canister>`          | The canister to upload the snapshot to.                                        |
 | --dir `<dir>`         | The directory to upload the snapshot from.                                     |
-| --replace `<replace>` | If a snapshot ID is specified, this snapshot will replace it and reuse the ID. |                                        |
+| --replace `<replace>` | If a snapshot ID is specified, the snapshot identified by this ID will be deleted and a snapshot with a new ID will be returned. |
 
 ### Examples
 


### PR DESCRIPTION
# Description

Fixed the document for canister snapshot with `--replace` option as it will return a new snapshot ID.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
