### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,5 +32,5 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions-rust-lang/audit@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions-rust-lang/audit@72c09e02f132669d52284a3323acdb503cfc1a24 # v1.2.7

--- a/.github/workflows/broadcast-frontend-hash.yml
+++ b/.github/workflows/broadcast-frontend-hash.yml
@@ -33,7 +33,7 @@ jobs:
         run: sudo apt-get install --yes moreutils
 
       - name: Checkout dfinity/sdk repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # workaround to fetch all tags: https://github.com/actions/checkout/issues/701
           path: sdk
@@ -47,14 +47,14 @@ jobs:
           echo "NEW_HASH=$(shasum -a 256 src/distributed/assetstorage.wasm.gz | cut -f1 -d" ")" >> $GITHUB_ENV
 
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
           private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
 
       - name: Checkout dfinity/motoko-playground repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: ${{ env.PLAYGROUND_REPO }}

--- a/.github/workflows/build-frontend-canister.yml
+++ b/.github/workflows/build-frontend-canister.yml
@@ -28,12 +28,12 @@ jobs:
     name: frontend-canister-up-to-date:required
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build frontend canister
         run: |
           ./scripts/update-frontend-canister.sh --release-build
       - name: Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: assetstorage
           path: ${{ github.workspace }}/src/distributed/assetstorage.wasm.gz

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -23,8 +23,8 @@ jobs:
     name: license-check:required
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: rm rust-toolchain.toml
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15
         with:
           command: check bans licenses sources # skip advisories, which are handled by audit.yml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,9 +25,9 @@ jobs:
     outputs:
       sources: ${{ steps.filter.outputs.sources }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -57,7 +57,7 @@ jobs:
         #   Error: IO: Dynamic loading not supported
         os: [macos-15, ubuntu-24.04, ubuntu-24.04-arm]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup environment variables
@@ -71,13 +71,13 @@ jobs:
         run: rustup toolchain remove stable 2>/dev/null || true
       # This step also handles Rust-specific caching
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: release
       - name: Build
         run: cargo build --locked --release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: dfx-${{ matrix.os }}-rs-${{ hashFiles('rust-toolchain.toml') }}
           path: target/release/dfx
@@ -89,7 +89,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: set-matrix
         run: echo "matrix=$(scripts/workflows/e2e-matrix.py)" >> $GITHUB_OUTPUT
 
@@ -102,9 +102,9 @@ jobs:
       matrix:
         os: [macos-15, ubuntu-24.04, ubuntu-24.04-arm]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download dfx binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dfx-${{ matrix.os }}-rs-${{ hashFiles('rust-toolchain.toml') }}
           path: /usr/local/bin
@@ -132,9 +132,9 @@ jobs:
     env:
       E2E_TEST: tests-${{ matrix.test }}.bash
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download dfx binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dfx-${{ matrix.os }}-rs-${{ hashFiles('rust-toolchain.toml') }}
           path: /usr/local/bin
@@ -155,7 +155,7 @@ jobs:
       - name: Download bats-support as a git submodule
         run: git submodule update --init --recursive
       - name: Cache mops files
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             e2e/assets/playground_backend/.mops
@@ -173,9 +173,9 @@ jobs:
         os: [macos-15, ubuntu-24.04, ubuntu-24.04-arm]
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setting up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.9"
       - name: Installing playwright
@@ -184,7 +184,7 @@ jobs:
           playwright install
           playwright install-deps
       - name: Download dfx binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dfx-${{ matrix.os }}-rs-${{ hashFiles('rust-toolchain.toml') }}
           path: /usr/local/bin

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -22,9 +22,9 @@ jobs:
     outputs:
       sources: ${{ steps.filter.outputs.sources }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           # Disable cache: fmt doesn't need target/ artifacts, so it would
           # save an empty cache that evicts the real one used by other workflows

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,9 @@ jobs:
     outputs:
       sources: ${{ steps.filter.outputs.sources }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -46,7 +46,7 @@ jobs:
         os: [ ubuntu-24.04, ubuntu-24.04-arm, macos-15 ]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Remove pre-installed stable toolchain so it doesn't pollute the
       # rust-cache environment hash.  macOS (and sometimes Linux) runner
       # images ship with varying stable versions, making the hash
@@ -55,7 +55,7 @@ jobs:
         run: rustup toolchain remove stable 2>/dev/null || true
       # This step also handles Rust-specific caching
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: debug
 

--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -23,7 +23,7 @@ jobs:
     name: install-script-shellcheck:required
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
       - name: Generate
@@ -37,7 +37,7 @@ jobs:
           cp public/manifest.json _out/manifest.json
       - name: Upload Artifacts
         if: github.event_name == 'push'
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           single-commit: true
           branch: public-manifest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,16 +34,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache: false
 
       - name: Authenticate with crates.io
         id: auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
 
       - name: Publish dfx-core
         if: inputs.dfx-core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
             name: aarch64-linux
             tar: tar
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup environment variables
         run: |
@@ -75,7 +75,7 @@ jobs:
 
       # This step also handles Rust-specific caching
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: release
 
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload Artifacts
         if: github.ref_type == 'tag'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: dfx-artifacts-${{ hashFiles('rust-toolchain.toml') }}-${{ matrix.name }}
           path: |
@@ -165,19 +165,19 @@ jobs:
     if: github.ref_type == 'tag'
     needs: build_dfx
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup environment variables
         run: echo "VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: dfx-artifacts-${{ hashFiles('rust-toolchain.toml') }}-*
           merge-multiple: true
 
       - name: Upload dfx tarballs and sha256
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dfx-*.tar.*
@@ -187,7 +187,7 @@ jobs:
           make_latest: false
 
       - name: Upload assets canister
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: src/distributed/assetstorage.{wasm.gz,did}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -27,7 +27,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check e2e scripts
         run: shellcheck e2e/**/*.*sh
       - name: Check scripts/

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,9 +25,9 @@ jobs:
     outputs:
       sources: ${{ steps.filter.outputs.sources }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: github.event_name == 'push'
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -47,7 +47,7 @@ jobs:
       matrix:
         os: [ ubuntu-24.04, ubuntu-24.04-arm, macos-15 ]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Remove pre-installed stable toolchain so it doesn't pollute the
       # rust-cache environment hash.  macOS (and sometimes Linux) runner
       # images ship with varying stable versions, making the hash
@@ -56,7 +56,7 @@ jobs:
         run: rustup toolchain remove stable 2>/dev/null || true
       # This step also handles Rust-specific caching
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           cache-shared-key: debug
       - name: Check cargo test

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -18,7 +18,7 @@ jobs:
     name: json-schema-docs-up-to-date:required
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Check cargo build

--- a/.github/workflows/update-ic-did.yml
+++ b/.github/workflows/update-ic-did.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout dfx repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-motoko.yml
+++ b/.github/workflows/update-motoko.yml
@@ -26,7 +26,7 @@ jobs:
   update-motoko:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.inputs.sdkBranch }}
 
@@ -61,14 +61,14 @@ jobs:
         git push origin chore-update-motoko-${{ env.MOTOKO_VERSION }}
 
     - name: Create GitHub App Token
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
       id: app-token
       with:
         app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
         private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
 
     - name: create Pull Request, with CHANGELOG.md entry suggestion
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         github-token: ${{ steps.app-token.outputs.token }}
         script: |

--- a/.github/workflows/update-replica-version.yml
+++ b/.github/workflows/update-replica-version.yml
@@ -33,7 +33,7 @@ jobs:
   update-replica:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.inputs.sdkBranch }}
 
