### PR TITLE
ci: ignore RUSTSEC-2026-0001 (rkyv) in audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -34,3 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/audit@v1
+        with:
+          # TODO: remove this once the fix is backported to rkyv v0.7
+          # https://github.com/rkyv/rkyv/issues/644
+          ignore: RUSTSEC-2026-0001


### PR DESCRIPTION
# Description

The security issue is in `rkyv` v0.7 and fixed in `v0.8.13`.
`rkyv` is an indirect dependency introduced by `rust_decimal`.  `rust_decimal` cannot bump its `rkyv` dependency to v0.8 because it will be a breaking change for them. ([issue](https://github.com/paupino/rust-decimal/issues/766))
I have asked `rkyv` maintainer to backport the fix to `v0.7`. ([request](https://github.com/rkyv/rkyv/issues/644))

Before the patch is released, let's temporarily ignore this RUSTSET rule to unblock our work.

