### PR TITLE
fix(ci): bitcoin-canister-update.yml creates app-token more than once

### DIFF
--- a/.github/workflows/bitcoin-canister-update.yml
+++ b/.github/workflows/bitcoin-canister-update.yml
@@ -55,13 +55,6 @@ jobs:
       - name: Update sources to use the latest bitcoin canister version
         run: ./scripts/update-btc-canister.sh "$LATEST_TAG"
 
-      - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v2
-        id: app-token
-        with:
-          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
-          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
-
       - name: Create PR
         env:
           GH_TOKEN: "${{ steps.app-token.outputs.token }}"


### PR DESCRIPTION
This daily job started to fail because of the [invalid](https://github.com/dfinity/sdk/actions/runs/17102183982/workflow) workflow definition.

[Similar fix](https://github.com/dfinity/sdk/pull/4350) recently.
