### PR TITLE
chore: update docs and regenerate schema

### DIFF
--- a/docs/dfx-json-schema.json
+++ b/docs/dfx-json-schema.json
@@ -1016,7 +1016,7 @@
         },
         "reserved_cycles_limit": {
           "title": "Reserved Cycles Limit",
-          "description": "Specifies the upper limit of the canister's reserved cycles balance.\n\nReserved cycles are cycles that the system sets aside for future use by the canister. If a subnet's storage exceeds 450 GiB, then every time a canister allocates new storage bytes, the system sets aside some amount of cycles from the main balance of the canister. These reserved cycles will be used to cover future payments for the newly allocated bytes. The reserved cycles are not transferable and the amount of reserved cycles depends on how full the subnet is.\n\nA setting of 0 means that the canister will trap if it tries to allocate new storage while the subnet's memory usage exceeds 450 GiB.",
+          "description": "Specifies the upper limit of the canister's reserved cycles balance.\n\nReserved cycles are cycles that the system sets aside for future use by the canister. If a subnet's storage exceeds 750 GiB, then every time a canister allocates new storage bytes, the system sets aside some amount of cycles from the main balance of the canister. These reserved cycles will be used to cover future payments for the newly allocated bytes. The reserved cycles are not transferable and the amount of reserved cycles depends on how full the subnet is.\n\nA setting of 0 means that the canister will trap if it tries to allocate new storage while the subnet's memory usage exceeds 750 GiB.",
           "default": null,
           "type": [
             "integer",

--- a/src/dfx-core/src/config/model/dfinity.rs
+++ b/src/dfx-core/src/config/model/dfinity.rs
@@ -475,12 +475,12 @@ pub struct InitializationValues {
     /// Specifies the upper limit of the canister's reserved cycles balance.
     ///
     /// Reserved cycles are cycles that the system sets aside for future use by the canister.
-    /// If a subnet's storage exceeds 450 GiB, then every time a canister allocates new storage bytes,
+    /// If a subnet's storage exceeds 750 GiB, then every time a canister allocates new storage bytes,
     /// the system sets aside some amount of cycles from the main balance of the canister.
     /// These reserved cycles will be used to cover future payments for the newly allocated bytes.
     /// The reserved cycles are not transferable and the amount of reserved cycles depends on how full the subnet is.
     ///
-    /// A setting of 0 means that the canister will trap if it tries to allocate new storage while the subnet's memory usage exceeds 450 GiB.
+    /// A setting of 0 means that the canister will trap if it tries to allocate new storage while the subnet's memory usage exceeds 750 GiB.
     #[schemars(with = "Option<u128>")]
     pub reserved_cycles_limit: Option<u128>,
 

--- a/src/dfx/src/commands/canister/create.rs
+++ b/src/dfx/src/commands/canister/create.rs
@@ -73,12 +73,12 @@ pub struct CanisterCreateOpts {
     /// Specifies the upper limit of the canister's reserved cycles balance.
     ///
     /// Reserved cycles are cycles that the system sets aside for future use by the canister.
-    /// If a subnet's storage exceeds 450 GiB, then every time a canister allocates new storage bytes,
+    /// If a subnet's storage exceeds 750 GiB, then every time a canister allocates new storage bytes,
     /// the system sets aside some amount of cycles from the main balance of the canister.
     /// These reserved cycles will be used to cover future payments for the newly allocated bytes.
     /// The reserved cycles are not transferable and the amount of reserved cycles depends on how full the subnet is.
     ///
-    /// A setting of 0 means that the canister will trap if it tries to allocate new storage while the subnet's memory usage exceeds 450 GiB.
+    /// A setting of 0 means that the canister will trap if it tries to allocate new storage while the subnet's memory usage exceeds 750 GiB.
     #[arg(long, value_parser = reserved_cycles_limit_parser, hide = true)]
     reserved_cycles_limit: Option<u128>,
 


### PR DESCRIPTION
Fix the docs so they match @ShuoWangNSL changes here: https://github.com/dfinity/portal/pull/6003/files#diff-fac0d15935fc55b6f6bb12607d5aba4a8eec982f1d05fe34cbfd01a8eb1f62ae

In https://github.com/dfinity/portal/pull/6059 - I'm trying to make it so that the portal is using files directly from the submodule instead of keeping a different copy.