### PR TITLE
fix: bump svelte dependencies in template

### DIFF
--- a/src/dfx/assets/project_templates/svelte/src/__frontend_name__/package.json
+++ b/src/dfx/assets/project_templates/svelte/src/__frontend_name__/package.json
@@ -16,13 +16,13 @@
     "@dfinity/principal": "^3.0.0"
   },
   "devDependencies": {
-    "@sveltejs/adapter-static": "^3.0.4",
-    "@sveltejs/kit": "^2.5.26",
-    "@sveltejs/vite-plugin-svelte": "^3.1.2",
+    "@sveltejs/adapter-static": "^3.0.10",
+    "@sveltejs/kit": "^2.46.2",
+    "@sveltejs/vite-plugin-svelte": "^4.0.4",
     "dotenv": "^16.3.1",
     "sass": "^1.63.6",
-    "svelte": "^4.2.19",
-    "svelte-check": "^4.0.1",
+    "svelte": "^5.39.9",
+    "svelte-check": "^4.3.2",
     "typescript": "^5.6.2",
     "vite": "^5.4.3",
     "vite-plugin-environment": "^1.1.3"

--- a/src/dfx/assets/project_templates/svelte/src/__frontend_name__/src/routes/+page.svelte
+++ b/src/dfx/assets/project_templates/svelte/src/__frontend_name__/src/routes/+page.svelte
@@ -2,9 +2,10 @@
   import "../index.scss";
   import { backend } from "$lib/canisters";
 
-  let greeting = "";
+  let greeting = $state("")
 
   function onSubmit(event) {
+    event.preventDefault();
     const name = event.target.name.value;
     backend.greet(name).then((response) => {
       greeting = response;
@@ -17,7 +18,7 @@
   <img src="/logo2.svg" alt="DFINITY logo" />
   <br />
   <br />
-  <form action="#" on:submit|preventDefault={onSubmit}>
+  <form action="#" onsubmit={onSubmit}>
     <label for="name">Enter your name: &nbsp;</label>
     <input id="name" alt="Name" type="text" />
     <button type="submit">Click Me!</button>


### PR DESCRIPTION
# Description

`@sveltejs/vite-plugin-svelte` could not be bumped to the latest version (v6) because vite is still on v5.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