@@ -68,14 +68,14 @@ jobs:
         git push origin chore-update-replica-${{ env.REPLICA_VERSION }}-${{ github.event.inputs.sdkBranch }}
 
     - name: Create GitHub App Token
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
       id: app-token
       with:
         app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
         private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
 
     - name: create Pull Request, with CHANGELOG.md entry suggestion
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         github-token: ${{ steps.app-token.outputs.token }}
         script: |


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v6` -> `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
  - Version: v6.0.2 | Latest: v6.0.2 | Release age: 88d
  - Commit: https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd

- `actions-rust-lang/audit@v1` -> `actions-rust-lang/audit@72c09e02f132669d52284a3323acdb503cfc1a24 # v1.2.7`
  - Version: v1.2.7 | Latest: v1.2.7 | Release age: 92d
  - Commit: https://github.com/actions-rust-lang/audit/commit/72c09e02f132669d52284a3323acdb503cfc1a24

- `actions/create-github-app-token@v3` -> `actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3`
  - Version: v3 | Latest: v3.0.0 | Release age: 25d
  - Commit: https://github.com/actions/create-github-app-token/commit/f8d387b68d61c58ab83c6c016672934102569859

- `actions/upload-artifact@v7` -> `actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7`
  - Version: v7 | Latest: v3.2.2 | Release age: 22d
  - Commit: https://github.com/actions/upload-artifact/commit/bbbca2ddaa5d8feaa63e36b76fdaad77386f024f

