### PR TITLE
chore: update replica version to 719ff387aab462ce5759c4c20c30de959fe9538c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,25 @@ Updated Motoko to [1.4.1](https://github.com/dfinity/motoko/releases/tag/1.4.1)
 
 ### Replica
 
-Updated replica to elected commit 17d483c60a09b393ad82a2091b68a242ac69c72d.
+Updated replica to elected commit 719ff387aab462ce5759c4c20c30de959fe9538c.
 This incorporates the following executed proposals:
+
+- [141436](https://dashboard.internetcomputer.org/proposal/141436)
+- [141326](https://dashboard.internetcomputer.org/proposal/141326)
+- [141215](https://dashboard.internetcomputer.org/proposal/141215)
+- [141082](https://dashboard.internetcomputer.org/proposal/141082)
+- [140946](https://dashboard.internetcomputer.org/proposal/140946)
+- [140853](https://dashboard.internetcomputer.org/proposal/140853)
+- [140768](https://dashboard.internetcomputer.org/proposal/140768)
+- [140659](https://dashboard.internetcomputer.org/proposal/140659)
+- [140602](https://dashboard.internetcomputer.org/proposal/140602)
+- [140506](https://dashboard.internetcomputer.org/proposal/140506)
+- [140491](https://dashboard.internetcomputer.org/proposal/140491)
+- [140395](https://dashboard.internetcomputer.org/proposal/140395)
+- [140270](https://dashboard.internetcomputer.org/proposal/140270)
+- [140176](https://dashboard.internetcomputer.org/proposal/140176)
+- [140091](https://dashboard.internetcomputer.org/proposal/140091)
+- [140089](https://dashboard.internetcomputer.org/proposal/140089)
 
 # 0.31.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6021,9 +6021,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,7 +760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae"
 dependencies = [
  "ahash 0.8.12",
- "cached_proc_macro 0.23.0",
+ "cached_proc_macro",
  "cached_proc_macro_types",
  "hashbrown 0.14.5",
  "once_cell",
@@ -775,8 +775,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801927ee168e17809ab8901d9f01f700cd7d8d6a6527997fee44e4b0327a253c"
 dependencies = [
  "ahash 0.8.12",
- "cached_proc_macro 0.25.0",
- "cached_proc_macro_types",
  "hashbrown 0.15.5",
  "once_cell",
  "thiserror 2.0.18",
@@ -788,18 +786,6 @@ name = "cached_proc_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9225bdcf4e4a9a4c08bf16607908eb2fbf746828d5e0b5e019726dbf6571f201"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -2124,15 +2110,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2880,11 +2857,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2913,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.47.0"
+version = "0.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087c953695a2581a1e58a23a88e16a19e5eb2638ecefeea0bde22f23d8896786"
+checksum = "fefe511d29d927aa5a2090c2e26e0b72cd0633ab7007927e19aeceb05c2a42b1"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -2936,7 +2911,7 @@ dependencies = [
  "http-body-util",
  "ic-certification 3.1.0",
  "ic-ed25519",
- "ic-transport-types 0.47.0",
+ "ic-transport-types 0.47.2",
  "ic-verify-bls-signature",
  "ic_principal",
  "k256 0.13.4",
@@ -2944,7 +2919,7 @@ dependencies = [
  "p256",
  "pem 3.0.6",
  "pkcs8 0.10.2",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rangemap",
  "reqwest 0.13.2",
  "sec1 0.7.3",
@@ -3594,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.47.0"
+version = "0.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a91a2dc71282291a7c26ec7c23e57335fc4a562a6b0b571ede0044790a68a3f"
+checksum = "a46a13c1e36d4ac5db68a84e68f2e9edf7773bea131e915e251709b00f5910d9"
 dependencies = [
  "candid",
  "hex",
@@ -5576,9 +5551,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -5799,11 +5774,9 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -5812,7 +5785,6 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -6776,27 +6748,6 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -7819,17 +7770,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5199,7 +5199,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pocket-ic"
 version = "13.0.0"
-source = "git+https://github.com/dfinity/ic?rev=17d483c60a09b393ad82a2091b68a242ac69c72d#17d483c60a09b393ad82a2091b68a242ac69c72d"
+source = "git+https://github.com/dfinity/ic?rev=719ff387aab462ce5759c4c20c30de959fe9538c#719ff387aab462ce5759c4c20c30de959fe9538c"
 dependencies = [
  "backoff",
  "base64 0.13.1",

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -84,7 +84,7 @@ os_str_bytes = { version = "6.3.0", features = ["conversions"] }
 patch = "0.7.0"
 pem.workspace = true
 petgraph = "0.6.0"
-pocket-ic = { git = "https://github.com/dfinity/ic", rev = "17d483c60a09b393ad82a2091b68a242ac69c72d" }
+pocket-ic = { git = "https://github.com/dfinity/ic", rev = "719ff387aab462ce5759c4c20c30de959fe9538c" }
 rand = "0.8.5"
 regex = "1.5.5"
 reqwest = { workspace = true, features = ["blocking", "json"] }

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -21,6 +21,7 @@ bytes = "1"
 flate2 = { version = "1.0.11", default-features = false, features = ["zlib-ng"] }
 hex = "0.4.3"
 reqwest.workspace = true
+semver.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10.6"
 tar = "0.4.26"

--- a/src/dfx/assets/build.rs
+++ b/src/dfx/assets/build.rs
@@ -1,5 +1,6 @@
 use flate2::Compression;
 use flate2::write::GzEncoder;
+use semver::Version;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -193,7 +194,7 @@ fn get_git_hash() -> Result<String, std::io::Error> {
             .next()
             .and_then(|v| v.parse::<u128>().ok())
         {
-            if count < latest_distance {
+            if Version::parse(tag).is_ok() && count < latest_distance {
                 latest_tag = String::from(tag);
                 latest_distance = count;
             }

--- a/src/dfx/assets/dfx-asset-sources.json
+++ b/src/dfx/assets/dfx-asset-sources.json
@@ -1,5 +1,5 @@
 {
-  "replica-rev": "17d483c60a09b393ad82a2091b68a242ac69c72d",
+  "replica-rev": "719ff387aab462ce5759c4c20c30de959fe9538c",
   "x86_64-darwin": {
     "motoko": {
       "url": "https://github.com/dfinity/motoko/releases/download/1.4.1/motoko-Darwin-x86_64-1.4.1.tar.gz",
@@ -7,9 +7,9 @@
       "version": "1.4.1"
     },
     "pocket-ic": {
-      "url": "https://download.dfinity.systems/ic/17d483c60a09b393ad82a2091b68a242ac69c72d/binaries/x86_64-darwin/pocket-ic.gz",
-      "sha256": "5b905178cf1bd28c469a3103ca712c21f5a0501e46c02ba1fe5789c41019ecaf",
-      "rev": "17d483c60a09b393ad82a2091b68a242ac69c72d"
+      "url": "https://download.dfinity.systems/ic/719ff387aab462ce5759c4c20c30de959fe9538c/binaries/x86_64-darwin/pocket-ic.gz",
+      "sha256": "05e46e490d608ee94ec8b64fe58111f064d6f36d0e9d8317b3dd0c9cf26ce331",
+      "rev": "719ff387aab462ce5759c4c20c30de959fe9538c"
     }
   },
   "arm64-darwin": {
@@ -19,9 +19,9 @@
       "version": "1.4.1"
     },
     "pocket-ic": {
-      "url": "https://download.dfinity.systems/ic/17d483c60a09b393ad82a2091b68a242ac69c72d/binaries/arm64-darwin/pocket-ic.gz",
-      "sha256": "76dc87bda23670e30168be3effb99fc8d62f7e3f9af375c6c6c2671e53c21410",
-      "rev": "17d483c60a09b393ad82a2091b68a242ac69c72d"
+      "url": "https://download.dfinity.systems/ic/719ff387aab462ce5759c4c20c30de959fe9538c/binaries/arm64-darwin/pocket-ic.gz",
+      "sha256": "7027f9622f8d552d54618ff469101b58455f888fe96cc87716b73dd4cc88b6a7",
+      "rev": "719ff387aab462ce5759c4c20c30de959fe9538c"
     }
   },
   "x86_64-linux": {
@@ -31,9 +31,9 @@
       "version": "1.4.1"
     },
     "pocket-ic": {
-      "url": "https://download.dfinity.systems/ic/17d483c60a09b393ad82a2091b68a242ac69c72d/binaries/x86_64-linux/pocket-ic.gz",
-      "sha256": "bb6bcc267fcd74f83b3d13f2bb14071f4b7c7fc6d4d6f0f67450e50b0e96011d",
-      "rev": "17d483c60a09b393ad82a2091b68a242ac69c72d"
+      "url": "https://download.dfinity.systems/ic/719ff387aab462ce5759c4c20c30de959fe9538c/binaries/x86_64-linux/pocket-ic.gz",
+      "sha256": "a67b88175828b8250753ba2978480f02ff2d5ad791bec99c3abf61c74e145883",
+      "rev": "719ff387aab462ce5759c4c20c30de959fe9538c"
     }
   },
   "arm64-linux": {
@@ -43,9 +43,9 @@
       "version": "1.4.1"
     },
     "pocket-ic": {
-      "url": "https://download.dfinity.systems/ic/17d483c60a09b393ad82a2091b68a242ac69c72d/binaries/arm64-linux/pocket-ic.gz",
-      "sha256": "d3155c403a05a5aca11fb6a72696c15b7530b41ea47c4e6a414f2e73f526580d",
-      "rev": "17d483c60a09b393ad82a2091b68a242ac69c72d"
+      "url": "https://download.dfinity.systems/ic/719ff387aab462ce5759c4c20c30de959fe9538c/binaries/arm64-linux/pocket-ic.gz",
+      "sha256": "ffe10ce5ffaf1c17d4a553c13a7693e8d6c1960ffe29b9089482e5a57075bef3",
+      "rev": "719ff387aab462ce5759c4c20c30de959fe9538c"
     }
   },
   "common": {

--- a/src/dfx/src/actors/pocketic.rs
+++ b/src/dfx/src/actors/pocketic.rs
@@ -372,6 +372,7 @@ async fn initialize_pocketic(
         verified_application: vec![],
         application: vec![],
         cloud_engine: vec![],
+        test_threshold_keys: None,
     };
     match replica_config.subnet_type {
         ReplicaSubnetType::Application => subnet_config_set.application.push(<_>::default()),


### PR DESCRIPTION
## Summary

- Updates replica to elected commit `719ff387aab462ce5759c4c20c30de959fe9538c`, incorporating proposals 140089–141436
- Fixes a build bug where non-version git tags (e.g. `asset-canister-404-support`) were picked as the nearest tag by `get_git_hash()`, producing an invalid semver string that crashed `dfx start`; fix uses `Version::parse(tag).is_ok()` to skip non-version tags
