### PR TITLE
chore: bump agent-rs to 0.48 git rev for rustls provider feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,7 +1719,7 @@ dependencies = [
  "ic-cdk",
  "ic-identity-hsm",
  "ic-management-canister-types 0.7.1",
- "ic-utils 0.47.3",
+ "ic-utils 0.48.0",
  "ic-wasm",
  "icrc-ledger-types",
  "idl2json",
@@ -1796,7 +1796,7 @@ dependencies = [
  "humantime-serde",
  "ic-agent",
  "ic-identity-hsm",
- "ic-utils 0.47.3",
+ "ic-utils 0.48.0",
  "itertools 0.10.5",
  "k256 0.11.6",
  "keyring",
@@ -2888,9 +2888,8 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.47.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85dbab284eac1806b77833cff143d66ae97aae74d34b0e60fb4ab4edf3d6fa12"
+version = "0.48.0"
+source = "git+https://github.com/dfinity/agent-rs?rev=01b6b2ce96ceb44871b2a4273166e8d1cd5440ca#01b6b2ce96ceb44871b2a4273166e8d1cd5440ca"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -2911,7 +2910,7 @@ dependencies = [
  "http-body-util",
  "ic-certification 3.1.0",
  "ic-ed25519",
- "ic-transport-types 0.47.3",
+ "ic-transport-types 0.48.0",
  "ic-verify-bls-signature",
  "ic_principal",
  "k256 0.13.4",
@@ -2922,6 +2921,7 @@ dependencies = [
  "rand 0.10.1",
  "rangemap",
  "reqwest 0.13.2",
+ "rustls",
  "sec1 0.7.3",
  "serde",
  "serde_bytes",
@@ -2951,7 +2951,7 @@ dependencies = [
  "globset",
  "hex",
  "ic-agent",
- "ic-utils 0.47.3",
+ "ic-utils 0.48.0",
  "itertools 0.10.5",
  "json5",
  "mime",
@@ -3395,9 +3395,8 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.47.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577e4411ea208f0bf7e6bf13535660df682fada94f45fbbc79b7e34c946a06ae"
+version = "0.48.0"
+source = "git+https://github.com/dfinity/agent-rs?rev=01b6b2ce96ceb44871b2a4273166e8d1cd5440ca#01b6b2ce96ceb44871b2a4273166e8d1cd5440ca"
 dependencies = [
  "hex",
  "ic-agent",
@@ -3569,9 +3568,8 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.47.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2116182b3ec5a831d579db0a205b6cf9c2ca96616493bef99480532d0b3c2f5"
+version = "0.48.0"
+source = "git+https://github.com/dfinity/agent-rs?rev=01b6b2ce96ceb44871b2a4273166e8d1cd5440ca#01b6b2ce96ceb44871b2a4273166e8d1cd5440ca"
 dependencies = [
  "candid",
  "hex",
@@ -3637,9 +3635,8 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.47.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f793db5d338dd9d0b659c2ce40080d7c9811cff6f171560f781cd2d6a43b7353"
+version = "0.48.0"
+source = "git+https://github.com/dfinity/agent-rs?rev=01b6b2ce96ceb44871b2a4273166e8d1cd5440ca#01b6b2ce96ceb44871b2a4273166e8d1cd5440ca"
 dependencies = [
  "async-trait",
  "candid",
@@ -3872,7 +3869,7 @@ dependencies = [
  "humantime",
  "ic-agent",
  "ic-asset",
- "ic-utils 0.47.3",
+ "ic-utils 0.48.0",
  "libflate 1.4.0",
  "num-traits",
  "pem 1.1.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ future_not_send = "warn"
 candid = "0.10.18"
 candid_parser = "0.3.0"
 dfx-core = { path = "src/dfx-core", version = "0.4.0" }
-ic-agent = "0.47.3"
+ic-agent = { git = "https://github.com/dfinity/agent-rs", rev = "01b6b2ce96ceb44871b2a4273166e8d1cd5440ca", default-features = false, features = ["pem"] }
 ic-asset = { path = "src/canisters/frontend/ic-asset", version = "0.29.0" }
 ic-cdk = "0.19.0-beta.2"
-ic-identity-hsm = "0.47.3"
-ic-utils = "0.47.3"
+ic-identity-hsm = { git = "https://github.com/dfinity/agent-rs", rev = "01b6b2ce96ceb44871b2a4273166e8d1cd5440ca" }
+ic-utils = { git = "https://github.com/dfinity/agent-rs", rev = "01b6b2ce96ceb44871b2a4273166e8d1cd5440ca" }
 ic-management-canister-types = "0.7.1"
 
 aes-gcm = { version = "0.10.3", features = ["std"] }

--- a/src/canisters/frontend/icx-asset/Cargo.toml
+++ b/src/canisters/frontend/icx-asset/Cargo.toml
@@ -18,7 +18,7 @@ candid = { workspace = true }
 clap = { workspace = true, features = ["derive", "cargo", "unstable-styles", "wrap_help"] }
 delay = "0.3.1"
 humantime.workspace = true
-ic-agent = { workspace = true }
+ic-agent = { workspace = true, features = ["tls-aws-lc-rs"] }
 ic-asset.workspace = true
 ic-utils = { workspace = true }
 libflate = "1.2.0"

--- a/src/dfx/Cargo.toml
+++ b/src/dfx/Cargo.toml
@@ -63,7 +63,7 @@ handlebars.workspace = true
 hex = { workspace = true, features = ["serde"] }
 humantime.workspace = true
 hyper-rustls = { version = "0.27.7", default-features = false, features = ["webpki-roots", "http2"] }
-ic-agent.workspace = true
+ic-agent = { workspace = true, features = ["tls-aws-lc-rs"] }
 ic-asset.workspace = true
 ic-cdk.workspace = true
 ic-identity-hsm.workspace = true


### PR DESCRIPTION
## Summary

- Pins `ic-agent`, `ic-utils`, `ic-identity-hsm` to HEAD of agent-rs `main` (`01b6b2c`, == 0.48.0), picking up [dfinity/agent-rs#732](https://github.com/dfinity/agent-rs/pull/732) which adds `tls-aws-lc-rs` (default) and `tls-ring` cargo features for rustls crypto provider selection.
- Workspace `ic-agent` declared with `default-features = false, features = ["pem"]` so each crate opts into its own TLS feature.
- `dfx` and `icx-asset` enable `tls-aws-lc-rs` because both call `Agent::builder()` with the default reqwest client (where ic-agent now needs a provider installed, else panics with "No provider set").
- `dfx-core` does **not** add any TLS feature plumbing. Its [`build_agent`](https://github.com/dfinity/sdk/blob/lwshang/agent-tls-features/src/dfx-core/src/interface/builder.rs#L138-L156) supplies its own client via `with_http_client`, on which ic-agent installs no provider, so `pem` alone is enough.

## Investigation notes

### Should dfx-core forward TLS features?
No. Two reasons:
1. dfx-core never uses ic-agent's default-client path — `with_http_client` short-circuits the provider install.
2. dfx-core doesn't `pub use ic_agent`, so any downstream consumer who calls `Agent::builder()` already has their own `ic-agent` dep and picks their TLS feature there.

### Should workspace `reqwest` switch to `rustls-no-provider`?
No. PR 732 made that switch in ic-agent because rustls 0.23 unification with both `ring` and `aws_lc_rs` features active panics when picking a default provider. Our workspace doesn't hit that — the only other reqwest is 0.12.28 (via `pocket-ic`) with no TLS features enabled. Switching would also require us to `CryptoProvider::install_default(...)` before each `Client::builder().use_rustls_tls()` call in dfx-core, [util/mod.rs](https://github.com/dfinity/sdk/blob/lwshang/agent-tls-features/src/dfx/src/util/mod.rs#L399-L400), and [project/import.rs](https://github.com/dfinity/sdk/blob/lwshang/agent-tls-features/src/dfx/src/lib/project/import.rs#L241-L242) — added complexity for no concrete benefit.

A cleaner refactor (drop the manual `use_rustls_tls()` calls, let ic-agent build its own default client) could centralize TLS choice in ic-agent's features, but is left as a possible follow-up.

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] `cargo check -p dfx-core` passes (no other workspace crate pulls in `tls-aws-lc-rs`)
- [ ] `cargo check -p dfx-core --no-default-features --features tls-ring` — N/A here (no dfx-core features added); but verified during investigation
- [ ] Smoke test `dfx` against mainnet / local replica to confirm TLS still works at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)