### PR TITLE
chore: bump agent-rs and ic-management-canister-types deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,9 +729,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cached"
@@ -728,19 +740,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec6d20b3d24b6c74e2c5331d2d3d8d1976a9883c7da179aa851afa4c90d62e36"
 dependencies = [
  "hashbrown 0.12.3",
- "instant",
- "once_cell",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cached"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8466736fe5dbcaf8b8ee24f9bbefe43c884dc3e9ff7178da70f55bffca1133c"
-dependencies = [
- "ahash 0.8.12",
- "hashbrown 0.14.5",
  "instant",
  "once_cell",
  "thiserror 1.0.69",
@@ -758,6 +757,19 @@ dependencies = [
  "hashbrown 0.14.5",
  "once_cell",
  "thiserror 1.0.69",
+ "web-time",
+]
+
+[[package]]
+name = "cached"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801927ee168e17809ab8901d9f01f700cd7d8d6a6527997fee44e4b0327a253c"
+dependencies = [
+ "ahash 0.8.12",
+ "hashbrown 0.15.4",
+ "once_cell",
+ "thiserror 2.0.12",
  "web-time",
 ]
 
@@ -1663,8 +1675,8 @@ dependencies = [
  "ic-asset",
  "ic-cdk",
  "ic-identity-hsm",
- "ic-management-canister-types 0.4.1",
- "ic-utils 0.44.2",
+ "ic-management-canister-types 0.5.0",
+ "ic-utils 0.45.0",
  "ic-wasm",
  "icrc-ledger-types",
  "idl2json",
@@ -1742,7 +1754,7 @@ dependencies = [
  "humantime-serde",
  "ic-agent",
  "ic-identity-hsm",
- "ic-utils 0.44.2",
+ "ic-utils 0.45.0",
  "itertools 0.10.5",
  "k256 0.11.6",
  "keyring",
@@ -2586,6 +2598,11 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -2622,6 +2639,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hkdf"
@@ -2860,18 +2883,18 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.44.2"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6777a6893e52254747abfd0a218aeafc03ada83faa9bff67ee8801739241b5ca"
+checksum = "20a6173286a80fc478462fc45de42faf37a79b0109a489743aeffb3e4a2fc772"
 dependencies = [
  "arc-swap",
- "async-channel",
+ "async-channel 2.5.0",
  "async-lock",
  "async-trait",
  "async-watch",
  "backoff",
  "bytes",
- "cached 0.52.0",
+ "cached 0.56.0",
  "candid",
  "der 0.7.10",
  "ecdsa 0.16.9",
@@ -2884,7 +2907,7 @@ dependencies = [
  "http-body-util",
  "ic-certification 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-ed25519",
- "ic-transport-types 0.44.2",
+ "ic-transport-types 0.45.0",
  "ic-verify-bls-signature",
  "k256 0.13.4",
  "leb128",
@@ -2923,7 +2946,7 @@ dependencies = [
  "globset",
  "hex",
  "ic-agent",
- "ic-utils 0.44.2",
+ "ic-utils 0.45.0",
  "itertools 0.10.5",
  "json5",
  "mime",
@@ -3270,14 +3293,16 @@ dependencies = [
 
 [[package]]
 name = "ic-ed25519"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a381e86a9d559c816a7ff4419e56f5d37f96357258fb63b0cb7026db0f729b"
+checksum = "6b73f85d01b7a3d538353050f1eda546f827ffe7f3ffa35f8e80faa8cff1da10"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
+ "hex-literal",
  "hkdf",
- "pem 1.1.1",
+ "ic_principal",
+ "pem 3.0.5",
  "rand 0.8.5",
  "thiserror 2.0.12",
  "zeroize",
@@ -3370,9 +3395,9 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.44.2"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ea5968ef808815e917f9a8bfab2bb2c7fbe6e822911276128295b16ce2bbff"
+checksum = "1cadfa7095085405ceaadc8aa7714e313cb778d1b98292dbfe23cd087b345b35"
 dependencies = [
  "hex",
  "ic-agent",
@@ -3530,9 +3555,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.44.2"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827e8e1da3e75382137f552b088c124618e770974e670fc4f40add86858a4743"
+checksum = "4a775244756a5d97ff19b08071a946a4b4896904e35deb036bf215e80f2e703d"
 dependencies = [
  "candid",
  "hex",
@@ -3601,32 +3626,31 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.44.2"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28a3fdfbf4bf4ef470a4d3980f823db299a2e021819171266827d9725efea5a"
+checksum = "30c22aaa2924df0321705dc01d408c8b75d1e1deb40b65defd2ff04008a720be"
 dependencies = [
  "async-trait",
  "candid",
  "futures-util",
  "ic-agent",
- "ic-management-canister-types 0.4.1",
+ "ic-management-canister-types 0.5.0",
  "once_cell",
  "semver",
  "serde",
  "serde_bytes",
  "sha2 0.10.9",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "thiserror 2.0.12",
  "time",
- "tokio",
 ]
 
 [[package]]
 name = "ic-verify-bls-signature"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d420b25c0091059f6c3c23a21427a81915e6e0aca3b79e0d403ed767f286a3b9"
+checksum = "cd6c4261586eb473fe1219de63186a98e554985d5fd6f3488036c8fb82452e27"
 dependencies = [
  "hex",
  "ic_bls12_381 0.10.1",
@@ -3838,7 +3862,7 @@ dependencies = [
  "humantime",
  "ic-agent",
  "ic-asset",
- "ic-utils 0.44.2",
+ "ic-utils 0.45.0",
  "libflate 1.4.0",
  "num-traits",
  "pem 1.1.1",
@@ -5510,9 +5534,9 @@ dependencies = [
 
 [[package]]
 name = "rangemap"
-version = "1.5.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rayon"
@@ -6405,7 +6429,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af91f480ee899ab2d9f8435bfdfc14d08a5754bd9d3fef1f1a1c23336aad6c8b"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "cfg-if",
  "futures-core",
  "pin-project-lite",
@@ -6460,6 +6484,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6495,6 +6525,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.104",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ future_not_send = "warn"
 candid = "0.10.18"
 candid_parser = "0.2.4"
 dfx-core = { path = "src/dfx-core", version = "0.2.0" }
-ic-agent = "0.44.2"
+ic-agent = "0.45.0"
 ic-asset = { path = "src/canisters/frontend/ic-asset", version = "0.26.0" }
 ic-cdk = "0.19.0-beta.2"
-ic-identity-hsm = "0.44.2"
-ic-utils = "0.44.2"
-ic-management-canister-types = "0.4.1"
+ic-identity-hsm = "0.45.0"
+ic-utils = "0.45.0"
+ic-management-canister-types = "0.5.0"
 
 aes-gcm = { version = "0.10.3", features = ["std"] }
 anyhow = "1.0.56"

--- a/src/dfx/src/commands/canister/snapshot.rs
+++ b/src/dfx/src/commands/canister/snapshot.rs
@@ -506,7 +506,11 @@ async fn upload(
             canister_id,
             replace_snapshot: replace.as_ref().map(|x| x.0.clone()),
             wasm_module_size: metadata.wasm_module_size,
-            globals: metadata.globals,
+            globals: metadata
+                .globals
+                .into_iter()
+                .map(|x| x.ok_or(anyhow!("Could not parse global in snapshot metadata")))
+                .collect::<Result<Vec<_>, _>>()?,
             wasm_memory_size: metadata.wasm_memory_size,
             stable_memory_size: metadata.stable_memory_size,
             certified_data: metadata.certified_data,


### PR DESCRIPTION
# Description

This PR bumps `ic-agent`, `ic-identity-hsm`, and `ic-utils` (from `dfinity/agent-rs`) to the latest public v0.45.0 and `ic-management-canister-types` to the compatible version v0.5.0. The bump is a prerequisite for follow-up work on canister migration.