### PR TITLE
fix: re-enable support for snapshot download/upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5147,8 +5147,8 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pocket-ic"
-version = "9.0.2"
-source = "git+https://github.com/dfinity/ic?rev=615045e039c57ed842c689e49a07ab3de3a8a781#615045e039c57ed842c689e49a07ab3de3a8a781"
+version = "10.0.0"
+source = "git+https://github.com/dfinity/ic?rev=9152ba15ab6cc3c12eb407e13f8ee483a1d5723c#9152ba15ab6cc3c12eb407e13f8ee483a1d5723c"
 dependencies = [
  "backoff",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.17"
+version = "0.10.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaac522d18020d5fbc8320ecb12a9b13b2137ae31133da2d42fa256a825507c4"
+checksum = "3ae495fbaf9ee8f4f7898affbd3df85dba8598bfa4ffaca24726c42aa4beb7b1"
 dependencies = [
  "anyhow",
  "binread",
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.17"
+version = "0.10.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1b4fddbd462182050989068d53604a91a3d0f117c3c8316c6818023df00add"
+checksum = "7388be3b345b1a2ad30e529619b4db0d1955852afb56da821fa6a805f7cbf6be"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -1663,7 +1663,7 @@ dependencies = [
  "ic-asset",
  "ic-cdk",
  "ic-identity-hsm",
- "ic-management-canister-types 0.4.0",
+ "ic-management-canister-types 0.4.1",
  "ic-utils 0.44.0",
  "ic-wasm",
  "icrc-ledger-types",
@@ -3008,7 +3008,7 @@ dependencies = [
  "ic-cdk-executor",
  "ic-cdk-macros",
  "ic-error-types 0.2.0",
- "ic-management-canister-types 0.3.2",
+ "ic-management-canister-types 0.3.3",
  "ic0",
  "serde",
  "serde_bytes",
@@ -3384,9 +3384,9 @@ dependencies = [
 
 [[package]]
 name = "ic-management-canister-types"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f3af3543f6d0cbdecd2dcdfd4737ada2bd42d935cc787eec22090c96492c76"
+checksum = "ea7e5b8a0f7c3b320d9450ac950547db4f24a31601b5d398f9680b64427455d2"
 dependencies = [
  "candid",
  "serde",
@@ -3395,9 +3395,9 @@ dependencies = [
 
 [[package]]
 name = "ic-management-canister-types"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300adbb554ca7d6003f6080b978f5f53730d93cc9d6c8223199cbcfd166b7b42"
+checksum = "8b5a939a84adbc30769d47e5de72c7b9f3713284e3ac87df4eb24795677a8df8"
 dependencies = [
  "candid",
  "serde",
@@ -3609,7 +3609,7 @@ dependencies = [
  "candid",
  "futures-util",
  "ic-agent",
- "ic-management-canister-types 0.4.0",
+ "ic-management-canister-types 0.4.1",
  "once_cell",
  "semver",
  "serde",
@@ -5156,7 +5156,7 @@ dependencies = [
  "flate2",
  "hex",
  "ic-certification 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ic-management-canister-types 0.3.2",
+ "ic-management-canister-types 0.3.3",
  "ic-transport-types 0.40.1",
  "reqwest",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ needless_lifetimes = "allow"
 future_not_send = "warn"
 
 [workspace.dependencies]
-candid = "0.10.17"
+candid = "0.10.18"
 candid_parser = "0.2.1"
 dfx-core = { path = "src/dfx-core", version = "0.2.0" }
 ic-agent = "0.44.0"
@@ -31,7 +31,7 @@ ic-asset = { path = "src/canisters/frontend/ic-asset", version = "0.25.0" }
 ic-cdk = "0.18.4"
 ic-identity-hsm = "0.44.0"
 ic-utils = "0.44.0"
-ic-management-canister-types = "0.4.0"
+ic-management-canister-types = "0.4.1"
 
 aes-gcm = { version = "0.10.3", features = ["std"] }
 anyhow = "1.0.56"

--- a/e2e/tests-dfx/canister_extra.bash
+++ b/e2e/tests-dfx/canister_extra.bash
@@ -46,7 +46,6 @@ teardown() {
 }
 
 @test "canister snapshots download and upload" {
-    skip "Enable this test when the management canister API is stablized and pocket-ic/agent are updated"
     dfx_start
     install_asset counter
     dfx deploy

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -84,7 +84,7 @@ os_str_bytes = { version = "6.3.0", features = ["conversions"] }
 patch = "0.7.0"
 pem.workspace = true
 petgraph = "0.6.0"
-pocket-ic = { git = "https://github.com/dfinity/ic", rev = "615045e039c57ed842c689e49a07ab3de3a8a781" }
+pocket-ic = { git = "https://github.com/dfinity/ic", rev = "9152ba15ab6cc3c12eb407e13f8ee483a1d5723c" }
 rand = "0.8.5"
 regex = "1.5.5"
 reqwest = { workspace = true, features = ["blocking", "json"] }

--- a/src/dfx/assets/dfx-asset-sources.json
+++ b/src/dfx/assets/dfx-asset-sources.json
@@ -1,5 +1,5 @@
 {
-  "replica-rev": "615045e039c57ed842c689e49a07ab3de3a8a781",
+  "replica-rev": "9152ba15ab6cc3c12eb407e13f8ee483a1d5723c",
   "x86_64-darwin": {
     "motoko": {
       "url": "https://github.com/dfinity/motoko/releases/download/0.16.1/motoko-Darwin-x86_64-0.16.1.tar.gz",
@@ -7,9 +7,9 @@
       "version": "0.16.1"
     },
     "pocket-ic": {
-      "url": "https://download.dfinity.systems/ic/615045e039c57ed842c689e49a07ab3de3a8a781/binaries/x86_64-darwin/pocket-ic.gz",
-      "sha256": "2c3ece5f20aa10628ea7c892a138e17c7eaf306b3b732d2acd3d450967dfb788",
-      "rev": "615045e039c57ed842c689e49a07ab3de3a8a781"
+      "url": "https://download.dfinity.systems/ic/9152ba15ab6cc3c12eb407e13f8ee483a1d5723c/binaries/x86_64-darwin/pocket-ic.gz",
+      "sha256": "2543d413250340e8d21c85696d1d427df60177603efe71a6d63b13b09f486f87",
+      "rev": "9152ba15ab6cc3c12eb407e13f8ee483a1d5723c"
     }
   },
   "arm64-darwin": {
@@ -19,9 +19,9 @@
       "version": "0.16.1"
     },
     "pocket-ic": {
-      "url": "https://download.dfinity.systems/ic/615045e039c57ed842c689e49a07ab3de3a8a781/binaries/arm64-darwin/pocket-ic-server-arm64-darwin",
-      "sha256": "e4ad4c1b8187edfec3961c90e9dd81a006d642f928638e7f3a8ce00e51963d90",
-      "rev": "615045e039c57ed842c689e49a07ab3de3a8a781"
+      "url": "https://download.dfinity.systems/ic/9152ba15ab6cc3c12eb407e13f8ee483a1d5723c/binaries/arm64-darwin/pocket-ic-server-arm64-darwin",
+      "sha256": "8ba2964dd8798374f2be513da10264113452e0a1fbc01244edba3fb5c6e85755",
+      "rev": "9152ba15ab6cc3c12eb407e13f8ee483a1d5723c"
     }
   },
   "x86_64-linux": {
@@ -31,9 +31,9 @@
       "version": "0.16.1"
     },
     "pocket-ic": {
-      "url": "https://download.dfinity.systems/ic/615045e039c57ed842c689e49a07ab3de3a8a781/binaries/x86_64-linux/pocket-ic.gz",
-      "sha256": "186e5be381773f7474f58ca8dacebcd1f10a5cb83766959608cb1dc0b234d638",
-      "rev": "615045e039c57ed842c689e49a07ab3de3a8a781"
+      "url": "https://download.dfinity.systems/ic/9152ba15ab6cc3c12eb407e13f8ee483a1d5723c/binaries/x86_64-linux/pocket-ic.gz",
+      "sha256": "7b99539256e8d8315e3d52911bfbecd9c42c300f655add20687665d6f7c3c8bb",
+      "rev": "9152ba15ab6cc3c12eb407e13f8ee483a1d5723c"
     }
   },
   "arm64-linux": {
@@ -43,9 +43,9 @@
       "version": "0.16.1"
     },
     "pocket-ic": {
-      "url": "https://download.dfinity.systems/ic/615045e039c57ed842c689e49a07ab3de3a8a781/binaries/arm64-linux/pocket-ic-server-arm64-linux",
-      "sha256": "a0367b023531e30d894821c357fcd9c120ada2fa72a54a623414ebbbdd98d01b",
-      "rev": "615045e039c57ed842c689e49a07ab3de3a8a781"
+      "url": "https://download.dfinity.systems/ic/9152ba15ab6cc3c12eb407e13f8ee483a1d5723c/binaries/arm64-linux/pocket-ic-server-arm64-linux",
+      "sha256": "60eaa087163ed0ebb55f2ef2240cdeab36e5a675b0f58fdc1f089a6bfe35244d",
+      "rev": "9152ba15ab6cc3c12eb407e13f8ee483a1d5723c"
     }
   },
   "common": {

--- a/src/dfx/src/actors/pocketic.rs
+++ b/src/dfx/src/actors/pocketic.rs
@@ -379,8 +379,8 @@ async fn initialize_pocketic(
 ) -> DfxResult<usize> {
     use dfx_core::config::model::dfinity::ReplicaSubnetType;
     use pocket_ic::common::rest::{
-        AutoProgressConfig, CreateInstanceResponse, ExtendedSubnetConfigSet, InstanceConfig,
-        RawTime, SubnetSpec,
+        AutoProgressConfig, CreateInstanceResponse, EmptyConfig, ExtendedSubnetConfigSet,
+        InstanceConfig, NonmainnetFeatures, RawTime, SubnetSpec,
     };
     use reqwest::Client;
     use time::OffsetDateTime;
@@ -403,16 +403,22 @@ async fn initialize_pocketic(
             subnet_config_set.verified_application.push(<_>::default())
         }
     }
+    let nonmainnet_features = NonmainnetFeatures {
+        enable_beta_features: Some(EmptyConfig {}),
+        ..Default::default()
+    };
     let resp = init_client
         .post(format!("http://localhost:{port}/instances"))
         .json(&InstanceConfig {
             subnet_config_set,
             state_dir: Some(replica_config.state_manager.state_root.clone()),
-            nonmainnet_features: true,
+            nonmainnet_features: Some(nonmainnet_features),
             log_level: Some(replica_config.log_level.to_pocketic_string()),
             bitcoind_addr: bitcoind_addr.clone(),
             icp_features: None,
             allow_incomplete_state: None,
+            http_gateway_config: None,
+            initial_time: None,
         })
         .send()
         .await?
@@ -426,6 +432,7 @@ async fn initialize_pocketic(
         CreateInstanceResponse::Created {
             instance_id,
             topology,
+            http_gateway_info: _,
         } => {
             let default_effective_canister_id: Principal =
                 topology.default_effective_canister_id.into();

--- a/src/dfx/src/commands/canister/snapshot.rs
+++ b/src/dfx/src/commands/canister/snapshot.rs
@@ -629,7 +629,7 @@ async fn read_blob(
                 offset: offset as u64,
                 size: chunk_size as u64,
             },
-            BlobKind::MainMemory => SnapshotDataKind::MainMemory {
+            BlobKind::MainMemory => SnapshotDataKind::WasmMemory {
                 offset: offset as u64,
                 size: chunk_size as u64,
             },
@@ -723,7 +723,7 @@ async fn upload_blob(
             BlobKind::WasmModule => SnapshotDataOffset::WasmModule {
                 offset: offset as u64,
             },
-            BlobKind::MainMemory => SnapshotDataOffset::MainMemory {
+            BlobKind::MainMemory => SnapshotDataOffset::WasmMemory {
                 offset: offset as u64,
             },
             BlobKind::StableMemory => SnapshotDataOffset::StableMemory {


### PR DESCRIPTION
SDK-2307

# Description

The API recently got some changes.
This PR updates both the `ic-management-canister-types` and `pocket-ic` to the latest versions that include the API modification.

# How Has This Been Tested?

Enabled the "canister snapshots download and upload" test in `canister_extra.bash`.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