- `EmbarkStudios/cargo-deny-action@v2` -> `EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15`
  - Version: v2.0.15 | Latest: v2.0.15 | Release age: 90d
  - Commit: https://github.com/EmbarkStudios/cargo-deny-action/commit/3fd3802e88374d3fe9159b834c7714ec57d6c979

- `dorny/paths-filter@v4` -> `dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1`
  - Version: v4.0.1 | Latest: v4.0.1 | Release age: 21d
  - Commit: https://github.com/dorny/paths-filter/commit/fbd0ab8f3e69293af611ebaee6363fc25e6d187d

- `actions-rust-lang/setup-rust-toolchain@v1` -> `actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4`
  - Version: v1.15.4 | Latest: v1.15.4 | Release age: 24d
  - Commit: https://github.com/actions-rust-lang/setup-rust-toolchain/commit/150fca883cd4034361b621bd4e6a9d34e5143606

- `actions/download-artifact@v8` -> `actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1`
  - Version: v8.0.1 | Latest: v3.1.0-node20 | Release age: 22d
  - Commit: https://github.com/actions/download-artifact/commit/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
  - Warnings: 1 security advisory(ies) found, Action has 1 known advisory(ies)

- `actions/cache@v5` -> `actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4`
  - Version: v5.0.4 | Latest: v5.0.4 | Release age: 20d
  - Commit: https://github.com/actions/cache/commit/668228422ae6a00e4ad889ee87cd7109ec5666a7

- `actions/setup-python@v6` -> `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0`
  - Version: v6.2.0 | Latest: v6.2.0 | Release age: 76d
  - Commit: https://github.com/actions/setup-python/commit/a309ff8b426b58ec0e2a45f0f869d46889d02405

- `JamesIves/github-pages-deploy-action@v4` -> `JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0`
  - Version: v4.8.0 | Latest: v4.8.0 | Release age: 88d
  - Commit: https://github.com/JamesIves/github-pages-deploy-action/commit/d92aa235d04922e8f08b40ce78cc5442fcfbfa2f

- `rust-lang/crates-io-auth-action@v1` -> `rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1`
  - Version: v1 | Latest: v1.0.4 | Release age: 15d
  - Commit: https://github.com/rust-lang/crates-io-auth-action/commit/b7e9a28eded4986ec6b1fa40eeee8f8f165559ec

- `svenstaro/upload-release-action@v2` -> `svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5`
  - Version: 2.11.5 | Latest: 2.11.5 | Release age: 22d
  - Commit: https://github.com/svenstaro/upload-release-action/commit/29e53e917877a24fad85510ded594ab3c9ca12de

- `actions/github-script@v8` -> `actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8`
  - Version: v8 | Latest: v8 | Release age: 215d
  - Commit: https://github.com/actions/github-script/commit/ed597411d8f924073f98dfc5c65a23a2325f34cd


### Files modified

- `.github/workflows/audit.yml`
- `.github/workflows/broadcast-frontend-hash.yml`
- `.github/workflows/build-frontend-canister.yml`
- `.github/workflows/deny.yml`
- `.github/workflows/e2e.yml`
- `.github/workflows/fmt.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/publish-manifest.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/release.yml`
- `.github/workflows/shellcheck.yml`
- `.github/workflows/unit.yml`
- `.github/workflows/update-docs.yml`
- `.github/workflows/update-ic-did.yml`
- `.github/workflows/update-motoko.yml`
- `.github/workflows/update-replica-version.yml`

### Security warnings

- 1 security advisory(ies) found
- Action has 1 known advisory(ies)