### PR TITLE
fix(e2e): fabricate cycles before setting high freezing threshold

### DIFF
--- a/e2e/tests-dfx/update_settings.bash
+++ b/e2e/tests-dfx/update_settings.bash
@@ -33,11 +33,13 @@ teardown() {
   assert_command_fail dfx canister update-settings hello_backend --freezing-threshold 100000000000
   assert_match "SECONDS" # error message pointing to the error
 
+  # fabricating 100T cycles onto it, so that it won't starve
+  assert_command dfx ledger fabricate-cycles --canister hello_backend --t 100
+
   # with manual override it's ok
   assert_command dfx canister update-settings hello_backend --freezing-threshold 100000000000 --confirm-very-long-freezing-threshold
 
-  # to check if threshold is set correctly we have to un-freeze the canister by adding cycles. Fabricating 100T cycles onto it
-  assert_command dfx ledger fabricate-cycles --canister hello_backend --t 100
+  # to check if threshold is set correctly we have to un-freeze the canister by adding cycles
   assert_command dfx canister status hello_backend
   assert_match "Freezing threshold: 100_000_000_000"
 


### PR DESCRIPTION
## Summary

The `set freezing threshold` test in `update_settings.bash` fails with newer replica versions because the canister runs out of cycles when a 100B freezing threshold is set before topping up.

Fix: move `fabricate-cycles` before the `update-settings --freezing-threshold` call.

Split from #4514 so the bot-authored replica update PR doesn't need to touch test files.

## Test plan

- [ ] `test (dfx/update_settings)` passes in CI