### PR TITLE
fix: start wallet canister after deployment

### DIFF
--- a/src/dfx/src/lib/identity/wallet.rs
+++ b/src/dfx/src/lib/identity/wallet.rs
@@ -122,6 +122,10 @@ pub async fn create_wallet(
         res => res.context("Failed while installing wasm.")?,
     }
 
+    mgr.start_canister(&canister_id)
+        .await
+        .context("Failed to start the wallet canister {canister_id}.")?;
+
     let wallet = build_wallet_canister(canister_id, agent).await?;
 
     wallet


### PR DESCRIPTION
This PR starts the wallet canister after deploying the wallet canister WASM to it. This is necessary if the wallet canister WASM is deployed to an existing stopped canister to ensure that the subsequent `build_wallet_canister(canister_id, agent).await` succeeds (it makes a query call to the wallet canister which requires that the canister is running).