### PR TITLE
chore: add 0.29.2 changelog header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ dfx canister update-settings to_canister --sync-with from_canister
 
 Updated Motoko to [0.16.2](https://github.com/dfinity/motoko/releases/tag/0.16.2)
 
+### Bitcoin canister
+
+Upgraded Bitcoin canister to [release/2025-07-02](https://github.com/dfinity/bitcoin-canister/releases/tag/release%2F2025-07-02)
+
 ### Replica
 
 Updated replica to commit 615045e039c57ed842c689e49a07ab3de3a8a781.


### PR DESCRIPTION
The [Update the Replica Version](https://github.com/dfinity/sdk/blob/master/docs/process/release.md#update-the-replica-version) step was not executed.
In PR #4376, I provided a detailed explanation for why the replica must be fixed to the current Git revision.

This release is primarily to support the upcoming launch of the "Canister Snapshot Download/Upload" feature.