### PR TITLE
fix(ci): bitcoin-canister-update.yml typo, run weekly

### DIFF
--- a/.github/workflows/bitcoin-canister-update.yml
+++ b/.github/workflows/bitcoin-canister-update.yml
@@ -3,7 +3,7 @@ name: Check Bitcoin Canister Release Update
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *" # Runs at UTC midnight every day
+    - cron: "0 4 * * 3" # 4:00 AM UTC every Wednesday
 
 env:
   # When getting Rust dependencies, retry on network error:
@@ -43,7 +43,7 @@ jobs:
 
       - name: Check if the latest release tag has been updated
         run: |
-          CURRENT_TAG=$(jq -r '.commmon."ic-btc-canister".version' src/dfx/assets/dfx-asset-sources.json)
+          CURRENT_TAG=$(jq -r '.common."ic-btc-canister".version' src/dfx/assets/dfx-asset-sources.json)
           echo "Current tag is $CURRENT_TAG"
           if [[ "$CURRENT_TAG" == "$LATEST_TAG" ]]; then
             echo "No update is required."


### PR DESCRIPTION
# Description

This daily job has been consistently [failing](https://github.com/dfinity/sdk/actions/workflows/bitcoin-canister-update.yml).
- Fixed a typo from `commmon` to `common`.
- Changed the cron schedule to run every Wednesday at 4:00 AM UTC. The bitcoin-canister doesn't update frequently, so a weekly check is sufficient.
