### PR TITLE
fix: extra requirement in asset canister docs

### DIFF
--- a/docs/design/asset-canister-interface.md
+++ b/docs/design/asset-canister-interface.md
@@ -282,8 +282,6 @@ Required Permission: [Prepare](#permission-prepare)
 
 This method stores a content chunk and extends the batch expiry time.
 
-When creating chunks for a given content encoding, the size of each chunk except the last must be the same.
-
 The asset canister must retain all data related to a batch for at least the [Minimum Batch Retention Duration](#constant-minimum-batch-retention-duration) after creating a chunk in a batch.
 
 Preconditions:

--- a/docs/design/asset-canister-interface.md
+++ b/docs/design/asset-canister-interface.md
@@ -70,7 +70,7 @@ The usual method of updating data in the asset canister is by calling the follow
 3. [commit_batch()](#method-commit_batch) zero or more times with `batch_id: 0`.
 4. [commit_batch()](#method-commit_batch) once with the batch ID from step 1, which indicates the batch is complete.
 
-The reason for multiple rather than single calls to [commit_batch][#method-commit_batch] is that certificate computation for an entire batch may exceed per-message computation limits.
+The reason for multiple rather than single calls to [commit_batch](#method-commit_batch) is that certificate computation for an entire batch may exceed per-message computation limits.
 
 ### Batch Updates By Proposal
 


### PR DESCRIPTION
This requirement does not hold and is not checked anywhere