### PR TITLE
fix: don't enable the bitcoin canister when --system-canisters is passed

### DIFF
--- a/src/dfx/src/actors/pocketic.rs
+++ b/src/dfx/src/actors/pocketic.rs
@@ -395,7 +395,7 @@ async fn initialize_pocketic(
             sns: Some(IcpFeaturesConfig::default()),
             ii: Some(IcpFeaturesConfig::default()),
             nns_ui: Some(IcpFeaturesConfig::default()),
-            bitcoin: Some(IcpFeaturesConfig::default()),
+            bitcoin: None,
         })
     } else {
         None


### PR DESCRIPTION
Since https://github.com/dfinity/ic/pull/7108 pocket-ic supports managing the bitcoin canister.
For now, we keep it disabled until/if we change the `--enable-bitcoin` flag on dfx