### PR TITLE
fix: ensure deterministic serialization of `tech_stack` metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # UNRELEASED
 
+### fix: ensure deterministic serialization of `tech_stack` metadata
+
+The `tech_stack` metadata was previously defined with `HashMap`, which resulted in non-deterministic serialization due to its random key ordering.
+This has been fixed by replacing it with `BTreeMap`, which sorts keys and guarantees consistent, deterministic output every time.
+
 # 0.29.0
 
 ### feat: add dfx native support for aarch64-Linux

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -58,7 +58,7 @@ use schemars::JsonSchema;
 use serde::de::{Error as _, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::default::Default;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
@@ -209,7 +209,7 @@ pub struct Pullable {
     pub init_arg: Option<String>,
 }
 
-pub type TechStackCategoryMap = HashMap<String, HashMap<String, String>>;
+pub type TechStackCategoryMap = BTreeMap<String, BTreeMap<String, String>>;
 
 /// # Tech Stack
 /// The tech stack used to build a canister.
@@ -1703,5 +1703,24 @@ mod tests {
             .unwrap();
         assert_eq!(None, compute_allocation);
         assert_eq!(None, memory_allocation);
+    }
+
+    #[test]
+    fn tech_stack_category_deterministic_serialization() {
+        let first = build_and_serialize();
+        // Repeat `build and serialize` many times and assert equality
+        for _ in 0..10 {
+            let next = build_and_serialize();
+            assert_eq!(first, next);
+        }
+    }
+
+    fn build_and_serialize() -> String {
+        use super::TechStackCategoryMap;
+        use std::collections::BTreeMap;
+        let mut data: TechStackCategoryMap = BTreeMap::new();
+        data.insert("typescript".into(), BTreeMap::new());
+        data.insert("javascript".into(), BTreeMap::new());
+        serde_json::to_string(&data).unwrap()
     }
 }


### PR DESCRIPTION
# Description

The `tech_stack` metadata was previously defined with `HashMap`, which resulted in non-deterministic serialization due to its random key ordering.
This has been fixed by replacing it with `BTreeMap`, which sorts keys and guarantees consistent, deterministic output every time.

# How Has This Been Tested?

Added a unit test.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
